### PR TITLE
perf: precompute per-path baseline counts in saveCodexCache (refs #2760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.48.2 — Unreleased
 
 ### Fixed
+- Codex: SQLite cost saves no longer rescan every stored row and snapshot per file — baseline counts and file lookups are precomputed once, cutting a large-corpus (1,700+ sessions) save pass from minutes of CPU to seconds (refs #2760).
 - Codex: restore JSON-cache retention semantics lost in the SQLite cutover — discovery pruning now reaches the scanner's round-tripped payload so deleted files stop resurfacing, the row budget never sacrifices in-window or recently active sessions, and fork-parent protection again drops stale lineage-only parents (refs #2760).
 - Codex: the SQLite cost store no longer deletes the whole database on transient failures — lock contention from a concurrent CLI/app writer, disk-full, or a constraint violation now preserve history and only genuine corruption or schema drift triggers a rebuild, which is now logged (refs #2760).
 - Menu: let long metric reset and pace details wrap to two lines instead of truncating, without clipping cached card heights (#2742). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
@@ -25,17 +25,18 @@ extension CostUsageStore {
         let previous = self.readSnapshot()
         let canReuseStoredRows = previous.metadata.timeZoneIdentifier == calendar.timeZone.identifier
         self.deleteRemovedFiles(previous: previous, cache: cache)
+        let previousFilesByPath = Dictionary(uniqueKeysWithValues: previous.files.map { ($0.path, $0) })
+        let snapshotCountsByPath = previous.tokenSnapshots
+            .reduce(into: [String: Int]()) { $0[$1.path, default: 0] += 1 }
+        let rowCountsByPath = previous.usageRows.reduce(into: [String: Int]()) { $0[$1.path, default: 0] += 1 }
         for (path, usage) in cache.files.sorted(by: { $0.key < $1.key }) {
-            let oldFile = previous.files.first { $0.path == path }
-            let oldSnapshotCount = previous.tokenSnapshots.count(where: { $0.path == path })
-            let oldRowCount = previous.usageRows.count(where: { $0.path == path })
             self.persistFile(
                 path: path,
                 usage: usage,
                 baseline: PersistedFileBaseline(
-                    file: oldFile,
-                    snapshotCount: oldSnapshotCount,
-                    rowCount: oldRowCount,
+                    file: previousFilesByPath[path],
+                    snapshotCount: snapshotCountsByPath[path] ?? 0,
+                    rowCount: rowCountsByPath[path] ?? 0,
                     canReuseRows: canReuseStoredRows),
                 calendar: calendar)
         }


### PR DESCRIPTION
## Summary

`saveCodexCache` ran three linear scans per file over the previous snapshot — `previous.files.first`, `previous.tokenSnapshots.count(where:)`, and `previous.usageRows.count(where:)` — making the save pass O(files x total_rows). On a real 2.0 GB / 1,725-file `~/.codex/sessions` corpus, a process sample attributed ~68% of save time (673/992 samples) to these lines; each save pass burned minutes of pure CPU.

This precomputes three per-path maps once before the loop (file lookup + snapshot/row counts), making each per-file baseline lookup O(1). The file map uses `Dictionary(uniqueKeysWithValues:)`, which is safe because `path` is the files table's key.

Introduced in #2761/#2762 (refs #2760).

## Proof

- All 53 `CostUsageStoreTests` pass; `CostUsagePerformanceGateTests`, `CodexForkAppendResumeTests`, and `UsageStoreCachedTokenHydrationTests` (32 tests) pass.
- Throwaway timed benchmark (1,200 files x 40 rows + 40 snapshots, timed re-save): 23.6s before, 4.4s after (5.3x); the gap grows linearly with total row count.
