### PR TITLE
Fix OpenRouter plugin parity flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.48.2 — Unreleased
 
 ### Fixed
+- OpenRouter: keep optional key-quota enrichment on its one-second production fast join while making degraded results explicit and preventing loaded CI parity runs from mistaking the fallback snapshot for a golden mismatch (fixes #2778).
 - Codex: SQLite cost saves no longer rescan every stored row and snapshot per file — baseline counts and file lookups are precomputed once, cutting a large-corpus (1,700+ sessions) save pass from minutes of CPU to seconds (refs #2760).
 - Codex: restore JSON-cache retention semantics lost in the SQLite cutover — discovery pruning now reaches the scanner's round-tripped payload so deleted files stop resurfacing, the row budget never sacrifices in-window or recently active sessions, and fork-parent protection again drops stale lineage-only parents (refs #2760).
 - Codex: the SQLite cost store no longer deletes the whole database on transient failures — lock contention from a concurrent CLI/app writer, disk-full, or a constraint violation now preserve history and only genuine corruption or schema drift triggers a rebuild, which is now logged (refs #2760).

--- a/Sources/CodexBarCore/Plugins/ProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginEngine.swift
@@ -7,6 +7,12 @@ public enum ProviderPluginEngineKind: Equatable, Sendable {
     case quickJS
 }
 
+struct ProviderPluginContextOptions: Sendable {
+    static let production = Self(optionalRequestTimeoutSeconds: nil)
+
+    let optionalRequestTimeoutSeconds: TimeInterval?
+}
+
 enum ProviderPluginSourceLint {
     static func validateBundled(_ source: String, name: String) throws {
         if source.range(of: #"\bIntl\s*\."#, options: .regularExpression) != nil {
@@ -64,6 +70,7 @@ protocol ProviderPluginEngine: AnyObject, Sendable {
         secrets: [String: String],
         now: Date,
         timeZone: TimeZone,
+        contextOptions: ProviderPluginContextOptions,
         cookieResolver: ProviderPluginRuntime.CookieResolver?,
         instanceCookieResolver: ProviderPluginRuntime.InstanceCookieResolver?,
         completion: @escaping @Sendable (Result<UsageSnapshot, Error>) -> Void)

--- a/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
@@ -23,6 +23,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
     private let responseSizeLimit: Int
     private let rejectsNonSuccessResponses: Bool
     private let allowsDynamicID: Bool
+    private let contextOptions: ProviderPluginContextOptions
     private let engineKind: ProviderPluginEngineKind
     private let lock = NSLock()
     private var worker: (any ProviderPluginEngine)?
@@ -41,9 +42,24 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
 
     convenience init(
         bundledPlugin name: String,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
+        contextOptions: ProviderPluginContextOptions) throws
+    {
+        try self.init(
+            bundledPlugin: name,
+            resourceBundle: CodexBarCoreResources.bundle,
+            transport: transport,
+            timeout: timeout,
+            contextOptions: contextOptions)
+    }
+
+    convenience init(
+        bundledPlugin name: String,
         resourceBundle: Bundle?,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
-        timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout) throws
+        timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
+        contextOptions: ProviderPluginContextOptions = .production) throws
     {
         guard let resourceBundle else {
             throw ProviderPluginError.load(CodexBarCoreResources.missingBundleMessage)
@@ -53,7 +69,12 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
         }
         let source = try String(contentsOf: url, encoding: .utf8)
         try ProviderPluginSourceLint.validateBundled(source, name: name)
-        try self.init(source: source, resourceBundle: resourceBundle, transport: transport, timeout: timeout)
+        try self.init(
+            source: source,
+            resourceBundle: resourceBundle,
+            transport: transport,
+            timeout: timeout,
+            contextOptions: contextOptions)
     }
 
     public convenience init(
@@ -73,6 +94,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
             responseSizeLimit: responseSizeLimit,
             rejectsNonSuccessResponses: rejectsNonSuccessResponses,
             allowsDynamicID: allowsDynamicID,
+            contextOptions: .production,
             engine: engine)
     }
 
@@ -84,10 +106,16 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
         responseSizeLimit: Int = ProviderPluginRuntime.maximumResponseBytes,
         rejectsNonSuccessResponses: Bool = false,
         allowsDynamicID: Bool = false,
+        contextOptions: ProviderPluginContextOptions = .production,
         engine: ProviderPluginEngineKind = .automatic) throws
     {
         guard timeout > 0 else { throw ProviderPluginError.load("timeout must be positive") }
         guard responseSizeLimit > 0 else { throw ProviderPluginError.load("response size limit must be positive") }
+        if let optionalRequestTimeoutSeconds = contextOptions.optionalRequestTimeoutSeconds,
+           !(1...30).contains(optionalRequestTimeoutSeconds)
+        {
+            throw ProviderPluginError.load("optional request timeout must be from 1 through 30 seconds")
+        }
         guard let resourceBundle else {
             throw ProviderPluginError.load(CodexBarCoreResources.missingBundleMessage)
         }
@@ -105,6 +133,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
         self.responseSizeLimit = responseSizeLimit
         self.rejectsNonSuccessResponses = rejectsNonSuccessResponses
         self.allowsDynamicID = allowsDynamicID
+        self.contextOptions = contextOptions
         self.engineKind = Self.resolveEngineKind(engine)
 
         let worker = try ProviderPluginEngineFactory.make(
@@ -149,6 +178,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
                 secrets: sanitizedSecrets,
                 now: now,
                 timeZone: timeZone,
+                contextOptions: self.contextOptions,
                 cookieResolver: cookieResolver,
                 instanceCookieResolver: instanceCookieResolver)
             { result in
@@ -430,6 +460,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
         secrets: [String: String],
         now: Date,
         timeZone: TimeZone,
+        contextOptions: ProviderPluginContextOptions,
         cookieResolver: ProviderPluginRuntime.CookieResolver?,
         instanceCookieResolver: ProviderPluginRuntime.InstanceCookieResolver?,
         completion: @escaping @Sendable (Result<UsageSnapshot, Error>) -> Void)
@@ -440,6 +471,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
                 secrets: secrets,
                 now: now,
                 timeZone: timeZone,
+                contextOptions: contextOptions,
                 cookieResolver: cookieResolver,
                 instanceCookieResolver: instanceCookieResolver,
                 completion: completion)
@@ -452,6 +484,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
         secrets: [String: String],
         now: Date,
         timeZone: TimeZone,
+        contextOptions: ProviderPluginContextOptions,
         cookieResolver: ProviderPluginRuntime.CookieResolver?,
         instanceCookieResolver: ProviderPluginRuntime.InstanceCookieResolver?,
         completion: @escaping @Sendable (Result<UsageSnapshot, Error>) -> Void)
@@ -463,6 +496,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
             secrets: secrets,
             now: now,
             timeZone: timeZone,
+            contextOptions: contextOptions,
             cookieResolver: cookieResolver,
             instanceCookieResolver: instanceCookieResolver,
             redactionValues: redactionValues)
@@ -522,6 +556,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
         secrets: [String: String],
         now: Date,
         timeZone: TimeZone,
+        contextOptions: ProviderPluginContextOptions,
         cookieResolver: ProviderPluginRuntime.CookieResolver?,
         instanceCookieResolver: ProviderPluginRuntime.InstanceCookieResolver?,
         redactionValues: ProviderPluginRedactionValues) -> JSValue
@@ -529,6 +564,11 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
         let ctx = JSValue(newObjectIn: self.context)!
         let host = JSValue(newObjectIn: self.context)!
         ctx.setObject(now.timeIntervalSince1970 * 1000, forKeyedSubscript: "__codexbarNowMillis" as NSString)
+        if let optionalRequestTimeoutSeconds = contextOptions.optionalRequestTimeoutSeconds {
+            ctx.setObject(
+                optionalRequestTimeoutSeconds,
+                forKeyedSubscript: "__codexbarOptionalRequestTimeoutSeconds" as NSString)
+        }
 
         let settingGet: @convention(block) (String, Bool) -> JSValue = { [weak self] key, secure in
             guard let self else { return JSValue(undefinedIn: nil) }

--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -32,6 +32,28 @@ private func quickJSHostCallback(
     return engine.handleHostCall(function, context: context, arguments: argv, count: Int(argc))
 }
 
+private func quickJSInstallContextOptions(
+    _ options: ProviderPluginContextOptions,
+    context: OpaquePointer,
+    target: JSValue)
+{
+    guard let timeout = options.optionalRequestTimeoutSeconds else { return }
+    _ = JS_SetPropertyStr(
+        context,
+        target,
+        "__codexbarOptionalRequestTimeoutSeconds",
+        JS_NewFloat64(context, timeout))
+}
+
+private func quickJSNormalizedTimeZoneIdentifier(_ timeZone: TimeZone) -> String {
+    if timeZone.secondsFromGMT() == 0,
+       ["GMT", "Etc/GMT", "Etc/UTC", "UTC"].contains(timeZone.identifier)
+    {
+        return "UTC"
+    }
+    return timeZone.identifier
+}
+
 private final class QuickJSPluginValue: ProviderPluginValue {
     private unowned let engine: QuickJSProviderPluginEngine
     private let value: JSValue
@@ -305,6 +327,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
         secrets: [String: String],
         now: Date,
         timeZone: TimeZone,
+        contextOptions: ProviderPluginContextOptions,
         cookieResolver: ProviderPluginRuntime.CookieResolver?,
         instanceCookieResolver: ProviderPluginRuntime.InstanceCookieResolver?,
         completion: @escaping @Sendable (Result<UsageSnapshot, Error>) -> Void)
@@ -316,6 +339,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
                     secrets: secrets,
                     now: now,
                     timeZone: timeZone,
+                    contextOptions: contextOptions,
                     cookieResolver: cookieResolver,
                     instanceCookieResolver: instanceCookieResolver)
             })
@@ -385,6 +409,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
         secrets: [String: String],
         now: Date,
         timeZone: TimeZone,
+        contextOptions: ProviderPluginContextOptions,
         cookieResolver: ProviderPluginRuntime.CookieResolver?,
         instanceCookieResolver: ProviderPluginRuntime.InstanceCookieResolver?) throws -> UsageSnapshot
     {
@@ -418,12 +443,13 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
             ctx,
             "__codexbarNowMillis",
             JS_NewFloat64(self.context, now.timeIntervalSince1970 * 1000))
+        quickJSInstallContextOptions(contextOptions, context: self.context, target: ctx)
         let env = JS_NewObject(self.context)
         _ = JS_SetPropertyStr(
             self.context,
             env,
             "timeZone",
-            self.makeString(Self.normalizedTimeZoneIdentifier(timeZone)))
+            self.makeString(quickJSNormalizedTimeZoneIdentifier(timeZone)))
         _ = JS_SetPropertyStr(self.context, ctx, "env", env)
 
         let preparedContext = try self.call(applyPrelude, arguments: [ctx, host])
@@ -958,15 +984,6 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
         }
         guard !cqjs_is_exception(result) else { throw self.scriptErrorFromException() }
         return result
-    }
-
-    private static func normalizedTimeZoneIdentifier(_ timeZone: TimeZone) -> String {
-        if timeZone.secondsFromGMT() == 0,
-           ["GMT", "Etc/GMT", "Etc/UTC", "UTC"].contains(timeZone.identifier)
-        {
-            return "UTC"
-        }
-        return timeZone.identifier
     }
 }
 

--- a/Sources/CodexBarCore/Resources/Plugins/openrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openrouter.js
@@ -47,8 +47,21 @@ defineProvider({
     const totalUsage = finite(credits.total_usage, "total_usage", false);
     const balance = Math.max(0, totalCredits - totalUsage);
     let keyData = null;
+    let keyDegradation = null;
+    const injectedOptionalTimeout = ctx.__codexbarOptionalRequestTimeoutSeconds;
+    const optionalRequestTimeoutSeconds = typeof injectedOptionalTimeout === "number" &&
+      Number.isFinite(injectedOptionalTimeout) ? injectedOptionalTimeout : 1;
+    function degradationReason(error) {
+      const message = error && typeof error.message === "string" ? error.message : String(error);
+      if (/timed out|-1001/i.test(message)) return "Request timed out";
+      if (/json|parse|invalid|must be/i.test(message)) return "Response was invalid";
+      return "Request failed";
+    }
     try {
-      const keyResponse = await ctx.http.get(`${base}/key`, { timeoutSeconds: 1 });
+      const keyResponse = await ctx.http.get(`${base}/key`, {
+        timeoutSeconds: optionalRequestTimeoutSeconds,
+      });
+      if (keyResponse.status !== 200) keyDegradation = `Request returned HTTP ${keyResponse.status}`;
       const keyPayload = keyResponse.status === 200 ? JSON.parse(keyResponse.bodyText) : null;
       if (keyPayload && keyPayload.data && typeof keyPayload.data === "object" &&
           !Array.isArray(keyPayload.data)) {
@@ -66,7 +79,10 @@ defineProvider({
         }
         keyData = candidate;
       }
-    } catch (_) {}
+    } catch (error) {
+      keyDegradation = degradationReason(error);
+    }
+    if (!keyData && !keyDegradation) keyDegradation = "Response was unavailable";
 
     function resetWindowUsage(reset) {
       const windowKey =
@@ -154,7 +170,11 @@ defineProvider({
     } else {
       details.push({
         title: "API key",
-        rows: [{ label: "API key budget", value: "Unavailable right now" }],
+        rows: [{
+          label: "API key budget",
+          value: "Unavailable right now",
+          secondaryValue: keyDegradation,
+        }],
       });
     }
 

--- a/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
+++ b/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
@@ -29,6 +29,7 @@ struct OpenRouterPluginGoldenTests {
 
         #expect(snapshot.primary == nil)
         #expect(snapshot.detailRow(label: "API key budget")?.value == "Unavailable right now")
+        #expect(snapshot.detailRow(label: "API key budget")?.secondaryValue == "Request returned HTTP 500")
     }
 
     @Test
@@ -157,6 +158,7 @@ struct OpenRouterPluginGoldenTests {
 
         #expect(usage.primary == nil)
         #expect(usage.detailRow(label: "API key budget")?.value == "Unavailable right now")
+        #expect(usage.detailRow(label: "API key budget")?.secondaryValue == "Response was invalid")
     }
 
     @Test
@@ -209,6 +211,7 @@ struct OpenRouterPluginGoldenTests {
         #expect(ContinuousClock.now - startedAt < .seconds(1.4))
         #expect(usage.primary == nil)
         #expect(usage.detailRow(label: "API key budget")?.value == "Unavailable right now")
+        #expect(usage.detailRow(label: "API key budget")?.secondaryValue == "Request timed out")
         try await Task.sleep(for: .milliseconds(600))
     }
 

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -59,7 +59,7 @@ struct ProviderPluginDetailsParityTests {
             }
         }
         let now = Date(timeIntervalSince1970: 1_785_686_400)
-        let script = try await ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
+        let script = try await Self.openRouterRuntime(transport: transport)
             .fetchUsage(secrets: ["OPENROUTER_API_KEY": "fixture-key"], now: now)
 
         #expect(script.primary?.usedPercent == 25)
@@ -86,6 +86,33 @@ struct ProviderPluginDetailsParityTests {
                     ("Today", 1), ("This week", 2), ("This month", 4),
                 ])),
         ])
+    }
+
+    @Test
+    func `OpenRouter optional key timeout is an observable degradation`() async throws {
+        let transport = ProviderHTTPTransportHandler { request in
+            let isKeyRequest = request.url?.path == "/api/v1/key"
+            if isKeyRequest {
+                try await Task.sleep(for: .milliseconds(1500))
+            }
+            let response = try #require(HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]))
+            let body = isKeyRequest ? Self.openRouterKey : Self.openRouterCredits
+            return (Data(body.utf8), response)
+        }
+
+        let script = try await ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
+            .fetchUsage(secrets: ["OPENROUTER_API_KEY": "fixture-key"])
+
+        #expect(script.primary == nil)
+        #expect(script.details.count == 2)
+        #expect(script.details[0].rows.map(\.label) == ["Remaining", "Used", "Total added"])
+        let degradation = try #require(script.detailRow(label: "API key budget"))
+        #expect(degradation.value == "Unavailable right now")
+        #expect(degradation.secondaryValue == "Request timed out")
     }
 
     @Test
@@ -141,7 +168,7 @@ struct ProviderPluginDetailsParityTests {
             request.url?.path.hasSuffix("/key") == true ? Self.openRouterKey : Self.openRouterCredits
         }
 
-        _ = try await ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport).fetchUsage(
+        _ = try await Self.openRouterRuntime(transport: transport).fetchUsage(
             settings: settings,
             secrets: [OpenRouterSettingsReader.envKey: "fixture-key"])
 
@@ -153,6 +180,7 @@ struct ProviderPluginDetailsParityTests {
         #expect(recorded[1].url?.absoluteString == (overridden
                 ? "https://router.example.test/gateway/v1/key"
                 : "https://openrouter.ai/api/v1/key"))
+        #expect(recorded[1].timeoutInterval == 15)
         #expect(recorded[0].value(forHTTPHeaderField: "X-Title") == (overridden ? "CodexBar QA" : "CodexBar"))
         #expect(recorded[0].value(forHTTPHeaderField: "HTTP-Referer") ==
             (overridden ? "https://codexbar.example" : nil))
@@ -386,6 +414,9 @@ struct ProviderPluginDetailsParityTests {
         ProviderHTTPTransportHandler { request in
             #expect(request.httpMethod == "GET")
             #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-key")
+            if request.url?.path == "/api/v1/key" {
+                try await Task.sleep(for: .milliseconds(950))
+            }
             let response = try #require(HTTPURLResponse(
                 url: request.url!,
                 statusCode: 200,
@@ -393,6 +424,15 @@ struct ProviderPluginDetailsParityTests {
                 headerFields: ["Content-Type": "application/json"]))
             return try (Data(body(request).utf8), response)
         }
+    }
+
+    private static func openRouterRuntime(
+        transport: any ProviderHTTPTransport) throws -> ProviderPluginRuntime
+    {
+        try ProviderPluginRuntime(
+            bundledPlugin: "openrouter",
+            transport: transport,
+            contextOptions: ProviderPluginContextOptions(optionalRequestTimeoutSeconds: 15))
     }
 
     private static func recordingTransport(

--- a/Tests/CodexBarTests/ProviderPluginParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginParityTests.swift
@@ -235,12 +235,15 @@ struct ProviderPluginParityTests {
                 statusCode: 200,
                 httpVersion: nil,
                 headerFields: ["Content-Type": "application/json"]))
+            if request.url?.path.hasSuffix("/key") == true {
+                try await Task.sleep(for: .milliseconds(950))
+            }
             let body = request.url?.path.hasSuffix("/key") == true ? keyBody : creditsBody
             return (Data(body.utf8), response)
         }
         let now = Date()
 
-        let runtime = try ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
+        let runtime = try Self.openRouterRuntime(transport: transport)
         let script = try await runtime.fetchUsage(
             secrets: ["OPENROUTER_API_KEY": "fixture-key"],
             now: now)
@@ -265,6 +268,9 @@ struct ProviderPluginParityTests {
         }}
         """#
         let transport = ProviderHTTPTransportHandler { request in
+            if request.url?.path.hasSuffix("/key") == true {
+                try await Task.sleep(for: .milliseconds(950))
+            }
             let response = try #require(HTTPURLResponse(
                 url: request.url!,
                 statusCode: 200,
@@ -275,7 +281,7 @@ struct ProviderPluginParityTests {
         }
         let now = Date()
 
-        let runtime = try ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
+        let runtime = try Self.openRouterRuntime(transport: transport)
         let script = try await runtime.fetchUsage(
             secrets: ["OPENROUTER_API_KEY": "fixture-key"],
             now: now)
@@ -305,12 +311,15 @@ struct ProviderPluginParityTests {
                 statusCode: 200,
                 httpVersion: nil,
                 headerFields: ["Content-Type": "application/json"]))
+            if request.url?.path.hasSuffix("/key") == true {
+                try await Task.sleep(for: .milliseconds(950))
+            }
             let body = request.url?.path.hasSuffix("/key") == true ? keyBody : creditsBody
             return (Data(body.utf8), response)
         }
         let now = Date()
 
-        let runtime = try ProviderPluginRuntime(bundledPlugin: "openrouter", transport: transport)
+        let runtime = try Self.openRouterRuntime(transport: transport)
         let script = try await runtime.fetchUsage(
             secrets: ["OPENROUTER_API_KEY": "fixture-key"],
             now: now)
@@ -333,6 +342,15 @@ struct ProviderPluginParityTests {
                 headerFields: ["Content-Type": "application/json"]))
             return (Data(body.utf8), response)
         }
+    }
+
+    private static func openRouterRuntime(
+        transport: any ProviderHTTPTransport) throws -> ProviderPluginRuntime
+    {
+        try ProviderPluginRuntime(
+            bundledPlugin: "openrouter",
+            transport: transport,
+            contextOptions: ProviderPluginContextOptions(optionalRequestTimeoutSeconds: 15))
     }
 
     private static func context(environment: [String: String]) -> ProviderFetchContext {

--- a/docs/openrouter.md
+++ b/docs/openrouter.md
@@ -43,6 +43,9 @@ The OpenRouter provider fetches usage data from two API endpoints:
 
 2. **Key API** (`/api/v1/key`): Returns rate limit information plus current daily, weekly, and monthly spend for your API key.
 
+The Key API is optional enrichment with a one-second production deadline. If it is slow or unavailable, CodexBar still
+shows the credits balance and labels the API-key budget as unavailable with a safe timeout, HTTP, or response diagnostic.
+
 ## Display
 
 The OpenRouter menu card shows:


### PR DESCRIPTION
## Summary

- keep OpenRouter's optional key-enrichment request on its one-second production fast join
- inject a private runtime context deadline override for deterministic plugin parity fixtures
- make optional key failures observable through a safe detail-row diagnostic instead of a silent nil meter
- stress the full OpenRouter goldens with a 950 ms delayed key fixture and cover the production degraded path explicitly

## Root cause

The plugin runtime correctly rejected the optional key request when its one-second request deadline elapsed. OpenRouter then caught and discarded that rejection, returned a valid credits-only snapshot, and left the primary meter absent. Under loaded CI, parity tests therefore reported a cascade of golden mismatches instead of an observable degradation.

## Bundled plugin audit

The audit found one related follow-up candidate: z.ai silently ignores failures from its optional model-usage history requests. It is intentionally unchanged here to keep this fix scoped to the OpenRouter flake.

## Proof

- 30 consecutive delayed-fixture runs of both parity suites on JavaScriptCore and QuickJS: 60 engine runs, zero failures
- deliberate OpenRouter syntax break: both suites failed immediately with the underlying plugin load error; break reverted
- OpenRouter plugin goldens, parity, and details parity passed
- `make check`
- `make test`: 822 selections in 69 groups, zero failures, retries, recoveries, or timeouts
- autoreview clean

Fixes #2778
