### PR TITLE
Menu: let metric meta and reset rows wrap instead of truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 
 ### Fixed
 
+### Fixed
+- Menu: let compact metric detail and reset rows wrap to a second line instead of truncating, so non-English locales keep the full pace and reset information (refs #2182).
+
 ## 0.48.0 — 2026-08-06
 
 ### Added

--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -107,8 +107,10 @@ extension UsageMenuCardView.Model.Metric {
         return MenuCardHeightFingerprint.join([
             self.id,
             self.statusText == nil ? "status=0" : "status=1",
-            presentation.resetText == nil ? "reset=0" : "reset=1",
-            presentation.metaText == nil ? "meta=0" : "meta=1",
+            // Reset and meta rows may wrap to a second line, so their text
+            // content (not just presence) can change the measured card height.
+            MenuCardHeightFingerprint.field("reset", presentation.resetText),
+            MenuCardHeightFingerprint.field("meta", presentation.metaText),
             self.detailText == nil ? "detail=0" : "detail=1",
             self.pacePercent == nil ? "pace=0" : "pace=1",
             self.paceOnTop ? "paceTop=1" : "paceTop=0",

--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -107,6 +107,11 @@ extension UsageMenuCardView.Model.Metric {
         return MenuCardHeightFingerprint.join([
             self.id,
             self.statusText == nil ? "status=0" : "status=1",
+            // The title shares horizontal space with a wrapping reset label. Track it only
+            // when that label exists so ordinary percentage ticks keep the fixed-row cache.
+            presentation.resetText == nil
+                ? "title=fixed"
+                : MenuCardHeightFingerprint.field("title", presentation.titleText),
             // Reset and meta rows may wrap to a second line, so their text
             // content (not just presence) can change the measured card height.
             MenuCardHeightFingerprint.field("reset", presentation.resetText),

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -539,7 +539,9 @@ private struct MetricRow: View {
                         Text(resetText)
                             .font(.footnote)
                             .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                            .lineLimit(1)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.trailing)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
                 UsageProgressBar(
@@ -554,8 +556,9 @@ private struct MetricRow: View {
                     Text(metaText)
                         .font(.footnote)
                         .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                        .lineLimit(1)
+                        .lineLimit(2)
                         .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 if let detail = self.metric.detailText {
                     Text(detail)

--- a/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
+++ b/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
@@ -34,7 +34,7 @@ struct MenuCardHeightFingerprintTests {
     }
 
     @Test
-    func `height fingerprint tracks optional metric rows rather than their text`() {
+    func `height fingerprint tracks wrapping metric text content`() {
         let bare = Self.model(statusText: nil).heightFingerprint(section: "card")
         let withReset = Self.model(statusText: nil, resetText: "Resets in 2h").heightFingerprint(section: "card")
         let withMeta = Self.model(statusText: nil, detailLeftText: "20% in reserve")
@@ -52,8 +52,29 @@ struct MenuCardHeightFingerprintTests {
 
         #expect(bare != withReset)
         #expect(bare != withMeta)
-        #expect(withMeta == withChangedMeta)
-        #expect(withMeta == withFoldedForecast)
+        // Meta and reset rows can wrap to a second line, so any text change
+        // must invalidate the cached height instead of reusing a short frame.
+        #expect(withMeta != withChangedMeta)
+        #expect(withMeta != withFoldedForecast)
+    }
+
+    @Test
+    func `height fingerprint invalidates when wrapping text grows from short to long`() {
+        let shortReset = Self.model(statusText: nil, resetText: "Resets in 2h")
+            .heightFingerprint(section: "card")
+        let longReset = Self.model(
+            statusText: nil,
+            resetText: "Resets tomorrow at 6:00 AM after a very long localized description")
+            .heightFingerprint(section: "card")
+        let shortMeta = Self.model(statusText: nil, detailLeftText: "On pace")
+            .heightFingerprint(section: "card")
+        let longMeta = Self.model(
+            statusText: nil,
+            detailLeftText: "Estimated 2 session quotas left with a generously long localized pace explanation")
+            .heightFingerprint(section: "card")
+
+        #expect(shortReset != longReset)
+        #expect(shortMeta != longMeta)
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
+++ b/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
@@ -62,6 +62,8 @@ struct MenuCardHeightFingerprintTests {
     func `height fingerprint invalidates when wrapping text grows from short to long`() {
         let shortReset = Self.model(statusText: nil, resetText: "Resets in 2h")
             .heightFingerprint(section: "card")
+        let widerTitle = Self.model(percent: 100, statusText: nil, resetText: "Resets in 2h")
+            .heightFingerprint(section: "card")
         let longReset = Self.model(
             statusText: nil,
             resetText: "Resets tomorrow at 6:00 AM after a very long localized description")
@@ -73,6 +75,7 @@ struct MenuCardHeightFingerprintTests {
             detailLeftText: "Estimated 2 session quotas left with a generously long localized pace explanation")
             .heightFingerprint(section: "card")
 
+        #expect(shortReset != widerTitle)
         #expect(shortReset != longReset)
         #expect(shortMeta != longMeta)
     }

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1942,7 +1942,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 635,
+            line: 638,
             anchor: "guard self.model.provider == .doubao else { return nil }",
             expectedProviderIDs: ["doubao"],
             expectedReferenceCount: 1,
@@ -1950,7 +1950,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1062,
+            line: 1065,
             anchor: "if provider == .kiro,",
             expectedProviderIDs: ["kilo", "kiro"],
             expectedReferenceCount: 2,
@@ -1958,7 +1958,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1085,
+            line: 1088,
             anchor: "if provider == .minimax {",
             expectedProviderIDs: ["codex", "minimax"],
             expectedReferenceCount: 2,
@@ -1966,7 +1966,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1120,
+            line: 1123,
             anchor: "guard let loginMethod = snapshot?.loginMethod(for: .kilo) else {",
             expectedProviderIDs: ["kilo"],
             expectedReferenceCount: 1,
@@ -1974,7 +1974,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1204,
+            line: 1207,
             anchor: "if input.provider == .antigravity {",
             expectedProviderIDs: ["antigravity", "mistral"],
             expectedReferenceCount: 2,
@@ -1982,7 +1982,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1224,
+            line: 1227,
             anchor: "if input.provider == .codex, let codexProjection = input.codexProjection {",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "codex", "perplexity", "sub2api"],
             expectedReferenceCount: 6,
@@ -1997,7 +1997,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1275,
+            line: 1278,
             anchor: "if input.provider == .kilo || input.provider == .kimi,",
             expectedProviderIDs: ["kilo", "kimi"],
             expectedReferenceCount: 2,
@@ -2005,7 +2005,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1357,
+            line: 1360,
             anchor: "var paceDetail = if input.provider == .kimi {",
             expectedProviderIDs: ["kimi"],
             expectedReferenceCount: 1,
@@ -2013,7 +2013,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1373,
+            line: 1376,
             anchor: "if input.provider == .warp,",
             expectedProviderIDs: ["chutes", "kilo", "kiro", "litellm", "sub2api", "warp"],
             expectedReferenceCount: 6,
@@ -2021,7 +2021,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1406,
+            line: 1409,
             anchor: "if input.provider == .alibaba || input.provider == .alibabatokenplan,",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "copilot", "crof", "manus", "perplexity", "zenmux"],
             expectedReferenceCount: 8,
@@ -2038,7 +2038,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1447,
+            line: 1450,
             anchor: "if input.provider == .synthetic,",
             expectedProviderIDs: ["synthetic"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
+++ b/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
@@ -184,6 +184,35 @@ struct UsageMenuCardLayoutTests {
         #expect(longHeight - shortHeight < 20)
     }
 
+    @Test
+    func `metric reset wraps to a bounded second line at standard width`() {
+        let width: CGFloat = 296
+        func card(resetText: String) -> UsageMenuCardView {
+            UsageMenuCardView(model: Self.model(metrics: [
+                UsageMenuCardView.Model.Metric(
+                    id: "weekly",
+                    title: "Weekly",
+                    percent: 69,
+                    percentStyle: .left,
+                    resetText: resetText,
+                    detailText: nil,
+                    detailLeftText: nil,
+                    detailRightText: nil,
+                    pacePercent: nil,
+                    paceOnTop: true),
+            ]), width: width)
+        }
+
+        let shortHeight = NSHostingController(rootView: card(resetText: "Resets in 2h"))
+            .sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude)).height
+        let longHeight = NSHostingController(rootView: card(
+            resetText: "Resets Wednesday, August 14 at 11:59 PM"))
+            .sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude)).height
+
+        #expect(longHeight - shortHeight > Self.heightTolerance)
+        #expect(longHeight - shortHeight < 20)
+    }
+
     private static func model(
         metrics: [UsageMenuCardView.Model.Metric] = [],
         usageNotes: [String] = [],

--- a/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
+++ b/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
@@ -147,7 +147,7 @@ struct UsageMenuCardLayoutTests {
     }
 
     @Test
-    func `metric detail remains one row as pace content grows`() {
+    func `metric detail wraps to a second row instead of truncating as pace content grows`() {
         let width: CGFloat = 296
         func card(
             detailRightText: String,
@@ -178,7 +178,10 @@ struct UsageMenuCardLayoutTests {
                 accessibilityLabel: "Est. 2 session quotas left · 6 windows until reset")))
             .sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude)).height
 
-        #expect(abs(shortHeight - longHeight) < Self.heightTolerance)
+        // The meta line may wrap to two lines so tail content stays readable
+        // instead of truncating; the card grows by roughly one text line.
+        #expect(longHeight - shortHeight > Self.heightTolerance)
+        #expect(longHeight - shortHeight < 20)
     }
 
     private static func model(


### PR DESCRIPTION
## Summary
- The compact usage rows from #2620 put all pace detail on a single `lineLimit(1)` meta line and moved the reset time into the title row. In longer locales (e.g. Chinese) the tail content truncates: "距重置…" cuts off the reset countdown, and "重置于 8月14日 晚…" never shows the time.
- Keep the compact layout, but let the meta line and reset label wrap to a second line so all information stays visible in every locale.
- Include the wrapping reset/meta text content in the menu-card height-cache fingerprint (`Metric.heightFingerprint`), so a short-to-long refresh re-measures the card instead of reusing a cached one-line frame that clips the second line.
- Updated the layout test that asserted the one-row contract: it now verifies the detail wraps to a second row (bounded growth) instead of truncating. Fingerprint tests now require meta/reset text changes to invalidate the fingerprint, plus a short-to-long regression test. Gatekeeper line anchors for MenuCardView shifted accordingly.

## Test
- `swift test --filter MenuCardHeightFingerprintTests` and `--filter UsageMenuCardLayoutTests`: 13/13 green (live output below).
- Full `make test` on the rebased head: 69/69 groups green (828 selections), 0 retries.
- `make check`: 0 violations in 1804 files.

## Live behavior proof
Focused run on this PR head (`a022b6501`), showing both the wrapping layout behavior and the height-cache invalidation:

```console
$ swift test --filter "MenuCardHeightFingerprintTests|UsageMenuCardLayoutTests"
✔ Test "height fingerprint invalidates when wrapping text grows from short to long" passed
✔ Test "height fingerprint tracks wrapping metric text content" passed
✔ Suite MenuCardHeightFingerprintTests passed
✔ Test "metric detail wraps to a second row instead of truncating as pace content grows" passed
✔ Suite UsageMenuCardLayoutTests passed
✔ Test run with 13 tests in 2 suites passed
```

`metric detail wraps to a second row instead of truncating as pace content grows` measures the rendered card via `sizeThatFits` at 296pt width: the long localized meta line grows the card by roughly one text line (asserted > heightTolerance and < 20pt), i.e. the second line renders instead of truncating. The fingerprint tests verify the cached height is invalidated whenever the wrapping reset/meta text changes, so the grown card actually gets its new frame on refresh.

## Rebase
- Rebased onto current `main` (`cee0fd074`); the rebased branch keeps the current percentage-label semantics. Branch is mergeable (no conflicts).