### PR TITLE
feat(cli): default dashboard identity to full emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.48.2 — Unreleased
+
+### Changed
+- CLI: dashboard snapshot identity now defaults to full; use `--identity redacted` to restore redacted emails.
+
 ## 0.48.1 — 2026-08-07
 
 ### Fixed

--- a/Sources/CodexBarCLI/CLIDashboardCommand.swift
+++ b/Sources/CodexBarCLI/CLIDashboardCommand.swift
@@ -29,8 +29,8 @@ struct DashboardOptions: CommanderParsable {
 
     @Option(
         name: .long("identity"),
-        help: "Account identity detail: redacted (default) or full. The HTTP serve transport is always " +
-            "redacted; full is for one-shot snapshots consumed on trusted, private surfaces.")
+        help: "Account identity detail: full (default) or redacted. Use redacted when the snapshot may leave a " +
+            "trusted, private surface.")
     var identity: String?
 
     @Option(
@@ -64,7 +64,7 @@ struct DashboardSnapshotProducer: Sendable {
         config: CodexBarConfig,
         refreshInterval: TimeInterval,
         codexBarVersion: String?,
-        identityMode: DashboardIdentityMode = .redacted,
+        identityMode: DashboardIdentityMode = .full,
         providers requestedProviders: [UsageProvider]? = nil) async throws -> DashboardSnapshotResult
     {
         let selection = requestedProviders.map(ProviderSelection.custom) ?? CodexBarCLI.providerSelection(
@@ -333,11 +333,11 @@ extension CodexBarCLI {
             ])
     }
 
-    /// `.none` is deliberately not accepted: the flag chooses between the safe
-    /// default and full identity for trusted local consumers; suppressing
-    /// identity entirely is not a supported dashboard shape.
+    /// `.none` is deliberately not accepted: the flag chooses between full
+    /// identity by default and opt-in email redaction; suppressing identity
+    /// entirely is not a supported dashboard shape.
     static func decodeDashboardIdentityMode(from values: ParsedValues) -> DashboardIdentityMode? {
-        guard let raw = values.options["identity"]?.last else { return .redacted }
+        guard let raw = values.options["identity"]?.last else { return .full }
         switch raw.lowercased() {
         case DashboardIdentityMode.redacted.rawValue:
             return .redacted

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -159,13 +159,15 @@ extension CodexBarCLI {
 
         Usage:
           codexbar dashboard [--pretty] [--timeout <seconds>] [--output <path>]
+                             [--identity <redacted|full>]
                              [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>]
                              [-v|--verbose]
 
         Description:
           Print one dashboard-v1 snapshot as JSON, then exit. Honors enabled providers
-          in stable order, always redacts account identity, and keeps provider
-          failures as row-level errors without dropping healthy rows.
+          in stable order and keeps provider failures as row-level errors without
+          dropping healthy rows. Account identity defaults to full emails;
+          --identity redacted hides email local parts.
           Stdout contains only the JSON document; diagnostics are written to stderr.
           --timeout accepts 0...86400 seconds and defaults to 30; 0 disables the deadline.
           --output atomically writes the snapshot to a file (0644) instead of stdout;
@@ -213,9 +215,8 @@ extension CodexBarCLI {
           non-loopback host the token also gates /usage and /cost (account data);
           / and /health are always open. Use a TLS-terminating reverse proxy for anything
           beyond a trusted network segment.
-          Snapshot identity defaults to redacted emails; --identity full exposes real
-          account emails to every authorized dashboard client. Reserve it for trusted,
-          private networks (e.g. a tailnet-only reverse proxy).
+          Snapshot identity defaults to full account emails. --identity redacted hides
+          email local parts and is recommended whenever responses cross a network.
 
         Endpoints:
           GET /                    Built-in web dashboard

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -38,8 +38,8 @@ struct ServeOptions: CommanderParsable {
 
     @Option(
         name: .long("identity"),
-        help: "Dashboard snapshot identity detail: redacted (default) or full. Full exposes real account " +
-            "emails to every authorized dashboard client; use it only on trusted, private networks.")
+        help: "Dashboard snapshot identity detail: full (default) or redacted. Use redacted to hide email local " +
+            "parts from authorized dashboard clients.")
     var identity: String?
 }
 
@@ -124,9 +124,9 @@ struct ServeRuntime {
     let requestTimeout: TimeInterval
     let healthVersion: String?
     let dashboardAuth: CLIServeDashboardAuth
-    /// Identity detail for dashboard snapshots. Defaults to `.redacted`; the
-    /// `--identity full` startup opt-in exposes real account emails to every
-    /// authorized dashboard client on trusted, private networks.
+    /// Identity detail for dashboard snapshots. Defaults to `.full`; the
+    /// `--identity redacted` startup option hides email local parts from every
+    /// authorized dashboard client.
     let dashboardIdentityMode: DashboardIdentityMode
     /// True for non-loopback binds: every data route (`/usage`, `/cost`,
     /// `/dashboard/v1/snapshot`) then requires the bearer token, so account data
@@ -143,7 +143,7 @@ struct ServeRuntime {
         requestTimeout: TimeInterval,
         healthVersion: String?,
         dashboardAuth: CLIServeDashboardAuth,
-        dashboardIdentityMode: DashboardIdentityMode = .redacted,
+        dashboardIdentityMode: DashboardIdentityMode = .full,
         bindHost: String)
     {
         self.configStore = configStore

--- a/Sources/CodexBarCLI/CLIServeWebUI+HTML.swift
+++ b/Sources/CodexBarCLI/CLIServeWebUI+HTML.swift
@@ -679,13 +679,6 @@ extension CLIServeWebUI {
                 const copy = { ...provider };
                 delete copy._pending;
                 delete copy._progressiveError;
-                copy.identity = redactedIdentity(copy.identity);
-                if (Array.isArray(copy.accounts)) {
-                  copy.accounts = copy.accounts.map(account => ({
-                    ...account,
-                    identity: redactedIdentity(account.identity)
-                  }));
-                }
                 return copy;
               })
             };
@@ -693,16 +686,6 @@ extension CLIServeWebUI {
           } catch (_) {
             // Rendering remains live when storage is unavailable or full.
           }
-        }
-
-        function redactedIdentity(identity) {
-          if (!identity || !identity.accountEmail) return identity;
-          const email = String(identity.accountEmail);
-          const at = email.lastIndexOf("@");
-          return {
-            ...identity,
-            accountEmail: at >= 0 ? `redacted${email.slice(at)}` : "redacted"
-          };
         }
 
         function clearSnapshot() {

--- a/Sources/CodexBarCLI/DashboardPayloads.swift
+++ b/Sources/CodexBarCLI/DashboardPayloads.swift
@@ -1,8 +1,8 @@
 import CodexBarCore
 import Foundation
 
-/// How much account identity a dashboard snapshot exposes. `codexbar serve`
-/// always uses `.redacted`; the other modes exist for the builder contract.
+/// How much account identity a dashboard snapshot exposes. Dashboard commands
+/// default to `.full`; `.redacted` remains available as an explicit privacy mode.
 enum DashboardIdentityMode: String, Equatable, Sendable {
     case none
     case redacted

--- a/Tests/CodexBarTests/CLIServeWebUITests.swift
+++ b/Tests/CodexBarTests/CLIServeWebUITests.swift
@@ -62,7 +62,9 @@ struct CLIServeWebUITests {
     @Test
     func `serve identity flag decodes like the dashboard command`() {
         #expect(CodexBarCLI.decodeDashboardIdentityMode(
-            from: ParsedValues(positional: [], options: [:], flags: [])) == .redacted)
+            from: ParsedValues(positional: [], options: [:], flags: [])) == .full)
+        #expect(CodexBarCLI.decodeDashboardIdentityMode(
+            from: ParsedValues(positional: [], options: ["identity": ["redacted"]], flags: [])) == .redacted)
         #expect(CodexBarCLI.decodeDashboardIdentityMode(
             from: ParsedValues(positional: [], options: ["identity": ["full"]], flags: [])) == .full)
         #expect(CodexBarCLI.decodeDashboardIdentityMode(

--- a/Tests/CodexBarTests/DashboardClaudeSwapSnapshotTests.swift
+++ b/Tests/CodexBarTests/DashboardClaudeSwapSnapshotTests.swift
@@ -55,7 +55,7 @@ struct DashboardClaudeSwapSnapshotTests {
 
     @Test
     func `dashboard identity flag decodes redacted full and rejects others`() {
-        #expect(CodexBarCLI.decodeDashboardIdentityMode(from: self.parsedValues(identity: nil)) == .redacted)
+        #expect(CodexBarCLI.decodeDashboardIdentityMode(from: self.parsedValues(identity: nil)) == .full)
         #expect(CodexBarCLI.decodeDashboardIdentityMode(from: self.parsedValues(identity: "redacted")) == .redacted)
         #expect(CodexBarCLI.decodeDashboardIdentityMode(from: self.parsedValues(identity: "full")) == .full)
         #expect(CodexBarCLI.decodeDashboardIdentityMode(from: self.parsedValues(identity: "FULL")) == .full)

--- a/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
+++ b/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
@@ -84,7 +84,7 @@ struct DashboardSnapshotBuilderTests {
     }
 
     @Test
-    func `producer keeps stable order redaction and partial errors`() async throws {
+    func `producer defaults to full identity and keeps stable order and partial errors`() async throws {
         let generatedAt = Date(timeIntervalSince1970: 1_800_000_000)
         let healthy = self.identityPayload(email: "user@example.com")
         let failed = ProviderPayload(
@@ -125,7 +125,7 @@ struct DashboardSnapshotBuilderTests {
         let claudeDisplay = try #require(providers[1]["display"] as? [String: Any])
 
         #expect(providers.compactMap { $0["id"] as? String } == ["codex", "claude"])
-        #expect(identity["accountEmail"] as? String == "redacted@example.com")
+        #expect(identity["accountEmail"] as? String == "user@example.com")
         #expect(error["message"] as? String == "temporary failure")
         #expect(codexDisplay["sortKey"] as? Int == 10)
         #expect(claudeDisplay["sortKey"] as? Int == 0)

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -151,7 +151,7 @@ The accepted multi-account design in
   Claude provider or `--source auto` remains eligible, while `--account`, `--account-index`, `--all-accounts`, and
   explicit non-auto source flags bypass the adapter. `codexbar usage` and serve `/usage`/`/cost` remain unchanged,
   while `codexbar dashboard` and `GET /dashboard/v1/snapshot` additionally nest one entry per swap account in the
-  Claude provider row, with identity redacted per the dashboard policy.
+  Claude provider row, with full identity by default or redacted email local parts when `--identity redacted` is set.
 - Isolation: CodexBar never reads claude-swap or Claude Code credential storage for this feature; the
   subprocess handles its own credential access. In the app, adapter failures keep the last successful accounts as
   stale data, surface the error in provider settings, and never affect the ambient Claude usage card. In terminal

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,13 +78,14 @@ See `docs/configuration.md` for the schema.
   - Force enhanced mode elsewhere with `CODEXBAR_CARDS_ENHANCED=1`.
   - Exit code is non-zero when any provider fetch fails.
 - `codexbar dashboard` prints one dashboard-v1 JSON snapshot and exits.
-  - Honors enabled providers in stable order, carries configured display sort keys, and always redacts account identity.
+  - Honors enabled providers in stable order, carries configured display sort keys, and defaults to full account identity; `--identity redacted` hides email local parts.
   - Provider failures remain row-level errors alongside healthy rows; a valid partial snapshot exits `0`.
   - Stdout contains only the snapshot document. Diagnostics and optional `--json-output` logs go to stderr.
   - `--pretty` formats the document. `--timeout <seconds>` accepts `0...86400`, defaults to `30`, and uses `0` to disable the command deadline.
   - `--output <path>` atomically writes the snapshot to a file (`0644`) instead of stdout — staged in the destination directory, fsync'd, then renamed over the target so readers never observe a partial document. The parent directory must already exist (it is not created), and stdout stays silent on success.
   - Starts no HTTP server and requires no dashboard bearer token. See `docs/dashboard-api.md` for the shared payload contract.
 - `codexbar serve` starts a foreground HTTP server for usage and cost JSON, a token-gated dashboard snapshot, and a built-in web UI at `/`.
+  - Dashboard snapshot identity defaults to full account emails; use `--identity redacted` to hide email local parts, especially when responses cross a network.
   - `--host <host>` accepts `localhost` or an IPv4 address and defaults to `127.0.0.1`; `localhost` is normalized to `127.0.0.1`. Binding a non-loopback host requires a dashboard token **and** `--allow-plain-http` (see `docs/dashboard-api.md` for the threat model).
   - `--port <port>` defaults to `8080`.
   - `--refresh-interval <seconds>` defaults to `60` and controls the in-memory response cache TTL.

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -32,7 +32,7 @@ On the default loopback bind, `/usage` and `/cost` are unchanged and unauthentic
 
 `GET /` serves a self-contained web dashboard that polls `/dashboard/v1/snapshot`. The static HTML is always unauthenticated, including on non-loopback binds, because it contains no account data. When the snapshot route returns `401`, the page asks for the dashboard token, stores it in the browser under the localStorage key `codexbar.dashboardToken`, and sends it in the `Authorization` header on each snapshot request. The token is never added to the URL.
 
-The browser keeps the last successfully merged snapshot in localStorage under `codexbar.lastSnapshot` and paints that redacted data immediately on the next load. It then fetches the config-only shell and streams concurrent per-provider snapshot updates into the page as they finish. Signing out clears both the token and cached snapshot.
+The browser keeps the last successfully merged snapshot in localStorage under `codexbar.lastSnapshot` and paints that data immediately on the next load, preserving the identity detail served by the configured mode. It then fetches the config-only shell and streams concurrent per-provider snapshot updates into the page as they finish. Signing out clears both the token and cached snapshot.
 
 The UI does not change the transport threat model: `codexbar serve` is plain HTTP. Off-loopback, a token typed into the page transits the network in cleartext like every other request unless a TLS-terminating reverse proxy protects the connection.
 
@@ -40,7 +40,8 @@ The UI does not change the transport threat model: `codexbar serve` is plain HTT
 
 - `codexbar dashboard` reads enabled providers from CodexBar config, emits them in stable order, and carries configured
   ordering through each row's `display.sortKey`.
-- Identity is always redacted. Provider failures stay in their rows without discarding healthy rows.
+- Identity defaults to full account emails. Pass `--identity redacted` to hide email local parts. Provider failures stay
+  in their rows without discarding healthy rows.
 - A valid full, partial, empty, or all-error snapshot exits `0`. Command-wide setup or encoding failure writes a
   diagnostic to stderr and exits non-zero without writing a substitute document to stdout.
 - Stdout contains exactly one JSON document plus a trailing newline. `--pretty` changes formatting only;
@@ -72,7 +73,7 @@ codexbar serve --dashboard-token YOUR_TOKEN
 Transport is **plain HTTP**. There is no TLS in `codexbar serve`, which means:
 
 - The bearer token crosses the network **in cleartext on every request**. Anyone who can observe the path (same Wi-Fi, ARP spoofing, a compromised switch, your ISP on a routed path) can capture the token and replay it until the server restarts with a new one.
-- The response bodies — plan labels, usage percentages, email domains, cost figures — cross the network in cleartext too.
+- The response bodies — plan labels, usage percentages, cost figures, and full account emails by default — cross the network in cleartext too. On non-loopback binds, use `--identity redacted` to hide email local parts unless clients need full identity.
 - Because non-loopback binds gate `/usage`, `/cost`, and `/dashboard/v1/snapshot` behind the same token, a passive observer sees your account data but an active client without the token gets `401` on every data route. Only the account-free static UI at `/` and `/health` are unauthenticated off-loopback.
 
 Deployments, from safest to least safe:
@@ -95,10 +96,10 @@ Deployments, from safest to least safe:
 3. **Trusted network segment, cleartext accepted.** Bind a LAN address directly:
 
    ```bash
-   CODEXBAR_DASHBOARD_TOKEN=... codexbar serve --host 0.0.0.0 --allow-plain-http
+   CODEXBAR_DASHBOARD_TOKEN=... codexbar serve --host 0.0.0.0 --allow-plain-http --identity redacted
    ```
 
-   A non-loopback `--host` refuses to start without a token, and refuses to start without `--allow-plain-http` — passing that flag is the explicit, operational acceptance that cleartext bearer transport is fine on this network. The token then gates all data routes, and the server logs a one-line warning at startup.
+   A non-loopback `--host` refuses to start without a token, and refuses to start without `--allow-plain-http` — passing that flag is the explicit, operational acceptance that cleartext bearer transport is fine on this network. Full account emails are included in dashboard responses by default, so `--identity redacted` is recommended for these deployments. The token gates all data routes, and the server logs a one-line warning at startup.
 
 The server compares tokens in constant time (fixed-length SHA-256 digest comparison), so timing does not leak a matching prefix. That protects the comparison, not the transport: on plain HTTP the token is still readable in transit.
 
@@ -136,7 +137,7 @@ After a fresh cache entry expires, `codexbar serve` may answer immediately with 
 
 ## Payload
 
-The snapshot is a stable display contract, not a raw dump of provider internals. Identity is always redacted: email local parts are hidden while domains and plan labels are kept.
+The snapshot is a stable display contract, not a raw dump of provider internals. Identity defaults to full account emails and plan labels. Pass `--identity redacted` to replace email local parts with `redacted` while keeping domains and plan labels.
 
 ```json
 {
@@ -159,7 +160,7 @@ The snapshot is a stable display contract, not a raw dump of provider internals.
         "updatedAt": "2026-07-16T11:59:00Z"
       },
       "identity": {
-        "accountEmail": "redacted@example.com",
+        "accountEmail": "user@example.com",
         "plan": "Pro 20x"
       },
       "windows": [
@@ -195,20 +196,21 @@ The snapshot is a stable display contract, not a raw dump of provider internals.
 
 When the claude-swap integration is enabled, the Claude provider row additionally includes an `accounts` array. This
 is an additive schema-v1 extension: other provider rows and Claude rows without the integration keep their existing
-shape. Account identity follows the dashboard's always-redacted policy. A failure limited to one account stays in that
-account's `error`; a failure of the whole adapter sets `accountsError` while leaving the ambient Claude row intact.
+shape. Account identity follows the dashboard identity mode: full by default, or redacted with `--identity redacted`.
+A failure limited to one account stays in that account's `error`; a failure of the whole adapter sets `accountsError`
+while leaving the ambient Claude row intact.
 
 ```json
 {
   "id": "claude",
-  "identity": { "accountEmail": "redacted@example.com", "plan": "Max" },
+  "identity": { "accountEmail": "user@example.com", "plan": "Max" },
   "windows": [{ "kind": "session", "label": "Session", "usedPercent": 20, "remainingPercent": 80, "resetAt": "2026-07-16T17:00:00Z" }],
   "accounts": [
     {
       "id": "claude-swap:2",
       "label": "Account 2",
       "active": true,
-      "identity": { "accountEmail": "redacted@personal.example", "plan": null },
+      "identity": { "accountEmail": "personal@personal.example", "plan": null },
       "windows": [
         { "kind": "session", "label": "Session", "usedPercent": 40, "remainingPercent": 60, "resetAt": "2026-07-16T17:00:00Z" },
         { "kind": "weekly", "label": "Weekly", "usedPercent": 60, "remainingPercent": 40, "resetAt": "2026-07-18T12:00:00Z" },
@@ -247,7 +249,7 @@ account's `error`; a failure of the whole adapter sets `accountsError` while lea
 - `providers[].enabled`: Whether the provider is enabled in CodexBar config.
 - `providers[].source`: Source used for the provider data.
 - `providers[].status`: Provider service status when available (`level`: `ok` | `warning` | `critical` | `unknown`).
-- `providers[].identity`: Redacted account email and plan label, or `null`.
+- `providers[].identity`: Account email and plan label, or `null`; the email local part is hidden only in redacted mode.
 - `providers[].windows`: Session, weekly, tertiary, or provider-specific rate windows.
 - `providers[].credits`: Remaining credits or balance when available.
 - `providers[].cost`: Local cost data when available.
@@ -259,7 +261,7 @@ account's `error`; a failure of the whole adapter sets `accountsError` while lea
   - `id`: Stable source and slot identifier, such as `claude-swap:2`.
   - `label`: Stable, non-sensitive display key, such as `Account 2`.
   - `active`: Whether this is the source's active account.
-  - `identity`: Dashboard-redacted account email with a `null` plan, or `null`.
+  - `identity`: Account email with a `null` plan, or `null`; the email local part is hidden only in redacted mode.
   - `windows`: Account-local session, weekly, and scoped windows in the same shape as `providers[].windows`.
   - `pace`: Account-local primary, secondary, and tertiary pace values when computable. Each pace value contains
     `stage`, `deltaPercent`, `expectedUsedPercent`, `willLastToReset`, `etaSeconds`, `runOutProbability`, and `summary`.


### PR DESCRIPTION
## Summary

Dashboard-v1 snapshots redacted account emails by default at every layer, even though the `--identity <redacted|full>` flag already existed on both `codexbar dashboard` and `codexbar serve`. Product call: full identity is now the default; `--identity redacted` is the opt-in privacy setting.

- `decodeDashboardIdentityMode` returns `.full` when the flag is absent; `DashboardSnapshotProducer.collect` and `ServeRuntime` defaults flipped to match. `.none` remains unsupported and invalid values still error.
- The web UI no longer re-redacts identity before persisting rows to localStorage, so the cached instant paint matches what the server serves in either mode.
- Help text and docs updated throughout (`dashboard-api.md`, `cli.md`, `claude.md`): the threat-model section now states plainly that full account emails cross the network in responses by default on non-loopback binds, and recommends `--identity redacted` for such deployments.
- Changelog entry opens the 0.48.2 unreleased section (0.48.1 shipped while this was in flight).

## Commands run

- `swift test --filter CLIServe` — 108 tests green
- `swift test --filter Dashboard` — 341 tests + 2 XCTest cases green
- `make test` — full sharded suite green, zero failed groups
- `make check` — 0 violations
- Codex autoreview — clean, no accepted findings
