### PR TITLE
Handle Codex reset credits omitted after redemption

### DIFF
--- a/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
@@ -143,8 +143,9 @@ struct CodexWeeklyResetConfirmation: Sendable {
                previousWeekly,
                capturedAt: previous.updatedAt)
         {
-            let confirmsManualReset = Self.confirmsManualResetCreditRedemption(
+            let confirmsManualReset = Self.confirmsManualResetCreditConsumption(
                 previous: previous,
+                initial: initial,
                 confirmation: confirmation)
             if confirmation.updatedAt < previousBoundary.addingTimeInterval(-2 * 60),
                !confirmsManualReset
@@ -160,15 +161,19 @@ struct CodexWeeklyResetConfirmation: Sendable {
         return .publishConfirmation
     }
 
-    private static func confirmsManualResetCreditRedemption(
+    private static func confirmsManualResetCreditConsumption(
         previous: UsageSnapshot,
+        initial: UsageSnapshot,
         confirmation: UsageSnapshot) -> Bool
     {
         guard let previousCredits = previous.codexResetCredits,
+              let initialCredits = initial.codexResetCredits,
               let confirmationCredits = confirmation.codexResetCredits,
               self.isFinite(previousCredits.updatedAt),
+              self.isFinite(initialCredits.updatedAt),
               self.isFinite(confirmationCredits.updatedAt),
-              confirmationCredits.updatedAt >= previousCredits.updatedAt
+              initialCredits.updatedAt >= previousCredits.updatedAt,
+              confirmationCredits.updatedAt >= initialCredits.updatedAt
         else {
             return false
         }
@@ -176,9 +181,29 @@ struct CodexWeeklyResetConfirmation: Sendable {
             .filter { $0.status == .available }
             .map(\.id))
         guard !previouslyAvailableIDs.isEmpty else { return false }
-        return confirmationCredits.credits.contains { credit in
-            previouslyAvailableIDs.contains(credit.id) && credit.status == .redeemed
+        return previouslyAvailableIDs.contains { creditID in
+            Self.inventoryConfirmsConsumption(
+                creditID: creditID,
+                current: initialCredits,
+                previousAvailableCount: previousCredits.availableCount) &&
+                Self.inventoryConfirmsConsumption(
+                    creditID: creditID,
+                    current: confirmationCredits,
+                    previousAvailableCount: previousCredits.availableCount)
         }
+    }
+
+    private static func inventoryConfirmsConsumption(
+        creditID: String,
+        current: CodexRateLimitResetCreditsSnapshot,
+        previousAvailableCount: Int) -> Bool
+    {
+        if let credit = current.credits.first(where: { $0.id == creditID }) {
+            return credit.status == .redeeming || credit.status == .redeemed
+        }
+        // The live provider omits a consumed credit instead of retaining a redeemed row.
+        // Require the successful inventory's aggregate count to corroborate the disappearance.
+        return current.availableCount < previousAvailableCount
     }
 
     private static func initialDecisionWithoutWeeklyBaseline(

--- a/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
@@ -177,32 +177,33 @@ struct CodexWeeklyResetConfirmation: Sendable {
         else {
             return false
         }
-        let previouslyAvailableIDs = Set(previousCredits.credits.lazy
-            .filter { $0.status == .available }
-            .map(\.id))
-        guard !previouslyAvailableIDs.isEmpty else { return false }
-        return previouslyAvailableIDs.contains { creditID in
+        let previouslyAvailableCredits = previousCredits.availableCredits(at: previousCredits.updatedAt)
+        guard !previouslyAvailableCredits.isEmpty else { return false }
+        return previouslyAvailableCredits.contains { previousCredit in
             Self.inventoryConfirmsConsumption(
-                creditID: creditID,
+                previousCredit: previousCredit,
                 current: initialCredits,
                 previousAvailableCount: previousCredits.availableCount) &&
                 Self.inventoryConfirmsConsumption(
-                    creditID: creditID,
+                    previousCredit: previousCredit,
                     current: confirmationCredits,
                     previousAvailableCount: previousCredits.availableCount)
         }
     }
 
     private static func inventoryConfirmsConsumption(
-        creditID: String,
+        previousCredit: CodexRateLimitResetCredit,
         current: CodexRateLimitResetCreditsSnapshot,
         previousAvailableCount: Int) -> Bool
     {
-        if let credit = current.credits.first(where: { $0.id == creditID }) {
+        if let credit = current.credits.first(where: { $0.id == previousCredit.id }) {
             return credit.status == .redeeming || credit.status == .redeemed
         }
-        // The live provider omits a consumed credit instead of retaining a redeemed row.
-        // Require the successful inventory's aggregate count to corroborate the disappearance.
+        // A credit can disappear because it expired. Only treat omission as consumption while
+        // the previously available credit would still be valid at this inventory timestamp.
+        guard previousCredit.expiresAt.map({ $0 > current.updatedAt }) ?? true else { return false }
+        // The live provider omits a consumed credit instead of retaining a redeemed row, so the
+        // successful inventory's aggregate count must also corroborate the disappearance.
         return current.availableCount < previousAvailableCount
     }
 

--- a/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
@@ -312,6 +312,78 @@ struct CodexWeeklyResetConfirmationTests {
     }
 
     @Test
+    func `consumed reset credit omitted by provider confirms an early manual weekly reset`() throws {
+        let formatter = ISO8601DateFormatter()
+        let previousCapturedAt = try #require(formatter.date(from: "2026-08-06T09:28:18Z"))
+        let previousReset = try #require(formatter.date(from: "2026-08-10T01:00:26Z"))
+        let initialCapturedAt = try #require(formatter.date(from: "2026-08-06T09:33:18Z"))
+        let initialReset = try #require(formatter.date(from: "2026-08-13T09:33:18Z"))
+        let previous = self.snapshot(
+            capturedAt: previousCapturedAt,
+            weeklyUsed: 99,
+            weeklyReset: previousReset,
+            resetCredits: self.resetCredits(
+                status: .available,
+                capturedAt: previousCapturedAt))
+        let initial = self.snapshot(
+            capturedAt: initialCapturedAt,
+            weeklyUsed: 0,
+            weeklyReset: initialReset,
+            resetCredits: self.emptyResetCredits(capturedAt: initialCapturedAt))
+        let confirmationCapturedAt = initialCapturedAt.addingTimeInterval(30)
+        let confirmation = self.snapshot(
+            capturedAt: confirmationCapturedAt,
+            weeklyUsed: 0,
+            weeklyReset: initialReset.addingTimeInterval(30),
+            resetCredits: self.emptyResetCredits(capturedAt: confirmationCapturedAt))
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: initial)
+                == .requiresConfirmation)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: confirmation)
+                == .publishConfirmation)
+    }
+
+    @Test
+    func `one missing reset credit inventory does not confirm an early manual weekly reset`() throws {
+        let formatter = ISO8601DateFormatter()
+        let previousCapturedAt = try #require(formatter.date(from: "2026-08-06T09:28:18Z"))
+        let previousReset = try #require(formatter.date(from: "2026-08-10T01:00:26Z"))
+        let initialCapturedAt = try #require(formatter.date(from: "2026-08-06T09:33:18Z"))
+        let initialReset = try #require(formatter.date(from: "2026-08-13T09:33:18Z"))
+        let previousCredits = self.resetCredits(
+            status: .available,
+            capturedAt: previousCapturedAt)
+        let previous = self.snapshot(
+            capturedAt: previousCapturedAt,
+            weeklyUsed: 99,
+            weeklyReset: previousReset,
+            resetCredits: previousCredits)
+        let initial = self.snapshot(
+            capturedAt: initialCapturedAt,
+            weeklyUsed: 0,
+            weeklyReset: initialReset,
+            resetCredits: previousCredits)
+        let confirmationCapturedAt = initialCapturedAt.addingTimeInterval(30)
+        let confirmation = self.snapshot(
+            capturedAt: confirmationCapturedAt,
+            weeklyUsed: 0,
+            weeklyReset: initialReset.addingTimeInterval(30),
+            resetCredits: self.emptyResetCredits(capturedAt: confirmationCapturedAt))
+
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: confirmation)
+                == .preservePrevious)
+    }
+
+    @Test
     func `prior boundary due tolerance includes the exact two minute edge`() {
         let previousBoundary = self.resetAt
         let nextBoundary = previousBoundary.addingTimeInterval(7 * 24 * 60 * 60)
@@ -536,6 +608,13 @@ struct CodexWeeklyResetConfirmationTests {
                 title: nil,
                 description: nil)],
             availableCount: status == .available ? 1 : 0,
+            updatedAt: capturedAt)
+    }
+
+    private func emptyResetCredits(capturedAt: Date) -> CodexRateLimitResetCreditsSnapshot {
+        CodexRateLimitResetCreditsSnapshot(
+            credits: [],
+            availableCount: 0,
             updatedAt: capturedAt)
     }
 }

--- a/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
@@ -384,6 +384,47 @@ struct CodexWeeklyResetConfirmationTests {
     }
 
     @Test
+    func `expired omitted reset credit does not confirm an early manual weekly reset`() throws {
+        let formatter = ISO8601DateFormatter()
+        let previousCapturedAt = try #require(formatter.date(from: "2026-08-06T09:28:18Z"))
+        let previousReset = try #require(formatter.date(from: "2026-08-10T01:00:26Z"))
+        let initialCapturedAt = try #require(formatter.date(from: "2026-08-06T09:33:18Z"))
+        let initialReset = try #require(formatter.date(from: "2026-08-13T09:33:18Z"))
+        let confirmationCapturedAt = initialCapturedAt.addingTimeInterval(30)
+
+        for expiresAt in [
+            initialCapturedAt.addingTimeInterval(-1),
+            initialCapturedAt.addingTimeInterval(15),
+        ] {
+            let previous = self.snapshot(
+                capturedAt: previousCapturedAt,
+                weeklyUsed: 99,
+                weeklyReset: previousReset,
+                resetCredits: self.resetCredits(
+                    status: .available,
+                    capturedAt: previousCapturedAt,
+                    expiresAt: expiresAt))
+            let initial = self.snapshot(
+                capturedAt: initialCapturedAt,
+                weeklyUsed: 0,
+                weeklyReset: initialReset,
+                resetCredits: self.emptyResetCredits(capturedAt: initialCapturedAt))
+            let confirmation = self.snapshot(
+                capturedAt: confirmationCapturedAt,
+                weeklyUsed: 0,
+                weeklyReset: initialReset.addingTimeInterval(30),
+                resetCredits: self.emptyResetCredits(capturedAt: confirmationCapturedAt))
+
+            #expect(
+                CodexWeeklyResetConfirmation.confirmationDecision(
+                    previous: previous,
+                    initial: initial,
+                    confirmation: confirmation)
+                    == .preservePrevious)
+        }
+    }
+
+    @Test
     func `prior boundary due tolerance includes the exact two minute edge`() {
         let previousBoundary = self.resetAt
         let nextBoundary = previousBoundary.addingTimeInterval(7 * 24 * 60 * 60)
@@ -594,7 +635,8 @@ struct CodexWeeklyResetConfirmationTests {
 
     private func resetCredits(
         status: CodexRateLimitResetCreditStatus,
-        capturedAt: Date) -> CodexRateLimitResetCreditsSnapshot
+        capturedAt: Date,
+        expiresAt: Date? = nil) -> CodexRateLimitResetCreditsSnapshot
     {
         CodexRateLimitResetCreditsSnapshot(
             credits: [CodexRateLimitResetCredit(
@@ -602,7 +644,7 @@ struct CodexWeeklyResetConfirmationTests {
                 resetType: "codex_rate_limits",
                 status: status,
                 grantedAt: capturedAt.addingTimeInterval(-24 * 60 * 60),
-                expiresAt: capturedAt.addingTimeInterval(24 * 60 * 60),
+                expiresAt: expiresAt ?? capturedAt.addingTimeInterval(24 * 60 * 60),
                 redeemStartedAt: status == .available ? nil : capturedAt,
                 redeemedAt: status == .redeemed ? capturedAt : nil,
                 title: nil,


### PR DESCRIPTION
## Summary

- follow up on #2710 for the provider shape observed after a real manual reset
- accept a consumed reset credit when the provider omits its row and the aggregate available count decreases
- require both the initial and confirmation inventories to independently corroborate consumption
- retain support for explicit `redeeming`/`redeemed` rows and all existing account, timestamp, boundary, and two-sample safeguards

## Why a follow-up is needed

#2710 was merged with support for a stable credit row transitioning from `available` to `redeemed`. A redacted provider trace recovered after that merge showed a different post-redemption representation: the successful inventory omitted the consumed row entirely and returned `availableCount: 0`.

The merged implementation therefore remains conservative for the observed real response and may continue preserving the stale pre-reset snapshot.

## Real provider behavior (redacted)

Observed on CodexBar 0.47.0 with a signed-in Codex OAuth account. Account identity, tokens, and reset-credit IDs are omitted.

| Captured at (UTC) | Weekly used | Reset boundary (UTC) |
|---|---:|---|
| 2026-08-06 08:59:18 | 98% | 2026-08-10 01:00:26 |
| 2026-08-06 09:28:18 | 99% | 2026-08-10 01:00:26 |
| 2026-08-06 09:33:18 | 0% | 2026-08-13 09:33:18 |

The successful reset-credit inventory persisted with the post-redemption observation was:

```json
{"availableCount":0,"credits":[]}
```

A later read-only live OAuth fetch returned the same successful empty inventory. This shows that the consumed credit is omitted in the observed provider response instead of being retained as a `redeemed` row.

## After-fix real-provider smoke (redacted)

On 2026-08-07, I built and launched the exact PR head `c07f9d43` as CodexBar 0.48.0 (build 112) with `./Scripts/compile_and_run.sh`. The release bundle remained running, and its packaged `CodexBarCLI` then completed a read-only live OAuth provider fetch without error:

```json
{
  "source": "oauth",
  "updatedAt": "2026-08-07T08:39:40Z",
  "weekly": {
    "usedPercent": 41,
    "windowMinutes": 10080,
    "resetsAt": "2026-08-13T09:29:11Z"
  },
  "resetCredits": {
    "availableCount": 0,
    "credits": []
  }
}
```

Account identity, tokens, and credit IDs are omitted. This confirms that an after-fix bundle starts successfully and that its real Codex OAuth provider path still accepts the currently observed successful empty reset-credit inventory.

This smoke run does **not** claim a second live redemption: by the time the fixed bundle was available, weekly usage had advanced to 41% and the account had no reset credit remaining, so an `available` -> omitted transition could not be triggered again. The exact 99% -> 0% omission decision path is therefore still validated by the focused production-code replay below.

## Safeguards

The omission path is accepted only when:

- a stable credit ID was previously `available`;
- reset-credit inventory timestamps are finite and monotonic;
- both independent low-usage samples either report that same credit as `redeeming`/`redeemed`, or omit it while reporting a lower aggregate available count;
- an omitted credit is still unexpired at each inventory timestamp, preventing natural expiry from being treated as consumption;
- the existing weekly reset-boundary and two-sample equivalence checks also pass.

A single missing inventory does not bypass the early-reset guard.

## Validation

- focused `CodexWeeklyResetConfirmationTests`: 19/19 passed
- fresh `./Scripts/compile_and_run.sh` bundle at `c07f9d43`: CodexBar 0.48.0 (112) launched and remained running
- packaged release `CodexBarCLI` live OAuth fetch: succeeded with weekly usage 41% and reset-credit inventory `availableCount: 0`, `credits: []`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make check`: SwiftFormat 0/1806, SwiftLint 0 violations/1805, all repository gates passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test`: 824 selections across 69 groups, 69 first-pass successes, 0 failures, 0 retries, 0 timeouts
- `git diff --check origin/main..HEAD`

The account has no reset credit remaining, so the after-fix validation replays the exact redacted 99% -> 0% timing/boundary shape through the production decision code; it is not presented as a second live redemption.

No UI changes; screenshots are not applicable.
