### PR TITLE
Fix CLI resource bundle resolution and packaging

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -385,8 +385,19 @@ jobs:
           ln -s "CodexBarCLI" "$OUT_DIR/codexbar"
           printf '%s\n' "${SAFE_REF_NAME#v}" > "$OUT_DIR/VERSION"
 
+          CORE_RESOURCE_BUNDLE="$BIN_DIR/CodexBar_CodexBarCore.bundle"
+          if [[ ! -d "$CORE_RESOURCE_BUNDLE" ]]; then
+            echo "Missing CodexBarCore resource bundle: $CORE_RESOURCE_BUNDLE" >&2
+            exit 1
+          fi
+          cp -R "$CORE_RESOURCE_BUNDLE" "$OUT_DIR/"
+          RESOURCE_SMOKE_OUTPUT="$RUNNER_TEMP/codexbar-cli-resource-smoke-${{ matrix.name }}.txt"
+          CODEXBAR_RESOURCE_SMOKE=1 "$OUT_DIR/CodexBarCLI" > "$RESOURCE_SMOKE_OUTPUT"
+          grep -Fx "CODEXBAR_RESOURCE_SMOKE_OK" "$RESOURCE_SMOKE_OUTPUT"
+
           ASSET="CodexBarCLI-${SAFE_REF_NAME}-${{ matrix.asset-platform }}-${{ matrix.asset-arch }}.tar.gz"
-          (cd "$OUT_DIR" && tar czf "$ASSET" CodexBarCLI codexbar VERSION)
+          (cd "$OUT_DIR" && tar czf "$ASSET" \
+            CodexBarCLI codexbar VERSION CodexBar_CodexBarCore.bundle)
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum "$OUT_DIR/$ASSET" > "$OUT_DIR/$ASSET.sha256"
           else

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -385,12 +385,20 @@ jobs:
           ln -s "CodexBarCLI" "$OUT_DIR/codexbar"
           printf '%s\n' "${SAFE_REF_NAME#v}" > "$OUT_DIR/VERSION"
 
-          CORE_RESOURCE_BUNDLE="$BIN_DIR/CodexBar_CodexBarCore.bundle"
-          if [[ ! -d "$CORE_RESOURCE_BUNDLE" ]]; then
-            echo "Missing CodexBarCore resource bundle: $CORE_RESOURCE_BUNDLE" >&2
+          CORE_RESOURCE_SOURCE=""
+          for candidate in \
+            "$BIN_DIR/CodexBar_CodexBarCore.bundle" \
+            "$BIN_DIR/CodexBar_CodexBarCore.resources"; do
+            if [[ -d "$candidate" ]]; then
+              CORE_RESOURCE_SOURCE="$candidate"
+              break
+            fi
+          done
+          if [[ -z "$CORE_RESOURCE_SOURCE" ]]; then
+            echo "Missing CodexBarCore resource bundle in $BIN_DIR" >&2
             exit 1
           fi
-          cp -R "$CORE_RESOURCE_BUNDLE" "$OUT_DIR/"
+          cp -R "$CORE_RESOURCE_SOURCE" "$OUT_DIR/CodexBar_CodexBarCore.bundle"
           RESOURCE_SMOKE_OUTPUT="$RUNNER_TEMP/codexbar-cli-resource-smoke-${{ matrix.name }}.txt"
           CODEXBAR_RESOURCE_SMOKE=1 "$OUT_DIR/CodexBarCLI" > "$RESOURCE_SMOKE_OUTPUT"
           grep -Fx "CODEXBAR_RESOURCE_SMOKE_OK" "$RESOURCE_SMOKE_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.48.2 — Unreleased
 
 ### Fixed
+- CLI: ship and safely resolve the provider-plugin resource bundle beside standalone executables, returning a clean reinstall/update error instead of trapping when it is missing (#2756).
 - Claude: the menu-bar indicator now renders the active claude-swap account's usage when the adapter owns account presentation (2+ accounts), instead of drawing empty bars from an ambient snapshot without usable windows (#2731). Thanks @Meldiron for the report!
 - z.ai/GLM: parse `CREDIT_LIMIT` quota entries from credit-based Coding Plans (lite/standard/pro) so usage no longer sticks at 100% remaining / 0% used and the 5-hour credit window drives the primary percentage and reset time (#2724, #2712). Thanks @stuible!
 

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -568,6 +568,17 @@ if [[ ! -d "$APP/Contents/Resources/KeyboardShortcuts_KeyboardShortcuts.bundle" 
   exit 1
 fi
 
+# The helper CLI resolves CodexBarCore resources beside its executable. Keep a
+# dedicated copy in Helpers; the app copy above remains in Contents/Resources.
+CORE_RESOURCE_BUNDLE="${PREFERRED_BUILD_DIR}/CodexBar_CodexBarCore.bundle"
+if [[ ! -d "$CORE_RESOURCE_BUNDLE" ]]; then
+  echo "ERROR: Missing CodexBarCore SwiftPM resource bundle for CodexBarCLI." >&2
+  echo "Expected: ${CORE_RESOURCE_BUNDLE}" >&2
+  exit 1
+fi
+rm -rf "$APP/Contents/Helpers/CodexBar_CodexBarCore.bundle"
+cp -R "$CORE_RESOURCE_BUNDLE" "$APP/Contents/Helpers/"
+
 # Ensure contents are writable before stripping attributes and signing.
 chmod -R u+w "$APP"
 
@@ -578,6 +589,9 @@ find "$APP" -name '._*' -delete
 # Sign helper binaries if present
 if [[ -f "${APP}/Contents/Helpers/CodexBarCLI" ]]; then
   codesign "${CODESIGN_ARGS[@]}" "${APP}/Contents/Helpers/CodexBarCLI"
+fi
+if [[ -d "${APP}/Contents/Helpers/CodexBar_CodexBarCore.bundle" ]]; then
+  codesign "${CODESIGN_ARGS[@]}" "${APP}/Contents/Helpers/CodexBar_CodexBarCore.bundle"
 fi
 if [[ -f "${APP}/Contents/Helpers/CodexBarClaudeWatchdog" ]]; then
   codesign "${CODESIGN_ARGS[@]}" "${APP}/Contents/Helpers/CodexBarClaudeWatchdog"

--- a/Scripts/verify_packaged_app_launch.sh
+++ b/Scripts/verify_packaged_app_launch.sh
@@ -33,6 +33,14 @@ if [[ ! -x "$APP_BUNDLE/Contents/MacOS/CodexBar" ]]; then
   echo "ERROR: Launch smoke check: missing executable in ${APP_BUNDLE}" >&2
   exit 1
 fi
+if [[ ! -x "$APP_BUNDLE/Contents/Helpers/CodexBarCLI" ]]; then
+  echo "ERROR: Launch smoke check: missing Helpers/CodexBarCLI in ${APP_BUNDLE}" >&2
+  exit 1
+fi
+if [[ ! -d "$APP_BUNDLE/Contents/Helpers/CodexBar_CodexBarCore.bundle" ]]; then
+  echo "ERROR: Launch smoke check: missing CodexBarCore resource bundle beside Helpers/CodexBarCLI" >&2
+  exit 1
+fi
 
 if ! command -v sandbox-exec >/dev/null 2>&1; then
   warn "Launch smoke check skipped: sandbox-exec is unavailable on this system."
@@ -71,8 +79,10 @@ trap cleanup EXIT INT TERM
 
 cp -R "$APP_BUNDLE" "$SMOKE_DIR/CodexBar.app"
 SMOKE_BIN="$SMOKE_DIR/CodexBar.app/Contents/MacOS/CodexBar"
+CLI_BIN="$SMOKE_DIR/CodexBar.app/Contents/Helpers/CodexBarCLI"
 SMOKE_LOG="$SMOKE_DIR/launch.log"
 PROBE_LOG="$SMOKE_DIR/probe.log"
+CLI_PROBE_LOG="$SMOKE_DIR/cli-probe.log"
 SANDBOX_PROFILE="(version 1)
 (allow default)
 (deny file-read* (subpath \"${ROOT}\"))"
@@ -84,6 +94,42 @@ fail_with_probe_log() {
   echo "-------------------------------" >&2
   exit 1
 }
+
+fail_with_cli_probe_log() {
+  echo "ERROR: $1" >&2
+  echo "----- CLI probe output (tail) -----" >&2
+  tail -40 "$CLI_PROBE_LOG" >&2 || true
+  echo "-----------------------------------" >&2
+  exit 1
+}
+
+# Probe the executable-context resolver before the app-context resolver. The
+# checkout denial proves the helper is using its adjacent bundle rather than
+# SwiftPM's compile-time development path.
+log "Launch smoke check: probing packaged Helpers CLI resource loads with ${ROOT} unreadable."
+(
+  cd "$SMOKE_DIR"
+  exec env CODEXBAR_RESOURCE_SMOKE=1 sandbox-exec -p "$SANDBOX_PROFILE" "$CLI_BIN"
+) >"$CLI_PROBE_LOG" 2>&1 &
+SMOKE_PID=$!
+CLI_PROBE_OK=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "$SMOKE_PID" 2>/dev/null; then
+    CLI_PROBE_OK=1
+    break
+  fi
+  sleep 0.5
+done
+if [[ "$CLI_PROBE_OK" == "0" ]]; then
+  fail_with_cli_probe_log "Launch smoke check FAILED: Helpers CLI resource probe did not finish within 30s."
+fi
+CLI_PROBE_STATUS=0
+wait "$SMOKE_PID" || CLI_PROBE_STATUS=$?
+SMOKE_PID=""
+if [[ "$CLI_PROBE_STATUS" -ne 0 ]] || ! grep -q "CODEXBAR_RESOURCE_SMOKE_OK" "$CLI_PROBE_LOG"; then
+  fail_with_cli_probe_log "Launch smoke check FAILED: packaged Helpers CLI cannot load CodexBarCore resources without the build checkout. Exit status: ${CLI_PROBE_STATUS}."
+fi
+log "Launch smoke check: Helpers CLI resource probe OK."
 
 # Phase 1 (deterministic, headless-safe): CODEXBAR_RESOURCE_SMOKE=1 makes the
 # app force the resource loads that trapped in 0.48.0 and exit before any UI.

--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -18,6 +18,15 @@ import FoundationNetworking
 @main
 enum CodexBarCLI {
     static func main() async {
+        if CodexBarCoreResourceSmoke.isRequested() {
+            #if canImport(Darwin)
+            Darwin.exit(CodexBarCoreResourceSmoke.run())
+            #elseif canImport(Glibc)
+            Glibc.exit(CodexBarCoreResourceSmoke.run())
+            #elseif canImport(Musl)
+            Musl.exit(CodexBarCoreResourceSmoke.run())
+            #endif
+        }
         self.configureLinuxTimeZoneIfNeeded()
 
         let rawArgv = Array(CommandLine.arguments.dropFirst())

--- a/Sources/CodexBarCore/CodexBarCoreResourceSmoke.swift
+++ b/Sources/CodexBarCore/CodexBarCoreResourceSmoke.swift
@@ -37,8 +37,8 @@ public enum CodexBarCoreResourceSmoke {
             failures.append("\(sucrase).js missing from \(bundle.bundleURL.path)")
         }
 
-        let pluginNames = (bundle.urls(forResourcesWithExtension: "js", subdirectory: nil) ?? [])
-            .map { $0.deletingPathExtension().lastPathComponent }
+        let pluginNames = bundle.paths(forResourcesOfType: "js", inDirectory: nil)
+            .map { URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent }
             .filter { $0 != "provider-plugin-prelude" && $0 != sucrase }
             .sorted()
         if pluginNames.isEmpty {

--- a/Sources/CodexBarCore/CodexBarCoreResourceSmoke.swift
+++ b/Sources/CodexBarCore/CodexBarCoreResourceSmoke.swift
@@ -25,12 +25,13 @@ public enum CodexBarCoreResourceSmoke {
         var failures: [String] = []
         // Touching the resolver (and, through it, `Bundle.module` outside app
         // contexts) is the load that trapped in 0.48.0.
-        let bundle = CodexBarCoreResources.bundle
+        guard let bundle = CodexBarCoreResources.bundle else {
+            return [CodexBarCoreResources.missingBundleMessage]
+        }
 
         if bundle.url(forResource: "provider-plugin-prelude", withExtension: "js") == nil {
             failures.append("provider-plugin-prelude.js missing from \(bundle.bundleURL.path)")
         }
-        #if canImport(JavaScriptCore)
         let sucrase = "sucrase-\(UserProviderPluginLoader.sucraseVersion).min"
         if bundle.url(forResource: sucrase, withExtension: "js") == nil {
             failures.append("\(sucrase).js missing from \(bundle.bundleURL.path)")
@@ -52,7 +53,6 @@ public enum CodexBarCoreResourceSmoke {
                 failures.append("bundled plugin runtime '\(name)' failed to load: \(error)")
             }
         }
-        #endif
         return failures
     }
 

--- a/Sources/CodexBarCore/CodexBarCoreResources.swift
+++ b/Sources/CodexBarCore/CodexBarCoreResources.swift
@@ -22,6 +22,7 @@ public enum CodexBarCoreResources {
     {
         let name = "CodexBar_CodexBarCore"
         let bundleName = "\(name).bundle"
+        let swiftPMBundleNames = [bundleName, "\(name).resources"]
 
         if mainBundle.bundleURL.pathExtension == "app" {
             if let url = mainBundle.url(forResource: name, withExtension: "bundle"),
@@ -39,18 +40,22 @@ public enum CodexBarCoreResources {
             }
         }
 
-        let executableCandidate = (executableBundleURL ?? mainBundle.bundleURL)
-            .appendingPathComponent(bundleName)
-        if let bundle = Bundle(url: executableCandidate) {
-            return bundle
+        let executableDirectory = executableBundleURL ?? mainBundle.bundleURL
+        for swiftPMBundleName in swiftPMBundleNames {
+            let executableCandidate = executableDirectory.appendingPathComponent(swiftPMBundleName)
+            if let bundle = Bundle(url: executableCandidate) {
+                return bundle
+            }
         }
 
         if let swiftPMBuildDirectory {
-            var isDirectory: ObjCBool = false
-            let buildCandidate = swiftPMBuildDirectory.appendingPathComponent(bundleName)
-            if FileManager.default.fileExists(atPath: buildCandidate.path, isDirectory: &isDirectory),
-               isDirectory.boolValue
-            {
+            let buildCandidateExists = swiftPMBundleNames.contains { buildBundleName in
+                var isDirectory: ObjCBool = false
+                let buildCandidate = swiftPMBuildDirectory.appendingPathComponent(buildBundleName)
+                return FileManager.default.fileExists(atPath: buildCandidate.path, isDirectory: &isDirectory)
+                    && isDirectory.boolValue
+            }
+            if buildCandidateExists {
                 return .module
             }
         }

--- a/Sources/CodexBarCore/CodexBarCoreResources.swift
+++ b/Sources/CodexBarCore/CodexBarCoreResources.swift
@@ -6,30 +6,67 @@ import Foundation
 /// app does not place `CodexBar_CodexBarCore.bundle` at the locations it probes
 /// (the app root and the compile-time build directory). The packaged app ships
 /// the bundle in `Contents/Resources`, so resolve through the main bundle first
-/// and fall back to `Bundle.module` only outside an app context (SwiftPM dev
-/// builds, the CLI, and tests), mirroring `resolveLocalizationResourceBundle`
-/// and `ProviderBrandIcon.resourceBundle`.
+/// and only touch `Bundle.module` after verifying that its development-build
+/// candidate exists. Shipped command-line tools resolve the bundle beside the
+/// executable; a missing bundle is reported by callers instead of trapping.
 public enum CodexBarCoreResources {
-    public static let bundle: Bundle = resolve(mainBundle: .main)
+    static let missingBundleMessage =
+        "CodexBarCore resource bundle is missing next to the executable; reinstall or update CodexBar"
 
-    static func resolve(mainBundle: Bundle) -> Bundle {
-        guard mainBundle.bundleURL.pathExtension == "app" else {
-            return .module
-        }
+    public static let bundle: Bundle? = resolve(mainBundle: .main)
+
+    static func resolve(
+        mainBundle: Bundle,
+        executableBundleURL: URL? = nil,
+        swiftPMBuildDirectory: URL? = Self.defaultSwiftPMBuildDirectory) -> Bundle?
+    {
         let name = "CodexBar_CodexBarCore"
-        if let url = mainBundle.url(forResource: name, withExtension: "bundle"),
-           let bundle = Bundle(url: url)
-        {
+        let bundleName = "\(name).bundle"
+
+        if mainBundle.bundleURL.pathExtension == "app" {
+            if let url = mainBundle.url(forResource: name, withExtension: "bundle"),
+               let bundle = Bundle(url: url)
+            {
+                return bundle
+            }
+            if let resourceURL = mainBundle.resourceURL,
+               let bundle = Bundle(url: resourceURL.appendingPathComponent(bundleName))
+            {
+                return bundle
+            }
+            if let bundle = Bundle(url: mainBundle.bundleURL.appendingPathComponent(bundleName)) {
+                return bundle
+            }
+        }
+
+        let executableCandidate = (executableBundleURL ?? mainBundle.bundleURL)
+            .appendingPathComponent(bundleName)
+        if let bundle = Bundle(url: executableCandidate) {
             return bundle
         }
-        if let resourceURL = mainBundle.resourceURL,
-           let bundle = Bundle(url: resourceURL.appendingPathComponent("\(name).bundle"))
-        {
-            return bundle
+
+        if let swiftPMBuildDirectory {
+            var isDirectory: ObjCBool = false
+            let buildCandidate = swiftPMBuildDirectory.appendingPathComponent(bundleName)
+            if FileManager.default.fileExists(atPath: buildCandidate.path, isDirectory: &isDirectory),
+               isDirectory.boolValue
+            {
+                return .module
+            }
         }
-        if let bundle = Bundle(url: mainBundle.bundleURL.appendingPathComponent("\(name).bundle")) {
-            return bundle
-        }
-        return .module
+        return nil
     }
+
+    private static let defaultSwiftPMBuildDirectory: URL = {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // CodexBarCore
+            .deletingLastPathComponent() // Sources
+            .deletingLastPathComponent() // package root
+        #if DEBUG
+        let configuration = "debug"
+        #else
+        let configuration = "release"
+        #endif
+        return packageRoot.appendingPathComponent(".build/\(configuration)", isDirectory: true)
+    }()
 }

--- a/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
@@ -32,16 +32,53 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout) throws
     {
-        guard let url = CodexBarCoreResources.bundle.url(forResource: name, withExtension: "js") else {
+        try self.init(
+            bundledPlugin: name,
+            resourceBundle: CodexBarCoreResources.bundle,
+            transport: transport,
+            timeout: timeout)
+    }
+
+    convenience init(
+        bundledPlugin name: String,
+        resourceBundle: Bundle?,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout) throws
+    {
+        guard let resourceBundle else {
+            throw ProviderPluginError.load(CodexBarCoreResources.missingBundleMessage)
+        }
+        guard let url = resourceBundle.url(forResource: name, withExtension: "js") else {
             throw ProviderPluginError.load("bundled plugin '\(name).js' was not found")
         }
         let source = try String(contentsOf: url, encoding: .utf8)
         try ProviderPluginSourceLint.validateBundled(source, name: name)
-        try self.init(source: source, transport: transport, timeout: timeout)
+        try self.init(source: source, resourceBundle: resourceBundle, transport: transport, timeout: timeout)
     }
 
-    public init(
+    public convenience init(
         source: String,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
+        responseSizeLimit: Int = ProviderPluginRuntime.maximumResponseBytes,
+        rejectsNonSuccessResponses: Bool = false,
+        allowsDynamicID: Bool = false,
+        engine: ProviderPluginEngineKind = .automatic) throws
+    {
+        try self.init(
+            source: source,
+            resourceBundle: CodexBarCoreResources.bundle,
+            transport: transport,
+            timeout: timeout,
+            responseSizeLimit: responseSizeLimit,
+            rejectsNonSuccessResponses: rejectsNonSuccessResponses,
+            allowsDynamicID: allowsDynamicID,
+            engine: engine)
+    }
+
+    init(
+        source: String,
+        resourceBundle: Bundle?,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
         responseSizeLimit: Int = ProviderPluginRuntime.maximumResponseBytes,
@@ -51,7 +88,10 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
     {
         guard timeout > 0 else { throw ProviderPluginError.load("timeout must be positive") }
         guard responseSizeLimit > 0 else { throw ProviderPluginError.load("response size limit must be positive") }
-        guard let preludeURL = CodexBarCoreResources.bundle.url(
+        guard let resourceBundle else {
+            throw ProviderPluginError.load(CodexBarCoreResources.missingBundleMessage)
+        }
+        guard let preludeURL = resourceBundle.url(
             forResource: "provider-plugin-prelude",
             withExtension: "js")
         else {

--- a/Sources/CodexBarCore/Plugins/UserProviderPlugins.swift
+++ b/Sources/CodexBarCore/Plugins/UserProviderPlugins.swift
@@ -226,15 +226,30 @@ public final class UserProviderPluginLoader: @unchecked Sendable {
     private let providersDirectory: URL
     private let cacheDirectory: URL
     private let transport: any ProviderHTTPTransport
+    private let resourceBundle: Bundle?
 
-    public init(
+    public convenience init(
         providersDirectory: URL = UserProviderPluginLoader.defaultProvidersDirectory,
         cacheDirectory: URL = UserProviderPluginLoader.defaultCacheDirectory,
         transport: (any ProviderHTTPTransport)? = nil)
     {
+        self.init(
+            providersDirectory: providersDirectory,
+            cacheDirectory: cacheDirectory,
+            transport: transport,
+            resourceBundle: CodexBarCoreResources.bundle)
+    }
+
+    init(
+        providersDirectory: URL,
+        cacheDirectory: URL,
+        transport: (any ProviderHTTPTransport)?,
+        resourceBundle: Bundle?)
+    {
         self.providersDirectory = providersDirectory
         self.cacheDirectory = cacheDirectory
         self.transport = transport ?? UserProviderPluginHTTPTransport.make()
+        self.resourceBundle = resourceBundle
     }
 
     public func discover() -> [UserProviderPluginLoadResult] {
@@ -295,6 +310,7 @@ public final class UserProviderPluginLoader: @unchecked Sendable {
         }
         let runtime = try ProviderPluginRuntime(
             source: output.source,
+            resourceBundle: self.resourceBundle,
             transport: self.transport,
             responseSizeLimit: UserProviderPlugin.maximumSourceBytes,
             rejectsNonSuccessResponses: true,
@@ -337,7 +353,10 @@ public final class UserProviderPluginLoader: @unchecked Sendable {
         if let cached = try? String(contentsOf: cacheURL, encoding: .utf8) {
             return (cached, cacheURL, true)
         }
-        guard let resourceURL = CodexBarCoreResources.bundle.url(
+        guard let resourceBundle = self.resourceBundle else {
+            throw ProviderPluginError.load(CodexBarCoreResources.missingBundleMessage)
+        }
+        guard let resourceURL = resourceBundle.url(
             forResource: "sucrase-\(Self.sucraseVersion).min",
             withExtension: "js")
         else {

--- a/Tests/CodexBarTests/CodexBarCoreResourcesTests.swift
+++ b/Tests/CodexBarTests/CodexBarCoreResourcesTests.swift
@@ -33,15 +33,15 @@ struct CodexBarCoreResourcesTests {
         #expect(resolved.url(forResource: "provider-plugin-prelude", withExtension: "js") != nil)
     }
 
-    @Test
-    func `resolver finds an executable adjacent resource bundle`() throws {
+    @Test(arguments: ["bundle", "resources"])
+    func `resolver finds an executable adjacent resource bundle`(pathExtension: String) throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("CodexBarCoreResourcesCLITests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
         let sourceBundle = try #require(CodexBarCoreResources.bundle)
-        let target = root.appendingPathComponent("CodexBar_CodexBarCore.bundle")
+        let target = root.appendingPathComponent("CodexBar_CodexBarCore.\(pathExtension)")
         try FileManager.default.copyItem(at: sourceBundle.bundleURL.resolvingSymlinksInPath(), to: target)
 
         let resolved = try #require(CodexBarCoreResources.resolve(

--- a/Tests/CodexBarTests/CodexBarCoreResourcesTests.swift
+++ b/Tests/CodexBarTests/CodexBarCoreResourcesTests.swift
@@ -4,8 +4,8 @@ import Testing
 
 struct CodexBarCoreResourcesTests {
     @Test
-    func `resolver finds bundled plugin resources outside an app context`() {
-        let bundle = CodexBarCoreResources.bundle
+    func `resolver finds bundled plugin resources outside an app context`() throws {
+        let bundle = try #require(CodexBarCoreResources.bundle)
         #expect(bundle.url(forResource: "provider-plugin-prelude", withExtension: "js") != nil)
     }
 
@@ -24,14 +24,44 @@ struct CodexBarCoreResourcesTests {
         let target = resourcesURL.appendingPathComponent("CodexBar_CodexBarCore.bundle")
         // `Bundle.module` here is the *test* module's bundle; source the copy from
         // CodexBarCore's own resolved bundle (non-app context, proven by the test above).
-        try FileManager.default.copyItem(
-            at: URL(fileURLWithPath: CodexBarCoreResources.bundle.bundleURL.path).resolvingSymlinksInPath(),
-            to: target)
+        let sourceBundle = try #require(CodexBarCoreResources.bundle)
+        try FileManager.default.copyItem(at: sourceBundle.bundleURL.resolvingSymlinksInPath(), to: target)
 
         let fakeApp = try #require(Bundle(url: appURL))
-        let resolved = CodexBarCoreResources.resolve(mainBundle: fakeApp)
+        let resolved = try #require(CodexBarCoreResources.resolve(mainBundle: fakeApp))
         #expect(resolved.bundleURL.path.contains("Contents/Resources/CodexBar_CodexBarCore.bundle"))
         #expect(resolved.url(forResource: "provider-plugin-prelude", withExtension: "js") != nil)
+    }
+
+    @Test
+    func `resolver finds an executable adjacent resource bundle`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarCoreResourcesCLITests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sourceBundle = try #require(CodexBarCoreResources.bundle)
+        let target = root.appendingPathComponent("CodexBar_CodexBarCore.bundle")
+        try FileManager.default.copyItem(at: sourceBundle.bundleURL.resolvingSymlinksInPath(), to: target)
+
+        let resolved = try #require(CodexBarCoreResources.resolve(
+            mainBundle: .main,
+            executableBundleURL: root,
+            swiftPMBuildDirectory: nil))
+        #expect(resolved.bundleURL.resolvingSymlinksInPath() == target.resolvingSymlinksInPath())
+    }
+
+    @Test
+    func `resolver returns nil when executable and build bundles are missing`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarCoreResourcesMissingTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(CodexBarCoreResources.resolve(
+            mainBundle: .main,
+            executableBundleURL: root,
+            swiftPMBuildDirectory: nil) == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -7,6 +7,13 @@ import Testing
 
 struct ProviderPluginRuntimeTests {
     @Test
+    func `missing resource bundle throws a provider load error`() {
+        #expect(throws: ProviderPluginError.load(CodexBarCoreResources.missingBundleMessage)) {
+            _ = try ProviderPluginRuntime(bundledPlugin: "openrouter", resourceBundle: nil)
+        }
+    }
+
+    @Test
     func `context exposes no browser or timer globals`() throws {
         let runtime = try ProviderPluginRuntime(source: Self.plugin())
 

--- a/TestsPlugin/UserProviderPluginPortableTests.swift
+++ b/TestsPlugin/UserProviderPluginPortableTests.swift
@@ -5,11 +5,12 @@ import Testing
 struct UserProviderPluginPortableTests {
     @Test
     func `bundled plugins are free of raw Intl references`() throws {
+        let bundle = try #require(CodexBarCoreResources.bundle)
         for name in [
             "crof", "venice", "openrouter", "clawrouter", "deepgram", "sub2api", "synthetic", "openai", "zai",
             "poe", "xai", "manus", "perplexity", "t3chat", "qoder",
         ] {
-            let url = try #require(CodexBarCoreResources.bundle.url(forResource: name, withExtension: "js"))
+            let url = try #require(bundle.url(forResource: name, withExtension: "js"))
             let source = try String(contentsOf: url, encoding: .utf8)
             try ProviderPluginSourceLint.validateBundled(source, name: name)
         }
@@ -21,7 +22,8 @@ struct UserProviderPluginPortableTests {
 
     @Test
     func `QuickJS executes the bundled Sucrase transform`() throws {
-        let resourceURL = try #require(CodexBarCoreResources.bundle.url(
+        let bundle = try #require(CodexBarCoreResources.bundle)
+        let resourceURL = try #require(bundle.url(
             forResource: "sucrase-3.35.1.min",
             withExtension: "js"))
         let sucraseSource = try String(contentsOf: resourceURL, encoding: .utf8)


### PR DESCRIPTION
## Summary

- make `CodexBarCoreResources.bundle` non-trapping and optional, preserving app resource lookup first, then checking the executable-adjacent bundle and a verified SwiftPM development candidate before touching `Bundle.module`
- turn a missing bundle into the agreed `ProviderPluginError.load` at the bundled runtime, prelude, and Sucrase call sites
- ship and sign `CodexBar_CodexBarCore.bundle` beside the app helper CLI, and include it beside the binary in every macOS, glibc Linux, and musl Linux CLI tarball
- extend the deterministic resource smoke probe to the Helpers CLI and standalone CLI artifact staging

The branch was rebased onto the newly merged #2753. Since QuickJS now runs bundled plugins on Linux, the release workflow deliberately includes and probes the bundle for all six CLI artifact jobs rather than limiting this fix to macOS.

Fixes #2756

## Proof

```text
$ swift test --filter 'CodexBarCoreResources|ProviderPluginRuntime|UserProviderPlugin'
Test run with 44 tests in 4 suites passed.

$ make check
SwiftFormat: 0 files require formatting
SwiftLint: Found 0 violations, 0 serious in 1804 files

$ CODEXBAR_SIGNING=identity ./Scripts/package_app.sh release
Launch smoke check: probing packaged Helpers CLI resource loads with the build checkout unreadable.
Launch smoke check: Helpers CLI resource probe OK.
Launch smoke check: probing packaged resource loads with the build checkout unreadable.
Launch smoke check: resource probe OK.
Launch smoke check OK: packaged app survived 6s without the build checkout.
Created CodexBar.app

$ ls -ld CodexBar.app/Contents/Helpers/CodexBar_CodexBarCore.bundle
drwxr-xr-x  CodexBar.app/Contents/Helpers/CodexBar_CodexBarCore.bundle

$ CODEXBAR_RESOURCE_SMOKE=1 <staged-macOS-tarball>/CodexBarCLI
CODEXBAR_RESOURCE_SMOKE_OK

$ tar tzf CodexBarCLI-macos-arm64.tar.gz | head
CodexBarCLI
CodexBar_CodexBarCore.bundle/
CodexBar_CodexBarCore.bundle/_CodeSignature/
CodexBar_CodexBarCore.bundle/poe.js
CodexBar_CodexBarCore.bundle/openrouter.js
```

Source-blind behavior validation also removed the adjacent bundle from an isolated CLI copy while denying all build-checkout reads. The process exited 1 with:

```text
RESOURCE SMOKE FAILURE: CodexBarCore resource bundle is missing next to the executable; reinstall or update CodexBar
```

There was no `Fatal error`, `could not load resource bundle`, or `unable to find bundle named` output.

Codex autoreview: clean, no accepted/actionable findings.

The full Linux glibc/musl release matrix cannot execute locally on this macOS host. The workflow edit applies the same required copy, resource smoke probe, success-marker check, and tar membership to every Linux job; CI will provide the platform runtime proof.
