### PR TITLE
fix: make usage labels follow bar fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Settings: localize every Plugins pane control, status, approval prompt, and alert across all complete app locales.
 
 ### Fixed
+- Menu: make the Usage bars fill setting apply to percentage labels as well as bars again. Thanks @FrankSmithXYZ!
 - Codex: bound the persisted cost-usage cache with entry/byte budgets, window-aware pruning, and a load-refusal cap, so the main process no longer grows without limit on large session corpora (#2646, refs #2637). Thanks @Yuxin-Qiao!
 - Codex: resume fork catch-up from a validated cached offset when a rollout is appended, charging only the appended suffix against scan budgets instead of restarting the bounded full scan (#2648). Thanks @xx205!
 - Claude: report a provably unreadable OAuth delegated refresh as terminal with a long cooldown, instead of looping "run claude login, then retry" and relaunching the CLI every poll cycle (#2650, refs #2634). Thanks @kes02!

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -86,7 +86,7 @@ struct UsageMenuCardView: View {
             }
 
             func linePresentation(title: String) -> LinePresentation {
-                let usedPercent = self.percentStyle == .used ? self.percent : 100 - self.percent
+                // Keep the title aligned with the configured used/remaining label semantics.
                 let metaParts = [
                     self.detailLeftText,
                     self.detailRightText,
@@ -99,7 +99,7 @@ struct UsageMenuCardView: View {
                     return text
                 }
                 return LinePresentation(
-                    titleText: "\(title) \(UsageFormatter.percentString(usedPercent))",
+                    titleText: "\(title) \(self.percentLabel)",
                     resetText: self.resetText,
                     metaText: metaParts.isEmpty ? nil : metaParts.joined(separator: " · "))
             }

--- a/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
+++ b/Tests/CodexBarTests/UsageMenuCardLayoutTests.swift
@@ -91,7 +91,7 @@ struct UsageMenuCardLayoutTests {
     }
 
     @Test
-    func `metric line presentation keeps used percent and reset in title row`() {
+    func `metric line presentation keeps remaining percent and reset in title row`() {
         let metric = UsageMenuCardView.Model.Metric(
             id: "weekly",
             title: "Weekly",
@@ -110,7 +110,7 @@ struct UsageMenuCardLayoutTests {
 
         let presentation = metric.linePresentation(title: metric.title)
 
-        #expect(presentation.titleText == "Weekly 31%")
+        #expect(presentation.titleText == "Weekly 69% left")
         #expect(presentation.resetText == "Resets Jul 22, 8:33 AM")
         #expect(presentation.metaText ==
             "26% in deficit · Runs out in 19h 7m (85% risk) · " +
@@ -118,7 +118,7 @@ struct UsageMenuCardLayoutTests {
     }
 
     @Test
-    func `metric title always reports used percent`() {
+    func `metric title follows configured percent style`() {
         let leftMetric = UsageMenuCardView.Model.Metric(
             id: "weekly",
             title: "Weekly",
@@ -142,8 +142,8 @@ struct UsageMenuCardLayoutTests {
             pacePercent: nil,
             paceOnTop: true)
 
-        #expect(leftMetric.linePresentation(title: leftMetric.title).titleText == "Weekly 31%")
-        #expect(usedMetric.linePresentation(title: usedMetric.title).titleText == "Weekly 31%")
+        #expect(leftMetric.linePresentation(title: leftMetric.title).titleText == "Weekly 69% left")
+        #expect(usedMetric.linePresentation(title: usedMetric.title).titleText == "Weekly 31% used")
     }
 
     @Test


### PR DESCRIPTION
## Summary

CodexBar 0.48.0's compact usage-row presentation regressed the title percentage so it always showed the used value, even when the existing Usage bars fill setting was configured for remaining usage. This restores the setting's original contract: the toggle now flips both the bar fill and its localized title label (`69% left` versus `31% used`) while leaving pace details unchanged.

Thanks @FrankSmithXYZ for reporting the regression.

## Proof

- Focused `UsageMenuCardLayoutTests`: 7/7 passed
- `ProviderArchitectureGatekeeperTests`: 38/38 passed
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer make check`: passed
- Full suite, split into the two official shards: 416 + 408 = all 824 selections; 69/69 groups passed first try with zero failures, retries, or timeouts
- Structured Codex autoreview: clean, with no accepted/actionable findings

This is a deterministic text/model presentation change covered by focused tests. No live-account screenshot was captured, to avoid exposing account data.
