### PR TITLE
Claude: report the terminal verdict when no refresh can restore the profile

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher+DelegatedRefreshMessages.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher+DelegatedRefreshMessages.swift
@@ -2,6 +2,20 @@ import Foundation
 
 /// Split out of `ClaudeUsageFetcher.swift` to keep that file within the file-length limit.
 extension ClaudeUsageFetcher {
+    /// Not "run `claude login`, then retry": that refreshes Claude Code's own Keychain item, which this build
+    /// never reads, so the same expired cache comes back.
+    static let unreadableCredentialsMessage =
+        "Claude OAuth credentials expired and CodexBar cannot read them back. Claude Code owns the "
+            + "Keychain item and no credentials file is present for this profile, so refreshing will not "
+            + "restore usage. Switch Claude Usage source to Web/CLI."
+
+    /// True when no refresh can restore this profile: CodexBar never reads Claude Code's Keychain item in
+    /// production, so with no credentials file there is nothing a delegated refresh could hand back.
+    static func isDelegatedRefreshProvablyUnreadable(environment: [String: String]) -> Bool {
+        guard !ClaudeOAuthCredentialsStore.keychainAccessAllowed else { return false }
+        return !ClaudeOAuthCredentialsStore.hasSelectedProfileOAuthCredentialsFile(environment: environment)
+    }
+
     static func delegatedRefreshOutcomeLabel(
         _ outcome: ClaudeOAuthDelegatedRefreshCoordinator.Outcome) -> String
     {
@@ -30,11 +44,7 @@ extension ClaudeUsageFetcher {
         }
 
         if result.isUnreadableAfterRefresh {
-            // Not "run `claude login`, then retry": that refreshes Claude Code's own Keychain item, which this
-            // build never reads, so the same expired cache comes back.
-            return "Claude OAuth credentials expired and CodexBar cannot read them back. Claude Code owns the "
-                + "Keychain item and no credentials file is present for this profile, so refreshing will not "
-                + "restore usage. Switch Claude Usage source to Web/CLI."
+            return Self.unreadableCredentialsMessage
         }
 
         switch result.outcome {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -191,7 +191,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         self.configuration.browserDetection
     }
 
-    private struct ClaudeOAuthKeychainPromptPolicy {
+    struct ClaudeOAuthKeychainPromptPolicy {
         let mode: ClaudeOAuthKeychainPromptMode
         let isApplicable: Bool
         let interaction: ProviderInteraction
@@ -243,9 +243,10 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             interaction: ProviderInteractionContext.current)
     }
 
-    private static func assertDelegatedRefreshAllowedInCurrentInteraction(
+    static func assertDelegatedRefreshAllowedInCurrentInteraction(
         policy: ClaudeOAuthKeychainPromptPolicy,
-        allowBackgroundDelegatedRefresh: Bool) throws
+        allowBackgroundDelegatedRefresh: Bool,
+        isProvablyUnreadable: Bool) throws
     {
         if policy.mode == .never {
             throw ClaudeUsageError.oauthFailed("Delegated refresh is disabled by 'never' keychain policy.")
@@ -254,6 +255,12 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
            policy.interaction != .userInitiated,
            !allowBackgroundDelegatedRefresh
         {
+            // Why: "Click Refresh" is a loop for a profile no refresh can restore — the user clicks, the
+            // delegated path reaches its terminal verdict, and the next background poll overwrites that verdict
+            // with this message again. Report the terminal outcome the delegated path would reach anyway.
+            if isProvablyUnreadable {
+                throw ClaudeUsageError.oauthFailed(unreadableCredentialsMessage)
+            }
             throw ClaudeUsageError.oauthFailed(
                 "Claude OAuth token expired, but background repair is suppressed when Keychain prompt policy "
                     + "is set to only prompt on user action. Click Refresh in the CodexBar menu to retry.")
@@ -403,7 +410,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             let delegatedPromptPolicy = ClaudeUsageFetcher.currentClaudeOAuthDelegatedRefreshPolicy()
             try ClaudeUsageFetcher.assertDelegatedRefreshAllowedInCurrentInteraction(
                 policy: delegatedPromptPolicy,
-                allowBackgroundDelegatedRefresh: self.fetcher.allowBackgroundDelegatedRefresh)
+                allowBackgroundDelegatedRefresh: self.fetcher.allowBackgroundDelegatedRefresh,
+                isProvablyUnreadable: ClaudeUsageFetcher.isDelegatedRefreshProvablyUnreadable(
+                    environment: self.fetcher.environment))
 
             let delegatedResult = await ClaudeUsageFetcher.attemptDelegatedRefresh(
                 environment: self.fetcher.environment)

--- a/Tests/CodexBarTests/ClaudeUnrecoverableOAuthGuidanceTests.swift
+++ b/Tests/CodexBarTests/ClaudeUnrecoverableOAuthGuidanceTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+/// Regression coverage for #2733: a profile no refresh can restore must not be told to click Refresh.
+@Suite(.serialized)
+struct ClaudeUnrecoverableOAuthGuidanceTests {
+    private func makeTemporaryDirectory() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("codexbar-guidance-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func makeCredentialsData(expiresAt: Date) -> Data {
+        let millis = Int(expiresAt.timeIntervalSince1970 * 1000)
+        return Data("""
+        {
+          "claudeAiOauth": {
+            "accessToken": "from-file",
+            "expiresAt": \(millis),
+            "scopes": ["user:profile"]
+          }
+        }
+        """.utf8)
+    }
+
+    private func backgroundPolicy() -> ClaudeUsageFetcher.ClaudeOAuthKeychainPromptPolicy {
+        ClaudeUsageFetcher.ClaudeOAuthKeychainPromptPolicy(
+            mode: .onlyOnUserAction,
+            isApplicable: true,
+            interaction: .background)
+    }
+
+    private func message(from error: Error) -> String? {
+        guard case let ClaudeUsageError.oauthFailed(message) = error else { return nil }
+        return message
+    }
+
+    @Test
+    func `a profile no refresh can restore is told to switch source, not to click Refresh`() async throws {
+        let root = try self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Keychain reads disabled (production always is) and no credentials file: nothing a delegated
+        // refresh produces can ever be read back, so "Click Refresh" would loop forever.
+        try await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(
+                root.appendingPathComponent(".credentials.json"))
+            {
+                #expect(ClaudeUsageFetcher.isDelegatedRefreshProvablyUnreadable(environment: [:]))
+
+                let thrown = #expect(throws: ClaudeUsageError.self) {
+                    try ClaudeUsageFetcher.assertDelegatedRefreshAllowedInCurrentInteraction(
+                        policy: self.backgroundPolicy(),
+                        allowBackgroundDelegatedRefresh: false,
+                        isProvablyUnreadable: true)
+                }
+                #expect(self.message(from: thrown!) == ClaudeUsageFetcher.unreadableCredentialsMessage)
+                #expect(self.message(from: thrown!)?.contains("Click Refresh") != true)
+            }
+        }
+    }
+
+    @Test
+    func `a recoverable profile keeps the click Refresh guidance`() async throws {
+        let root = try self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let credentialsURL = root.appendingPathComponent(".credentials.json")
+        try self.makeCredentialsData(expiresAt: Date(timeIntervalSinceNow: 3600)).write(to: credentialsURL)
+
+        try await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(credentialsURL) {
+                // A credentials file is present, so a delegated refresh can still hand something back.
+                #expect(!ClaudeUsageFetcher.isDelegatedRefreshProvablyUnreadable(environment: [:]))
+
+                let thrown = #expect(throws: ClaudeUsageError.self) {
+                    try ClaudeUsageFetcher.assertDelegatedRefreshAllowedInCurrentInteraction(
+                        policy: self.backgroundPolicy(),
+                        allowBackgroundDelegatedRefresh: false,
+                        isProvablyUnreadable: false)
+                }
+                #expect(self.message(from: thrown!)?.contains("Click Refresh") == true)
+            }
+        }
+    }
+
+    @Test
+    func `a user initiated refresh is never blocked by the prompt policy`() throws {
+        let policy = ClaudeUsageFetcher.ClaudeOAuthKeychainPromptPolicy(
+            mode: .onlyOnUserAction,
+            isApplicable: true,
+            interaction: .userInitiated)
+        // Delegation must still run for user actions: on older Claude Code the touch itself can create the
+        // credentials file, which is exactly the case the terminal verdict must not pre-empt.
+        try ClaudeUsageFetcher.assertDelegatedRefreshAllowedInCurrentInteraction(
+            policy: policy,
+            allowBackgroundDelegatedRefresh: false,
+            isProvablyUnreadable: true)
+    }
+}

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -269,6 +269,19 @@ struct ClaudeUsageTests {
         let loadCounter = AsyncCounter()
         let delegatedCounter = AsyncCounter()
 
+        // Pinned: a present credentials file means a refresh could still restore this profile, which is what
+        // makes the retry suggestion below genuine. Without pinning, the message would depend on whether the
+        // host running the tests happens to have one.
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("codexbar-delegated-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let credentialsURL = root.appendingPathComponent(".credentials.json")
+        let expiresAt = Int(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000)
+        try Data("""
+        {"claudeAiOauth":{"accessToken":"t","expiresAt":\(expiresAt),"scopes":["user:profile"]}}
+        """.utf8).write(to: credentialsURL)
+
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
             environment: [:],
@@ -291,23 +304,27 @@ struct ClaudeUsageTests {
         }
 
         do {
-            _ = try await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
-                .securityFramework,
-                operation: {
-                    try await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.onlyOnUserAction) {
-                        try await ProviderInteractionContext.$current.withValue(.background) {
-                            try await ClaudeUsageFetcher.$delegatedRefreshAttemptOverride.withValue(
-                                delegatedOverride)
-                            {
-                                try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(
-                                    loadCredsOverride)
+            _ = try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(credentialsURL) {
+                try await ClaudeOAuthKeychainReadStrategyPreference.withTaskOverrideForTesting(
+                    .securityFramework,
+                    operation: {
+                        try await ClaudeOAuthKeychainPromptPreference
+                            .withTaskOverrideForTesting(.onlyOnUserAction)
+                        {
+                            try await ProviderInteractionContext.$current.withValue(.background) {
+                                try await ClaudeUsageFetcher.$delegatedRefreshAttemptOverride.withValue(
+                                    delegatedOverride)
                                 {
-                                    try await fetcher.loadLatestUsage(model: "sonnet")
+                                    try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride.withValue(
+                                        loadCredsOverride)
+                                    {
+                                        try await fetcher.loadLatestUsage(model: "sonnet")
+                                    }
                                 }
                             }
                         }
-                    }
-                })
+                    })
+            }
             Issue.record("Expected delegated refresh to be suppressed in background")
         } catch let error as ClaudeUsageError {
             guard case let .oauthFailed(message) = error else {

--- a/TestsLinux/ClaudeOAuthDelegatedRefreshLinuxTests.swift
+++ b/TestsLinux/ClaudeOAuthDelegatedRefreshLinuxTests.swift
@@ -57,11 +57,24 @@ struct ClaudeOAuthDelegatedRefreshLinuxTests {
     }
 
     @Test
-    func appOAuthBackgroundRespectsPlatformKeychainPromptPolicy() async {
+    func appOAuthBackgroundRespectsPlatformKeychainPromptPolicy() async throws {
+        // A credentials file means a delegated refresh could still hand something back, so the retry
+        // suggestion is genuine and must be preserved.
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("codexbar-linux-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let credentialsURL = root.appendingPathComponent(".credentials.json")
+        let expiresAt = Int(Date(timeIntervalSinceNow: 3600).timeIntervalSince1970 * 1000)
+        try Data("""
+        {"claudeAiOauth":{"accessToken":"t","expiresAt":\(expiresAt),"scopes":["user:profile"]}}
+        """.utf8).write(to: credentialsURL)
+
         let result = await self.runDelegatedRefresh(
             runtime: .app,
             interaction: .background,
-            promptMode: .onlyOnUserAction)
+            promptMode: .onlyOnUserAction,
+            credentialsURL: credentialsURL)
 
         #expect(result.attempts == 0)
         #expect(result.message.contains("background repair is suppressed"))
@@ -69,10 +82,29 @@ struct ClaudeOAuthDelegatedRefreshLinuxTests {
         #expect(!result.message.contains("Open the CodexBar menu or"))
     }
 
+    @Test
+    func appOAuthBackgroundReportsUnrecoverableProfileInsteadOfSuggestingRefresh() async {
+        // No credentials file and no readable Claude Keychain item: a refresh cannot restore this profile,
+        // so "Click Refresh" would send the user round a loop that always lands back here.
+        let result = await self.runDelegatedRefresh(
+            runtime: .app,
+            interaction: .background,
+            promptMode: .onlyOnUserAction)
+
+        #expect(result.attempts == 0)
+        #expect(result.message == ClaudeUsageFetcher.unreadableCredentialsMessage)
+        #expect(!result.message.contains("Click Refresh in the CodexBar menu"))
+    }
+
     private func runDelegatedRefresh(
         runtime: ProviderRuntime,
         interaction: ProviderInteraction,
-        promptMode: ClaudeOAuthKeychainPromptMode) async -> (attempts: Int, message: String)
+        promptMode: ClaudeOAuthKeychainPromptMode,
+        // Pinned so the suppression message does not depend on whether the host running the tests happens to
+        // have a Claude credentials file: its presence decides whether a refresh could restore this profile.
+        credentialsURL: URL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("codexbar-absent-\(UUID().uuidString)")
+            .appendingPathComponent(".credentials.json")) async -> (attempts: Int, message: String)
     {
         let counter = Counter()
         let fetcher = ClaudeUsageFetcher(
@@ -95,15 +127,17 @@ struct ClaudeOAuthDelegatedRefreshLinuxTests {
             }
 
         do {
-            _ = try await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(promptMode) {
-                try await ProviderInteractionContext.$current.withValue(interaction) {
-                    try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride
-                        .withValue(credentialsOverride) {
-                            try await ClaudeUsageFetcher.$delegatedRefreshAttemptOverride
-                                .withValue(delegatedOverride) {
-                                    try await fetcher.loadLatestUsage(model: "sonnet")
-                                }
-                        }
+            _ = try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(credentialsURL) {
+                try await ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(promptMode) {
+                    try await ProviderInteractionContext.$current.withValue(interaction) {
+                        try await ClaudeUsageFetcher.$loadOAuthCredentialsOverride
+                            .withValue(credentialsOverride) {
+                                try await ClaudeUsageFetcher.$delegatedRefreshAttemptOverride
+                                    .withValue(delegatedOverride) {
+                                        try await fetcher.loadLatestUsage(model: "sonnet")
+                                    }
+                            }
+                    }
                 }
             }
             Issue.record("Expected delegated-refresh path to fail with mocked stale credentials")


### PR DESCRIPTION
Fixes the user-facing half of #2733: a Claude profile that no refresh can restore is told to click Refresh, which sends the user round a loop that always lands back in the same place.

## The loop

CodexBar already has the right message for this state — `delegatedRefreshFailureMessage` returns *"Claude OAuth credentials expired and CodexBar cannot read them back… Switch Claude Usage source to Web/CLI."* But under the default prompt policy the user rarely sees it, and never keeps it:

1. A background cycle throws at `ClaudeUsageFetcher.swift:404` (`assertDelegatedRefreshAllowedInCurrentInteraction`, with `allowBackgroundDelegatedRefresh` hardcoded `false` at `ClaudeProviderDescriptor.swift:676`) with *"background repair is suppressed… Click Refresh in the CodexBar menu to retry."*
2. The user clicks Refresh. That interaction is `.userInitiated`, so delegation runs and reaches the accurate terminal verdict.
3. The next background poll throws the retry message again, overwriting it.

So the actionable guidance is transient and the misleading guidance is the steady state. Clicking Refresh cannot fix this profile — there is nothing for a refresh to hand back.

## Why the profile is unrecoverable

`keychainAccessAllowed` is hardcoded `false` outside `#if DEBUG` (`ClaudeOAuthCredentials.swift:2855-2871`) — production never reads Claude Code's Keychain item, deliberately, because Claude Code rewrites that item on every refresh and resets its ACL. With no `~/.claude/.credentials.json` either, a delegated refresh has no channel to return a credential through.

That is precisely what `isRefreshResultUnreadable` already detects — but only *after* the touch, which background cycles never reach.

## The change

When the prompt-policy branch is about to suppress background delegation, and the profile is provably unreadable, throw the terminal message instead of the retry suggestion.

Deliberately message-only:

- **Delegation behavior is unchanged.** Background still skips it; `.userInitiated` still runs it. That matters because the coordinator notes *"on older Claude Code a retried touch can still create the credentials file"* — so the terminal verdict must not pre-empt the touch. It doesn't; this only picks the message on the path where delegation was already being skipped.
- **No prompt policy or Keychain gate is relaxed.** Nothing about when CodexBar reads or prompts changes.
- `unreadableCredentialsMessage` is extracted from `delegatedRefreshFailureMessage` and shared, so both paths stay in sync by construction.

## Testing

- New `ClaudeUnrecoverableOAuthGuidanceTests` — 3 cases: unrecoverable profile gets the terminal message, recoverable profile keeps the retry message, user-initiated is never suppressed.
- Verified the key test **fails without the fix**, producing exactly the reported symptom: `"…Click Refresh in the CodexBar menu to retry."` where the terminal message is expected.
- New `appOAuthBackgroundReportsUnrecoverableProfileInsteadOfSuggestingRefresh` covering the same via the full fetcher path.
- `make check` → 0 violations across 1806 files.
- No regressions vs `main` at `22b24b8`. Remaining failures under a wide filter are pre-existing order-dependent suites (`ClaudeOAuthPromptCoalescingTests`, `ClaudeCLISessionTests`) — they fail on `main` too, the set shifts between runs of the same commit, and both pass 12/12 twice in isolation.

**Two existing tests changed, and I want to flag why rather than bury it.** `appOAuthBackgroundRespectsPlatformKeychainPromptPolicy` and `oauth delegated retry only on user action background suppresses delegation` both assert the retry wording while using `environment: [:]` with no credentials-file override. My change makes that message depend on whether a credentials file exists, so as written they would have become host-dependent. Both now pin a credentials file explicitly and keep their original assertions unchanged — the retry wording is still correct for a profile that *is* recoverable. Their behavioral assertions (`attempts == 0`, `delegatedCounter == 0`) are untouched.

## Context

Reported from a real stuck profile: credential ~44h expired, `hasRefreshToken=true`, `owner=claudeCLI`, `source=cacheKeychain`, delegating every cycle and never recovering, on Developer ID signed 0.48.0 while `claude` itself worked throughout. The user spent a day on it because the message pointed at a Keychain setting; the fix was to stop using the OAuth source, which the app already knew and only said transiently.

This supersedes #2739, which I closed as a no-op — that one un-gated a sync that `keychainAccessAllowed` disables in production anyway. This change is on a path I've confirmed executes in production, which is what that one wasn't.
