### PR TITLE
feat(serve): render claude-swap accounts in the web dashboard; add --identity full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Dashboard v1 snapshot: Claude rows now include all claude-swap accounts (windows, pace, active flag, redacted identity) when the integration is enabled.
 - CLI: add a built-in auto-refreshing web dashboard at `/` to `codexbar serve`.
 - CLI: `codexbar dashboard --output <path>` atomically writes the snapshot to a file (temp file + fsync + rename, `0644`) instead of stdout, so static-webroot publishers no longer need a shell wrapper.
+- CLI: the serve web dashboard renders per-account sections for claude-swap providers, and `codexbar serve --identity full` opts authorized dashboard clients into real account emails on trusted, private networks.
 - CLI: expose Codex cost-history completeness in JSON and add an experimental provider-native-only scan mode (#2520). Thanks @NickGuAI!
 - Usage & Spend: add an accessible daily, weekly, and cumulative token-activity heatmap backed by the existing persistent cost scan cache (#2548). Thanks @Yuxin-Qiao!
 - Settings: the sidebar is now resizable — drag the divider between 200–380pt; the width persists across launches.

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -195,6 +195,7 @@ extension CodexBarCLI {
           codexbar serve [--host <host>] [--port <port>] [--refresh-interval <seconds>]
                          [--request-timeout <seconds>]
                          [--dashboard-token <token>] [--allow-plain-http]
+                         [--identity <redacted|full>]
                          [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>]
                          [-v|--verbose]
 
@@ -212,6 +213,9 @@ extension CodexBarCLI {
           non-loopback host the token also gates /usage and /cost (account data);
           / and /health are always open. Use a TLS-terminating reverse proxy for anything
           beyond a trusted network segment.
+          Snapshot identity defaults to redacted emails; --identity full exposes real
+          account emails to every authorized dashboard client. Reserve it for trusted,
+          private networks (e.g. a tailnet-only reverse proxy).
 
         Endpoints:
           GET /                    Built-in web dashboard

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -35,6 +35,11 @@ struct ServeOptions: CommanderParsable {
         name: .long("allow-plain-http"),
         help: "Accept sending the dashboard token over cleartext HTTP on a non-loopback host")
     var allowPlainHTTP: Bool = false
+
+    @Option(
+        name: .long("identity"),
+        help: "Dashboard snapshot identity detail: redacted (default) or full. Full exposes real account emails to every authorized dashboard client; use it only on trusted, private networks.")
+    var identity: String?
 }
 
 enum CLIServeRoute: Equatable {
@@ -110,6 +115,10 @@ struct ServeRuntime {
     let requestTimeout: TimeInterval
     let healthVersion: String?
     let dashboardAuth: CLIServeDashboardAuth
+    /// Identity detail for dashboard snapshots. Defaults to `.redacted`; the
+    /// `--identity full` startup opt-in exposes real account emails to every
+    /// authorized dashboard client on trusted, private networks.
+    let dashboardIdentityMode: DashboardIdentityMode
     /// True for non-loopback binds: every data route (`/usage`, `/cost`,
     /// `/dashboard/v1/snapshot`) then requires the bearer token, so account data
     /// is never exposed to the network unauthenticated. `/` and `/health` stay open.
@@ -125,6 +134,7 @@ struct ServeRuntime {
         requestTimeout: TimeInterval,
         healthVersion: String?,
         dashboardAuth: CLIServeDashboardAuth,
+        dashboardIdentityMode: DashboardIdentityMode = .redacted,
         bindHost: String)
     {
         self.configStore = configStore
@@ -135,6 +145,7 @@ struct ServeRuntime {
         self.requestTimeout = requestTimeout
         self.healthVersion = healthVersion
         self.dashboardAuth = dashboardAuth
+        self.dashboardIdentityMode = dashboardIdentityMode
         self.dataRoutesRequireAuth = !CLIServeSecurity.isLoopbackHost(bindHost)
     }
 }
@@ -655,6 +666,13 @@ extension CodexBarCLI {
 
         let bindHost = CLIServeSecurity.bindHost(host)
         let allowPlainHTTP = Self.decodeServeAllowPlainHTTP(from: values)
+        guard let dashboardIdentityMode = Self.decodeDashboardIdentityMode(from: values) else {
+            Self.exit(
+                code: .failure,
+                message: "--identity must be redacted or full.",
+                output: output,
+                kind: .args)
+        }
         if let startupError = Self.validateServeStartup(
             host: bindHost,
             hasConfiguredBearer: dashboardBearer != nil,
@@ -680,6 +698,7 @@ extension CodexBarCLI {
             requestTimeout: requestTimeout,
             healthVersion: Self.currentVersion(),
             dashboardAuth: CLIServeDashboardAuth(bearer: dashboardBearer),
+            dashboardIdentityMode: dashboardIdentityMode,
             bindHost: bindHost)
         let server = CLILocalHTTPServer(
             host: bindHost,
@@ -937,7 +956,8 @@ extension CodexBarCLI {
                                 now: { ContinuousClock().now },
                                 providerOperations: runtime.costOperations),
                             costRefreshesPricingInBackground: Self.serveCostRefreshesPricingInBackground,
-                            codexBarVersion: runtime.healthVersion))
+                            codexBarVersion: runtime.healthVersion),
+                        identityMode: runtime.dashboardIdentityMode)
                 }))
         }
     }
@@ -1169,13 +1189,17 @@ extension CodexBarCLI {
     /// Adapts the shared dashboard snapshot producer to the authenticated HTTP
     /// route. Auth, response caching, and `Cache-Control: no-store` remain owned
     /// by the surrounding serve request path.
-    private static func serveDashboardSnapshot(context: DashboardSnapshotContext) async -> CLILocalHTTPResponse {
+    private static func serveDashboardSnapshot(
+        context: DashboardSnapshotContext,
+        identityMode: DashboardIdentityMode) async -> CLILocalHTTPResponse
+    {
         let result: DashboardSnapshotResult
         do {
             result = try await DashboardSnapshotProducer.live(context: context).collect(
                 config: context.config,
                 refreshInterval: context.usage.refreshInterval,
-                codexBarVersion: context.codexBarVersion)
+                codexBarVersion: context.codexBarVersion,
+                identityMode: identityMode)
         } catch {
             return Self.serveError(status: .internalServerError, message: error.localizedDescription)
         }

--- a/Sources/CodexBarCLI/CLIServeWebUI.swift
+++ b/Sources/CodexBarCLI/CLIServeWebUI.swift
@@ -324,6 +324,50 @@ enum CLIServeWebUI {
           gap: 12px;
         }
 
+        .accounts {
+          display: grid;
+          gap: 12px;
+        }
+
+        .account {
+          padding: 11px 12px;
+          border: 1px solid var(--line);
+          border-radius: 10px;
+          background: var(--surface-muted);
+        }
+
+        .account.active {
+          border-color: color-mix(in srgb, var(--ok), var(--line) 45%);
+        }
+
+        .account-head {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          gap: 10px;
+          margin-bottom: 9px;
+        }
+
+        .account-name {
+          overflow: hidden;
+          font-size: 13px;
+          font-weight: 650;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .account-badge {
+          flex: none;
+          padding: 1px 8px;
+          border: 1px solid color-mix(in srgb, var(--ok), transparent 45%);
+          border-radius: 999px;
+          color: var(--ok);
+          font-size: 10px;
+          font-weight: 650;
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+        }
+
         .window-head {
           justify-content: space-between;
           gap: 10px;
@@ -611,6 +655,27 @@ enum CLIServeWebUI {
           return item;
         }
 
+        function renderAccount(account) {
+          const section = node("section", "account");
+          if (account.active) section.classList.add("active");
+
+          const head = node("div", "account-head");
+          const name = account.identity?.accountEmail || account.label || "Account";
+          head.append(node("span", "account-name", name));
+          if (account.active) head.append(node("span", "account-badge", "active"));
+          section.append(head);
+
+          if (account.error) {
+            section.append(node("p", "error-message", account.error));
+            return section;
+          }
+
+          const windows = node("div", "windows");
+          for (const window of account.windows || []) windows.append(renderWindow(window));
+          section.append(windows);
+          return section;
+        }
+
         function renderProvider(provider) {
           const card = node("article", "card");
           card.style.setProperty("--accent", accentColor(provider.display?.accentColor));
@@ -646,9 +711,21 @@ enum CLIServeWebUI {
             card.append(node("p", "error-message", provider.error.message || "Provider data is unavailable."));
           }
 
-          const windows = node("div", "windows");
-          for (const window of provider.windows || []) windows.append(renderWindow(window));
-          card.append(windows);
+          const accounts = Array.isArray(provider.accounts) ? provider.accounts : [];
+          if (accounts.length) {
+            // Multi-account providers (claude-swap): per-account sections replace
+            // the ambient windows, which describe only the active slot.
+            const list = node("div", "accounts");
+            for (const account of accounts) list.append(renderAccount(account));
+            card.append(list);
+          } else {
+            const windows = node("div", "windows");
+            for (const window of provider.windows || []) windows.append(renderWindow(window));
+            card.append(windows);
+          }
+          if (provider.accountsError) {
+            card.append(node("p", "error-message", provider.accountsError));
+          }
 
           const metrics = node("div", "metrics");
           if (provider.credits?.remaining !== null && provider.credits?.remaining !== undefined) {

--- a/Tests/CodexBarTests/CLIServeWebUITests.swift
+++ b/Tests/CodexBarTests/CLIServeWebUITests.swift
@@ -1,0 +1,37 @@
+import Commander
+import Foundation
+import Testing
+@testable import CodexBarCLI
+
+struct CLIServeWebUITests {
+    private var html: String {
+        String(decoding: CLIServeWebUI.response().body, as: UTF8.self)
+    }
+
+    @Test
+    func `web ui renders per account sections for multi account providers`() {
+        let html = self.html
+        // Multi-account rendering replaces ambient windows and falls back to the
+        // slot label when identity is redacted away entirely.
+        #expect(html.contains("function renderAccount(account)"))
+        #expect(html.contains("account.identity?.accountEmail || account.label"))
+        #expect(html.contains("provider.accountsError"))
+    }
+
+    @Test
+    func `web ui keeps ambient windows when no accounts are present`() {
+        let html = self.html
+        #expect(html.contains("Array.isArray(provider.accounts)"))
+        #expect(html.contains("renderWindow(window)"))
+    }
+
+    @Test
+    func `serve identity flag decodes like the dashboard command`() {
+        #expect(CodexBarCLI.decodeDashboardIdentityMode(
+            from: ParsedValues(positional: [], options: [:], flags: [])) == .redacted)
+        #expect(CodexBarCLI.decodeDashboardIdentityMode(
+            from: ParsedValues(positional: [], options: ["identity": ["full"]], flags: [])) == .full)
+        #expect(CodexBarCLI.decodeDashboardIdentityMode(
+            from: ParsedValues(positional: [], options: ["identity": ["nope"]], flags: [])) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2713/#2715/#2716 closing the loop for multi-account Claude on the built-in serve web dashboard:

- The web UI now renders per-account sections from the Claude row's `accounts[]` (email or slot-label header, active badge, per-account windows, per-account error), replacing the ambient windows that describe only the active swap slot. `accountsError` surfaces on the card. Providers without accounts render exactly as before.
- New `codexbar serve --identity redacted|full` startup flag (same decoder and validation as `codexbar dashboard --identity`, #2716). Default remains `redacted`; `full` exposes real account emails to every *authorized* dashboard client and is documented as reserved for trusted, private networks (e.g. tailnet-only reverse proxies). The static web UI itself stays unauthenticated and carries no account data.

## Testing

- New `CLIServeWebUITests`: account-section rendering markers, ambient-window fallback, serve identity decoding.
- `swift test --filter 'CLIServeWebUITests|CLIServeRouterTests|DashboardClaudeSwapSnapshotTests'` — 61/61 pass.
- Release build clean; Codex autoreview clean (P0 scope).
