### PR TITLE
style: format Fireworks provider files

### DIFF
--- a/Sources/CodexBarCore/Providers/Fireworks/FireworksUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Fireworks/FireworksUsageFetcher.swift
@@ -107,8 +107,8 @@ public struct FireworksUsageFetcher: Sendable {
         }
 
         let startTime = now.addingTimeInterval(-TimeInterval(self.lookbackDays * 24 * 60 * 60))
-        var request = URLRequest(
-            url: try Self.resolveSummaryURL(accountSlug: cleanedSlug, startTime: startTime, endTime: now))
+        var request = try URLRequest(
+            url: Self.resolveSummaryURL(accountSlug: cleanedSlug, startTime: startTime, endTime: now))
         request.httpMethod = "GET"
         request.setValue("Bearer \(cleanedKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -154,7 +154,7 @@ public struct FireworksUsageFetcher: Sendable {
         startTime: Date? = nil,
         endTime: Date? = nil) throws -> URL
     {
-        guard accountSlug.rangeOfCharacter(from: Self.accountSlugAllowedCharacters.inverted) == nil else {
+        guard accountSlug.rangeOfCharacter(from: self.accountSlugAllowedCharacters.inverted) == nil else {
             throw FireworksUsageError.invalidAccountSlug(accountSlug)
         }
         guard let components = URLComponents(
@@ -198,8 +198,8 @@ public struct FireworksUsageFetcher: Sendable {
                   let units = cost.units.flatMap(Double.init),
                   let nanos = cost.nanos,
                   let code = cost.currencyCode?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-                  !code.isEmpty
+                      .trimmingCharacters(in: .whitespacesAndNewlines),
+                      !code.isEmpty
             else {
                 continue
             }

--- a/Tests/CodexBarTests/FireworksUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/FireworksUsageFetcherTests.swift
@@ -106,7 +106,7 @@ struct FireworksUsageFetcherTests {
         let url = try FireworksUsageFetcher.resolveSummaryURL(
             accountSlug: "x0mh0x",
             startTime: Date(timeIntervalSince1970: 0),
-            endTime: Date(timeIntervalSince1970: 86_400))
+            endTime: Date(timeIntervalSince1970: 86400))
 
         #expect(url.absoluteString.hasPrefix("https://api.fireworks.ai/v1/accounts/x0mh0x/billing/summary?"))
         #expect(url.absoluteString.contains("startTime=1970-01-01T00:00:00Z"))


### PR DESCRIPTION
SwiftFormat-only pass over the two Fireworks files landed in #2687, which failed CI's macOS lint gate (hoistTry, indent, redundantSelf, numberFormatting). No behavior change; build and the Fireworks test suite verified locally. Third and final CI unblock after #2780 (test compilation) and #2781 (provider count).
