### PR TITLE
Decode Codex monthly credit limit from spend_control.individual_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.48.1 — Unreleased
 
+### Fixed
+- Codex: decode the monthly credit limit from `spend_control.individual_limit` and accept the `reset_at` spelling, so team/enterprise workspaces stop dropping the whole credits payload over OAuth (#2736).
+
 ## 0.48.0 — 2026-08-06
 
 ### Added

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -723,7 +723,9 @@ public struct OpenAIDashboardFetcher {
             extraRateWindows: CodexAdditionalRateLimitMapper.extraRateWindows(
                 from: response.additionalRateLimits),
             creditsRemaining: response.credits?.balance,
-            codexCreditLimit: (response.individualLimit ?? response.rateLimit?.individualLimit)?
+            codexCreditLimit: (response.individualLimit
+                ?? response.rateLimit?.individualLimit
+                ?? response.spendControlIndividualLimit)?
                 .codexCreditLimitSnapshot(updatedAt: Date()),
             accountPlan: response.planType?.rawValue)
     }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -723,10 +723,7 @@ public struct OpenAIDashboardFetcher {
             extraRateWindows: CodexAdditionalRateLimitMapper.extraRateWindows(
                 from: response.additionalRateLimits),
             creditsRemaining: response.credits?.balance,
-            codexCreditLimit: (response.individualLimit
-                ?? response.rateLimit?.individualLimit
-                ?? response.spendControlIndividualLimit)?
-                .codexCreditLimitSnapshot(updatedAt: Date()),
+            codexCreditLimit: response.resolvedIndividualLimit?.codexCreditLimitSnapshot(updatedAt: Date()),
             accountPlan: response.planType?.rawValue)
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -8,6 +8,10 @@ public struct CodexUsageResponse: Decodable, Sendable {
     public let rateLimit: RateLimitDetails?
     public let credits: CreditDetails?
     public let individualLimit: SpendControlLimitSnapshot?
+    /// Team/enterprise workspaces report the monthly credit pool here instead of at the response root.
+    /// Kept separate from `individualLimit` so the established root → `rate_limit` precedence is preserved;
+    /// consumers select this only when both of those are absent.
+    public let spendControlIndividualLimit: SpendControlLimitSnapshot?
     /// Model-specific limits (e.g. GPT-5.3-Codex-Spark) that sit alongside the primary/weekly windows.
     public let additionalRateLimits: [AdditionalRateLimit]?
     let additionalRateLimitsDecodeFailed: Bool
@@ -32,7 +36,7 @@ public struct CodexUsageResponse: Decodable, Sendable {
             SpendControlLimitSnapshot.self,
             forKey: .individualLimit))
             ?? (try? container.decodeIfPresent(SpendControlLimitSnapshot.self, forKey: .individualLimitCamel))
-            ?? Self.decodeSpendControlIndividualLimit(container: container)
+        self.spendControlIndividualLimit = Self.decodeSpendControlIndividualLimit(container: container)
         // Optional and additive: missing/malformed extra limits must never disturb primary/weekly mapping.
         // Decode per element so a single malformed entry cannot discard its valid siblings; a non-array
         // value (or absent field) leaves `additionalRateLimits` nil and primary/weekly mapping untouched.
@@ -58,9 +62,6 @@ public struct CodexUsageResponse: Decodable, Sendable {
         return (try? container.decodeNil(forKey: key)) == false
     }
 
-    /// Team/enterprise workspaces return the monthly credit pool under `spend_control.individual_limit`
-    /// instead of at the response root. Purely additive: only consulted when the root/rate-limit
-    /// spellings are absent.
     private static func decodeSpendControlIndividualLimit(
         container: KeyedDecodingContainer<CodingKeys>) -> SpendControlLimitSnapshot?
     {

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -18,6 +18,8 @@ public struct CodexUsageResponse: Decodable, Sendable {
         case credits
         case individualLimit = "individual_limit"
         case individualLimitCamel = "individualLimit"
+        case spendControl = "spend_control"
+        case spendControlCamel = "spendControl"
         case additionalRateLimits = "additional_rate_limits"
     }
 
@@ -30,6 +32,7 @@ public struct CodexUsageResponse: Decodable, Sendable {
             SpendControlLimitSnapshot.self,
             forKey: .individualLimit))
             ?? (try? container.decodeIfPresent(SpendControlLimitSnapshot.self, forKey: .individualLimitCamel))
+            ?? Self.decodeSpendControlIndividualLimit(container: container)
         // Optional and additive: missing/malformed extra limits must never disturb primary/weekly mapping.
         // Decode per element so a single malformed entry cannot discard its valid siblings; a non-array
         // value (or absent field) leaves `additionalRateLimits` nil and primary/weekly mapping untouched.
@@ -53,6 +56,35 @@ public struct CodexUsageResponse: Decodable, Sendable {
     {
         guard container.contains(key) else { return false }
         return (try? container.decodeNil(forKey: key)) == false
+    }
+
+    /// Team/enterprise workspaces return the monthly credit pool under `spend_control.individual_limit`
+    /// instead of at the response root. Purely additive: only consulted when the root/rate-limit
+    /// spellings are absent.
+    private static func decodeSpendControlIndividualLimit(
+        container: KeyedDecodingContainer<CodingKeys>) -> SpendControlLimitSnapshot?
+    {
+        let details = (try? container.decodeIfPresent(SpendControlDetails.self, forKey: .spendControl))
+            ?? (try? container.decodeIfPresent(SpendControlDetails.self, forKey: .spendControlCamel))
+        return details?.individualLimit
+    }
+
+    /// `spend_control` wrapper from `wham/usage`; only the individual limit is consumed today.
+    public struct SpendControlDetails: Decodable, Sendable {
+        public let individualLimit: SpendControlLimitSnapshot?
+
+        enum CodingKeys: String, CodingKey {
+            case individualLimit = "individual_limit"
+            case individualLimitCamel = "individualLimit"
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.individualLimit = (try? container.decodeIfPresent(
+                SpendControlLimitSnapshot.self,
+                forKey: .individualLimit))
+                ?? (try? container.decodeIfPresent(SpendControlLimitSnapshot.self, forKey: .individualLimitCamel))
+        }
     }
 
     public enum PlanType: Sendable, Decodable, Equatable {
@@ -244,6 +276,7 @@ public struct CodexUsageResponse: Decodable, Sendable {
             case remainingPercentSnake = "remaining_percent"
             case resetsAt
             case resetsAtSnake = "resets_at"
+            case resetAtSnake = "reset_at"
         }
 
         public init(from decoder: Decoder) throws {
@@ -252,8 +285,10 @@ public struct CodexUsageResponse: Decodable, Sendable {
             self.used = Self.decodeFlexibleDouble(container, forKey: .used)
             self.remainingPercent = Self.decodeFlexibleDouble(container, forKey: .remainingPercent)
                 ?? Self.decodeFlexibleDouble(container, forKey: .remainingPercentSnake)
+            // `wham/usage` spells this `reset_at` (matching `WindowSnapshot`), other shapes use `resets_at`.
             self.resetsAt = Self.decodeFlexibleInt(container, forKey: .resetsAt)
                 ?? Self.decodeFlexibleInt(container, forKey: .resetsAtSnake)
+                ?? Self.decodeFlexibleInt(container, forKey: .resetAtSnake)
         }
 
         private static func decodeFlexibleDouble(

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -62,6 +62,11 @@ public struct CodexUsageResponse: Decodable, Sendable {
         return (try? container.decodeNil(forKey: key)) == false
     }
 
+    /// Credit-limit source precedence: response root, then `rate_limit`, then `spend_control`.
+    public var resolvedIndividualLimit: SpendControlLimitSnapshot? {
+        self.individualLimit ?? self.rateLimit?.individualLimit ?? self.spendControlIndividualLimit
+    }
+
     private static func decodeSpendControlIndividualLimit(
         container: KeyedDecodingContainer<CodingKeys>) -> SpendControlLimitSnapshot?
     {

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -385,7 +385,9 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
         updatedAt: Date) -> CreditsSnapshot?
     {
         let balance = response.credits?.balance
-        let creditLimit = (response.individualLimit ?? response.rateLimit?.individualLimit)?
+        let creditLimit = (response.individualLimit
+            ?? response.rateLimit?.individualLimit
+            ?? response.spendControlIndividualLimit)?
             .codexCreditLimitSnapshot(updatedAt: updatedAt)
         guard balance != nil || creditLimit != nil else { return nil }
         return CreditsSnapshot(

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -385,10 +385,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
         updatedAt: Date) -> CreditsSnapshot?
     {
         let balance = response.credits?.balance
-        let creditLimit = (response.individualLimit
-            ?? response.rateLimit?.individualLimit
-            ?? response.spendControlIndividualLimit)?
-            .codexCreditLimitSnapshot(updatedAt: updatedAt)
+        let creditLimit = response.resolvedIndividualLimit?.codexCreditLimitSnapshot(updatedAt: updatedAt)
         guard balance != nil || creditLimit != nil else { return nil }
         return CreditsSnapshot(
             remaining: balance ?? 0,

--- a/Tests/CodexBarTests/CodexOAuthCreditLimitTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthCreditLimitTests.swift
@@ -399,11 +399,12 @@ struct CodexOAuthCreditLimitTests {
         let response = try CodexOAuthUsageFetcher._decodeUsageResponseForTesting(
             Data(self.teamSpendControlJSON().utf8))
 
+        #expect(response.individualLimit == nil)
         #expect(response.rateLimit?.individualLimit == nil)
-        #expect(response.individualLimit?.limit == 1000)
-        #expect(response.individualLimit?.used == 36.79748725891113)
-        #expect(response.individualLimit?.remainingPercent == 96)
-        #expect(response.individualLimit?.resetsAt == 1_788_220_800)
+        #expect(response.spendControlIndividualLimit?.limit == 1000)
+        #expect(response.spendControlIndividualLimit?.used == 36.79748725891113)
+        #expect(response.spendControlIndividualLimit?.remainingPercent == 96)
+        #expect(response.spendControlIndividualLimit?.resetsAt == 1_788_220_800)
     }
 
     @Test
@@ -419,6 +420,19 @@ struct CodexOAuthCreditLimitTests {
         #expect(result.sourceLabel == "oauth")
     }
 
+    private func spendControlBlockJSON() -> String {
+        """
+        "spend_control": {
+          "individual_limit": {
+            "limit": "1000",
+            "used": "36.79748725891113",
+            "remaining_percent": 96,
+            "reset_at": 1788220800
+          }
+        }
+        """
+    }
+
     @Test
     func `root individual limit still wins over spend control`() throws {
         let json = """
@@ -430,19 +444,45 @@ struct CodexOAuthCreditLimitTests {
             "remaining_percent": 80,
             "resets_at": 1782864000
           },
-          "spend_control": {
+          \(self.spendControlBlockJSON())
+        }
+        """
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(json.utf8),
+            credentials: self.makeCredentials())
+
+        #expect(result.credits?.codexCreditLimit?.limit == 500)
+        #expect(result.credits?.codexCreditLimit?.resetsAt == Date(timeIntervalSince1970: 1_782_864_000))
+    }
+
+    @Test
+    func `rate limit individual limit still wins over spend control`() throws {
+        let json = """
+        {
+          "plan_type": "team",
+          "rate_limit": {
+            "primary_window": null,
+            "secondary_window": null,
             "individual_limit": {
-              "limit": "1000",
-              "used": "36.79748725891113",
-              "remaining_percent": 96,
-              "reset_at": 1788220800
+              "limit": 100000,
+              "used": 7761,
+              "remaining_percent": 92.239,
+              "resets_at": 1782864000
             }
-          }
+          },
+          \(self.spendControlBlockJSON())
         }
         """
         let response = try CodexOAuthUsageFetcher._decodeUsageResponseForTesting(Data(json.utf8))
+        #expect(response.rateLimit?.individualLimit?.limit == 100_000)
+        #expect(response.spendControlIndividualLimit?.limit == 1000)
 
-        #expect(response.individualLimit?.limit == 500)
-        #expect(response.individualLimit?.resetsAt == 1_782_864_000)
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(json.utf8),
+            credentials: self.makeCredentials())
+
+        #expect(result.credits?.codexCreditLimit?.limit == 100_000)
+        #expect(result.credits?.codexCreditLimit?.remaining == 92239)
+        #expect(result.credits?.codexCreditLimit?.resetsAt == Date(timeIntervalSince1970: 1_782_864_000))
     }
 }

--- a/Tests/CodexBarTests/CodexOAuthCreditLimitTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthCreditLimitTests.swift
@@ -354,4 +354,95 @@ struct CodexOAuthCreditLimitTests {
         #expect(result.sourceLabel == "oauth")
         #expect(result.credits?.codexCreditLimit == nil)
     }
+
+    /// Team workspaces nest the monthly pool under `spend_control.individual_limit` and spell the
+    /// reset timestamp `reset_at`; the root and `rate_limit` spellings are both absent.
+    private func teamSpendControlJSON() -> String {
+        """
+        {
+          "plan_type": "team",
+          "rate_limit": {
+            "allowed": false,
+            "limit_reached": true,
+            "primary_window": {
+              "used_percent": 100,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 45962,
+              "reset_at": 1786161204
+            },
+            "secondary_window": null
+          },
+          "credits": {
+            "has_credits": true,
+            "unlimited": false,
+            "balance": null
+          },
+          "spend_control": {
+            "reached": false,
+            "individual_limit": {
+              "source": "workspace_spend_controls",
+              "limit": "1000",
+              "used": "36.79748725891113",
+              "remaining": "963.2025127410889",
+              "used_percent": 4,
+              "remaining_percent": 96,
+              "reset_after_seconds": 2105558,
+              "reset_at": 1788220800
+            }
+          }
+        }
+        """
+    }
+
+    @Test
+    func `decodes monthly credit limit from spend control payload`() throws {
+        let response = try CodexOAuthUsageFetcher._decodeUsageResponseForTesting(
+            Data(self.teamSpendControlJSON().utf8))
+
+        #expect(response.rateLimit?.individualLimit == nil)
+        #expect(response.individualLimit?.limit == 1000)
+        #expect(response.individualLimit?.used == 36.79748725891113)
+        #expect(response.individualLimit?.remainingPercent == 96)
+        #expect(response.individualLimit?.resetsAt == 1_788_220_800)
+    }
+
+    @Test
+    func `spend control payload surfaces monthly credit limit when balance is null`() throws {
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(self.teamSpendControlJSON().utf8),
+            credentials: self.makeCredentials())
+
+        #expect(result.credits?.codexCreditLimit?.limit == 1000)
+        #expect(result.credits?.codexCreditLimit?.used == 36.79748725891113)
+        #expect(result.credits?.codexCreditLimit?.remainingPercent == 96)
+        #expect(result.credits?.codexCreditLimit?.resetsAt == Date(timeIntervalSince1970: 1_788_220_800))
+        #expect(result.sourceLabel == "oauth")
+    }
+
+    @Test
+    func `root individual limit still wins over spend control`() throws {
+        let json = """
+        {
+          "plan_type": "team",
+          "individual_limit": {
+            "limit": 500,
+            "used": 100,
+            "remaining_percent": 80,
+            "resets_at": 1782864000
+          },
+          "spend_control": {
+            "individual_limit": {
+              "limit": "1000",
+              "used": "36.79748725891113",
+              "remaining_percent": 96,
+              "reset_at": 1788220800
+            }
+          }
+        }
+        """
+        let response = try CodexOAuthUsageFetcher._decodeUsageResponseForTesting(Data(json.utf8))
+
+        #expect(response.individualLimit?.limit == 500)
+        #expect(response.individualLimit?.resetsAt == 1_782_864_000)
+    }
 }


### PR DESCRIPTION
Fixes #2736.

## Summary

Codex team/enterprise workspaces return the monthly credit pool under **`spend_control.individual_limit`** in `wham/usage`, but the OAuth decoder only reads `individual_limit` at the response root or under `rate_limit`. With `credits.balance` also `null` on these accounts, `mapCredits` sees `balance == nil && creditLimit == nil` and returns `nil` — so the entire `credits` object is dropped, not just the limit. No `Credits` line in the CLI, no `credits` key in `--format json`.

Everything downstream (`CodexSpendControlLimitMapping`, `CodexCreditLimitSnapshot`, `CLIRenderer.appendCreditsLine`) already handles this data correctly; it just never received a value.

## Changes

- `CodexUsageResponse`: decode `spend_control.individual_limit` into a **separate** `spendControlIndividualLimit` property, plus a `resolvedIndividualLimit` helper that fixes selection order as root -> `rate_limit` -> `spend_control`. Both consumers (`CodexOAuthFetchStrategy.mapCredits`, `OpenAIDashboardFetcher`) use the helper, so existing payloads resolve exactly as before.
- `SpendControlLimitSnapshot`: also accept `reset_at` alongside `resetsAt` / `resets_at`. The live payload uses `reset_at` (same spelling as `WindowSnapshot`), so without this the reset timestamp decoded as `nil` even once the nesting was handled.
- Four tests in `CodexOAuthCreditLimitTests`: decode-level, map-level (the limit survives a `null` balance), and two precedence regressions proving a root or `rate_limit` value still wins over `spend_control`.
- CHANGELOG entry under 0.48.1.

## Evidence

Redacted `GET /backend-api/wham/usage` from the affected account (`plan_type: team`, CodexBar CLI 0.48.0, Codex CLI 0.147.0):

```json
{
  "plan_type": "team",
  "rate_limit": {
    "allowed": false,
    "limit_reached": true,
    "primary_window": {
      "used_percent": 100,
      "limit_window_seconds": 604800,
      "reset_after_seconds": 45962,
      "reset_at": 1786161204
    },
    "secondary_window": null
  },
  "credits": {
    "has_credits": true,
    "unlimited": false,
    "overage_limit_reached": false,
    "balance": null,
    "approx_local_messages": null,
    "approx_cloud_messages": null
  },
  "spend_control": {
    "reached": false,
    "individual_limit": {
      "source": "workspace_spend_controls",
      "limit": "1000",
      "used": "36.79748725891113",
      "remaining": "963.2025127410889",
      "used_percent": 4,
      "remaining_percent": 96,
      "reset_after_seconds": 2105558,
      "reset_at": 1788220800
    }
  },
  "rate_limit_reached_type": null,
  "promo": null,
  "rate_limit_reset_credits": {
    "available_count": 1,
    "applicable_available_count": 1
  }
}
```

`user_id`, `account_id`, and `email` were redacted; nothing else was altered. The test fixture is this payload trimmed to the fields the decoder reads.

Before (0.48.0 release binary, same account, same moment) — no `Credits` line:

```
== Codex 0.147.0 (oauth) ==
Weekly: 0% left [------------]
Resets in 14h 40m
Limit Reset Credits: 1 available
Next reset credit expires in 5d 4h
Account: REDACTED@example.com
Plan: Team
```

Expected after: `36.8 of 1000 credits used`, resetting 2026-09-02.

## Commands run

None locally — this was reported and patched from Linux aarch64 (Ubuntu 20.04), which cannot host a Swift 6.2 toolchain, and I have no macOS machine. CI on this PR is the gate: `lint`, `build-linux-cli` (x64 and arm64), and `build-linux-musl-cli` are green as of `c1c4196`.

## After-fix proof

Built this branch's head on CI and ran the resulting binary against the same live Team account — full transcript in [this comment](https://github.com/steipete/CodexBar/pull/2737#issuecomment-5219422429):

```
== Codex (oauth) ==
Weekly: 0% left [------------]
Credits: 963.2 left
Limit Reset Credits: 1 available
Account: REDACTED@example.com
Plan: Team
```

`credits.codexCreditLimit` now resolves to `limit 1000 / used 36.797 / remainingPercent 96 / resetsAt 2026-09-01T00:00:00Z`, where the released 0.48.0 binary emitted no `credits` object at all.
