### PR TITLE
Kimi: hide Code 7-day row when it duplicates the weekly lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.48.1 — Unreleased
 
+### Fixed
+- Kimi: hide the Code 7-day window when it reports the same percentage and reset time as the primary weekly quota, so the menu no longer shows one allowance twice.
+
 ## 0.48.0 — 2026-08-06
 
 ### Added

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1430,3 +1430,6 @@
 "Enter every endpoint setting to review the exact network origins." = "أدخل جميع إعدادات نقاط النهاية لمراجعة أصول الشبكة الدقيقة.";
 "Approve" = "موافقة";
 "Install" = "تثبيت";
+"5-hour usage" = "الاستخدام خلال 5 ساعات";
+"7-day usage" = "الاستخدام خلال 7 أيام";
+"Total usage" = "إجمالي الاستخدام";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1429,3 +1429,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Introdueix tots els paràmetres dels endpoints per revisar els orígens de xarxa exactes.";
 "Approve" = "Aprova";
 "Install" = "Instal·la";
+"5-hour usage" = "Ús de 5 hores";
+"7-day usage" = "Ús de 7 dies";
+"Total usage" = "Ús total";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1427,3 +1427,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Geben Sie alle Endpunkt-Einstellungen ein, um die genauen Netzwerkursprünge zu prüfen.";
 "Approve" = "Genehmigen";
 "Install" = "Installieren";
+"5-hour usage" = "5-Stunden-Nutzung";
+"7-day usage" = "7-Tage-Nutzung";
+"Total usage" = "Gesamtnutzung";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1431,3 +1431,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Enter every endpoint setting to review the exact network origins.";
 "Approve" = "Approve";
 "Install" = "Install";
+"5-hour usage" = "5-hour usage";
+"7-day usage" = "7-day usage";
+"Total usage" = "Total usage";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1425,3 +1425,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Introduce todos los ajustes de endpoint para revisar los orígenes de red exactos.";
 "Approve" = "Aprobar";
 "Install" = "Instalar";
+"5-hour usage" = "Uso de 5 horas";
+"7-day usage" = "Uso de 7 días";
+"Total usage" = "Uso total";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1430,3 +1430,6 @@
 "Enter every endpoint setting to review the exact network origins." = "همهٔ تنظیمات نقطهٔ پایانی را وارد کنید تا مبدأهای دقیق شبکه را بررسی کنید.";
 "Approve" = "تأیید";
 "Install" = "نصب";
+"5-hour usage" = "مصرف ۵ ساعته";
+"7-day usage" = "مصرف ۷ روزه";
+"Total usage" = "مصرف کل";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1426,3 +1426,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Renseignez tous les paramètres des points de terminaison pour vérifier les origines réseau exactes.";
 "Approve" = "Approuver";
 "Install" = "Installer";
+"5-hour usage" = "Utilisation sur 5 heures";
+"7-day usage" = "Utilisation sur 7 jours";
+"Total usage" = "Utilisation totale";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1426,3 +1426,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Introduce todos os axustes dos puntos de conexión para revisar as orixes de rede exactas.";
 "Approve" = "Aprobar";
 "Install" = "Instalar";
+"5-hour usage" = "Uso de 5 horas";
+"7-day usage" = "Uso de 7 días";
+"Total usage" = "Uso total";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1430,3 +1430,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Masukkan semua pengaturan endpoint untuk meninjau origin jaringan yang tepat.";
 "Approve" = "Setujui";
 "Install" = "Pasang";
+"5-hour usage" = "Penggunaan 5 jam";
+"7-day usage" = "Penggunaan 7 hari";
+"Total usage" = "Total penggunaan";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1430,3 +1430,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Inserisci tutte le impostazioni degli endpoint per verificare le origini di rete esatte.";
 "Approve" = "Approva";
 "Install" = "Installa";
+"5-hour usage" = "Utilizzo di 5 ore";
+"7-day usage" = "Utilizzo di 7 giorni";
+"Total usage" = "Utilizzo totale";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1427,3 +1427,6 @@
 "Enter every endpoint setting to review the exact network origins." = "正確なネットワークオリジンを確認するには、すべてのエンドポイント設定を入力してください。";
 "Approve" = "承認";
 "Install" = "インストール";
+"5-hour usage" = "5時間の使用量";
+"7-day usage" = "7日間の使用量";
+"Total usage" = "合計使用量";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1394,3 +1394,6 @@
 "Enter every endpoint setting to review the exact network origins." = "정확한 네트워크 오리진을 검토하려면 모든 엔드포인트 설정을 입력하세요.";
 "Approve" = "승인";
 "Install" = "설치";
+"5-hour usage" = "5시간 사용량";
+"7-day usage" = "7일 사용량";
+"Total usage" = "총 사용량";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1426,3 +1426,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Vul alle eindpuntinstellingen in om de exacte netwerkherkomsten te controleren.";
 "Approve" = "Goedkeuren";
 "Install" = "Installeren";
+"5-hour usage" = "5-uursgebruik";
+"7-day usage" = "7-dagengebruik";
+"Total usage" = "Totaal gebruik";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1430,3 +1430,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Wprowadź wszystkie ustawienia punktów końcowych, aby sprawdzić dokładne źródła sieciowe.";
 "Approve" = "Zatwierdź";
 "Install" = "Zainstaluj";
+"5-hour usage" = "Użycie 5-godzinne";
+"7-day usage" = "Użycie 7-dniowe";
+"Total usage" = "Łączne użycie";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1427,3 +1427,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Preencha todos os ajustes de endpoint para conferir as origens de rede exatas.";
 "Approve" = "Aprovar";
 "Install" = "Instalar";
+"5-hour usage" = "Uso de 5 horas";
+"7-day usage" = "Uso de 7 dias";
+"Total usage" = "Uso total";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1428,3 +1428,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Укажите все параметры эндпоинта, чтобы просмотреть точные сетевые источники.";
 "Approve" = "Одобрить";
 "Install" = "Установить";
+"5-hour usage" = "Использование за 5 часов";
+"7-day usage" = "Использование за 7 дней";
+"Total usage" = "Общее использование";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1425,3 +1425,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Ange alla slutpunktsinställningar för att granska de exakta ursprungsadresserna.";
 "Approve" = "Godkänn";
 "Install" = "Installera";
+"5-hour usage" = "5-timmarsanvändning";
+"7-day usage" = "7-dagarsanvändning";
+"Total usage" = "Total användning";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1430,3 +1430,6 @@
 "Enter every endpoint setting to review the exact network origins." = "กรอกการตั้งค่าปลายทางทุกค่าเพื่อตรวจสอบต้นทางเครือข่ายที่แน่นอน";
 "Approve" = "อนุมัติ";
 "Install" = "ติดตั้ง";
+"5-hour usage" = "การใช้งาน 5 ชั่วโมง";
+"7-day usage" = "การใช้งาน 7 วัน";
+"Total usage" = "การใช้งานทั้งหมด";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1428,3 +1428,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Kullanılacak ağ kaynaklarını tam olarak incelemek için tüm uç nokta ayarlarını girin.";
 "Approve" = "Onayla";
 "Install" = "Yükle";
+"5-hour usage" = "5 saatlik kullanım";
+"7-day usage" = "7 günlük kullanım";
+"Total usage" = "Toplam kullanım";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1426,3 +1426,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Введіть усі параметри кінцевих точок, щоб переглянути точні джерела мережевих запитів.";
 "Approve" = "Схвалити";
 "Install" = "Встановити";
+"5-hour usage" = "Використання за 5 годин";
+"7-day usage" = "Використання за 7 днів";
+"Total usage" = "Загальне використання";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1427,3 +1427,6 @@
 "Enter every endpoint setting to review the exact network origins." = "Nhập đầy đủ các cài đặt điểm cuối để xem chính xác các nguồn mạng.";
 "Approve" = "Phê duyệt";
 "Install" = "Cài đặt";
+"5-hour usage" = "Mức sử dụng 5 giờ";
+"7-day usage" = "Mức sử dụng 7 ngày";
+"Total usage" = "Tổng mức sử dụng";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1405,3 +1405,6 @@
 "Enter every endpoint setting to review the exact network origins." = "请填写所有端点设置，以查看确切的网络来源。";
 "Approve" = "批准";
 "Install" = "安装";
+"5-hour usage" = "5 小时用量";
+"7-day usage" = "7 天用量";
+"Total usage" = "总用量";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1457,3 +1457,6 @@
 "Enter every endpoint setting to review the exact network origins." = "請填寫所有端點設定，以檢視確切的網路來源。";
 "Approve" = "核准";
 "Install" = "安裝";
+"5-hour usage" = "5 小時用量";
+"7-day usage" = "7 天用量";
+"Total usage" = "總用量";

--- a/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
@@ -18,6 +18,7 @@ struct KimiSubscriptionBalance: Codable, Sendable {
     let feature: String?
     let type: String?
     let amountUsedRatio: Double?
+    let kimiCodeUsedRatio: Double?
     let expireTime: String?
 }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -40,8 +40,8 @@ public enum KimiProviderDescriptor {
             metadata: ProviderMetadata(
                 id: .kimi,
                 displayName: "Kimi Code",
-                sessionLabel: "Weekly",
-                weeklyLabel: "Rate Limit",
+                sessionLabel: "7-day usage",
+                weeklyLabel: "5-hour usage",
                 opusLabel: nil,
                 supportsOpus: false,
                 supportsCredits: false,

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
@@ -172,15 +172,11 @@ extension KimiUsageSnapshot {
     }
 
     private static func isEquivalentToWeeklyWindow(_ window: RateWindow, weeklyWindow: RateWindow?) -> Bool {
-        guard let weeklyWindow else { return false }
+        // Suppress only on positive evidence: unreliable weekly counters deliberately withhold
+        // windowMinutes, and two lanes without reset timestamps cannot be proven to be the same quota.
+        guard let weeklyWindow, weeklyWindow.windowMinutes != nil else { return false }
         guard abs(window.usedPercent - weeklyWindow.usedPercent) <= 1 else { return false }
-        switch (window.resetsAt, weeklyWindow.resetsAt) {
-        case let (codeReset?, weeklyReset?):
-            return abs(codeReset.timeIntervalSince(weeklyReset)) <= 5 * 60
-        case (nil, nil):
-            return true
-        case (nil, .some), (.some, nil):
-            return false
-        }
+        guard let codeReset = window.resetsAt, let weeklyReset = weeklyWindow.resetsAt else { return false }
+        return abs(codeReset.timeIntervalSince(weeklyReset)) <= 5 * 60
     }
 }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
@@ -143,7 +143,17 @@ extension KimiUsageSnapshot {
             return NamedRateWindow(id: "kimi-code-7d", title: "Code 7-day", window: window)
         }
 
-        let extraRateWindows = [monthlyWindow, subscriptionCodeWeeklyWindow].compactMap(\.self)
+        // The membership 7-day Code ratio and the FEATURE_CODING weekly detail report the same
+        // underlying quota through two endpoints. When they agree, the extra row only duplicates
+        // the primary lane, so keep it just for the cases where it genuinely diverges.
+        let showsDistinctCodeWeeklyWindow = subscriptionCodeWeeklyWindow.map { codeWeekly in
+            !Self.isEquivalentToWeeklyWindow(codeWeekly.window, weeklyWindow: weeklyWindow)
+        } ?? false
+
+        let extraRateWindows = [
+            monthlyWindow,
+            showsDistinctCodeWeeklyWindow ? subscriptionCodeWeeklyWindow : nil,
+        ].compactMap(\.self)
 
         let identity = ProviderIdentitySnapshot(
             providerID: .kimi,
@@ -159,5 +169,18 @@ extension KimiUsageSnapshot {
             providerCost: nil,
             updatedAt: self.updatedAt,
             identity: identity)
+    }
+
+    private static func isEquivalentToWeeklyWindow(_ window: RateWindow, weeklyWindow: RateWindow?) -> Bool {
+        guard let weeklyWindow else { return false }
+        guard abs(window.usedPercent - weeklyWindow.usedPercent) <= 1 else { return false }
+        switch (window.resetsAt, weeklyWindow.resetsAt) {
+        case let (codeReset?, weeklyReset?):
+            return abs(codeReset.timeIntervalSince(weeklyReset)) <= 5 * 60
+        case (nil, nil):
+            return true
+        case (nil, .some), (.some, nil):
+            return false
+        }
     }
 }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
@@ -119,8 +119,9 @@ extension KimiUsageSnapshot {
         }
 
         let monthlyWindow = self.subscriptionBalance.flatMap { balance -> NamedRateWindow? in
-            // Monthly = shared subscription pool (`amountUsedRatio`), not the Code-only `kimiCodeUsedRatio`:
-            // the pool is shared across features, so amountUsedRatio is the real "subscription remaining".
+            // Total usage = shared subscription pool (`amountUsedRatio`), not the Code-only
+            // `kimiCodeUsedRatio`: the pool is shared across features, so amountUsedRatio is the
+            // real "subscription remaining". Matches the official "Total usage" lane.
             guard balance.feature == nil || balance.feature == "FEATURE_OMNI" else { return nil }
             guard balance.type == nil || balance.type == "SUBSCRIPTION" else { return nil }
             guard let ratio = balance.amountUsedRatio, ratio.isFinite else { return nil }
@@ -129,7 +130,7 @@ extension KimiUsageSnapshot {
                 windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
                 resetsAt: Self.parseDate(balance.expireTime),
                 resetDescription: nil)
-            return NamedRateWindow(id: "kimi-monthly", title: "Monthly", window: window)
+            return NamedRateWindow(id: "kimi-monthly", title: "Total usage", window: window)
         }
 
         let subscriptionCodeWeeklyWindow = self.subscriptionCodeWeeklyLimit.flatMap { limit -> NamedRateWindow? in

--- a/Tests/CodexBarTests/CLIUnificationGoldenTests.swift
+++ b/Tests/CodexBarTests/CLIUnificationGoldenTests.swift
@@ -90,10 +90,10 @@ struct CLIUnificationGoldenTests {
         Resets in 5d
         ---
         == kimi ==
-        Weekly: 70% left [========----]
+        7-day usage: 70% left [========----]
         Pace: 13% in reserve | Expected 43% used | Lasts until reset
         Resets in 4d
-        Rate Limit: 90% left [==========--]
+        5-hour usage: 90% left [==========--]
         Pace: 10% in reserve | Expected 20% used | Lasts until reset
         Resets in 4h
         ---

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -393,9 +393,9 @@ struct CodexBarWidgetProviderTests {
             secondary: RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
             tertiary: nil,
             usageRows: [
-                WidgetSnapshot.WidgetUsageRowSnapshot(id: "primary", title: "Weekly", percentLeft: 75),
-                WidgetSnapshot.WidgetUsageRowSnapshot(id: "secondary", title: "Rate Limit", percentLeft: 50),
-                WidgetSnapshot.WidgetUsageRowSnapshot(id: "kimi-monthly", title: "Monthly", percentLeft: 25),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "primary", title: "7-day usage", percentLeft: 75),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "secondary", title: "5-hour usage", percentLeft: 50),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "kimi-monthly", title: "Total usage", percentLeft: 25),
                 WidgetSnapshot.WidgetUsageRowSnapshot(id: "kimi-code-7d", title: "Code 7-day", percentLeft: 90),
             ],
             creditsRemaining: nil,

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -827,6 +827,7 @@ struct KimiUsageResponseParsingTests {
         #expect(response.subscriptionBalance?.feature == "FEATURE_OMNI")
         #expect(response.subscriptionBalance?.type == "SUBSCRIPTION")
         #expect(response.subscriptionBalance?.amountUsedRatio == 1)
+        #expect(response.subscriptionBalance?.kimiCodeUsedRatio == 0.2854)
         #expect(response.subscriptionBalance?.expireTime == "2026-07-23T00:00:00Z")
         #expect(response.ratelimitCode7d?.ratio == 0.0946)
         #expect(response.ratelimitCode7d?.enabled == true)
@@ -1096,6 +1097,7 @@ struct KimiUsageSnapshotConversionTests {
             feature: "FEATURE_OMNI",
             type: "SUBSCRIPTION",
             amountUsedRatio: 1,
+            kimiCodeUsedRatio: nil,
             expireTime: "2026-07-23T00:00:00Z")
 
         let snapshot = KimiUsageSnapshot(
@@ -1107,7 +1109,7 @@ struct KimiUsageSnapshotConversionTests {
 
         let monthly = try #require(usageSnapshot.extraRateWindows?.first)
         #expect(monthly.id == "kimi-monthly")
-        #expect(monthly.title == "Monthly")
+        #expect(monthly.title == "Total usage")
         #expect(monthly.window.usedPercent == 100)
         #expect(monthly.window.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
         #expect(monthly.window.resetsAt == Self.date("2026-07-23T00:00:00Z"))
@@ -1127,6 +1129,7 @@ struct KimiUsageSnapshotConversionTests {
             feature: "FEATURE_OMNI",
             type: "SUBSCRIPTION",
             amountUsedRatio: 0.7716,
+            kimiCodeUsedRatio: nil,
             expireTime: "2026-07-23T00:00:00Z")
 
         let snapshot = KimiUsageSnapshot(
@@ -1270,6 +1273,7 @@ struct KimiUsageSnapshotConversionTests {
                     feature: "FEATURE_OMNI",
                     type: "SUBSCRIPTION",
                     amountUsedRatio: .nan,
+                    kimiCodeUsedRatio: nil,
                     expireTime: nil),
                 subscriptionCodeWeeklyLimit: limit,
                 updatedAt: Date())

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -1171,6 +1171,55 @@ struct KimiUsageSnapshotConversionTests {
     }
 
     @Test
+    func `hides code weekly window when it matches the primary weekly lane`() {
+        // Live Kimi responses report the same 7-day Code quota from both GetUsages (FEATURE_CODING
+        // detail) and GetSubscriptionStats (ratelimitCode7d); showing both rows duplicates one lane.
+        let now = Date()
+        let weeklyDetail = KimiUsageDetail(
+            limit: "100",
+            used: "29",
+            remaining: "71",
+            resetTime: "2026-08-13T17:02:44Z")
+        let subscriptionCodeWeeklyLimit = KimiSubscriptionRateLimit(
+            ratio: 0.2935,
+            enabled: true,
+            resetTime: "2026-08-13T17:02:43Z")
+
+        let snapshot = KimiUsageSnapshot(
+            weekly: weeklyDetail,
+            rateLimit: nil,
+            subscriptionBalance: nil,
+            subscriptionCodeWeeklyLimit: subscriptionCodeWeeklyLimit,
+            updatedAt: now)
+
+        #expect(snapshot.toUsageSnapshot().extraRateWindows == nil)
+    }
+
+    @Test
+    func `keeps code weekly window when the weekly detail is unreliable`() throws {
+        let now = Date()
+        let weeklyDetail = KimiUsageDetail(
+            limit: "not-a-number",
+            used: nil,
+            remaining: nil,
+            resetTime: nil)
+        let subscriptionCodeWeeklyLimit = KimiSubscriptionRateLimit(
+            ratio: 0.2935,
+            enabled: true,
+            resetTime: "2026-08-13T17:02:43Z")
+
+        let snapshot = KimiUsageSnapshot(
+            weekly: weeklyDetail,
+            rateLimit: nil,
+            subscriptionBalance: nil,
+            subscriptionCodeWeeklyLimit: subscriptionCodeWeeklyLimit,
+            updatedAt: now)
+        let windows = try #require(snapshot.toUsageSnapshot().extraRateWindows)
+
+        #expect(windows.map(\.id) == ["kimi-code-7d"])
+    }
+
+    @Test
     func `omits disabled and nonfinite subscription quota ratios`() {
         let weeklyDetail = KimiUsageDetail(
             limit: "2048",

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -1199,14 +1199,44 @@ struct KimiUsageSnapshotConversionTests {
     func `keeps code weekly window when the weekly detail is unreliable`() throws {
         let now = Date()
         let weeklyDetail = KimiUsageDetail(
-            limit: "not-a-number",
+            limit: "100",
             used: nil,
             remaining: nil,
             resetTime: nil)
         let subscriptionCodeWeeklyLimit = KimiSubscriptionRateLimit(
+            ratio: 0,
+            enabled: true,
+            resetTime: nil)
+
+        let snapshot = KimiUsageSnapshot(
+            weekly: weeklyDetail,
+            rateLimit: nil,
+            subscriptionBalance: nil,
+            subscriptionCodeWeeklyLimit: subscriptionCodeWeeklyLimit,
+            updatedAt: now)
+        let usageSnapshot = snapshot.toUsageSnapshot()
+        let windows = try #require(usageSnapshot.extraRateWindows)
+
+        // The numeric-limit fallback creates an unreliable 0% primary lane with no duration; it must
+        // never suppress the subscription Code quota, which is the only reliable 7-day reading here.
+        #expect(usageSnapshot.primary?.windowMinutes == nil)
+        #expect(windows.map(\.id) == ["kimi-code-7d"])
+    }
+
+    @Test
+    func `keeps code weekly window when neither lane reports a reset time`() throws {
+        // Matching percentages alone cannot prove the lanes are the same quota: without reset
+        // evidence on both sides, two independent quotas could coincide, so keep the Code row.
+        let now = Date()
+        let weeklyDetail = KimiUsageDetail(
+            limit: "100",
+            used: "29",
+            remaining: "71",
+            resetTime: nil)
+        let subscriptionCodeWeeklyLimit = KimiSubscriptionRateLimit(
             ratio: 0.2935,
             enabled: true,
-            resetTime: "2026-08-13T17:02:43Z")
+            resetTime: nil)
 
         let snapshot = KimiUsageSnapshot(
             weekly: weeklyDetail,

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -139,7 +139,7 @@ struct ProviderInlineDashboardModelTests {
             now: now))
 
         #expect(model.metrics.map(\.id) == ["secondary", "primary"])
-        #expect(model.metrics.map(\.title) == ["Rate Limit", "Weekly"])
+        #expect(model.metrics.map(\.title) == ["5-hour usage", "7-day usage"])
         #expect(model.metrics.map(\.detailLeftText) == ["11% in reserve", "25% in reserve"])
         #expect(model.metrics.map(\.detailRightText) == ["Lasts until reset", "Lasts until reset"])
         #expect(model.metrics.allSatisfy { $0.pacePercent != nil })

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -92,7 +92,7 @@ struct UsageStoreWidgetSnapshotTests {
                         resetDescription: nil)),
                 NamedRateWindow(
                     id: "kimi-monthly",
-                    title: "Monthly",
+                    title: "Total usage",
                     window: RateWindow(
                         usedPercent: 75,
                         windowMinutes: nil,
@@ -117,7 +117,7 @@ struct UsageStoreWidgetSnapshotTests {
         let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .kimi })
         // Widgets preserve persisted lane order; menu-only presentation may reorder these lanes.
         #expect(entry.usageRows?.map(\.id) == ["primary", "secondary", "kimi-monthly", "kimi-code-7d"])
-        #expect(entry.usageRows?.map(\.title) == ["Weekly", "Rate Limit", "Monthly", "Code 7-day"])
+        #expect(entry.usageRows?.map(\.title) == ["7-day usage", "5-hour usage", "Total usage", "Code 7-day"])
         #expect(entry.usageRows?.compactMap(\.percentLeft) == [75, 50, 25, 90])
     }
 


### PR DESCRIPTION
## Summary
- Kimi Code accounts were showing the same 7-day quota twice: once as the primary "Weekly" lane and again as a "Code 7-day" extra window.
- Verified against a live Kimi account (read-only): the `GetUsages` FEATURE_CODING detail and the `GetSubscriptionStats` `ratelimitCode7d` field report the same 7-day Code quota (identical usage counts and reset timestamps, e.g. 29/100 requests resetting at the same instant).
- Hide the Code 7-day extra window only on positive evidence that it duplicates the primary weekly lane: the primary lane must be reliable (unreliable counters withhold `windowMinutes`), used percent must be within 1pt, AND both lanes must report reset timestamps within 5 minutes. Two missing resets no longer count as a match, so genuine separate quotas still render.

## Review follow-up (353531681)
- Addressed both ClawSweeper findings on the suppression helper:
  - [P2] Preserve the Code quota for unreliable weekly counters: a numeric weekly limit with absent/malformed counters produces a 0% primary window with no duration; that unreliable lane can no longer suppress the subscription Code quota.
  - [P2] Require reset evidence before treating quota lanes as duplicates: when either lane omits a reset timestamp the Code row is kept, so coincidentally similar percentages cannot hide an independent quota.
- Regression tests:
  - numeric-limit fallback with missing counters (unreliable 0% primary lane, matching 0% ratio, no resets on either side) keeps the Code row;
  - matching percentages with both reset timestamps missing keeps the Code row.

## Test
- `swift test --filter "code weekly window"`: 3 passed (hide-on-match, keep-on-unreliable, keep-on-missing-resets).
- `swift test --filter KimiProviderTests`: 73 passed.
- `make check`: 0 violations.
- Real-app proof: rebuilt app shows only `kimi-monthly` as the extra window; the duplicate Code 7-day row no longer renders.

## Official naming alignment (36e8981f)
- Kimi lanes now match the official Kimi "Usage Progress" descriptions and order: `5-hour usage` (secondary), `7-day usage` (primary), `Total usage` (subscription pool). The menu already rendered in this order; the previous generic "Rate Limit"/"Weekly"/"Monthly" labels are replaced with the official terms, including translations in all app locales.
- Confirmed the official `GetSubscriptionStats` API returns the total-quota breakdown: `subscriptionBalance.amountUsedRatio` is the total quota usage (official UI: 93.81%) and `subscriptionBalance.kimiCodeUsedRatio` is the Code share of that total (official UI tooltip: Kimi Code usage 73.68%). `KimiSubscriptionBalance` now decodes `kimiCodeUsedRatio` and the parsing test asserts it (0.2854 from the live fixture).
- Updated menu-card, widget, and CLI golden expectations for the new labels; 217 focused tests pass and `make check` reports 0 violations.
