### PR TITLE
Add codexbar-cosmic-applet to Linux desktop integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ CLI install:
 
 ## Linux desktop integration?
 - [codexbar-waybar](https://github.com/Marouan-chak/codexbar-waybar) — Waybar custom module + GTK4 popover for Hyprland / Sway / other Wayland compositors, built on top of the bundled Linux CLI.
+- [codexbar-cosmic-applet](https://github.com/andrew-verde/codexbar-cosmic-applet) — Native COSMIC (System76) desktop panel applet with a tab per provider, pace projections, and cost/token stats, built on top of the bundled Linux CLI.
 - [Codexbar GNOME](https://extensions.gnome.org/extension/9841/codexbar/) — GNOME Shell extension that brings CodexBar usage into the desktop panel.
 - [codexbar-cinnamon-applet](https://github.com/jacobcalvert/codexbar-cinnamon-applet) — Linux Mint Cinnamon panel applet powered by CodexBar's JSON output.
 - [noctalia-codex-usage](https://github.com/rayoplateado/noctalia-codex-usage) — Noctalia/Quickshell plugin that shows Codex 5-hour and weekly usage limits, built on top of the bundled Linux CLI.


### PR DESCRIPTION
Adds a native COSMIC (System76) desktop panel applet to the Linux integrations list, in the same style as the other entries: built on top of the bundled Linux CLI (`codexbar usage`/`codexbar cost`).

Repo: https://github.com/andrew-verde/codexbar-cosmic-applet

## Real behavior proof

Installed and running on a real Fedora COSMIC machine, rendering live output from the bundled CLI.

**Screenshot** (from the linked repo's own README, same image, hosted [in-repo](https://github.com/andrew-verde/codexbar-cosmic-applet/blob/main/docs/screenshot.png)):

![codexbar-cosmic-applet popup showing Claude session/weekly usage, pace projection, and cost/token stats](https://raw.githubusercontent.com/andrew-verde/codexbar-cosmic-applet/main/docs/screenshot.png)

**Terminal output** the applet is built on, confirmed on the same machine (account identifiers stripped, structure/values real):

```sh
$ codexbar usage --format json | ...
[
  {
    "provider": "codex",
    "source": "oauth",
    "identity_present": true,
    "primary_used_percent": null,
    "secondary_used_percent": 75
  },
  {
    "provider": "claude",
    "source": "claude",
    "identity_present": false,
    "primary_used_percent": 39,
    "secondary_used_percent": 31
  },
  {
    "provider": "antigravity",
    "source": "cli",
    "identity_present": true,
    "primary_used_percent": 0,
    "secondary_used_percent": 0
  }
]
```

The applet shells out to exactly this (`codexbar usage --format json` and `codexbar cost --format json --days 30`) and renders the result — no other data source.