### PR TITLE
test: make cost-usage debounce and token-hydration tests order-independent

### DIFF
--- a/Tests/CodexBarTests/CostUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CostUsageFetcherTests.swift
@@ -859,6 +859,7 @@ extension CostUsageFetcherTests {
         let first = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
+            allowPricingRefresh: false,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)
         #expect(first.daily.first?.totalTokens == 110)
@@ -884,6 +885,7 @@ extension CostUsageFetcherTests {
         let debounced = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
+            allowPricingRefresh: false,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)
         #expect(debounced.daily.first?.totalTokens == 110)
@@ -891,6 +893,7 @@ extension CostUsageFetcherTests {
         let refreshed = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
+            allowPricingRefresh: false,
             bypassScannerDebounce: true,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)

--- a/Tests/CodexBarTests/UsageStoreCachedTokenHydrationTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCachedTokenHydrationTests.swift
@@ -39,9 +39,7 @@ struct UsageStoreCachedTokenHydrationTests {
 
         store.hydrateCachedTokenSnapshots(now: day)
 
-        for _ in 0..<100 where store.tokenSnapshot(for: .codex) == nil {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        try await Self.waitForCodexTokenSnapshot(in: store)
 
         #expect(store.tokenSnapshot(for: .codex)?.sessionTokens == 42)
         #expect(store.tokenSnapshot(for: .codex)?.daily.map(\.date) == ["2026-04-08"])
@@ -132,9 +130,7 @@ struct UsageStoreCachedTokenHydrationTests {
         store._test_tokenUsageRefreshOverride = { _, _ in tokenRefreshCount += 1 }
 
         store.hydrateCachedTokenSnapshots(now: now)
-        for _ in 0..<100 where store.tokenSnapshot(for: .codex) == nil {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        try await Self.waitForCodexTokenSnapshot(in: store)
 
         await store.refreshTokenUsageNow(for: .codex, force: false)
 
@@ -180,9 +176,7 @@ struct UsageStoreCachedTokenHydrationTests {
         store._test_tokenUsageRefreshOverride = { _, _ in tokenRefreshCount += 1 }
 
         store.hydrateCachedTokenSnapshots(now: now)
-        for _ in 0..<100 where store.tokenSnapshot(for: .codex) == nil {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        try await Self.waitForCodexTokenSnapshot(in: store)
 
         await store.refreshTokenUsageNow(for: .codex, force: false)
 
@@ -311,6 +305,16 @@ struct UsageStoreCachedTokenHydrationTests {
             last30DaysCostUSD: 1,
             daily: [],
             updatedAt: Date())
+    }
+
+    private static func waitForCodexTokenSnapshot(in store: UsageStore) async throws {
+        // Parallel suites can occupy the process-global CostUsageScanExecutor, so use a real deadline instead of
+        // assuming the cached read will reach the front of that queue within a fixed number of scheduler turns.
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(60))
+        while store.tokenSnapshot(for: .codex) == nil, clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
     }
 
     private static func writeCodexSessionFile(


### PR DESCRIPTION
## Summary

- Disable pricing refreshes in the scanner debounce test so a background models.dev download cannot change `codexPricingKey` between loads and bypass the cached result.
- Replace three fixed one-second polling windows with a shared 60-second deadline because parallel suites can occupy the process-global `CostUsageScanExecutor` for several seconds.

Both failures were order-dependent test flakes that passed in isolation and predated this branch. This is test-only, so no changelog entry is needed.

## Failing filters

```sh
swift test --filter CostUsage
swift test --filter 'CodexForkAppendResume|CodexCompactSubagent|CodexSubagentAccounting|CodexLocalProjectUsage|UsageStoreCachedTokenHydration'
```

## Proof

- Both focused filter commands passed three consecutive runs each, plus one additional independent run.
- `make test` passed all 822 selections across 69/69 groups.
- `make check` passed.
