### PR TITLE
Fix custom menu bar reset countdown mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.48.1 — Unreleased
 
+### Fixed
+- Menu bar: keep custom reset countdowns aligned with the opened menu instead of rounding their clock back to the start of the wall minute.
+
 ## 0.48.0 — 2026-08-06
 
 ### Added

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -49,14 +49,35 @@ struct MenuBarLayoutRenderOptions: Hashable {
     let showUsed: Bool
     let appearanceName: String
     let isDebugApp: Bool
-    /// Minute-granularity clock. Countdown tokens refresh without invalidating cached titles every tick.
+    /// Exact display clock. The cache keys on the resulting reset strings, so animation ticks that keep
+    /// the same visible countdown still reuse the cached title.
     let now: Date
 }
 
 struct MenuBarLayoutRenderKey: Hashable {
     let layout: MenuBarLayout
     let data: MenuBarLayoutRenderData
-    let options: MenuBarLayoutRenderOptions
+    let size: MenuBarLayoutSize
+    let highContrast: Bool
+    let showUsed: Bool
+    let appearanceName: String
+    let isDebugApp: Bool
+    let resetText: MenuBarLayoutResetText
+}
+
+struct MenuBarLayoutResetText: Hashable {
+    let countdown: String?
+    let absolute: String?
+
+    init(window: MenuBarLayoutRenderWindow?, now: Date) {
+        if let resetsAt = window?.resetsAt {
+            self.countdown = UsageFormatter.resetCountdownDescription(from: resetsAt, now: now)
+            self.absolute = UsageFormatter.resetDescription(from: resetsAt, now: now)
+        } else {
+            self.countdown = window?.resetDescription
+            self.absolute = window?.resetDescription
+        }
+    }
 }
 
 struct MenuBarLayoutRenderedTitle {
@@ -123,7 +144,16 @@ final class MenuBarLayoutRenderer {
         options: MenuBarLayoutRenderOptions)
         -> MenuBarLayoutRenderedTitle
     {
-        let key = MenuBarLayoutRenderKey(layout: layout, data: data, options: options)
+        let resetText = MenuBarLayoutResetText(window: data.automatic, now: options.now)
+        let key = MenuBarLayoutRenderKey(
+            layout: layout,
+            data: data,
+            size: options.size,
+            highContrast: options.highContrast,
+            showUsed: options.showUsed,
+            appearanceName: options.appearanceName,
+            isDebugApp: options.isDebugApp,
+            resetText: resetText)
         return self.cache.value(for: key) {
             Self.renderUncached(layout: layout, data: data, icon: icon, options: options)
         }

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -27,7 +27,6 @@ extension StatusItemController {
             snapshot: snapshot,
             warningFlash: warningFlash,
             now: now)
-        let minute = Date(timeIntervalSince1970: floor(now.timeIntervalSince1970 / 60) * 60)
         let appearanceName = button.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua])?.rawValue ?? "default"
         let options = MenuBarLayoutRenderOptions(
             size: self.settings.menuBarLayoutSize,
@@ -35,7 +34,7 @@ extension StatusItemController {
             showUsed: self.settings.usageBarsShowUsed,
             appearanceName: appearanceName,
             isDebugApp: Self.isDebugApp(bundleIdentifier: Bundle.main.bundleIdentifier),
-            now: minute)
+            now: now)
         let rendered = self.menuBarLayoutRenderer.render(
             layout: resolution.layout,
             data: data,

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -277,6 +277,41 @@ struct MenuBarLayoutRendererTests {
     }
 
     @Test
+    func `countdown uses the exact clock while caching an unchanged displayed minute`() {
+        let renderer = MenuBarLayoutRenderer()
+        let minuteStart = self.now
+        let now = minuteStart.addingTimeInterval(51)
+        let resetAt = minuteStart.addingTimeInterval(6 * 60 + 50)
+        let data = self.data(automaticResetAt: resetAt)
+        let layout = MenuBarLayout(lines: [[.resetCountdown]])
+
+        // Rounding the clock back to the wall-minute boundary reproduces the reported one-minute mismatch.
+        #expect(UsageFormatter.resetCountdownDescription(from: resetAt, now: minuteStart) == "in 7m")
+        let first = renderer.render(
+            layout: layout,
+            data: data,
+            icon: nil,
+            options: self.options(now: now))
+        #expect(first.attributedTitle.string == "in 6m")
+
+        // A different exact instant with the same visible value still hits the attributed-title cache.
+        let sameMinute = renderer.render(
+            layout: layout,
+            data: data,
+            icon: nil,
+            options: self.options(now: now.addingTimeInterval(20)))
+        #expect(first.attributedTitle === sameMinute.attributedTitle)
+
+        let nextMinute = renderer.render(
+            layout: layout,
+            data: data,
+            icon: nil,
+            options: self.options(now: now.addingTimeInterval(60)))
+        #expect(nextMinute.attributedTitle.string == "in 5m")
+        #expect(first.attributedTitle !== nextMinute.attributedTitle)
+    }
+
+    @Test
     func `usage bar follows remaining display direction`() {
         let renderer = MenuBarLayoutRenderer()
         let output = renderer.render(
@@ -351,7 +386,11 @@ struct MenuBarLayoutRendererTests {
             .attribute(.foregroundColor, at: textIndex, effectiveRange: nil) as? NSColor == .labelColor)
     }
 
-    private func data(automaticUsedPercent: Double = 50) -> MenuBarLayoutRenderData {
+    private func data(
+        automaticUsedPercent: Double = 50,
+        automaticResetAt: Date? = nil)
+        -> MenuBarLayoutRenderData
+    {
         MenuBarLayoutRenderData(
             iconKey: "codex",
             providerName: "Codex",
@@ -375,7 +414,7 @@ struct MenuBarLayoutRendererTests {
             automatic: MenuBarLayoutRenderWindow(RateWindow(
                 usedPercent: automaticUsedPercent,
                 windowMinutes: 300,
-                resetsAt: self.now.addingTimeInterval(2 * 60 * 60),
+                resetsAt: automaticResetAt ?? self.now.addingTimeInterval(2 * 60 * 60),
                 resetDescription: nil)),
             sessionPace: "-8%",
             weeklyPace: "+11%",
@@ -385,14 +424,14 @@ struct MenuBarLayoutRendererTests {
             cost30d: "$20.00")
     }
 
-    private func options() -> MenuBarLayoutRenderOptions {
+    private func options(now: Date? = nil) -> MenuBarLayoutRenderOptions {
         MenuBarLayoutRenderOptions(
             size: .regular,
             highContrast: false,
             showUsed: true,
             appearanceName: "aqua",
             isDebugApp: false,
-            now: self.now)
+            now: now ?? self.now)
     }
 
     private func averageBrightness(

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2499,7 +2499,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+MenuBarLayout.swift",
-            line: 126,
+            line: 125,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,


### PR DESCRIPTION
  ## Summary

  - use the exact display time for custom menu bar reset countdowns so they match the opened menu
  - preserve attributed-title cache reuse by keying reset values on their formatted display text
  - add regression coverage for the one-minute mismatch and the unchanged-title cache path
  - document the fix in the changelog

  ## Root cause

  The opened menu formatted reset times from the current instant, while the custom menu bar layout rounded that instant down to the start of the wall-clock minute before calling the same formatter.

  Because the countdown formatter rounds remaining seconds up, this could make the menu bar show one additional minute. For example, 5m 59s remaining appeared as `in 6m` in the menu but as `in 7m` in the menu bar.

  Passing the exact `Date` directly through the existing renderer cache key would invalidate the cache on animation ticks. The cache now keys reset values on their formatted countdown and absolute strings, so it changes only when the visible reset text changes.

  ## User impact

  Custom reset countdown tokens in the menu bar now stay aligned with the opened menu while retaining the existing refresh scheduling and rendering cache behavior.

  ## Validation

  - `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter MenuBarLayoutRendererTests` — 14 tests passed
  - `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter 'cross provider case clusters are derived or specifically justified'` — 1 test passed
  - `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make check` — passed
  - `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make test` — 824 selections across 69 groups; 0 failures, retries, or timeouts

  ## Screenshots

  - Before: 
<img width="314" height="175" alt="Screenshot 2026-08-07 at 8 44 51 PM" src="https://github.com/user-attachments/assets/2c396e22-c517-46d9-92d9-30940f066264" />

  - After: 
<img width="320" height="154" alt="Screenshot 2026-08-07 at 10 04 00 PM" src="https://github.com/user-attachments/assets/b44ab6e4-f6e2-4e81-8dab-a6976117ad6b" />
