### PR TITLE
fix: start QuickJS plugin request timeouts when the transport task begins executing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fireworks: track 30-day rated billing spend with an API key and account slug (#2687). Thanks @x0mh0x!
 
 ### Fixed
+- Plugins: the QuickJS HTTP/cookie bridge now starts a request's per-call timeout when the transport actually begins executing instead of when it is scheduled, so short deadlines (like OpenRouter's one-second key fast join) no longer fire spuriously under CPU load (refs #2778).
 - Codex: preserve recently modified cost-cache sessions across complete local calendar-day windows, avoiding needless rediscovery and rescans (#2764). Thanks @Yuxin-Qiao!
 - Codex: price persisted usage from token classes when reports are read, so a cold rebuild racing the models.dev catalog can no longer permanently bake fallback rates into SQLite (#2772).
 - OpenRouter: keep optional key-quota enrichment on its one-second production fast join while making degraded results explicit and preventing loaded CI parity runs from mistaking the fallback snapshot for a golden mismatch (fixes #2778).

--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -780,8 +780,10 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
         timeout: TimeInterval,
         operation: @escaping @Sendable () async throws -> Value) throws -> Value
     {
+        let fetchDeadline = self.fetchState?.deadline ?? Date().addingTimeInterval(timeout)
         let box = QuickJSBlockingResult<Value>()
         let task = Task.detached {
+            box.markStarted()
             do {
                 let value = try await operation()
                 box.finish(.success(value))
@@ -790,17 +792,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
             }
         }
         defer { task.cancel() }
-        let fetchRemaining = self.fetchState.map { max(0, $0.deadline.timeIntervalSinceNow) } ?? timeout
-        let deadline = Date().addingTimeInterval(min(timeout, fetchRemaining))
-        while Date() < deadline {
-            if let result = box.wait(until: min(deadline, Date().addingTimeInterval(0.05))) {
-                return try result.get()
-            }
-            if let watchdog = self.watchdog, cqjs_watchdog_is_interrupted(watchdog) {
-                throw ProviderPluginError.timedOut
-            }
-        }
-        throw URLError(.timedOut)
+        return try box.value(timeout: timeout, fetchDeadline: fetchDeadline, watchdog: self.watchdog)
     }
 
     private func invoke(_ function: JSValue, argument: JSValue) throws {
@@ -1046,7 +1038,15 @@ private final class QuickJSSerialWorker: @unchecked Sendable {
 
 final class QuickJSBlockingResult<Value: Sendable>: @unchecked Sendable {
     private let condition = NSCondition()
+    private var startedAt: Date?
     private var result: Result<Value, Error>?
+
+    func markStarted() {
+        self.condition.lock()
+        self.startedAt = Date()
+        self.condition.broadcast()
+        self.condition.unlock()
+    }
 
     func finish(_ result: Result<Value, Error>) {
         self.condition.lock()
@@ -1055,13 +1055,45 @@ final class QuickJSBlockingResult<Value: Sendable>: @unchecked Sendable {
         self.condition.unlock()
     }
 
+    func value(
+        timeout: TimeInterval,
+        fetchDeadline: Date,
+        watchdog: OpaquePointer?) throws -> Value
+    {
+        var startedAt: Date?
+        while true {
+            let deadline = startedAt.map {
+                $0.addingTimeInterval(min(timeout, max(0, fetchDeadline.timeIntervalSince($0))))
+            } ?? fetchDeadline
+            let now = Date()
+            guard now < deadline else { throw URLError(.timedOut) }
+            let state = self.wait(
+                until: min(deadline, now.addingTimeInterval(0.05)),
+                waitingForStart: startedAt == nil)
+            if let result = state.result {
+                return try result.get()
+            }
+            startedAt = state.startedAt
+            if let watchdog, cqjs_watchdog_is_interrupted(watchdog) {
+                throw ProviderPluginError.timedOut
+            }
+        }
+    }
+
     func wait(until deadline: Date) -> Result<Value, Error>? {
+        self.wait(until: deadline, waitingForStart: false).result
+    }
+
+    func wait(
+        until deadline: Date,
+        waitingForStart: Bool) -> (startedAt: Date?, result: Result<Value, Error>?)
+    {
         self.condition.lock()
         defer { self.condition.unlock() }
-        if self.result == nil {
+        if self.result == nil, !waitingForStart || self.startedAt == nil {
             _ = self.condition.wait(until: deadline)
         }
-        return self.result
+        return (self.startedAt, self.result)
     }
 
     func wait() -> Result<Value, Error> {


### PR DESCRIPTION
## Summary

The QuickJS blocking bridge (`hostHTTP`/`hostCookieHeader`) started a request's wall-clock timeout at `Task.detached` **scheduling** time. On a loaded machine the detached transport task can wait longer than a short deadline (OpenRouter's `/key` uses 1s) just to get CPU, so instantly-responding transports "timed out". This was the root cause of the intermittent Linux CI parity failures (#2778). #2779 stabilized the tests via an injectable optional-request timeout but deliberately kept the 1s production deadline, so production could still spuriously degrade under load — now more relevant since #2775 made QuickJS the default engine everywhere.

This PR fixes the underlying defect: the per-request timeout clock starts when the transport operation actually **begins executing** (recorded under the result-box lock as the task's first action); until then the wait is bounded by the fetch-level 20s deadline and the watchdog. Genuine timeouts are unaffected — the 1s-vs-5s cancellation contract test still aborts in under 2s, and #2779's "optional key timeout is an observable degradation" test still passes.

## Proof

- macOS: `ProviderPluginRuntimeTests` + both parity suites — 51/51 green on the rebased tree; `make test` (822 selections) and `make check` clean pre-rebase; autoreview clean.
- Linux Docker (Swift 6.3.3, `--cpus=2`, `swift test --parallel` + 8 CPU burners): 30/30 stressed iterations green on the fixed tree.
- Lint: `lint.sh lint-macos` and `lint-linux` both clean.

Refs #2778. Follow-up to #2779.
