### PR TITLE
Claude: adopt a valid credential when the delegated-refresh touch changed nothing

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -288,13 +288,13 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
 
         // "Touch succeeded" must mean we actually observed the Claude keychain entry change.
         // Otherwise we end up in a long cooldown with still-expired credentials.
-        let changed = await self.waitForClaudeKeychainChange(
+        let observation = await self.waitForClaudeKeychainChange(
             from: baseline,
             readStrategy: configuration.readStrategy,
             keychainAccessDisabled: configuration.keychainAccessDisabled,
             configuration: configuration,
             timeout: min(max(timeout, 1), 2))
-        if changed {
+        if observation == .changed {
             self.recordAttempt(
                 now: now,
                 cooldown: self.defaultCooldownInterval,
@@ -302,6 +302,19 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
                 state: state)
             self.log.info("Claude OAuth delegated refresh touch succeeded")
             return AttemptResult(.attemptedSucceeded)
+        }
+
+        // Why: an unreadable keychain proves nothing about the touch, so this stays retryable on the short
+        // cooldown rather than being recorded as a refusal. Adopting a credential the CLI may already have
+        // refreshed is the caller's job — see the unconditional silent sync in ClaudeUsageFetcher.
+        if observation == .indeterminate {
+            self.recordAttempt(
+                now: now,
+                cooldown: self.shortCooldownInterval,
+                profileIdentifier: profileIdentifier,
+                state: state)
+            self.log.warning("Claude OAuth delegated refresh could not observe the Claude keychain")
+            return AttemptResult(.attemptedFailed("Claude keychain was unreadable after the Claude CLI touch."))
         }
 
         // A touch *error* deliberately stays retryable even when nothing is readable: the error may be transient,
@@ -416,49 +429,65 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         return .securityFramework(fingerprint: self.currentClaudeKeychainFingerprint(configuration: configuration))
     }
 
+    /// Why: "the keychain did not change" and "the keychain could not be read" demand opposite responses —
+    /// the first is a real refresh failure, the second says nothing at all. Collapsing them into `Bool` reported a
+    /// live, freshly-rewritten keychain as unchanged and parked the account in a cooldown it never left.
+    enum KeychainChangeObservation: Equatable, Sendable {
+        case changed
+        case unchanged
+        case indeterminate
+    }
+
+    /// Why: an unreadable `current` is the whole bug — it used to fold into "unchanged", which reported a
+    /// keychain the Claude CLI had just rewritten as untouched.
+    static func classifyObservation<Value: Equatable>(
+        before: Value?,
+        current: Value?,
+        missingBaselineIsIndeterminate: Bool) -> KeychainChangeObservation
+    {
+        guard let current else { return .indeterminate }
+        if before == nil, missingBaselineIsIndeterminate { return .indeterminate }
+        return current == before ? .unchanged : .changed
+    }
+
     private static func waitForClaudeKeychainChange(
         from baseline: KeychainChangeObservationBaseline,
         readStrategy: ClaudeOAuthKeychainReadStrategy,
         keychainAccessDisabled: Bool,
         configuration: AttemptConfiguration?,
-        timeout: TimeInterval) async -> Bool
+        timeout: TimeInterval) async -> KeychainChangeObservation
     {
         // Prefer correctness but bound the delay. Keychain writes can be slightly delayed after the CLI touch.
         // Keep this short to avoid "prompt storms" on configurations where "no UI" queries can still surface UI.
         let clampedTimeout = max(0, min(timeout, 2))
-        if clampedTimeout == 0 { return false }
+        if clampedTimeout == 0 { return .indeterminate }
 
         let delays: [TimeInterval] = [0.2, 0.5, 0.8].filter { $0 <= clampedTimeout }
         let deadline = Date().addingTimeInterval(clampedTimeout)
 
-        func isObservedChange() -> Bool {
+        func observe() -> KeychainChangeObservation {
             switch baseline {
             case let .securityFramework(fingerprintBefore):
-                // Treat "no fingerprint" as "not observed"; we only succeed if we can read a fingerprint and it
-                // differs.
-                guard let current = self.currentClaudeKeychainFingerprintForObservation(configuration: configuration)
-                else {
-                    return false
-                }
-                return current != fingerprintBefore
+                self.classifyObservation(
+                    before: fingerprintBefore,
+                    current: self.currentClaudeKeychainFingerprintForObservation(configuration: configuration),
+                    missingBaselineIsIndeterminate: false)
             case let .securityCLI(dataBefore):
                 // In experimental mode, avoid Security.framework observation entirely and detect change from
-                // /usr/bin/security output only.
-                // If baseline capture failed (nil), treat observation as inconclusive and do not infer a change from
-                // a later successful read.
-                guard let dataBefore else { return false }
-                guard let current = self.currentClaudeKeychainDataViaSecurityCLIForObservation(
-                    readStrategy: readStrategy,
-                    keychainAccessDisabled: keychainAccessDisabled,
-                    interaction: .background)
-                else { return false }
-                return current != dataBefore
+                // /usr/bin/security output only. A failed baseline capture stays inconclusive here rather than
+                // letting a later successful read masquerade as a change.
+                self.classifyObservation(
+                    before: dataBefore,
+                    current: self.currentClaudeKeychainDataViaSecurityCLIForObservation(
+                        readStrategy: readStrategy,
+                        keychainAccessDisabled: keychainAccessDisabled,
+                        interaction: .background),
+                    missingBaselineIsIndeterminate: true)
             }
         }
 
-        if isObservedChange() {
-            return true
-        }
+        var observation = observe()
+        if observation == .changed { return .changed }
 
         for delay in delays {
             if Date() >= deadline { break }
@@ -466,15 +495,14 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
                 try Task.checkCancellation()
                 try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             } catch {
-                return false
+                return observation
             }
 
-            if isObservedChange() {
-                return true
-            }
+            observation = observe()
+            if observation == .changed { return .changed }
         }
 
-        return false
+        return observation
     }
 
     private static func currentClaudeKeychainFingerprint(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -304,19 +304,6 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             return AttemptResult(.attemptedSucceeded)
         }
 
-        // Why: an unreadable keychain proves nothing about the touch, so this stays retryable on the short
-        // cooldown rather than being recorded as a refusal. Adopting a credential the CLI may already have
-        // refreshed is the caller's job — see the unconditional silent sync in ClaudeUsageFetcher.
-        if observation == .indeterminate {
-            self.recordAttempt(
-                now: now,
-                cooldown: self.shortCooldownInterval,
-                profileIdentifier: profileIdentifier,
-                state: state)
-            self.log.warning("Claude OAuth delegated refresh could not observe the Claude keychain")
-            return AttemptResult(.attemptedFailed("Claude keychain was unreadable after the Claude CLI touch."))
-        }
-
         // A touch *error* deliberately stays retryable even when nothing is readable: the error may be transient,
         // and on older Claude Code a retried touch can still create the credentials file. Only the
         // completes-cleanly-but-unobservable variant is provably terminal.
@@ -327,6 +314,10 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
             cooldown: unreadable ? self.defaultCooldownInterval : self.shortCooldownInterval,
             profileIdentifier: profileIdentifier,
             state: state)
+        // Why: this verdict must be reached before the indeterminate branch below. A profile whose keychain
+        // CodexBar cannot read produces an indeterminate observation *and* satisfies this terminal condition;
+        // answering "retry shortly" there would drop `isUnreadableAfterRefresh`, lose the "switch source"
+        // guidance, and relaunch the CLI on the short cooldown forever (the loop #2650 removed).
         if unreadable {
             self.log.warning("Claude OAuth delegated refresh produced no readable credential source")
             return AttemptResult(
@@ -340,6 +331,14 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
                 metadata: ["errorType": errorType])
             self.log.debug("Claude OAuth delegated refresh touch error: \(touchError.localizedDescription)")
             return AttemptResult(.attemptedFailed(touchError.localizedDescription))
+        }
+
+        // Why: reaching here means the profile is readable in principle, so an unobservable keychain says nothing
+        // about the touch and stays retryable on the short cooldown already recorded above — distinct from having
+        // observed the entry genuinely not move.
+        if observation == .indeterminate {
+            self.log.warning("Claude OAuth delegated refresh could not observe the Claude keychain")
+            return AttemptResult(.attemptedFailed("Claude keychain was unreadable after the Claude CLI touch."))
         }
 
         self.log.warning("Claude OAuth delegated refresh touch did not update Claude keychain")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -432,10 +432,14 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                 _ = ClaudeOAuthCredentialsStore.invalidateCacheIfCredentialsFileChanged(
                     environment: self.fetcher.environment)
 
-                let didSyncSilently = delegatedOutcome == .attemptedSucceeded
-                    && ClaudeOAuthCredentialsStore.syncFromClaudeKeychainWithoutPrompt(
-                        now: Date(),
-                        environment: self.fetcher.environment)
+                // Why: a touch changes nothing when the Claude CLI's own token is still valid, which reads as
+                // `.attemptedFailed` even though the keychain holds a perfectly good credential. Gating the sync on
+                // `.attemptedSucceeded` therefore skipped the one step that adopts it, pinning the card to an
+                // expired cache until a manual refresh. The sync never prompts and only adopts a non-expired
+                // credential, so attempting it on every outcome cannot regress a working account.
+                let didSyncSilently = ClaudeOAuthCredentialsStore.syncFromClaudeKeychainWithoutPrompt(
+                    now: Date(),
+                    environment: self.fetcher.environment)
 
                 let promptPolicy = ClaudeUsageFetcher.currentClaudeOAuthInteractivePromptPolicy()
                 ClaudeUsageFetcher.logDeferredBackgroundDelegatedRecoveryIfNeeded(

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshUnreadableResultTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshUnreadableResultTests.swift
@@ -50,6 +50,7 @@ struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
     private func attemptWithUnreadableKeychain(
         credentialsURL: URL,
         now: Date,
+        fingerprint: ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint? = Self.unchangedFingerprint,
         touchAuthPath: @escaping @Sendable (TimeInterval, [String: String]) async throws -> Void)
         async throws -> ClaudeOAuthDelegatedRefreshCoordinator.AttemptResult
     {
@@ -62,7 +63,7 @@ struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
                             defer { ClaudeOAuthDelegatedRefreshCoordinator.resetForTesting() }
                             return try await ClaudeOAuthDelegatedRefreshCoordinator
                                 .withKeychainFingerprintOverrideForTesting {
-                                    Self.unchangedFingerprint
+                                    fingerprint
                                 } operation: {
                                     try await ClaudeOAuthDelegatedRefreshCoordinator
                                         .withCLIAvailableOverrideForTesting(true) {
@@ -95,6 +96,26 @@ struct ClaudeOAuthDelegatedRefreshUnreadableResultTests {
 
         #expect(outcome.isUnreadableAfterRefresh)
         // The touch still runs: on older Claude Code it can create the credentials file we would then read.
+        #expect(touches.count() == 1)
+    }
+
+    @Test
+    func `unreadable refresh result outranks an unobservable keychain`() async throws {
+        // An unreadable profile also yields an indeterminate observation, since the fingerprint cannot be read.
+        // The terminal verdict must still win: answering "retry shortly" here would drop the switch-source
+        // guidance and put the CLI back on a short-cooldown relaunch loop.
+        let root = try self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let touches = UnreadableResultTouchCounter()
+        let outcome = try await self.attemptWithUnreadableKeychain(
+            credentialsURL: root.appendingPathComponent(".credentials.json"),
+            now: Date(timeIntervalSince1970: 70000),
+            fingerprint: nil,
+            touchAuthPath: { _, _ in touches.increment() })
+
+        #expect(outcome.isUnreadableAfterRefresh)
+        #expect(outcome.outcome == .attemptedFailed("No readable Claude credential source after the Claude CLI touch."))
         #expect(touches.count() == 1)
     }
 

--- a/Tests/CodexBarTests/ClaudeOAuthKeychainChangeObservationTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthKeychainChangeObservationTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
-@Suite
+/// Regression coverage for #2733: an unreadable keychain must never read as "unchanged".
 struct ClaudeOAuthKeychainChangeObservationTests {
     private typealias Observation = ClaudeOAuthDelegatedRefreshCoordinator.KeychainChangeObservation
 
@@ -17,35 +17,35 @@ struct ClaudeOAuthKeychainChangeObservationTests {
             missingBaselineIsIndeterminate: missingBaselineIsIndeterminate)
     }
 
-    @Test("an unreadable current reading is indeterminate, never unchanged")
-    func unreadableCurrentIsIndeterminate() {
-        // The regression this guards: a background probe that could not read the keychain used to be reported as
-        // "did not change", which parked an account on an expired cached token until a manual refresh.
+    @Test
+    func `an unreadable current reading is indeterminate rather than unchanged`() {
+        // The regression this guards: a probe that could not read the keychain used to report "did not change",
+        // which parked an account on an expired cached token until a manual refresh.
         #expect(self.classify(before: "fingerprint-a", current: nil) == .indeterminate)
     }
 
-    @Test("an unreadable reading is distinct from an equal reading")
-    func indeterminateIsNotUnchanged() {
+    @Test
+    func `an unreadable reading stays distinct from an equal reading`() {
         let unreadable = self.classify(before: "fingerprint-a", current: nil)
         let equal = self.classify(before: "fingerprint-a", current: "fingerprint-a")
         #expect(unreadable != equal)
         #expect(equal == .unchanged)
     }
 
-    @Test("a differing reading is a change")
-    func differingReadingIsChange() {
+    @Test
+    func `a differing reading is a change`() {
         #expect(self.classify(before: "fingerprint-a", current: "fingerprint-b") == .changed)
     }
 
-    @Test("a missing baseline stays a change for Security.framework observation")
-    func missingBaselineIsChangeWhenNotStrict() {
+    @Test
+    func `a missing baseline stays a change for security framework observation`() {
         // Preserves pre-existing Security.framework behavior: something readable where nothing was readable
         // before still counts as movement.
         #expect(self.classify(before: nil, current: "fingerprint-a") == .changed)
     }
 
-    @Test("a missing baseline is inconclusive for security CLI observation")
-    func missingBaselineIsIndeterminateWhenStrict() {
+    @Test
+    func `a missing baseline is inconclusive for security CLI observation`() {
         #expect(
             self.classify(
                 before: nil,
@@ -53,8 +53,8 @@ struct ClaudeOAuthKeychainChangeObservationTests {
                 missingBaselineIsIndeterminate: true) == .indeterminate)
     }
 
-    @Test("both readings unreadable is indeterminate rather than unchanged")
-    func bothUnreadableIsIndeterminate() {
+    @Test
+    func `both readings unreadable is indeterminate rather than unchanged`() {
         #expect(self.classify(before: nil, current: nil) == .indeterminate)
     }
 }

--- a/Tests/CodexBarTests/ClaudeOAuthKeychainChangeObservationTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthKeychainChangeObservationTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite
+struct ClaudeOAuthKeychainChangeObservationTests {
+    private typealias Observation = ClaudeOAuthDelegatedRefreshCoordinator.KeychainChangeObservation
+
+    private func classify(
+        before: String?,
+        current: String?,
+        missingBaselineIsIndeterminate: Bool = false) -> Observation
+    {
+        ClaudeOAuthDelegatedRefreshCoordinator.classifyObservation(
+            before: before,
+            current: current,
+            missingBaselineIsIndeterminate: missingBaselineIsIndeterminate)
+    }
+
+    @Test("an unreadable current reading is indeterminate, never unchanged")
+    func unreadableCurrentIsIndeterminate() {
+        // The regression this guards: a background probe that could not read the keychain used to be reported as
+        // "did not change", which parked an account on an expired cached token until a manual refresh.
+        #expect(self.classify(before: "fingerprint-a", current: nil) == .indeterminate)
+    }
+
+    @Test("an unreadable reading is distinct from an equal reading")
+    func indeterminateIsNotUnchanged() {
+        let unreadable = self.classify(before: "fingerprint-a", current: nil)
+        let equal = self.classify(before: "fingerprint-a", current: "fingerprint-a")
+        #expect(unreadable != equal)
+        #expect(equal == .unchanged)
+    }
+
+    @Test("a differing reading is a change")
+    func differingReadingIsChange() {
+        #expect(self.classify(before: "fingerprint-a", current: "fingerprint-b") == .changed)
+    }
+
+    @Test("a missing baseline stays a change for Security.framework observation")
+    func missingBaselineIsChangeWhenNotStrict() {
+        // Preserves pre-existing Security.framework behavior: something readable where nothing was readable
+        // before still counts as movement.
+        #expect(self.classify(before: nil, current: "fingerprint-a") == .changed)
+    }
+
+    @Test("a missing baseline is inconclusive for security CLI observation")
+    func missingBaselineIsIndeterminateWhenStrict() {
+        #expect(
+            self.classify(
+                before: nil,
+                current: "fingerprint-a",
+                missingBaselineIsIndeterminate: true) == .indeterminate)
+    }
+
+    @Test("both readings unreadable is indeterminate rather than unchanged")
+    func bothUnreadableIsIndeterminate() {
+        #expect(self.classify(before: nil, current: nil) == .indeterminate)
+    }
+}


### PR DESCRIPTION
> **Scope corrected after review.** This PR originally claimed it restored background recovery for an expired Claude OAuth credential. That was wrong for the default configuration, and I've rewritten the title and this body to describe what it actually does. The original framing is preserved in the comments below rather than quietly edited away. Details in [the correction comment](#issuecomment-correction).

## What this fixes

`ClaudeUsageFetcher.loadAfterDelegatedRefresh` gated the silent keychain re-sync on the delegated-refresh outcome:

```swift
let didSyncSilently = delegatedOutcome == .attemptedSucceeded
    && ClaudeOAuthCredentialsStore.syncFromClaudeKeychainWithoutPrompt(...)
```

The touch changes nothing when the Claude CLI's own token is still valid, so the keychain-change probe reports no change and the attempt is recorded `.attemptedFailed`. The `&&` then short-circuits, skipping the step that would adopt the valid credential already present in the keychain. The subsequent retry at `ClaudeUsageFetcher.swift:464` runs with `allowKeychainPrompt: false` and so cannot benefit from a credential the sync never loaded.

`syncFromClaudeKeychainWithoutPrompt` passes `allowKeychainPrompt: false` on every read (`ClaudeOAuthCredentials.swift:1219`, `:1288`, `:1316`), its candidates probe is no-UI (`:2360-2369`), and it only adopts a credential that is **not expired** (`:1225`, `:1296`, `:1321`). Running it when the outcome was `.attemptedFailed` therefore cannot prompt and cannot regress a working account.

## What this does NOT fix

**This does not restore background recovery under the default prompt policy**, and the original version of this PR wrongly implied it did.

With `claudeOAuthKeychainPromptMode` at its default `.onlyOnUserAction`, a background refresh throws at `ClaudeUsageFetcher.swift:404` — `assertDelegatedRefreshAllowedInCurrentInteraction`, with `allowBackgroundDelegatedRefresh` hardcoded `false` at `ClaudeProviderDescriptor.swift:676` — long before reaching the sync at `:440`. `syncFromClaudeKeychainWithoutPrompt` self-gates on the same policy anyway (`shouldAllowClaudeCodeKeychainAccess`: `.onlyOnUserAction` returns `ProviderInteractionContext.current == .userInitiated`).

So the effect of this PR is:

| prompt mode | effect |
|---|---|
| `.always` | background recovery works where it previously did not |
| `.onlyOnUserAction` (default) | the post-delegation retry can now find an adopted credential instead of none; the background gate above is untouched |
| `.never` | no change |

Two further scope limits, for accuracy: in default Auto mode `oauthKeychainPromptCooldownEnabled` is true (`ClaudeProviderDescriptor.swift:674`), so `.skippedByCooldown` / `.skippedByPromptPolicy` / `.cliUnavailable` still throw at `:419-427` before the sync — "runs on every outcome" was overstated. And `saveClaudeKeychainFingerprint` inside the sync now fires on paths where it previously did not.

Making the default configuration self-heal is a separate, larger change: it means letting a provably-non-prompting read run under `.onlyOnUserAction`. That is a policy decision I don't think a drive-by PR should make — I tried relaxing an adjacent prompt gate earlier in this branch and it caused 8 test regressions, which is a fair warning about that surface.

## Commits

- **`508c9f3`** — the fix: drop the `&&` gate on the silent sync.
- **`653816c`** — `waitForClaudeKeychainChange` returned `Bool`, collapsing "could not read the keychain" into "did not change". Now a tri-state. Honest caveat: with the ordering below, the practical effect is limited to log and message text — call it tidying rather than hardening, and it is separable if you'd rather not carry it.
- **`695f478`** — review fix. Both bots caught that the indeterminate branch preceded `isRefreshResultUnreadable`; an unreadable profile satisfies both at once, which dropped `isUnreadableAfterRefresh` (losing the "switch source" guidance) and took the 20s cooldown instead of 5m, restoring the CLI relaunch loop #2650 removed. Precedence is now `unreadable` → `touchError` → `.indeterminate` → `.unchanged`.
- **`c9775a2`** — `make check` naming violations.

## Testing

- `swift test --filter ClaudeOAuthDelegatedRefresh` → **29/29**.
- `make check` → **0 violations across 1806 files**.
- The regression test for `695f478` is verified to actually catch its defect: against the pre-fix ordering it fails with `isUnreadableAfterRefresh: false` and the wrong message string.
- No regressions vs `main` at `22b24b8`. Residual failures under a wide filter come from suites that are order-dependent under parallel execution (`ClaudeOAuthPromptCoalescingTests`, `ClaudeCLISessionTests`, `ClaudeLoginRunnerTests`, `ClaudeCLITimeoutRetryTests`, `ClaudeOAuthDelegatedRefreshProfileIsolationTests`); the set differs between runs of the same commit, each also fails on `main`, and all pass in isolation.

**Known gap:** the `508c9f3` change itself has no direct test — restoring the `&&` would still pass the suite. The existing tests cover the tri-state classifier and the `695f478` ordering. Worth fixing before merge; flagging it rather than leaving it to be discovered.

## Verification I could not do

I have not observed a card recover with this patch in the release-signed keychain state. A locally built app is ad-hoc signed and cannot durably read CodexBar's own ACL-bound cache items (`Keychain cache item is unusable by this executable (oauth.claude.profile.<hash>)`), so the precondition can't be reproduced from a fork. That check needs the release signing identity.

Prior traces in this thread are pre-fix, from a Developer ID signed 0.48.0: a credential ~44h expired with `hasRefreshToken=true` and `source=cacheKeychain`, delegating every cycle without recovering. They establish the symptom on current release; they do not by themselves establish the mechanism, which is reasoning from the code paths cited above.