### PR TITLE
fix(zai): Add support for CREDIT_LIMIT limit type

### DIFF
--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -7,6 +7,7 @@ import FoundationNetworking
 public enum ZaiLimitType: String, Sendable {
     case timeLimit = "TIME_LIMIT"
     case tokensLimit = "TOKENS_LIMIT"
+    case creditLimit = "CREDIT_LIMIT"
 }
 
 /// Z.ai usage limit unit types
@@ -224,10 +225,14 @@ extension ZaiUsageSnapshot {
             loginMethod: loginMethod)
         var quotaRows: [ProviderDetailSection.Row] = []
         if let tokenLimit = self.tokenLimit {
-            quotaRows.append(Self.detailRow(label: "Token quota", limit: tokenLimit))
+            quotaRows.append(Self.detailRow(
+                label: tokenLimit.type == .creditLimit ? "Credit quota" : "Token quota",
+                limit: tokenLimit))
         }
         if let sessionTokenLimit = self.sessionTokenLimit {
-            quotaRows.append(Self.detailRow(label: "Session token quota", limit: sessionTokenLimit))
+            quotaRows.append(Self.detailRow(
+                label: sessionTokenLimit.type == .creditLimit ? "Session credit quota" : "Session token quota",
+                limit: sessionTokenLimit))
         }
         if let timeLimit = self.timeLimit {
             quotaRows.append(Self.detailRow(label: "MCP quota", limit: timeLimit))
@@ -303,7 +308,7 @@ extension ZaiUsageSnapshot {
     private static func rateWindow(for limit: ZaiLimitEntry) -> RateWindow {
         RateWindow(
             usedPercent: limit.usedPercent,
-            windowMinutes: limit.type == .tokensLimit ? limit.windowMinutes : nil,
+            windowMinutes: (limit.type == .tokensLimit || limit.type == .creditLimit) ? limit.windowMinutes : nil,
             resetsAt: limit.nextResetTime,
             resetDescription: self.resetDescription(for: limit))
     }
@@ -312,7 +317,7 @@ extension ZaiUsageSnapshot {
         if limit.type == .timeLimit {
             return "MCP"
         }
-        if limit.type == .tokensLimit, limit.windowMinutes == 5 * 60 {
+        if (limit.type == .tokensLimit || limit.type == .creditLimit), limit.windowMinutes == 5 * 60 {
             return "5-hour"
         }
         if let label = limit.windowLabel {
@@ -568,7 +573,7 @@ public struct ZaiUsageFetcher: Sendable {
         for limit in responseData.limits {
             if let entry = limit.toLimitEntry() {
                 switch entry.type {
-                case .tokensLimit:
+                case .tokensLimit, .creditLimit:
                     tokenLimits.append(entry)
                 case .timeLimit:
                     timeLimit = entry

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -45,7 +45,7 @@ defineProvider({
           !Number.isInteger(raw.number) || !Number.isInteger(raw.percentage)) {
         throw new Error("Failed to parse z.ai limit entry");
       }
-      if (raw.type !== "TOKENS_LIMIT" && raw.type !== "TIME_LIMIT") return null;
+      if (raw.type !== "TOKENS_LIMIT" && raw.type !== "TIME_LIMIT" && raw.type !== "CREDIT_LIMIT") return null;
       const usage = optionalInteger(raw.usage, "limit.usage");
       const current = optionalInteger(raw.currentValue, "limit.currentValue");
       const remaining = optionalInteger(raw.remaining, "limit.remaining");
@@ -66,7 +66,7 @@ defineProvider({
     }
     function window(limit) {
       const result = { usedPercent: limit.percent };
-      if (limit.raw.type === "TOKENS_LIMIT" && limit.windowMinutes !== null) {
+      if ((limit.raw.type === "TOKENS_LIMIT" || limit.raw.type === "CREDIT_LIMIT") && limit.windowMinutes !== null) {
         result.windowMinutes = limit.windowMinutes;
       }
       if (limit.reset !== null) result.resetsAt = ctx.date.unixMillis(limit.reset);
@@ -87,7 +87,7 @@ defineProvider({
     }
 
     const limits = root.data.limits.map(parseLimit).filter(Boolean);
-    const tokenLimits = limits.filter(item => item.raw.type === "TOKENS_LIMIT")
+    const tokenLimits = limits.filter(item => item.raw.type === "TOKENS_LIMIT" || item.raw.type === "CREDIT_LIMIT")
       .sort((a, b) => (a.windowMinutes || Number.MAX_SAFE_INTEGER) - (b.windowMinutes || Number.MAX_SAFE_INTEGER));
     const timeLimit = limits.filter(item => item.raw.type === "TIME_LIMIT").pop() || null;
     const tokenLimit = tokenLimits.length ? tokenLimits[tokenLimits.length - 1] : null;
@@ -102,8 +102,8 @@ defineProvider({
     if ((tokenLimit || sessionLimit) && timeLimit) {
       result.extraWindows = [{ id: "zai-mcp", title: "MCP", window: window(timeLimit) }];
     }
-    if (tokenLimit) result.details[0].rows.push(limitRow("Token quota", tokenLimit));
-    if (sessionLimit) result.details[0].rows.push(limitRow("Session token quota", sessionLimit));
+    if (tokenLimit) result.details[0].rows.push(limitRow(tokenLimit.raw.type === "CREDIT_LIMIT" ? "Credit quota" : "Token quota", tokenLimit));
+    if (sessionLimit) result.details[0].rows.push(limitRow(sessionLimit.raw.type === "CREDIT_LIMIT" ? "Session credit quota" : "Session token quota", sessionLimit));
     if (timeLimit) {
       result.details[0].rows.push(limitRow("MCP quota", timeLimit));
       for (const detail of timeLimit.details.slice(0, 20)) {

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -112,7 +112,7 @@ defineProvider({
         }
       }
     }
-    const plan = [root.data.planName, root.data.plan, root.data.plan_type, root.data.packageName]
+    const plan = [root.data.planName, root.data.plan, root.data.plan_type, root.data.packageName, root.data.level]
       .find(value => typeof value === "string" && value.trim());
     if (plan) result.identity.loginMethod = plan.trim();
 

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -291,11 +291,10 @@ struct ProviderPluginDetailsParityTests {
     @Test
     func `zai CREDIT_LIMIT fixture has Swift core parity and stable details`() async throws {
         let transport = Self.transport { request in
+            // Quota only: model-usage is intentionally unserved so the plugin's non-fatal
+            // model-usage fetch fails and both paths produce only Quota details.
             if request.url?.path.hasSuffix("/quota/limit") == true {
                 return Self.zaiCreditQuota
-            }
-            if request.url?.path.hasSuffix("/model-usage") == true {
-                return Self.zaiModelUsage
             }
             throw FixtureError.unexpectedURL(request.url)
         }
@@ -312,16 +311,17 @@ struct ProviderPluginDetailsParityTests {
                 now: now)
 
         Self.expectCoreParity(swift, script)
-        #expect(swift.primary?.usedPercent == 3)
+        #expect(swift.details == script.details)
+        #expect(swift.primary?.usedPercent == 5)
         #expect(swift.primary?.windowMinutes == 300)
         #expect(swift.primary?.resetDescription == "5-hour")
-        #expect(swift.secondary?.usedPercent == 1)
+        #expect(swift.secondary?.usedPercent == 10)
         #expect(swift.secondary?.windowMinutes == 10080)
-        #expect(script.identity?.loginMethod == "lite")
+        #expect(swift.identity?.loginMethod == "lite")
         #expect(try script.details == [
             Self.section("Quota details", rows: [
-                Self.row("Credit quota", "3% used", "2000 limit · 1929 remaining"),
-                Self.row("Session credit quota", "1% used", "10000 limit · 9929 remaining"),
+                Self.row("Credit quota", "10% used", "10000 limit · 9000 remaining"),
+                Self.row("Session credit quota", "5% used", "2000 limit · 1900 remaining"),
             ]),
         ])
     }
@@ -509,10 +509,10 @@ struct ProviderPluginDetailsParityTests {
     """#
     private static let zaiCreditQuota = #"""
     {"code":200,"msg":"success","success":true,"data":{"level":"lite","limits":[
-      {"type":"CREDIT_LIMIT","unit":3,"number":5,"usage":2000,"currentValue":71,"remaining":1929,
-       "percentage":3,"nextResetTime":1786073946574},
-      {"type":"CREDIT_LIMIT","unit":6,"number":1,"usage":10000,"currentValue":71,"remaining":9929,
-       "percentage":1,"nextResetTime":1786660486998}
+      {"type":"CREDIT_LIMIT","unit":3,"number":5,"usage":2000,"currentValue":100,"remaining":1900,
+       "percentage":5,"nextResetTime":1786073946574},
+      {"type":"CREDIT_LIMIT","unit":6,"number":1,"usage":10000,"currentValue":1000,"remaining":9000,
+       "percentage":10,"nextResetTime":1786660486998}
     ]}}
     """#
     private static let zaiModelUsage = #"""

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -289,6 +289,44 @@ struct ProviderPluginDetailsParityTests {
     }
 
     @Test
+    func `zai CREDIT_LIMIT fixture has Swift core parity and stable details`() async throws {
+        let transport = Self.transport { request in
+            if request.url?.path.hasSuffix("/quota/limit") == true {
+                return Self.zaiCreditQuota
+            }
+            if request.url?.path.hasSuffix("/model-usage") == true {
+                return Self.zaiModelUsage
+            }
+            throw FixtureError.unexpectedURL(request.url)
+        }
+        let now = Date(timeIntervalSince1970: 1_786_073_946)
+        let swift = try await ZaiUsageFetcher.fetchUsage(apiKey: "fixture-key", environment: [:], transport: transport)
+            .toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "zai", transport: transport)
+            .fetchUsage(
+                settings: [
+                    "Z_AI_REGION": "global",
+                    "Z_AI_USAGE_SCOPE": "personal",
+                ],
+                secrets: ["Z_AI_API_KEY": "fixture-key"],
+                now: now)
+
+        Self.expectCoreParity(swift, script)
+        #expect(swift.primary?.usedPercent == 3)
+        #expect(swift.primary?.windowMinutes == 300)
+        #expect(swift.primary?.resetDescription == "5-hour")
+        #expect(swift.secondary?.usedPercent == 1)
+        #expect(swift.secondary?.windowMinutes == 10080)
+        #expect(script.identity?.loginMethod == "lite")
+        #expect(try script.details == [
+            Self.section("Quota details", rows: [
+                Self.row("Credit quota", "3% used", "2000 limit · 1929 remaining"),
+                Self.row("Session credit quota", "1% used", "10000 limit · 9929 remaining"),
+            ]),
+        ])
+    }
+
+    @Test
     func `OpenAI fixture has Swift core parity and stable details`() async throws {
         let transport = Self.transport { request in
             if request.url?.path.hasSuffix("/organization/costs") == true {
@@ -467,6 +505,14 @@ struct ProviderPluginDetailsParityTests {
       {"type":"TIME_LIMIT","unit":5,"number":1,"usage":1000,"currentValue":224,"remaining":776,
        "percentage":22,"usageDetails":[{"modelCode":"search-prime","usage":210},
        {"modelCode":"web-reader","usage":14}]}
+    ]}}
+    """#
+    private static let zaiCreditQuota = #"""
+    {"code":200,"msg":"success","success":true,"data":{"level":"lite","limits":[
+      {"type":"CREDIT_LIMIT","unit":3,"number":5,"usage":2000,"currentValue":71,"remaining":1929,
+       "percentage":3,"nextResetTime":1786073946574},
+      {"type":"CREDIT_LIMIT","unit":6,"number":1,"usage":10000,"currentValue":71,"remaining":9929,
+       "percentage":1,"nextResetTime":1786660486998}
     ]}}
     """#
     private static let zaiModelUsage = #"""


### PR DESCRIPTION
z.ai API now returns `CREDIT_LIMIT` instead of `TOKENS_LIMIT` for credit-based quota plans (lite/standard/pro). Previously, these entries were being filtered out, causing the menu bar to show 100% remaining / 0% used.

## Changes

**Swift (`ZaiUsageStats.swift`):**
- Add `creditLimit = "CREDIT_LIMIT"` to `ZaiLimitType` enum
- Update token limits collection to include `CREDIT_LIMIT` entries
- Update `rateWindow()` and `resetDescription()` to handle `CREDIT_LIMIT` like `TOKENS_LIMIT`
- Update quota display labels to show "Credit quota" vs "Token quota" based on type

**JavaScript (`zai.js`):**
- Update `parseLimit()` filter to accept `CREDIT_LIMIT`
- Include `CREDIT_LIMIT` in token limits filter
- Treat `CREDIT_LIMIT` same as `TOKENS_LIMIT` for window calculation
- Update detail row labels to show "Credit quota" when appropriate

## Example API Response (from a lite plan)

```json
{
  "data": {
    "limits": [
      {
        "type": "CREDIT_LIMIT",
        "unit": 3,
        "number": 5,
        "usage": 2000,
        "currentValue": 71,
        "remaining": 1929,
        "percentage": 3,
        "nextResetTime": 1786073946574
      },
      {
        "type": "CREDIT_LIMIT",
        "unit": 6,
        "number": 1,
        "usage": 10000,
        "currentValue": 71,
        "remaining": 9929,
        "percentage": 1,
        "nextResetTime": 1786660486998
      }
    ],
    "level": "lite"
  }
}
```

Fixes #2724