### PR TITLE
Add CodexBar Plasma to Linux integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ CLI install:
 - [noctalia-codex-usage](https://github.com/rayoplateado/noctalia-codex-usage) — Noctalia/Quickshell plugin that shows Codex 5-hour and weekly usage limits, built on top of the bundled Linux CLI.
 - [KodexBar](https://github.com/tylxr59/KodexBar) — KDE Plasma widget that shows CodexBar usage in the Plasma panel, built on top of the bundled Linux CLI.
 - [codexbar-plasmoid](https://github.com/psimaker/codexbar-plasmoid) — KDE Plasma 6 widget for CodexBar's meter icon, provider switcher, quota windows, pace, credits, local cost, and status, powered by the bundled Linux CLI.
+- [CodexBar Plasma](https://github.com/Lucenx9/codexbar-plasma) — KDE Plasma 6 widget with multi-provider views, account selection, cost history, notifications, configurable providers, and installable `.plasmoid` releases, powered by the bundled Linux CLI.
 - [CodexBar Meter](https://github.com/noctalia-dev/community-plugins/tree/main/codexbar-meter) — Noctalia v5 bar widget and panel showing every enabled provider's quota windows, credits, and pace, installable from Noctalia's plugin store, built on the bundled Linux CLI.
 
 ## Status bar & terminal integration


### PR DESCRIPTION
## Summary

- add [CodexBar Plasma](https://github.com/Lucenx9/codexbar-plasma) to the Linux desktop integrations
- describe its Plasma-native multi-provider views, account selection, cost history, notifications, provider configuration, and installable releases

## Why

CodexBar Plasma is an independent KDE Plasma 6 frontend built on CodexBar's official Linux CLI and JSON contracts. Listing it alongside the existing community integrations makes the packaged Plasma option discoverable without changing CodexBar itself.

## Validation

- `git diff --check`
- verified that the repository link and latest packaged release resolve
