### PR TITLE
feat(cli): paint the serve dashboard instantly and stream data in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.48.1 — Unreleased
 
+### Added
+- CLI: add provider/detail snapshot queries and progressive cached-shell rendering to the built-in serve dashboard.
+
+### Fixed
+- CLI: answer expired serve-cache requests from the last-good response while rebuilding in the background instead of blocking the dashboard for up to a minute.
+
 ## 0.48.0 — 2026-08-06
 
 ### Added

--- a/Sources/CodexBarCLI/CLIDashboardCommand.swift
+++ b/Sources/CodexBarCLI/CLIDashboardCommand.swift
@@ -64,16 +64,22 @@ struct DashboardSnapshotProducer: Sendable {
         config: CodexBarConfig,
         refreshInterval: TimeInterval,
         codexBarVersion: String?,
-        identityMode: DashboardIdentityMode = .redacted) async throws -> DashboardSnapshotResult
+        identityMode: DashboardIdentityMode = .redacted,
+        providers requestedProviders: [UsageProvider]? = nil) async throws -> DashboardSnapshotResult
     {
-        let selection = CodexBarCLI.providerSelection(
+        let selection = requestedProviders.map(ProviderSelection.custom) ?? CodexBarCLI.providerSelection(
             rawOverride: nil,
             enabled: config.enabledProviders().compactMap(\.firstPartyProvider))
         let usageOutput = try await self.collectUsage(selection.asList)
         let costPayloads = await self.collectCost(
             CodexBarCLI.costProviders(from: selection),
             config)
-        let claudeSwap = await self.collectClaudeSwapAccounts(config)
+        // Provider-specific by design: claude-swap account enrichment is a
+        // Claude-only integration, so provider-filtered snapshots skip it
+        // unless the Claude row is requested.
+        let claudeSwap = selection.asList.contains(.claude)
+            ? await self.collectClaudeSwapAccounts(config)
+            : nil
         let generatedAt = self.now()
 
         let payload = DashboardSnapshotBuilder.makeSnapshot(

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -49,7 +49,7 @@ enum CLIServeRoute: Equatable {
     case health
     case usage(provider: String?)
     case cost(provider: String?)
-    case dashboardSnapshot
+    case dashboardSnapshot(provider: String?, detail: String?)
 }
 
 enum CLIServeRouteError: Error, Equatable {
@@ -80,7 +80,10 @@ enum CLIServeRouter {
         case "/cost":
             return .cost(provider: normalizedProvider)
         case "/dashboard/v1/snapshot":
-            return .dashboardSnapshot
+            let detail = queryItems["detail"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return .dashboardSnapshot(
+                provider: normalizedProvider,
+                detail: detail)
         default:
             throw CLIServeRouteError.notFound
         }
@@ -161,6 +164,7 @@ private struct ServeResponseRequest: Sendable {
     let configFingerprint: String
     let refreshInterval: TimeInterval
     let deadline: ContinuousClock.Instant?
+    let allowsStaleWhileRevalidate: Bool
 }
 
 struct CLIServeCoordinatedResponse: Sendable {
@@ -304,6 +308,24 @@ actor CLIServeResponseCache {
         return self.response(for: key)
     }
 
+    /// Returns a recently expired whole response for stale-while-revalidate.
+    /// Failure fallback keeps its provider-specific merge rules in
+    /// `completeFetch`; this path is only used before a refresh starts.
+    func staleResponseForRevalidation(
+        for key: String,
+        staleTTL: TimeInterval,
+        now: Date) -> CLILocalHTTPResponse?
+    {
+        guard staleTTL > 0 else { return nil }
+        self.pruneExpiredEntries(now: now)
+        guard let entry = self.lastGood[key],
+              now.timeIntervalSince(entry.recordedAt) <= staleTTL
+        else {
+            return nil
+        }
+        return entry.response
+    }
+
     /// Transforms a fetched response through the cache's stale policy. Successful
     /// responses are cached normally. Failed non-usage
     /// fetches may use a whole-response fallback within `staleTTL`; usage
@@ -331,18 +353,12 @@ actor CLIServeResponseCache {
             replaceCachedItems: shouldCache)
         if shouldCache {
             self.store(response, for: key, ttl: policy.ttl, now: now)
-            if key.hasPrefix("usage:") || key.hasPrefix("cost:") {
-                self.lastGood[key] = nil
-            } else {
-                self.lastGood[key] = LastGoodEntry(recordedAt: now, response: response)
-            }
+            self.lastGood[key] = LastGoodEntry(recordedAt: now, response: response)
             delivered = response
         } else if let usageMerge {
             delivered = usageMerge.response
-            self.lastGood[key] = nil
         } else if let costMerge {
             delivered = costMerge.response
-            self.lastGood[key] = nil
         } else {
             delivered = staleResponse ?? response
         }
@@ -555,7 +571,10 @@ actor CLIServeResponseCache {
     }
 
     func cachedStaleVariantCount() -> Int {
-        self.lastGood.count + self.lastGoodUsageItems.count + self.lastGoodCostItems.count
+        Set(self.lastGood.keys)
+            .union(self.lastGoodUsageItems.keys)
+            .union(self.lastGoodCostItems.keys)
+            .count
     }
 }
 
@@ -566,6 +585,7 @@ private enum CLIServeArgumentError: LocalizedError {
     case invalidRequestTimeout
     case emptyDashboardToken(source: String)
     case invalidProvider(String)
+    case invalidDashboardDetail(String)
 
     var errorDescription: String? {
         switch self {
@@ -581,6 +601,8 @@ private enum CLIServeArgumentError: LocalizedError {
             "\(source) must not be empty or whitespace."
         case let .invalidProvider(provider):
             "Unknown provider '\(provider)'."
+        case let .invalidDashboardDetail(detail):
+            "Unknown dashboard detail '\(detail)'."
         }
     }
 }
@@ -879,7 +901,8 @@ extension CodexBarCLI {
                     key: operationKey,
                     configFingerprint: snapshot.cacheToken,
                     refreshInterval: runtime.refreshInterval,
-                    deadline: requestDeadline),
+                    deadline: requestDeadline,
+                    allowsStaleWhileRevalidate: true),
                 cache: runtime.cache,
                 makeResponse: {
                     await Self.serveUsage(
@@ -910,7 +933,8 @@ extension CodexBarCLI {
                     key: operationKey,
                     configFingerprint: snapshot.cacheToken,
                     refreshInterval: runtime.refreshInterval,
-                    deadline: requestDeadline),
+                    deadline: requestDeadline,
+                    allowsStaleWhileRevalidate: true),
                 cache: runtime.cache,
                 makeResponse: {
                     await Self.serveCost(
@@ -924,7 +948,7 @@ extension CodexBarCLI {
                                 now: { ContinuousClock().now },
                                 providerOperations: runtime.costOperations)))
                 }))
-        case .dashboardSnapshot:
+        case let .dashboardSnapshot(provider, rawDetail):
             // Auth comes first: an unauthenticated request must not warm, read, or
             // deduplicate against the response cache.
             guard runtime.dashboardAuth.authorize(request) else {
@@ -932,19 +956,30 @@ extension CodexBarCLI {
             }
             let snapshot: CLIServeConfigSnapshot
             let operationKey: String
+            let detail: DashboardSnapshotDetail
+            let providers: [UsageProvider]?
             do {
                 snapshot = try Self.loadServeConfigSnapshot(configStore: runtime.configStore)
-                operationKey = try Self.serveOperationKey(kind: "dashboard", provider: nil)
+                operationKey = try Self.serveOperationKey(kind: "dashboard", provider: provider)
+                detail = try Self.dashboardSnapshotDetail(rawDetail)
+                providers = try Self.dashboardSnapshotProviders(provider)
             } catch {
                 let status: CLIHTTPStatus = error is CLIServeArgumentError ? .badRequest : .internalServerError
                 return Self.addingNoStore(Self.serveError(status: status, message: error.localizedDescription))
+            }
+            if detail == .shell {
+                return Self.addingNoStore(Self.serveDashboardShell(
+                    config: snapshot.config,
+                    providers: providers,
+                    runtime: runtime))
             }
             return await Self.addingNoStore(Self.cachedServeResponse(
                 request: ServeResponseRequest(
                     key: operationKey,
                     configFingerprint: snapshot.cacheToken,
                     refreshInterval: runtime.refreshInterval,
-                    deadline: requestDeadline),
+                    deadline: requestDeadline,
+                    allowsStaleWhileRevalidate: true),
                 cache: runtime.cache,
                 makeResponse: {
                     await Self.serveDashboardSnapshot(
@@ -966,9 +1001,40 @@ extension CodexBarCLI {
                                 providerOperations: runtime.costOperations),
                             costRefreshesPricingInBackground: Self.serveCostRefreshesPricingInBackground,
                             codexBarVersion: runtime.healthVersion),
-                        identityMode: runtime.dashboardIdentityMode)
+                        identityMode: runtime.dashboardIdentityMode,
+                        providers: providers)
                 }))
         }
+    }
+
+    private static func dashboardSnapshotDetail(_ rawDetail: String?) throws -> DashboardSnapshotDetail {
+        guard let rawDetail else { return .full }
+        guard let detail = DashboardSnapshotDetail(rawValue: rawDetail) else {
+            throw CLIServeArgumentError.invalidDashboardDetail(rawDetail)
+        }
+        return detail
+    }
+
+    private static func dashboardSnapshotProviders(_ rawProvider: String?) throws -> [UsageProvider]? {
+        try rawProvider.map { provider in
+            guard let selection = ProviderSelection(argument: provider) else {
+                throw CLIServeArgumentError.invalidProvider(provider)
+            }
+            return selection.asList
+        }
+    }
+
+    private static func serveDashboardShell(
+        config: CodexBarConfig,
+        providers: [UsageProvider]?,
+        runtime: ServeRuntime) -> CLILocalHTTPResponse
+    {
+        self.serveJSON(DashboardSnapshotBuilder.makeShellSnapshot(
+            config: config,
+            providers: providers,
+            generatedAt: Date(),
+            refreshInterval: runtime.refreshInterval,
+            codexBarVersion: runtime.healthVersion))
     }
 
     static func loadServeConfigSnapshot(
@@ -1009,16 +1075,19 @@ extension CodexBarCLI {
         cache: CLIServeResponseCache,
         refreshInterval: TimeInterval,
         requestTimeout: TimeInterval = CodexBarCLI.defaultServeRequestTimeout,
+        configFingerprint: String = "",
+        staleWhileRevalidate: Bool = false,
         makeResponse: @Sendable @escaping () async -> CLILocalHTTPResponse) async -> CLILocalHTTPResponse
     {
         await self.cachedServeResponse(
             request: ServeResponseRequest(
                 key: key,
-                configFingerprint: "",
+                configFingerprint: configFingerprint,
                 refreshInterval: refreshInterval,
                 deadline: self.serveRequestDeadline(
                     startedAt: ContinuousClock().now,
-                    requestTimeout: requestTimeout)),
+                    requestTimeout: requestTimeout),
+                allowsStaleWhileRevalidate: staleWhileRevalidate),
             cache: cache,
             makeResponse: makeResponse)
     }
@@ -1035,6 +1104,41 @@ extension CodexBarCLI {
             return response
         }
 
+        let policy = CLIServeResponseCache.CachePolicy(
+            ttl: request.refreshInterval,
+            staleTTL: Self.serveStaleTTL(refreshInterval: request.refreshInterval))
+        if request.allowsStaleWhileRevalidate,
+           let stale = await cache.staleResponseForRevalidation(
+               for: cacheKey,
+               staleTTL: policy.staleTTL,
+               now: Date())
+        {
+            Task.detached {
+                _ = await Self.refreshServeResponse(
+                    request: request,
+                    cacheKey: cacheKey,
+                    policy: policy,
+                    cache: cache,
+                    makeResponse: makeResponse)
+            }
+            return stale
+        }
+
+        return await Self.refreshServeResponse(
+            request: request,
+            cacheKey: cacheKey,
+            policy: policy,
+            cache: cache,
+            makeResponse: makeResponse)
+    }
+
+    private static func refreshServeResponse(
+        request: ServeResponseRequest,
+        cacheKey: String,
+        policy: CLIServeResponseCache.CachePolicy,
+        cache: CLIServeResponseCache,
+        makeResponse: @Sendable @escaping () async -> CLILocalHTTPResponse) async -> CLILocalHTTPResponse
+    {
         let timeoutResponse = Self.serveTimeoutResponse()
         let outcome = await cache.operations.value(
             for: request.key,
@@ -1045,9 +1149,7 @@ extension CodexBarCLI {
                 let committed = await cache.completeFetch(
                     fetched.response,
                     for: cacheKey,
-                    policy: CLIServeResponseCache.CachePolicy(
-                        ttl: request.refreshInterval,
-                        staleTTL: Self.serveStaleTTL(refreshInterval: request.refreshInterval)),
+                    policy: policy,
                     now: Date(),
                     shouldCache: Self.shouldCacheServeResponse(fetched.response))
                 return CLIServeCoordinatedResponse(response: committed, isCommitted: true)
@@ -1068,9 +1170,7 @@ extension CodexBarCLI {
         return await cache.completeFetch(
             outcome.response,
             for: cacheKey,
-            policy: CLIServeResponseCache.CachePolicy(
-                ttl: request.refreshInterval,
-                staleTTL: Self.serveStaleTTL(refreshInterval: request.refreshInterval)),
+            policy: policy,
             now: Date(),
             shouldCache: Self.shouldCacheServeResponse(outcome.response))
     }
@@ -1200,7 +1300,8 @@ extension CodexBarCLI {
     /// by the surrounding serve request path.
     private static func serveDashboardSnapshot(
         context: DashboardSnapshotContext,
-        identityMode: DashboardIdentityMode) async -> CLILocalHTTPResponse
+        identityMode: DashboardIdentityMode,
+        providers: [UsageProvider]? = nil) async -> CLILocalHTTPResponse
     {
         let result: DashboardSnapshotResult
         do {
@@ -1208,7 +1309,8 @@ extension CodexBarCLI {
                 config: context.config,
                 refreshInterval: context.usage.refreshInterval,
                 codexBarVersion: context.codexBarVersion,
-                identityMode: identityMode)
+                identityMode: identityMode,
+                providers: providers)
         } catch {
             return Self.serveError(status: .internalServerError, message: error.localizedDescription)
         }

--- a/Sources/CodexBarCLI/CLIServeWebUI+HTML.swift
+++ b/Sources/CodexBarCLI/CLIServeWebUI+HTML.swift
@@ -242,6 +242,33 @@ extension CLIServeWebUI {
           border-color: color-mix(in srgb, var(--ok), var(--line) 45%);
         }
 
+        .card.pending {
+          min-height: 132px;
+        }
+
+        .pending-lines {
+          display: grid;
+          gap: 9px;
+          margin-top: 18px;
+        }
+
+        .pending-line {
+          height: 9px;
+          border-radius: 999px;
+          background: color-mix(in srgb, var(--accent), transparent 84%);
+          animation: pending-pulse 1.6s ease-in-out infinite;
+        }
+
+        .pending-line:last-child {
+          width: 62%;
+          animation-delay: 120ms;
+        }
+
+        @keyframes pending-pulse {
+          0%, 100% { opacity: 0.42; }
+          50% { opacity: 0.9; }
+        }
+
         .group {
           margin-bottom: 26px;
         }
@@ -535,7 +562,9 @@ extension CLIServeWebUI {
         }
 
         @media (prefers-reduced-motion: reduce) {
-          .fill {
+          .fill,
+          .pending-line {
+            animation: none;
             transition: none;
           }
         }
@@ -579,11 +608,16 @@ extension CLIServeWebUI {
         "use strict";
 
         const tokenKey = "codexbar.dashboardToken";
+        const snapshotKey = "codexbar.lastSnapshot";
         const providerIconURLs = __PROVIDER_ICON_URLS__;
         const state = {
           snapshot: null,
           timer: null,
           fetching: false,
+          fillPromise: null,
+          fillGeneration: 0,
+          fillComplete: false,
+          forceStale: false,
           refreshSeconds: 15,
           costHistories: {}
         };
@@ -621,6 +655,59 @@ extension CLIServeWebUI {
         function clearToken() {
           try {
             localStorage.removeItem(tokenKey);
+          } catch (_) {
+            // Nothing else to clear when storage is unavailable.
+          }
+        }
+
+        function storedSnapshot() {
+          try {
+            const snapshot = JSON.parse(localStorage.getItem(snapshotKey) || "null");
+            return snapshot && snapshot.schemaVersion === 1 && Array.isArray(snapshot.providers)
+              ? snapshot
+              : null;
+          } catch (_) {
+            return null;
+          }
+        }
+
+        function persistSnapshot(snapshot) {
+          try {
+            const persisted = {
+              ...snapshot,
+              providers: (snapshot.providers || []).filter(provider => !provider._pending).map(provider => {
+                const copy = { ...provider };
+                delete copy._pending;
+                delete copy._progressiveError;
+                copy.identity = redactedIdentity(copy.identity);
+                if (Array.isArray(copy.accounts)) {
+                  copy.accounts = copy.accounts.map(account => ({
+                    ...account,
+                    identity: redactedIdentity(account.identity)
+                  }));
+                }
+                return copy;
+              })
+            };
+            localStorage.setItem(snapshotKey, JSON.stringify(persisted));
+          } catch (_) {
+            // Rendering remains live when storage is unavailable or full.
+          }
+        }
+
+        function redactedIdentity(identity) {
+          if (!identity || !identity.accountEmail) return identity;
+          const email = String(identity.accountEmail);
+          const at = email.lastIndexOf("@");
+          return {
+            ...identity,
+            accountEmail: at >= 0 ? `redacted${email.slice(at)}` : "redacted"
+          };
+        }
+
+        function clearSnapshot() {
+          try {
+            localStorage.removeItem(snapshotKey);
           } catch (_) {
             // Nothing else to clear when storage is unavailable.
           }
@@ -834,7 +921,7 @@ extension CLIServeWebUI {
         }
 
         function renderProvider(provider) {
-          const card = node("article", "card");
+          const card = node("article", provider._pending ? "card pending" : "card");
           card.style.setProperty("--accent", accentColor(provider.display?.accentColor));
           if (provider.enabled === false) card.classList.add("disabled");
           if (provider.error) card.classList.add("error");
@@ -860,6 +947,13 @@ extension CLIServeWebUI {
             head.append(status);
           }
           card.append(head);
+
+          if (provider._pending) {
+            const lines = node("div", "pending-lines");
+            lines.append(node("span", "pending-line"), node("span", "pending-line"));
+            card.append(lines);
+            return card;
+          }
 
           if (provider.identity) {
             const identity = node("div", "identity");
@@ -909,12 +1003,14 @@ extension CLIServeWebUI {
             ? "Updated time unavailable"
             : `Updated ${relativeTime(state.snapshot.generatedAt)}`;
           const staleAfter = Math.max(0, finiteNumber(state.snapshot.staleAfterSeconds));
-          const stale = generatedAt !== null && (Date.now() - generatedAt) / 1000 > staleAfter;
+          const stale = state.forceStale
+            || (generatedAt !== null && (Date.now() - generatedAt) / 1000 > staleAfter);
           elements.stale.classList.toggle("visible", stale);
         }
 
-        function renderSnapshot(snapshot) {
+        function renderSnapshot(snapshot, forceStale = false) {
           state.snapshot = snapshot;
+          state.forceStale = forceStale;
           const host = snapshot.host || {};
           const interval = finiteNumber(host.refreshIntervalSeconds, 15);
           state.refreshSeconds = Math.max(interval, 15);
@@ -961,6 +1057,7 @@ extension CLIServeWebUI {
         }
 
         function showTokenForm() {
+          state.fillGeneration += 1;
           state.snapshot = null;
           elements.providers.replaceChildren();
           elements.error.classList.remove("visible");
@@ -982,6 +1079,119 @@ extension CLIServeWebUI {
           clearTimeout(state.timer);
           if (elements.auth.classList.contains("visible")) return;
           state.timer = setTimeout(refresh, state.refreshSeconds * 1000);
+        }
+
+        function requestHeaders(overrideToken) {
+          const token = overrideToken || storedToken();
+          return token ? { Authorization: `Bearer ${token}` } : {};
+        }
+
+        function progressiveErrorMessage(error) {
+          return error instanceof Error ? error.message : "Provider data is unavailable.";
+        }
+
+        function replaceProgressiveProvider(provider, snapshot, persist) {
+          if (!state.snapshot) return;
+          const providers = (state.snapshot.providers || []).map(existing => {
+            return existing.id === provider.id ? provider : existing;
+          });
+          state.snapshot = {
+            ...state.snapshot,
+            generatedAt: snapshot?.generatedAt || state.snapshot.generatedAt,
+            staleAfterSeconds: snapshot?.staleAfterSeconds ?? state.snapshot.staleAfterSeconds,
+            host: snapshot?.host || state.snapshot.host,
+            providers
+          };
+          renderSnapshot(state.snapshot, true);
+          if (persist) persistSnapshot(state.snapshot);
+        }
+
+        async function fetchProgressiveProvider(provider, headers, generation) {
+          try {
+            const response = await fetch(
+              `/dashboard/v1/snapshot?provider=${encodeURIComponent(provider.id)}`,
+              { headers, cache: "no-store" }
+            );
+            if (generation !== state.fillGeneration) return;
+            if (response.status === 401) {
+              showTokenForm();
+              return;
+            }
+            if (!response.ok) throw new Error(`Server returned HTTP ${response.status}`);
+            const snapshot = await response.json();
+            if (generation !== state.fillGeneration) return;
+            const row = (snapshot.providers || []).find(candidate => candidate.id === provider.id);
+            if (!row) throw new Error("Provider data was missing from the response.");
+            replaceProgressiveProvider(row, snapshot, true);
+          } catch (error) {
+            if (generation !== state.fillGeneration) return;
+            replaceProgressiveProvider({
+              ...provider,
+              _pending: false,
+              _progressiveError: true,
+              status: null,
+              identity: null,
+              windows: [],
+              credits: null,
+              cost: null,
+              accounts: null,
+              error: { message: progressiveErrorMessage(error) }
+            }, null, false);
+          }
+        }
+
+        async function runProgressiveFill(overrideToken) {
+          clearTimeout(state.timer);
+          const generation = ++state.fillGeneration;
+          const headers = requestHeaders(overrideToken);
+          let shell;
+          try {
+            const response = await fetch(
+              "/dashboard/v1/snapshot?detail=shell",
+              { headers, cache: "no-store" }
+            );
+            if (response.status === 401) {
+              showTokenForm();
+              return;
+            }
+            if (!response.ok) throw new Error(`Server returned HTTP ${response.status}`);
+            shell = await response.json();
+          } catch (error) {
+            if (!state.snapshot || !(state.snapshot.providers || []).length) {
+              showError(progressiveErrorMessage(error));
+              return;
+            }
+            shell = state.snapshot;
+          }
+          if (generation !== state.fillGeneration) return;
+
+          const cachedRows = new Map((state.snapshot?.providers || []).map(provider => [provider.id, provider]));
+          const shellRows = Array.isArray(shell.providers) ? shell.providers : [];
+          const providers = shellRows.map(provider => {
+            const cached = cachedRows.get(provider.id);
+            return cached
+              ? { ...cached, name: provider.name, enabled: provider.enabled, display: provider.display }
+              : { ...provider, _pending: true };
+          });
+          state.snapshot = { ...shell, providers };
+          renderSnapshot(state.snapshot, cachedRows.size > 0);
+
+          await Promise.allSettled(
+            providers.map(provider => fetchProgressiveProvider(provider, headers, generation))
+          );
+          if (generation !== state.fillGeneration) return;
+          state.fillComplete = true;
+          state.forceStale = false;
+          if (state.snapshot) renderSnapshot(state.snapshot);
+          scheduleRefresh();
+        }
+
+        function startProgressiveFill(overrideToken) {
+          if (state.fillPromise) return state.fillPromise;
+          state.fillPromise = runProgressiveFill(overrideToken).finally(() => {
+            state.fillPromise = null;
+          });
+          return state.fillPromise;
         }
 
         async function refreshCostHistory(headers) {
@@ -1011,8 +1221,7 @@ extension CLIServeWebUI {
           state.fetching = true;
           clearTimeout(state.timer);
           try {
-            const token = overrideToken || storedToken();
-            const headers = token ? { Authorization: `Bearer ${token}` } : {};
+            const headers = requestHeaders(overrideToken);
             const [response] = await Promise.all([
               fetch("/dashboard/v1/snapshot", { headers, cache: "no-store" }),
               refreshCostHistory(headers)
@@ -1028,7 +1237,9 @@ extension CLIServeWebUI {
               );
             }
             if (!response.ok) throw new Error(`Server returned HTTP ${response.status}`);
-            renderSnapshot(await response.json());
+            const snapshot = await response.json();
+            renderSnapshot(snapshot);
+            persistSnapshot(snapshot);
           } catch (error) {
             showError(error instanceof Error ? error.message : "The dashboard could not be refreshed.");
           } finally {
@@ -1043,21 +1254,28 @@ extension CLIServeWebUI {
           if (!token) return;
           saveToken(token);
           elements.token.value = "";
-          refresh(token);
+          if (state.fillComplete) refresh(token);
+          else startProgressiveFill(token);
         });
 
         elements.signOut.addEventListener("click", () => {
           clearToken();
+          clearSnapshot();
           clearTimeout(state.timer);
           showTokenForm();
         });
 
-        elements.retry.addEventListener("click", () => refresh());
+        elements.retry.addEventListener("click", () => {
+          if (state.fillComplete) refresh();
+          else startProgressiveFill();
+        });
 
         // No document.hidden gating: embedded panes and sidebars often report
         // "hidden" permanently, and browsers already throttle background timers.
         setInterval(updateFreshness, 1000);
-        refresh();
+        const cached = storedSnapshot();
+        if (cached) renderSnapshot(cached, true);
+        startProgressiveFill();
       </script>
     </body>
     </html>

--- a/Sources/CodexBarCLI/DashboardPayloads.swift
+++ b/Sources/CodexBarCLI/DashboardPayloads.swift
@@ -9,6 +9,11 @@ enum DashboardIdentityMode: String, Equatable, Sendable {
     case full
 }
 
+enum DashboardSnapshotDetail: String, Equatable, Sendable {
+    case full
+    case shell
+}
+
 struct DashboardSnapshotPayload: Encodable {
     let schemaVersion: Int
     let generatedAt: Date
@@ -51,6 +56,41 @@ struct DashboardProviderPayload: Encodable {
     let accounts: [DashboardAccountPayload]?
     /// Row-local failure of the multi-account source; the ambient provider row stays intact.
     let accountsError: String?
+    private let detail: DashboardSnapshotDetail
+
+    init(
+        id: String,
+        name: String,
+        enabled: Bool,
+        source: String,
+        status: DashboardStatusPayload?,
+        identity: DashboardIdentityPayload?,
+        windows: [DashboardWindowPayload],
+        credits: DashboardCreditsPayload?,
+        cost: DashboardCostPayload?,
+        display: DashboardDisplayPayload,
+        error: ProviderErrorPayload?,
+        updatedAt: Date?,
+        accounts: [DashboardAccountPayload]?,
+        accountsError: String?,
+        detail: DashboardSnapshotDetail = .full)
+    {
+        self.id = id
+        self.name = name
+        self.enabled = enabled
+        self.source = source
+        self.status = status
+        self.identity = identity
+        self.windows = windows
+        self.credits = credits
+        self.cost = cost
+        self.display = display
+        self.error = error
+        self.updatedAt = updatedAt
+        self.accounts = accounts
+        self.accountsError = accountsError
+        self.detail = detail
+    }
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -74,13 +114,14 @@ struct DashboardProviderPayload: Encodable {
         try container.encode(self.id, forKey: .id)
         try container.encode(self.name, forKey: .name)
         try container.encode(self.enabled, forKey: .enabled)
+        try container.encode(self.display, forKey: .display)
+        guard self.detail == .full else { return }
         try container.encode(self.source, forKey: .source)
         try container.encode(self.status, forKey: .status)
         try container.encode(self.identity, forKey: .identity)
         try container.encode(self.windows, forKey: .windows)
         try container.encode(self.credits, forKey: .credits)
         try container.encode(self.cost, forKey: .cost)
-        try container.encode(self.display, forKey: .display)
         try container.encode(self.error, forKey: .error)
         try container.encode(self.updatedAt, forKey: .updatedAt)
         try container.encodeIfPresent(self.accounts, forKey: .accounts)

--- a/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
+++ b/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
@@ -10,6 +10,13 @@ struct DashboardClaudeSwapInput {
 /// Projects the CLI's provider usage and cost payloads into the stable,
 /// display-oriented `/dashboard/v1/snapshot` contract.
 enum DashboardSnapshotBuilder {
+    private struct ProviderPresentation {
+        let id: String
+        let name: String
+        let enabled: Bool
+        let display: DashboardDisplayPayload
+    }
+
     // swiftlint:disable:next function_parameter_count
     static func makeSnapshot(
         usagePayloads: [ProviderPayload],
@@ -25,12 +32,6 @@ enum DashboardSnapshotBuilder {
         for cost in costPayloads {
             costByProvider[cost.provider] = cost
         }
-        let enabledProviders = Set(config.enabledProviders().compactMap(\.firstPartyProvider))
-        var sortKeys: [String: Int] = [:]
-        for (index, provider) in config.orderedProviders().enumerated() where sortKeys[provider.rawValue] == nil {
-            sortKeys[provider.rawValue] = index * 10
-        }
-
         var attachedClaudeSwap = false
         let providers = usagePayloads.enumerated().map { index, payload in
             var rowClaudeSwap: DashboardClaudeSwapInput?
@@ -39,11 +40,14 @@ enum DashboardSnapshotBuilder {
                 rowClaudeSwap = claudeSwap
                 attachedClaudeSwap = true
             }
+            let presentation = self.providerPresentation(
+                id: payload.provider,
+                config: config,
+                fallbackSortKey: 10000 + index)
             return self.makeProvider(
                 payload: payload,
                 cost: costByProvider[payload.provider],
-                enabledProviders: enabledProviders,
-                sortKey: sortKeys[payload.provider] ?? (10000 + index),
+                presentation: presentation,
                 identityMode: identityMode,
                 generatedAt: generatedAt,
                 claudeSwap: rowClaudeSwap)
@@ -60,12 +64,53 @@ enum DashboardSnapshotBuilder {
             providers: providers)
     }
 
+    static func makeShellSnapshot(
+        config: CodexBarConfig,
+        providers requestedProviders: [UsageProvider]? = nil,
+        generatedAt: Date,
+        refreshInterval: TimeInterval,
+        codexBarVersion: String?) -> DashboardSnapshotPayload
+    {
+        let providers = requestedProviders
+            ?? config.enabledProviders().compactMap(\.firstPartyProvider)
+        let rows = providers.enumerated().map { index, provider in
+            let presentation = self.providerPresentation(
+                id: provider.rawValue,
+                config: config,
+                fallbackSortKey: 10000 + index)
+            return DashboardProviderPayload(
+                id: presentation.id,
+                name: presentation.name,
+                enabled: presentation.enabled,
+                source: "",
+                status: nil,
+                identity: nil,
+                windows: [],
+                credits: nil,
+                cost: nil,
+                display: presentation.display,
+                error: nil,
+                updatedAt: nil,
+                accounts: nil,
+                accountsError: nil,
+                detail: .shell)
+        }
+        let refreshSeconds = self.dashboardRefreshSeconds(refreshInterval)
+        return DashboardSnapshotPayload(
+            schemaVersion: 1,
+            generatedAt: generatedAt,
+            staleAfterSeconds: max(180, refreshSeconds * 3),
+            host: DashboardHostPayload(
+                codexBarVersion: codexBarVersion,
+                refreshIntervalSeconds: refreshSeconds),
+            providers: rows)
+    }
+
     // swiftlint:disable:next function_parameter_count
     private static func makeProvider(
         payload: ProviderPayload,
         cost: CostPayload?,
-        enabledProviders: Set<UsageProvider>,
-        sortKey: Int,
+        presentation: ProviderPresentation,
         identityMode: DashboardIdentityMode,
         generatedAt: Date,
         claudeSwap: DashboardClaudeSwapInput?) -> DashboardProviderPayload
@@ -85,19 +130,16 @@ enum DashboardSnapshotBuilder {
             }
             : nil
         return DashboardProviderPayload(
-            id: payload.provider,
-            name: metadata?.displayName ?? payload.provider,
-            enabled: provider.map { enabledProviders.contains($0) } ?? true,
+            id: presentation.id,
+            name: presentation.name,
+            enabled: presentation.enabled,
             source: self.dashboardSource(from: payload.source),
             status: self.makeStatus(payload.status),
             identity: self.makeIdentity(provider: provider, usage: payload.usage, mode: identityMode),
             windows: self.makeWindows(provider: provider, metadata: metadata, usage: payload.usage),
             credits: self.makeCredits(payload.credits),
             cost: self.makeCost(cost, referenceDate: generatedAt),
-            display: DashboardDisplayPayload(
-                accentColor: self.hexColor(descriptor?.branding.color),
-                sortKey: sortKey,
-                priority: "normal"),
+            display: presentation.display,
             error: error,
             updatedAt: self.updatedAt(
                 payload: payload,
@@ -106,6 +148,26 @@ enum DashboardSnapshotBuilder {
                 generatedAt: generatedAt),
             accounts: accounts,
             accountsError: claudeSwap?.adapterError)
+    }
+
+    private static func providerPresentation(
+        id: String,
+        config: CodexBarConfig,
+        fallbackSortKey: Int) -> ProviderPresentation
+    {
+        let provider = UsageProvider(rawValue: id)
+        let descriptor = provider.map { ProviderDescriptorRegistry.descriptor(for: $0) }
+        let enabledProviders = Set(config.enabledProviders().compactMap(\.firstPartyProvider))
+        let sortKey = config.orderedProviders().firstIndex { $0.rawValue == id }.map { $0 * 10 }
+            ?? fallbackSortKey
+        return ProviderPresentation(
+            id: id,
+            name: descriptor?.metadata.displayName ?? id,
+            enabled: provider.map { enabledProviders.contains($0) } ?? true,
+            display: DashboardDisplayPayload(
+                accentColor: self.hexColor(descriptor?.branding.color),
+                sortKey: sortKey,
+                priority: "normal"))
     }
 
     private static func makeClaudeSwapAccount(

--- a/Tests/CodexBarTests/CLIServeRawHTTPTests.swift
+++ b/Tests/CodexBarTests/CLIServeRawHTTPTests.swift
@@ -201,6 +201,64 @@ struct CLIServeRawHTTPTests {
     }
 
     @Test
+    func `snapshot shell returns minimal provider rows without waiting for fetches`() async throws {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .claude, enabled: true),
+            ProviderConfig(id: .codex, enabled: false),
+        ])
+        try await Self.withServeRuntime(token: "secret", config: config, body: { port in
+            let startedAt = ContinuousClock().now
+            let response = try await Self.rawExchange(
+                port: port,
+                request: "GET /dashboard/v1/snapshot?detail=shell HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+                    + "Authorization: Bearer secret\r\n\r\n")
+            let elapsed = startedAt.duration(to: ContinuousClock().now)
+
+            #expect(response.statusLine == "HTTP/1.1 200 OK")
+            #expect(response.headerValue("Cache-Control") == "no-store")
+            #expect(elapsed < .seconds(1))
+            let object = try #require(
+                JSONSerialization.jsonObject(with: Data(response.body.utf8)) as? [String: Any])
+            let providers = try #require(object["providers"] as? [[String: Any]])
+            #expect(providers.count == 1)
+            #expect(providers[0]["id"] as? String == "claude")
+            #expect(Set(providers[0].keys) == ["id", "name", "enabled", "display"])
+        })
+    }
+
+    @Test
+    func `snapshot shell supports provider filter and rejects invalid query values`() async throws {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .claude, enabled: true),
+            ProviderConfig(id: .codex, enabled: true),
+        ])
+        try await Self.withServeRuntime(token: "secret", config: config, body: { port in
+            let filtered = try await Self.rawExchange(
+                port: port,
+                request: "GET /dashboard/v1/snapshot?detail=shell&provider=codex HTTP/1.1\r\n"
+                    + "Host: 127.0.0.1\r\nAuthorization: Bearer secret\r\n\r\n")
+            let invalidProvider = try await Self.rawExchange(
+                port: port,
+                request: "GET /dashboard/v1/snapshot?provider=missing HTTP/1.1\r\n"
+                    + "Host: 127.0.0.1\r\nAuthorization: Bearer secret\r\n\r\n")
+            let invalidDetail = try await Self.rawExchange(
+                port: port,
+                request: "GET /dashboard/v1/snapshot?detail=summary HTTP/1.1\r\n"
+                    + "Host: 127.0.0.1\r\nAuthorization: Bearer secret\r\n\r\n")
+
+            let object = try #require(
+                JSONSerialization.jsonObject(with: Data(filtered.body.utf8)) as? [String: Any])
+            let providers = try #require(object["providers"] as? [[String: Any]])
+            #expect(filtered.statusLine == "HTTP/1.1 200 OK")
+            #expect(providers.compactMap { $0["id"] as? String } == ["codex"])
+            #expect(invalidProvider.statusLine == "HTTP/1.1 400 Bad Request")
+            #expect(invalidProvider.body == #"{"error":"Unknown provider 'missing'."}"#)
+            #expect(invalidDetail.statusLine == "HTTP/1.1 400 Bad Request")
+            #expect(invalidDetail.body == #"{"error":"Unknown dashboard detail 'summary'."}"#)
+        })
+    }
+
+    @Test
     func `snapshot never accepts the token from the query string`() async throws {
         try await Self.withServeRuntime(token: "secret", body: { port in
             let response = try await Self.rawExchange(
@@ -391,12 +449,13 @@ struct CLIServeRawHTTPTests {
     static func withServeRuntime(
         token: String?,
         bindHost: String = "127.0.0.1",
+        config: CodexBarConfig? = nil,
         rawConfigJSON: String? = nil,
         body: (UInt16) async throws -> Void) async throws
     {
         let store = testConfigStore(suiteName: "CLIServeRawHTTPTests-\(UUID().uuidString)")
         defer { try? store.deleteIfPresent() }
-        try store.save(CodexBarConfig(providers: UsageProvider.allCases.map {
+        try store.save(config ?? CodexBarConfig(providers: UsageProvider.allCases.map {
             ProviderConfig(id: $0.instanceID, enabled: false)
         }))
         if let rawConfigJSON {

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -146,7 +146,28 @@ struct CLIServeRouterTests {
             try CLIServeRouter.route(
                 method: "GET",
                 path: "/dashboard/v1/snapshot",
-                queryItems: [:]) == .dashboardSnapshot)
+                queryItems: [:]) == .dashboardSnapshot(provider: nil, detail: nil))
+        #expect(
+            try CLIServeRouter.route(
+                method: "GET",
+                path: "/dashboard/v1/snapshot",
+                queryItems: ["provider": "claude"]) == .dashboardSnapshot(provider: "claude", detail: nil))
+        #expect(
+            try CLIServeRouter.route(
+                method: "GET",
+                path: "/dashboard/v1/snapshot",
+                queryItems: ["detail": "shell"]) == .dashboardSnapshot(provider: nil, detail: "shell"))
+        #expect(
+            try CLIServeRouter.route(
+                method: "GET",
+                path: "/dashboard/v1/snapshot",
+                queryItems: ["detail": "full"]) == .dashboardSnapshot(provider: nil, detail: "full"))
+        #expect(
+            try CLIServeRouter.route(
+                method: "GET",
+                path: "/dashboard/v1/snapshot",
+                queryItems: ["provider": "codex", "detail": "shell"]) ==
+                .dashboardSnapshot(provider: "codex", detail: "shell"))
     }
 
     @Test

--- a/Tests/CodexBarTests/CLIServeTimeoutTests.swift
+++ b/Tests/CodexBarTests/CLIServeTimeoutTests.swift
@@ -766,6 +766,21 @@ struct CLIServeTimeoutTests {
             sleepUntil: { deadline in try await clock.sleep(until: deadline) })
     }
 
+    private func seedExpiredLastGood(
+        _ response: CLILocalHTTPResponse,
+        key: String,
+        fingerprint: String,
+        cache: CLIServeResponseCache) async
+    {
+        let recordedAt = Date().addingTimeInterval(-61)
+        _ = await cache.completeFetch(
+            response,
+            for: CodexBarCLI.serveCacheKey(operationKey: key, configToken: fingerprint),
+            policy: CLIServeResponseCache.CachePolicy(ttl: 60, staleTTL: 600),
+            now: recordedAt,
+            shouldCache: true)
+    }
+
     private func waitForOperationCount(
         _ expected: Int,
         coordinator: CLIServeOperationCoordinator<some Sendable>) async
@@ -793,6 +808,154 @@ struct CLIServeTimeoutTests {
     }
 }
 
+extension CLIServeTimeoutTests {
+    @Test
+    func `expired response returns stale immediately while background refresh commits`() async {
+        let clock = ServeManualDeadlineClock()
+        let source = ServeFetchGate<CLILocalHTTPResponse>()
+        let operations: CLIServeOperationCoordinator<CLIServeCoordinatedResponse> = self.makeCoordinator(clock: clock)
+        let cache = CLIServeResponseCache(operations: operations)
+        let old = CLILocalHTTPResponse(status: .ok, body: Data(#"{"value":"old"}"#.utf8))
+        let new = CLILocalHTTPResponse(status: .ok, body: Data(#"{"value":"new"}"#.utf8))
+        await self.seedExpiredLastGood(old, key: "dashboard:default", fingerprint: "config-a", cache: cache)
+
+        let returned = await CodexBarCLI.cachedServeResponse(
+            key: "dashboard:default",
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 30,
+            configFingerprint: "config-a",
+            staleWhileRevalidate: true)
+        {
+            await source.run(new)
+        }
+
+        #expect(returned.body == old.body)
+        await source.waitForStarts(1)
+        #expect(await source.startCount() == 1)
+        await source.releaseAll()
+        await self.waitForOperationCount(0, coordinator: operations)
+
+        let refreshed = await CodexBarCLI.cachedServeResponse(
+            key: "dashboard:default",
+            cache: cache,
+            refreshInterval: 60,
+            requestTimeout: 30,
+            configFingerprint: "config-a")
+        {
+            await source.run(old)
+        }
+        #expect(refreshed.body == new.body)
+        #expect(await source.startCount() == 1)
+    }
+
+    @Test
+    func `concurrent stale hits coalesce into one background rebuild`() async {
+        let clock = ServeManualDeadlineClock()
+        let source = ServeFetchGate<CLILocalHTTPResponse>()
+        let operations: CLIServeOperationCoordinator<CLIServeCoordinatedResponse> = self.makeCoordinator(clock: clock)
+        let cache = CLIServeResponseCache(operations: operations)
+        let old = CLILocalHTTPResponse(status: .ok, body: Data(#"{"value":"old"}"#.utf8))
+        let new = CLILocalHTTPResponse(status: .ok, body: Data(#"{"value":"new"}"#.utf8))
+        await self.seedExpiredLastGood(old, key: "dashboard:default", fingerprint: "config-a", cache: cache)
+
+        let responses = await withTaskGroup(of: CLILocalHTTPResponse.self) { group in
+            for _ in 0..<2 {
+                group.addTask {
+                    await CodexBarCLI.cachedServeResponse(
+                        key: "dashboard:default",
+                        cache: cache,
+                        refreshInterval: 60,
+                        requestTimeout: 30,
+                        configFingerprint: "config-a",
+                        staleWhileRevalidate: true)
+                    {
+                        await source.run(new)
+                    }
+                }
+            }
+            var values: [CLILocalHTTPResponse] = []
+            for await response in group {
+                values.append(response)
+            }
+            return values
+        }
+
+        #expect(responses.allSatisfy { $0.body == old.body })
+        await source.waitForStarts(1)
+        #expect(await source.startCount() == 1)
+        await source.releaseAll()
+        await self.waitForOperationCount(0, coordinator: operations)
+        #expect(await source.startCount() == 1)
+    }
+
+    @Test
+    func `refresh interval zero blocks instead of serving stale`() async {
+        let clock = ServeManualDeadlineClock()
+        let source = ServeFetchGate<CLILocalHTTPResponse>()
+        let completion = ServeCompletionProbe()
+        let operations: CLIServeOperationCoordinator<CLIServeCoordinatedResponse> = self.makeCoordinator(clock: clock)
+        let cache = CLIServeResponseCache(operations: operations)
+        let old = CLILocalHTTPResponse(status: .ok, body: Data(#"{"value":"old"}"#.utf8))
+        let new = CLILocalHTTPResponse(status: .ok, body: Data(#"{"value":"new"}"#.utf8))
+        await self.seedExpiredLastGood(old, key: "dashboard:default", fingerprint: "config-a", cache: cache)
+
+        let request = Task {
+            let response = await CodexBarCLI.cachedServeResponse(
+                key: "dashboard:default",
+                cache: cache,
+                refreshInterval: 0,
+                requestTimeout: 30,
+                configFingerprint: "config-a",
+                staleWhileRevalidate: true)
+            {
+                await source.run(new)
+            }
+            await completion.finish()
+            return response
+        }
+        await source.waitForStarts(1)
+        #expect(await !(completion.isFinished()))
+        await source.releaseAll()
+
+        #expect(await request.value.body == new.body)
+        #expect(await source.startCount() == 1)
+    }
+
+    @Test
+    func `config fingerprint change blocks instead of serving another keys stale response`() async {
+        let clock = ServeManualDeadlineClock()
+        let source = ServeFetchGate<CLILocalHTTPResponse>()
+        let completion = ServeCompletionProbe()
+        let operations: CLIServeOperationCoordinator<CLIServeCoordinatedResponse> = self.makeCoordinator(clock: clock)
+        let cache = CLIServeResponseCache(operations: operations)
+        let old = CLILocalHTTPResponse(status: .ok, body: Data(#"{"config":"a"}"#.utf8))
+        let new = CLILocalHTTPResponse(status: .ok, body: Data(#"{"config":"b"}"#.utf8))
+        await self.seedExpiredLastGood(old, key: "dashboard:default", fingerprint: "config-a", cache: cache)
+
+        let request = Task {
+            let response = await CodexBarCLI.cachedServeResponse(
+                key: "dashboard:default",
+                cache: cache,
+                refreshInterval: 60,
+                requestTimeout: 30,
+                configFingerprint: "config-b",
+                staleWhileRevalidate: true)
+            {
+                await source.run(new)
+            }
+            await completion.finish()
+            return response
+        }
+        await source.waitForStarts(1)
+        #expect(await !(completion.isFinished()))
+        await source.releaseAll()
+
+        #expect(await request.value.body == new.body)
+        #expect(await source.startCount() == 1)
+    }
+}
+
 private actor ServeAcceptanceProbe<Value: Sendable> {
     private var calls = 0
 
@@ -803,6 +966,18 @@ private actor ServeAcceptanceProbe<Value: Sendable> {
 
     func callCount() -> Int {
         self.calls
+    }
+}
+
+private actor ServeCompletionProbe {
+    private var finished = false
+
+    func finish() {
+        self.finished = true
+    }
+
+    func isFinished() -> Bool {
+        self.finished
     }
 }
 

--- a/Tests/CodexBarTests/CLIServeWebUITests.swift
+++ b/Tests/CodexBarTests/CLIServeWebUITests.swift
@@ -50,6 +50,16 @@ struct CLIServeWebUITests {
     }
 
     @Test
+    func `web ui progressively paints cached shell and provider snapshots`() {
+        let html = self.html
+        #expect(html.contains("codexbar.lastSnapshot"))
+        #expect(html.contains("/dashboard/v1/snapshot?detail=shell"))
+        #expect(html.contains("card pending"))
+        #expect(html.contains("Promise.allSettled"))
+        #expect(html.contains("encodeURIComponent(provider.id)"))
+    }
+
+    @Test
     func `serve identity flag decodes like the dashboard command`() {
         #expect(CodexBarCLI.decodeDashboardIdentityMode(
             from: ParsedValues(positional: [], options: [:], flags: [])) == .redacted)

--- a/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
+++ b/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
@@ -132,6 +132,73 @@ struct DashboardSnapshotBuilderTests {
         #expect(object["generatedAt"] as? String == "2027-01-15T08:00:00Z")
     }
 
+    @Test
+    func `producer provider filter collects and returns exactly one row`() async throws {
+        let recorder = DashboardProviderSelectionRecorder()
+        let producer = DashboardSnapshotProducer(
+            collectUsage: { providers in
+                await recorder.recordUsage(providers)
+                var output = UsageCommandOutput()
+                output.payload = providers.map { provider in
+                    ProviderPayload(
+                        provider: provider,
+                        account: nil,
+                        version: nil,
+                        source: "test",
+                        status: nil,
+                        usage: nil,
+                        credits: nil,
+                        antigravityPlanInfo: nil,
+                        openaiDashboard: nil,
+                        error: nil)
+                }
+                return output
+            },
+            collectCost: { providers, _ in
+                await recorder.recordCost(providers)
+                return []
+            },
+            now: { Date(timeIntervalSince1970: 0) })
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .claude, enabled: true),
+            ProviderConfig(id: .codex, enabled: true),
+        ])
+
+        let result = try await producer.collect(
+            config: config,
+            refreshInterval: 60,
+            codexBarVersion: nil,
+            providers: [.codex])
+        let object = try self.jsonObject(result.payload)
+        let providers = try #require(object["providers"] as? [[String: Any]])
+
+        #expect(providers.compactMap { $0["id"] as? String } == ["codex"])
+        #expect(await recorder.usageProviders() == [.codex])
+        #expect(await recorder.costProviders() == [.codex])
+    }
+
+    @Test
+    func `shell builder emits config fields only without fetch collaborators`() throws {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .claude, enabled: true),
+            ProviderConfig(id: .codex, enabled: true),
+            ProviderConfig(id: .gemini, enabled: false),
+        ])
+        let snapshot = DashboardSnapshotBuilder.makeShellSnapshot(
+            config: config,
+            generatedAt: Date(timeIntervalSince1970: 0),
+            refreshInterval: 300,
+            codexBarVersion: "9.8.7")
+        let object = try self.jsonObject(snapshot)
+        let providers = try #require(object["providers"] as? [[String: Any]])
+
+        #expect(object["schemaVersion"] as? Int == 1)
+        #expect(providers.compactMap { $0["id"] as? String } == ["claude", "codex"])
+        #expect(providers.allSatisfy { Set($0.keys) == ["id", "name", "enabled", "display"] })
+        #expect((providers[0]["display"] as? [String: Any])?["sortKey"] as? Int == 0)
+        #expect((providers[1]["display"] as? [String: Any])?["sortKey"] as? Int == 10)
+    }
+
     private func costCollectionContext() -> ServeCostCollectionContext {
         ServeCostCollectionContext(
             configFingerprint: "dashboard-cost-policy",
@@ -623,5 +690,26 @@ private actor DashboardCostConfigRecorder {
 
     func call() -> Call? {
         self.recordedCall
+    }
+}
+
+private actor DashboardProviderSelectionRecorder {
+    private var usage: [UsageProvider] = []
+    private var cost: [UsageProvider] = []
+
+    func recordUsage(_ providers: [UsageProvider]) {
+        self.usage = providers
+    }
+
+    func recordCost(_ providers: [UsageProvider]) {
+        self.cost = providers
+    }
+
+    func usageProviders() -> [UsageProvider] {
+        self.usage
+    }
+
+    func costProviders() -> [UsageProvider] {
+        self.cost
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,8 +94,9 @@ See `docs/configuration.md` for the schema.
   - `--allow-plain-http` is the explicit acknowledgment that the bearer token crosses the network **in cleartext on every request** when serving on a non-loopback host. `serve` refuses to start on a non-loopback host without it.
   - Provider config is reloaded for each usage/cost request; cache entries are keyed by the loaded config so provider toggles and source changes do not require restarting `serve`.
   - Transient refresh failures fall back to the last good response for up to ten refresh intervals (minimum five minutes) so polling clients do not flicker between data and errors; disabled when `--refresh-interval 0`.
+  - After a cached response expires, `serve` returns the last-good response immediately while rebuilding it in the background; `--refresh-interval 0` keeps every request blocking.
   - The default loopback bind rejects non-loopback `Host` headers; a configured non-loopback `--host` additionally accepts its own name. No CORS, TLS, or daemon mode.
-  - Endpoints: `GET /` (web UI), `GET /health`, `GET /usage`, `GET /usage?provider=<id|both|all>`, `GET /cost`, `GET /cost?provider=<id|both|all>`, `GET /dashboard/v1/snapshot`.
+  - Endpoints: `GET /` (web UI), `GET /health`, `GET /usage`, `GET /usage?provider=<id|both|all>`, `GET /cost`, `GET /cost?provider=<id|both|all>`, `GET /dashboard/v1/snapshot` (plus `provider=<id>` and `detail=<full|shell>`).
   - `GET /dashboard/v1/snapshot` requires `Authorization: Bearer YOUR_TOKEN`; responses (and all `401`s) carry `Cache-Control: no-store`. The token is never accepted via query string. See `docs/dashboard-api.md` for the payload contract.
   - `GET /health` returns `{"status":"ok"}` plus a `version` field with the running build (e.g. `"0.37.2"`) when resolvable; clients can compare it against `codexbar --version` to detect a `serve` process still running an older binary after an update.
   - Codex usage responses include every visible Codex account, matching the menu bar switcher.

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -32,6 +32,8 @@ On the default loopback bind, `/usage` and `/cost` are unchanged and unauthentic
 
 `GET /` serves a self-contained web dashboard that polls `/dashboard/v1/snapshot`. The static HTML is always unauthenticated, including on non-loopback binds, because it contains no account data. When the snapshot route returns `401`, the page asks for the dashboard token, stores it in the browser under the localStorage key `codexbar.dashboardToken`, and sends it in the `Authorization` header on each snapshot request. The token is never added to the URL.
 
+The browser keeps the last successfully merged snapshot in localStorage under `codexbar.lastSnapshot` and paints that redacted data immediately on the next load. It then fetches the config-only shell and streams concurrent per-provider snapshot updates into the page as they finish. Signing out clears both the token and cached snapshot.
+
 The UI does not change the transport threat model: `codexbar serve` is plain HTTP. Off-loopback, a token typed into the page transits the network in cleartext like every other request unless a TLS-terminating reverse proxy protects the connection.
 
 ## One-shot command semantics
@@ -121,6 +123,16 @@ Snapshot requests share the serve cache and coordination machinery used by `/usa
 - Concurrent cache misses coalesce into one fetch; `--request-timeout` bounds each request with `504 Gateway Timeout`.
 - Slow builds keep running past the request deadline; the finished result is committed to the response cache and handed to any same-config request already waiting, so a 504 first load self-heals on retry (the built-in web UI retries automatically).
 - Authorization is checked before the cache, so unauthenticated requests can neither warm nor read it.
+
+### Snapshot query parameters
+
+- `provider=<id>` returns a snapshot containing only the selected provider row. Provider names are validated like `/usage`; unknown providers return `400` with the normal JSON error shape.
+- `detail=full` is the default and returns the complete snapshot. `detail=shell` returns schema-v1 host metadata plus config-derived provider rows containing only `id`, `name`, `enabled`, and `display`; it performs no provider fetches or cost scans. Other detail values return `400`.
+- `detail=shell&provider=<id>` is supported and returns the config-only shell for that provider.
+
+### Stale responses and background refresh
+
+After a fresh cache entry expires, `codexbar serve` may answer immediately with its last-good response while rebuilding that same route and configuration in the background. Concurrent refresh triggers still coalesce, and a slow rebuild commits even if it outlives the initiating request deadline. Clients can use `generatedAt` together with `staleAfterSeconds` to decide how to present freshness. This behavior is disabled when `--refresh-interval 0`.
 
 ## Payload
 


### PR DESCRIPTION
## Summary

Follow-up to #2715/#2717. The dashboard was still slow in practice: measured on the portal host, a cold snapshot rebuild takes ~46.5s while a warm cache hit takes 22ms — so with `--refresh-interval 300`, the first request after any idle period blocked the browser for the full rebuild. This PR makes the dashboard paint instantly in every scenario and stream data in as it becomes available. Three layers:

**1. Stale-while-revalidate (no contract change).** When the fresh cache entry has expired but a last-good response within staleTTL exists, serve answers immediately from last-good and kicks a coalesced background rebuild through the coordinator (whose #2717 late-commit semantics guarantee the result lands even past the deadline). Applies uniformly to `/usage`, `/cost`, and the snapshot. Failure-fallback rules are untouched: the whole-response lastGood store now exists for usage/cost keys too, but the failure path still refuses whole-response fallback for usage and keeps cost's per-item merge. `--refresh-interval 0` keeps today's always-blocking behavior. Config-fingerprint changes bypass stale (different cache key) and block for a fresh build.

**2. Snapshot query params (schema stays v1).** `GET /dashboard/v1/snapshot?provider=<id>` builds, coalesces, and caches one provider row independently (validated like `/usage`; unknown id → 400). `?detail=shell` returns a schema-valid document with config-only rows (id, name, enabled, display) — no provider fetches, no cost scans, millisecond response. Auth identical to the existing snapshot route for every variant.

**3. Progressive web UI.** Revisits render the last snapshot from localStorage (`codexbar.lastSnapshot`, redacted data, cleared on sign-out) before any network I/O, marked stale until refreshed. Cold starts paint skeleton cards from the shell (provider icons preserved, `prefers-reduced-motion` respected) and fill each card as its `?provider=` fetch resolves; per-provider failures render that card's error state without blocking the rest. A generation counter invalidates in-flight merges on token changes or re-fills, and normal full-snapshot polling resumes after the fill settles.

The claude-swap enrichment is now skipped unless the Claude row is requested (annotated for the provider-architecture gatekeeper — it's a Claude-only integration by design).

## Measured

- Expired-cache request: **~2ms** (was: blocked ~46.5s on the portal host).
- Cold start: skeleton cards in milliseconds; fast providers render in ~1s while slow cost scans continue filling their own card.

## Commands run

- `swift test --filter CLIServe` — 108 tests, 5 suites
- `swift test --filter Dashboard` — 341 tests, 34 suites
- `make test` — full sharded suite, 824 selections, 69/69 groups green
- `make check` — 0 violations
- Codex autoreview — clean, no accepted findings
- Live browser verification of all three layers (cold fill with skeletons, localStorage instant revisit, 2ms SWR responses)
