### PR TITLE
test: fix test compilation on Swift 6.3.3

### DIFF
--- a/Tests/CodexBarTests/CostUsageStoreScaleProofTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreScaleProofTests.swift
@@ -248,10 +248,13 @@ extension CostUsageStoreScaleProofTests {
             outputTokens: 3,
             reasoningTokens: 1,
             requestCount: 1,
-            knownCostNanos: 1000,
-            unpricedTokens: 4,
-            standardCostNanos: 600,
-            priorityCostNanos: 400,
+            authoritativeCostNanos: 1000,
+            standardInputTokens: 6,
+            standardCachedTokens: 1,
+            standardOutputTokens: 2,
+            priorityInputTokens: 4,
+            priorityCachedTokens: 1,
+            priorityOutputTokens: 1,
             standardTokens: 9,
             priorityTokens: 6)
     }

--- a/Tests/CodexBarTests/FireworksUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/FireworksUsageFetcherTests.swift
@@ -34,13 +34,13 @@ struct FireworksUsageFetcherTests {
 
         let summary = try FireworksUsageFetcher._parseSummaryForTesting(Data(json.utf8))
 
-        #expect((summary.last30DaysSpend ?? -1) == 1.525548296, accuracy: 0.000000001)
+        #expect(abs((summary.last30DaysSpend ?? -1) - 1.525548296) <= 0.000000001)
         #expect(summary.currencyCode == "USD")
 
         let usage = FireworksUsageSnapshot(summary: summary).toUsageSnapshot()
         #expect(usage.primary == nil)
         #expect(usage.secondary == nil)
-        #expect(usage.providerCost?.used == 1.525548296, accuracy: 0.000000001)
+        #expect(abs((usage.providerCost?.used ?? -1) - 1.525548296) <= 0.000000001)
         #expect(usage.providerCost?.currencyCode == "USD")
         #expect(usage.providerCost?.period == "Last 30 days")
         #expect(usage.providerCost?.limit == 0)
@@ -71,7 +71,7 @@ struct FireworksUsageFetcherTests {
         let summary = try FireworksUsageFetcher._parseSummaryForTesting(Data(json.utf8))
 
         #expect(summary.currencyCode == "USD")
-        #expect((summary.last30DaysSpend ?? -1) == 1.35, accuracy: 0.000000001)
+        #expect(abs((summary.last30DaysSpend ?? -1) - 1.35) <= 0.000000001)
     }
 
     @Test
@@ -180,7 +180,7 @@ struct FireworksUsageFetcherTests {
             session: session)
 
         #expect(FireworksStubURLProtocol.requests.count == 1)
-        #expect((snapshot.summary.last30DaysSpend ?? -1) == 0.5, accuracy: 0.000000001)
+        #expect(abs((snapshot.summary.last30DaysSpend ?? -1) - 0.5) <= 0.000000001)
     }
 
     @Test
@@ -216,7 +216,8 @@ struct FireworksUsageFetcherTests {
                     accountSlug: "x0mh0x",
                     session: session)
             } throws: { error in
-                error == expectedError
+                guard let error = error as? FireworksUsageError else { return false }
+                return error == expectedError
             }
         }
     }
@@ -229,7 +230,8 @@ struct FireworksUsageFetcherTests {
                 accountSlug: "x0mh0x",
                 session: URLSession(configuration: .ephemeral))
         } throws: { error in
-            error == FireworksUsageError.missingCredentials
+            guard let error = error as? FireworksUsageError else { return false }
+            return error == FireworksUsageError.missingCredentials
         }
 
         await #expect {
@@ -238,7 +240,8 @@ struct FireworksUsageFetcherTests {
                 accountSlug: "",
                 session: URLSession(configuration: .ephemeral))
         } throws: { error in
-            error == FireworksUsageError.missingAccountSlug
+            guard let error = error as? FireworksUsageError else { return false }
+            return error == FireworksUsageError.missingAccountSlug
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replace unsupported swift-testing accuracy arguments in `FireworksUsageFetcherTests` with equivalent absolute-difference expectations.
- Cast caught `any Error` values to `FireworksUsageError` before asserting the exact expected cases.
- Update the scale-proof aggregate fixture for the current authoritative-cost and standard/priority token-split fields.

The Fireworks tests landed in #2687 after its CI runs were cancelled, so Swift 6.3.3 never compiled these assertions. Separately, the cost-split signature changed after the #2763 scale-proof tests landed, leaving that fixture call site stale.

This is test-only and unblocks CI test compilation for all in-flight PRs.

## Validation

- `swift build --build-tests`
- `swift test --filter "FireworksUsageFetcherTests|CostUsageStoreScaleProofTests"` (12 tests passed)
- SwiftLint strict: 0 violations

`make check` reaches a pre-existing `origin/main` documentation consistency failure: provider manifests report 68 providers while `README.md` advertises 67. That unrelated file is intentionally outside this test-only patch.
