### PR TITLE
fix(cli): keep claude-swap account emails when the usage fetch fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - CLI: dashboard snapshot identity now defaults to full; use `--identity redacted` to restore redacted emails.
 
+### Fixed
+- CLI: claude-swap accounts with expired or missing credentials now keep their email on the serve dashboard instead of showing a bare slot number.
+
 ## 0.48.1 — 2026-08-07
 
 ### Fixed

--- a/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
+++ b/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
@@ -176,16 +176,20 @@ enum DashboardSnapshotBuilder {
         weeklyWorkDays: Int?,
         generatedAt: Date) -> DashboardAccountPayload
     {
-        let email = account.snapshot?.identity?.accountEmail
-        let redactedEmail = identityMode != .none && email?.contains("@") == true
+        // Provider-specific by design: claude-swap keeps the source email in displayLabel when usage is unavailable.
+        let snapshotEmail = account.snapshot?.identity?.accountEmail
+        let email = snapshotEmail?.contains("@") == true
+            ? snapshotEmail
+            : (account.displayLabel.contains("@") ? account.displayLabel : nil)
+        let presentedEmail = identityMode != .none && email?.contains("@") == true
             ? self.dashboardEmail(email, mode: identityMode)
             : nil
-        let identity = redactedEmail.map { DashboardIdentityPayload(accountEmail: $0, plan: nil) }
+        let identity = presentedEmail.map { DashboardIdentityPayload(accountEmail: $0, plan: nil) }
         // Provider-specific by design: claude-swap account windows and pace use Claude's presentation semantics.
         let metadata = ProviderDescriptorRegistry.descriptor(for: UsageProvider.claude).metadata
         return DashboardAccountPayload(
             id: "\(account.id.source):\(account.id.opaqueID)",
-            label: "Account \(account.id.opaqueID)",
+            label: presentedEmail ?? "Account \(account.id.opaqueID)",
             active: account.isActive,
             identity: identity,
             windows: self.makeWindows(provider: .claude, metadata: metadata, usage: account.snapshot),

--- a/Tests/CodexBarTests/DashboardClaudeSwapSnapshotTests.swift
+++ b/Tests/CodexBarTests/DashboardClaudeSwapSnapshotTests.swift
@@ -21,7 +21,9 @@ struct DashboardClaudeSwapSnapshotTests {
         #expect(rows.compactMap { $0["id"] as? String } == [
             "claude-swap:2", "claude-swap:1", "claude-swap:3",
         ])
-        #expect(rows.compactMap { $0["label"] as? String } == ["Account 2", "Account 1", "Account 3"])
+        #expect(rows.compactMap { $0["label"] as? String } == [
+            "redacted@personal.example", "redacted@example.com", "redacted@example.net",
+        ])
         #expect(rows.compactMap { $0["active"] as? Bool } == [true, false, false])
 
         let active = try #require(rows.first)
@@ -115,7 +117,8 @@ struct DashboardClaudeSwapSnapshotTests {
         #expect(failed["error"] as? String ==
             "Token expired. Switch to this account in claude-swap to refresh it.")
         #expect((failed["windows"] as? [Any])?.isEmpty == true)
-        #expect(failed["identity"] is NSNull)
+        #expect(failed["label"] as? String == "redacted@example.com")
+        #expect((failed["identity"] as? [String: Any])?["accountEmail"] as? String == "redacted@example.com")
         #expect(failed["pace"] is NSNull)
         #expect(failed["updatedAt"] is NSNull)
         #expect(claude["error"] is NSNull)

--- a/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
+++ b/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
@@ -439,6 +439,50 @@ struct DashboardSnapshotBuilderTests {
     }
 
     @Test
+    func `claude swap account keeps email when usage fetch fails`() throws {
+        let snapshot = self.claudeSwapSnapshot(
+            number: 1,
+            email: "stale@example.com",
+            usageStatus: .tokenExpired,
+            identityMode: .full)
+        let account = try self.firstClaudeSwapAccount(snapshot)
+        let identity = try #require(account["identity"] as? [String: Any])
+
+        #expect(identity["accountEmail"] as? String == "stale@example.com")
+        #expect(account["label"] as? String == "stale@example.com")
+        #expect((account["windows"] as? [Any])?.isEmpty == true)
+    }
+
+    @Test
+    func `claude swap failed account redacts email in identity and label`() throws {
+        let snapshot = self.claudeSwapSnapshot(
+            number: 4,
+            email: "private-person@example.com",
+            usageStatus: .noCredentials,
+            identityMode: .redacted)
+        let account = try self.firstClaudeSwapAccount(snapshot)
+        let identity = try #require(account["identity"] as? [String: Any])
+        let encoded = try #require(CodexBarCLI.encodeJSON(snapshot, pretty: false))
+
+        #expect(identity["accountEmail"] as? String == "redacted@example.com")
+        #expect(account["label"] as? String == "redacted@example.com")
+        #expect(!encoded.contains("private-person"))
+    }
+
+    @Test
+    func `claude swap placeholder label stays a slot label without identity`() throws {
+        let snapshot = self.claudeSwapSnapshot(
+            number: 7,
+            email: "",
+            usageStatus: .unavailable,
+            identityMode: .full)
+        let account = try self.firstClaudeSwapAccount(snapshot)
+
+        #expect(account["label"] as? String == "Account 7")
+        #expect(account["identity"] is NSNull)
+    }
+
+    @Test
     func `dashboard redaction keeps only the final email domain`() throws {
         let snapshot = DashboardSnapshotBuilder.makeSnapshot(
             usagePayloads: [self.identityPayload(email: #""foo@bar"@example.com"#)],
@@ -626,6 +670,39 @@ struct DashboardSnapshotBuilderTests {
             antigravityPlanInfo: nil,
             openaiDashboard: nil,
             error: nil)
+    }
+
+    private func claudeSwapSnapshot(
+        number: Int,
+        email: String,
+        usageStatus: ClaudeSwapUsageStatus,
+        identityMode: DashboardIdentityMode) -> DashboardSnapshotPayload
+    {
+        // Provider-specific by design: these fixtures cover claude-swap labels without usage snapshots.
+        let account = ClaudeSwapAccountProjection.accountSnapshots(from: ClaudeSwapAccountList(
+            activeAccountNumber: number,
+            accounts: [ClaudeSwapAccountRow(
+                number: number,
+                email: email,
+                isActive: true,
+                usageStatus: usageStatus,
+                fiveHour: nil,
+                sevenDay: nil)]))
+        return DashboardSnapshotBuilder.makeSnapshot(
+            usagePayloads: [self.identityPayload(email: "ambient@example.com")],
+            costPayloads: [],
+            config: CodexBarConfig(providers: [ProviderConfig(id: .claude, enabled: true)]),
+            identityMode: identityMode,
+            generatedAt: Date(timeIntervalSince1970: 0),
+            refreshInterval: 60,
+            codexBarVersion: nil,
+            claudeSwap: DashboardClaudeSwapInput(accounts: account, adapterError: nil, weeklyWorkDays: nil))
+    }
+
+    private func firstClaudeSwapAccount(_ snapshot: DashboardSnapshotPayload) throws -> [String: Any] {
+        let object = try self.jsonObject(snapshot)
+        let provider = try #require((object["providers"] as? [[String: Any]])?.first)
+        return try #require((provider["accounts"] as? [[String: Any]])?.first)
     }
 
     private func firstIdentity(_ snapshot: DashboardSnapshotPayload) -> [String: Any]? {

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -196,7 +196,9 @@ The snapshot is a stable display contract, not a raw dump of provider internals.
 
 When the claude-swap integration is enabled, the Claude provider row additionally includes an `accounts` array. This
 is an additive schema-v1 extension: other provider rows and Claude rows without the integration keep their existing
-shape. Account identity follows the dashboard identity mode: full by default, or redacted with `--identity redacted`.
+shape. An account's `label` is its email when known and otherwise falls back to its slot label; `identity` is present
+whenever claude-swap reports an email, independently of whether that account's usage fetch succeeds. Both fields follow
+the dashboard identity mode: full by default, or redacted with `--identity redacted`.
 A failure limited to one account stays in that account's `error`; a failure of the whole adapter sets `accountsError`
 while leaving the ambient Claude row intact.
 
@@ -208,7 +210,7 @@ while leaving the ambient Claude row intact.
   "accounts": [
     {
       "id": "claude-swap:2",
-      "label": "Account 2",
+      "label": "personal@personal.example",
       "active": true,
       "identity": { "accountEmail": "personal@personal.example", "plan": null },
       "windows": [
@@ -225,9 +227,9 @@ while leaving the ambient Claude row intact.
     },
     {
       "id": "claude-swap:1",
-      "label": "Account 1",
+      "label": "expired@example.com",
       "active": false,
-      "identity": null,
+      "identity": { "accountEmail": "expired@example.com", "plan": null },
       "windows": [],
       "pace": null,
       "error": "Token expired. Switch to this account in claude-swap to refresh it.",
@@ -259,9 +261,11 @@ while leaving the ambient Claude row intact.
 - `providers[].accounts`: Ordered local multi-account entries when an integration supplies them; an enabled source
   with no accounts emits `[]`.
   - `id`: Stable source and slot identifier, such as `claude-swap:2`.
-  - `label`: Stable, non-sensitive display key, such as `Account 2`.
+  - `label`: Account email when known, otherwise a slot label such as `Account 2`; email labels follow the dashboard
+    identity mode.
   - `active`: Whether this is the source's active account.
-  - `identity`: Account email with a `null` plan, or `null`; the email local part is hidden only in redacted mode.
+  - `identity`: Account email with a `null` plan whenever claude-swap reports one, even if usage fetching fails;
+    otherwise `null`. The email local part is hidden only in redacted mode.
   - `windows`: Account-local session, weekly, and scoped windows in the same shape as `providers[].windows`.
   - `pace`: Account-local primary, secondary, and tertiary pace values when computable. Each pace value contains
     `stage`, `deltaPercent`, `expectedUsedPercent`, `willLastToReset`, `etaSeconds`, `runOutProbability`, and `summary`.


### PR DESCRIPTION
## Summary

On the serve web dashboard, claude-swap accounts with stale credentials rendered as bare slot numbers ("Account 1", "Account 4") instead of their email — even though `claude-swap list --json` reports an email for every slot, and the menu bar app displays it correctly.

Root cause: `DashboardSnapshotBuilder.makeClaudeSwapAccount` read the email only from `account.snapshot?.identity?.accountEmail`, but `ClaudeSwapAccountProjection.usageSnapshot(for:)` returns `nil` unless the row's usage status is `ok`. So any account whose usage fetch failed produced `identity: null`, and the web UI's `account.identity?.accountEmail || account.label` fell through to the hardcoded `"Account N"`. An account's *name* should not depend on whether its *usage fetch* succeeded.

Fix: resolve the email from the projection's `displayLabel` when the snapshot carries none (the projection already puts the email there, falling back to `"Account N"` only when claude-swap reports no email), then feed that single value through the existing `identityMode` treatment for **both** `identity` and `label`. Redaction stays honest — in `--identity redacted` mode both fields carry the redacted form, and a new test asserts the raw local part appears nowhere in the encoded payload.

Unchanged: `usageSnapshot(for:)`'s `guard row.usageStatus == .ok` (accounts with broken credentials genuinely have no windows; their `error` row already explains why), the web UI JS, the schema, and auth.

## Contract note

Two existing assertions changed because they encoded the bug: a token-expired account previously asserted `identity is NSNull` and `label == "Account 1"`. `accounts[].label` is now the account's email when known — documented in `dashboard-api.md`, including that email labels follow the dashboard identity mode.

## Commands run

- `swift test --filter Dashboard` — 344 tests green
- `swift test --filter CLIServe` — 108 tests green
- `swift test --filter ClaudeSwap` — 81 tests green
- `make test` — full sharded suite green, 69/69 groups, architecture gatekeeper included
- `make check` — 0 violations
- Codex autoreview — clean, no accepted findings
