### PR TITLE
build: oxlint/oxfmt toolchain and typed TypeScript authoring for plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install lint tools
-        run: ./Scripts/install_lint_tools.sh swiftlint
+        run: ./Scripts/install_lint_tools.sh swiftlint oxlint oxfmt typescript
 
       - name: Lint
         run: ./Scripts/lint.sh lint-linux

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "ignorePatterns": [
+    "Sources/CodexBarCore/Resources/Plugins/sucrase-*.min.js"
+  ]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,28 @@
+{
+  "categories": {
+    "correctness": "error"
+  },
+  "ignorePatterns": [
+    "Sources/CodexBarCore/Resources/Plugins/sucrase-*.min.js"
+  ],
+  "overrides": [
+    {
+      "files": ["Sources/CodexBarCore/Resources/Plugins/*.{js,ts}"],
+      "globals": {
+        "defineProvider": "readonly"
+      }
+    },
+    {
+      "files": ["docs/site.js"],
+      "env": {
+        "browser": true
+      }
+    },
+    {
+      "files": ["Scripts/*.mjs"],
+      "env": {
+        "node": true
+      }
+    }
+  ]
+}

--- a/Scripts/check-app-locales.mjs
+++ b/Scripts/check-app-locales.mjs
@@ -12,8 +12,28 @@ const strictLocales = ["ar", "ca", "fa", "th"];
 // Catalogs that have reached full English-key coverage. New locales can remain
 // warning-only while they are being bootstrapped, then join this list once complete.
 const completeLocales = [
-  "ar", "ca", "de", "es", "fa", "fr", "gl", "id", "it", "ja", "ko", "nl", "pl", "pt-BR", "ru", "sv",
-  "th", "tr", "uk", "vi", "zh-Hans", "zh-Hant",
+  "ar",
+  "ca",
+  "de",
+  "es",
+  "fa",
+  "fr",
+  "gl",
+  "id",
+  "it",
+  "ja",
+  "ko",
+  "nl",
+  "pl",
+  "pt-BR",
+  "ru",
+  "sv",
+  "th",
+  "tr",
+  "uk",
+  "vi",
+  "zh-Hans",
+  "zh-Hant",
 ];
 const languageKeys = ["language_arabic", "language_persian", "language_thai"];
 const isTest = process.argv.includes("--test");
@@ -82,25 +102,26 @@ if (isTest) {
   assertEqual(
     tokenSignature("\\(self.store.metadata(for: self.provider).displayName) failed"),
     tokenSignature("Fehler: \\(self.store.metadata(for: self.provider).displayName)"),
-    "nested Swift interpolation");
+    "nested Swift interpolation",
+  );
   assertNotEqual(
     tokenSignature("\\(self.store.metadata(for: self.provider).displayName) failed"),
     tokenSignature("\\(self.store.metadata(for: self.provider) failed"),
-    "truncated Swift interpolation");
+    "truncated Swift interpolation",
+  );
   assertEqual(formatKeyList(["alpha", "beta"]), "alpha, beta", "short key list");
-  assertEqual(
-    formatKeyList(["alpha", "beta", "gamma", "delta"], 2),
-    "alpha, beta, ... +2 more",
-    "truncated key list");
+  assertEqual(formatKeyList(["alpha", "beta", "gamma", "delta"], 2), "alpha, beta, ... +2 more", "truncated key list");
   assertEqual(
     blankKeys({ alpha: "", beta: "  ", gamma: "ok" }, ["alpha", "beta", "gamma", "delta"]),
     ["alpha", "beta"],
-    "blank keys");
+    "blank keys",
+  );
   assertEqual([...new Set(completeLocales)], completeLocales, "unique complete locales");
   assertEqual(
     strictLocales.filter((locale) => !completeLocales.includes(locale)),
     [],
-    "strict locales are complete locales");
+    "strict locales are complete locales",
+  );
   console.log("app locale checker tests OK");
   process.exit(0);
 }
@@ -119,7 +140,7 @@ for (const completeLocale of completeLocales) {
 for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith(".lproj"))) {
   const locale = directory.replace(/\.lproj$/, "");
   if (locale === "en" || locale === "Base") continue;
-  
+
   const catalog = readCatalog(locale);
   if (!catalog) continue;
 
@@ -133,7 +154,8 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
     const missingKeyList = formatKeyList(missingKeys);
     if (completeLocales.includes(locale)) {
       console.error(
-        `\x1b[31m[${locale}] Error: Missing ${missingKeys.length} keys in complete locale: ${missingKeyList}.\x1b[0m`);
+        `\x1b[31m[${locale}] Error: Missing ${missingKeys.length} keys in complete locale: ${missingKeyList}.\x1b[0m`,
+      );
       hasErrors = true;
     } else {
       console.warn(`\x1b[33m[${locale}] Warning: Missing ${missingKeys.length} keys: ${missingKeyList}.\x1b[0m`);
@@ -156,7 +178,8 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
 
   if (emptyKeys.length > 0) {
     console.error(
-      `\x1b[31m[${locale}] Error: Blank values for ${emptyKeys.length} keys: ${formatKeyList(emptyKeys)}.\x1b[0m`);
+      `\x1b[31m[${locale}] Error: Blank values for ${emptyKeys.length} keys: ${formatKeyList(emptyKeys)}.\x1b[0m`,
+    );
     hasErrors = true;
   }
 
@@ -186,7 +209,9 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
   // Warn if identical translation count exceeds 15% of the total keys (approx > 150 out of 1050)
   const identicalRatio = identicalCount / englishKeys.length;
   if (identicalRatio > 0.15) {
-    console.warn(`\x1b[33m[${locale}] Warning: High number of identical translations: ${identicalCount}/${englishKeys.length} (${(identicalRatio * 100).toFixed(1)}%)\x1b[0m`);
+    console.warn(
+      `\x1b[33m[${locale}] Warning: High number of identical translations: ${identicalCount}/${englishKeys.length} (${(identicalRatio * 100).toFixed(1)}%)\x1b[0m`,
+    );
   }
 }
 
@@ -195,7 +220,9 @@ if (hasErrors) {
   process.exit(1);
 }
 
-console.log(`\n\x1b[32mApp locales OK: Checked ${checkedCount} catalogs against ${englishKeys.length} English keys.\x1b[0m`);
+console.log(
+  `\n\x1b[32mApp locales OK: Checked ${checkedCount} catalogs against ${englishKeys.length} English keys.\x1b[0m`,
+);
 
 function assertEqual(actual, expected, label) {
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {

--- a/Scripts/check-documentation-links.mjs
+++ b/Scripts/check-documentation-links.mjs
@@ -4,19 +4,14 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const approvedRootDocumentation = new Set([
-  "README.md",
-  "CHANGELOG.md",
-  "LICENSE",
-  "VISION.md",
-].map((relativePath) => path.join(repoRoot, relativePath)));
+const approvedRootDocumentation = new Set(
+  ["README.md", "CHANGELOG.md", "LICENSE", "VISION.md"].map((relativePath) => path.join(repoRoot, relativePath)),
+);
 
 const readme = readText("README.md");
-const readmeLinks = [
-  ...markdownLinks(readme),
-  ...markdownImageLinks(readme),
-  ...htmlLinks(readme),
-].filter(isRepositoryDocReference);
+const readmeLinks = [...markdownLinks(readme), ...markdownImageLinks(readme), ...htmlLinks(readme)].filter(
+  isRepositoryDocReference,
+);
 
 assert(readmeLinks.length > 0, "README.md has no local documentation links");
 for (const link of readmeLinks) validateLocalDocLink(link, repoRoot, "README.md");
@@ -27,11 +22,9 @@ for (const link of providerLinks) validateLocalDocLink(link, repoRoot, "docs/pro
 
 const docsLinks = markdownFiles("docs").flatMap((relativePath) => {
   const markdown = readText(relativePath);
-  const links = [
-    ...markdownLinks(markdown),
-    ...markdownImageLinks(markdown),
-    ...htmlLinks(markdown),
-  ].filter(isLocalDocumentationReference);
+  const links = [...markdownLinks(markdown), ...markdownImageLinks(markdown), ...htmlLinks(markdown)].filter(
+    isLocalDocumentationReference,
+  );
 
   return links.map((link) => ({ link, relativePath }));
 });
@@ -40,9 +33,7 @@ for (const { link, relativePath } of docsLinks) {
   validateLocalDocLink(link, path.join(repoRoot, path.dirname(relativePath)), relativePath);
 }
 
-console.log(
-  `documentation links OK: ${readmeLinks.length + providerLinks.length + docsLinks.length} local links`,
-);
+console.log(`documentation links OK: ${readmeLinks.length + providerLinks.length + docsLinks.length} local links`);
 
 function readText(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
@@ -51,7 +42,8 @@ function readText(relativePath) {
 function markdownLinks(markdown) {
   const source = markdownTextOutsideCode(markdown);
   const links = [];
-  const inlinePattern = /(?<!!)\[(?:\\.|[^\]\\])+\]\(\s*(?:<([^>\n]+)>|([^\s)]+))(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?\s*\)/g;
+  const inlinePattern =
+    /(?<!!)\[(?:\\.|[^\]\\])+\]\(\s*(?:<([^>\n]+)>|([^\s)]+))(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?\s*\)/g;
   for (const match of source.matchAll(inlinePattern)) {
     links.push(encodeSpaces(match[1] ?? match[2]));
   }
@@ -65,7 +57,8 @@ function markdownLinks(markdown) {
 
 function markdownImageLinks(markdown) {
   const source = markdownTextOutsideCode(markdown);
-  const pattern = /!\[(?:\\.|[^\]\\])*\]\(\s*(?:<([^>\n]+)>|([^\s)]+))(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?\s*\)/g;
+  const pattern =
+    /!\[(?:\\.|[^\]\\])*\]\(\s*(?:<([^>\n]+)>|([^\s)]+))(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?\s*\)/g;
   return [...source.matchAll(pattern)].map((match) => match[1] ?? match[2]);
 }
 
@@ -131,12 +124,15 @@ function localDocPath(rawLink, baseDirectory, sourcePath) {
 
 function markdownFiles(relativeDir) {
   const dir = path.join(repoRoot, relativeDir);
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    if (entry.name.startsWith(".") || entry.name === "node_modules") return [];
-    const relativePath = path.join(relativeDir, entry.name);
-    if (entry.isDirectory()) return markdownFiles(relativePath);
-    return entry.isFile() && entry.name.endsWith(".md") ? [relativePath] : [];
-  }).sort((a, b) => a.localeCompare(b));
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") return [];
+      const relativePath = path.join(relativeDir, entry.name);
+      if (entry.isDirectory()) return markdownFiles(relativePath);
+      return entry.isFile() && entry.name.endsWith(".md") ? [relativePath] : [];
+    })
+    .sort((a, b) => a.localeCompare(b));
 }
 
 function parseRelativeURL(rawLink) {
@@ -192,26 +188,26 @@ function removeMarkdownFormatting(text) {
 }
 
 function markdownTextOutsideCode(markdown) {
-  return markdownTextOutsideFencedCode(markdown)
-    .split("\n")
-    .map(removeInlineCode)
-    .join("\n");
+  return markdownTextOutsideFencedCode(markdown).split("\n").map(removeInlineCode).join("\n");
 }
 
 function markdownTextOutsideFencedCode(markdown) {
   let fence = null;
-  return markdown.split("\n").map((line) => {
-    if (fence) {
-      if (isClosingFence(line, fence.marker, fence.count)) fence = null;
-      return "";
-    }
-    const openingFence = parseOpeningFence(line);
-    if (openingFence) {
-      fence = openingFence;
-      return "";
-    }
-    return line;
-  }).join("\n");
+  return markdown
+    .split("\n")
+    .map((line) => {
+      if (fence) {
+        if (isClosingFence(line, fence.marker, fence.count)) fence = null;
+        return "";
+      }
+      const openingFence = parseOpeningFence(line);
+      if (openingFence) {
+        fence = openingFence;
+        return "";
+      }
+      return line;
+    })
+    .join("\n");
 }
 
 function parseOpeningFence(line) {

--- a/Scripts/check-site-locales.mjs
+++ b/Scripts/check-site-locales.mjs
@@ -7,13 +7,8 @@ import { localeCatalog, localeMessages } from "../docs/site-locales.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const indexHtml = fs.readFileSync(path.join(repoRoot, "docs/index.html"), "utf8");
-const providerSource = fs.readFileSync(
-  path.join(repoRoot, "Sources/CodexBarCore/Providers/Providers.swift"),
-  "utf8",
-);
-const providerEnumBody = providerSource.match(
-  /public enum UsageProvider:[^{]+\{([\s\S]*?)\n\}/,
-)?.[1];
+const providerSource = fs.readFileSync(path.join(repoRoot, "Sources/CodexBarCore/Providers/Providers.swift"), "utf8");
+const providerEnumBody = providerSource.match(/public enum UsageProvider:[^{]+\{([\s\S]*?)\n\}/)?.[1];
 assert(providerEnumBody, "could not locate UsageProvider cases");
 const providerIDs = [...providerEnumBody.matchAll(/^\s*case\s+(\w+)\s*$/gm)].map((match) => match[1]);
 assert(providerIDs.length > 0, "UsageProvider must define at least one provider");
@@ -30,7 +25,10 @@ for (const [relativePath, expectedText] of publicCountFiles) {
   const contents = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
   assert(contents.includes(expectedText), `${relativePath} must advertise ${providerCount} providers`);
 }
-assert(indexHtml.includes(`across ${providerCount} providers`), `index metadata must advertise ${providerCount} providers`);
+assert(
+  indexHtml.includes(`across ${providerCount} providers`),
+  `index metadata must advertise ${providerCount} providers`,
+);
 assert(
   indexHtml.includes(`across ${providerCount} AI coding providers`),
   `index social metadata must advertise ${providerCount} providers`,
@@ -45,23 +43,40 @@ for (const match of indexHtml.matchAll(/<link rel="stylesheet" href="\.\/([^"?]+
   assert(fs.existsSync(path.join(repoRoot, "docs", match[1])), `missing local stylesheet ${match[1]}`);
 }
 const expectedCodes = [
-  "en", "zh-CN", "zh-TW", "ja-JP", "es", "pt-BR", "ko", "de", "fr", "ar", "it",
-  "vi", "nl", "tr", "uk", "ru", "id", "pl", "fa", "th", "gl", "ca", "sv",
+  "en",
+  "zh-CN",
+  "zh-TW",
+  "ja-JP",
+  "es",
+  "pt-BR",
+  "ko",
+  "de",
+  "fr",
+  "ar",
+  "it",
+  "vi",
+  "nl",
+  "tr",
+  "uk",
+  "ru",
+  "id",
+  "pl",
+  "fa",
+  "th",
+  "gl",
+  "ca",
+  "sv",
 ];
 const catalogCodes = localeCatalog.map((locale) => locale.code);
-const appLanguageSource = fs.readFileSync(
-  path.join(repoRoot, "Sources/CodexBar/PreferencesGeneralPane.swift"),
-  "utf8",
-);
+const appLanguageSource = fs.readFileSync(path.join(repoRoot, "Sources/CodexBar/PreferencesGeneralPane.swift"), "utf8");
 
 assertEqual(catalogCodes, expectedCodes, "locale catalog");
 assertEqual(
   localeCatalog.filter((locale) => locale.direction === "rtl").map((locale) => locale.code),
   ["ar", "fa"],
-  "RTL locale catalog");
-const appLanguageEnumBody = appLanguageSource.match(
-  /enum AppLanguage:[^{]+\{([\s\S]*?)\n\}/,
-)?.[1];
+  "RTL locale catalog",
+);
+const appLanguageEnumBody = appLanguageSource.match(/enum AppLanguage:[^{]+\{([\s\S]*?)\n\}/)?.[1];
 assert(appLanguageEnumBody, "could not locate AppLanguage cases");
 const appCatalogCodes = [...appLanguageEnumBody.matchAll(/case \w+ = "([^"]+)"/g)]
   .map((match) => match[1])
@@ -94,10 +109,11 @@ for (const key of referencedKeys) {
   assert(englishKeys.includes(key), `index.html references unknown locale key ${key}`);
 }
 
-const siteJs = fs.readFileSync(path.join(repoRoot, 'docs/site.js'), 'utf8');
-const hasLanguagePicker = indexHtml.includes('id="language-picker-list"')
-  && (indexHtml.includes('localeCatalog') || siteJs.includes('localeCatalog'));
-assert(hasLanguagePicker, 'site must include the language picker backed by localeCatalog');
+const siteJs = fs.readFileSync(path.join(repoRoot, "docs/site.js"), "utf8");
+const hasLanguagePicker =
+  indexHtml.includes('id="language-picker-list"') &&
+  (indexHtml.includes("localeCatalog") || siteJs.includes("localeCatalog"));
+assert(hasLanguagePicker, "site must include the language picker backed by localeCatalog");
 
 for (const code of catalogCodes) {
   assert(indexHtml.includes(`href="https://codexbar.app/?lang=${code}"`), `missing hreflang URL for ${code}`);
@@ -105,11 +121,11 @@ for (const code of catalogCodes) {
 
 const providerCards = [...indexHtml.matchAll(/<li class="provider-card"([^>]*)>([\s\S]*?)<\/li>/g)];
 for (const [, attrs, body] of providerCards) {
-  if (!attrs.includes('hidden')) {
-    assert(body.includes('class="provider-card-link"'), 'provider cards must link to provider documentation');
-    assert(body.includes('class="provider-logo'), 'provider cards must use logo assets');
+  if (!attrs.includes("hidden")) {
+    assert(body.includes('class="provider-card-link"'), "provider cards must link to provider documentation");
+    assert(body.includes('class="provider-logo'), "provider cards must use logo assets");
     for (const match of body.matchAll(/src="\.\/([^"]+)"/g)) {
-      assert(fs.existsSync(path.join(repoRoot, 'docs', match[1])), `missing provider logo asset ${match[1]}`);
+      assert(fs.existsSync(path.join(repoRoot, "docs", match[1])), `missing provider logo asset ${match[1]}`);
     }
   }
 }

--- a/Scripts/docs-list.mjs
+++ b/Scripts/docs-list.mjs
@@ -1,23 +1,23 @@
 #!/usr/bin/env node
-import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join, relative } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const DOCS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs');
-const EXCLUDED_DIRS = new Set(['archive', 'research']);
+const DOCS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "docs");
+const EXCLUDED_DIRS = new Set(["archive", "research"]);
 
 function walkMarkdownFiles(dir, base = dir) {
   const entries = readdirSync(dir, { withFileTypes: true });
   const files = [];
 
   for (const entry of entries) {
-    if (entry.name.startsWith('.')) continue;
+    if (entry.name.startsWith(".")) continue;
     const fullPath = join(dir, entry.name);
 
     if (entry.isDirectory()) {
       if (EXCLUDED_DIRS.has(entry.name)) continue;
       files.push(...walkMarkdownFiles(fullPath, base));
-    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
       files.push(relative(base, fullPath));
     }
   }
@@ -26,19 +26,19 @@ function walkMarkdownFiles(dir, base = dir) {
 }
 
 function extractMetadata(fullPath) {
-  const content = readFileSync(fullPath, 'utf8');
+  const content = readFileSync(fullPath, "utf8");
 
-  if (!content.startsWith('---')) {
-    return { summary: null, readWhen: [], error: 'missing front matter' };
+  if (!content.startsWith("---")) {
+    return { summary: null, readWhen: [], error: "missing front matter" };
   }
 
-  const endIndex = content.indexOf('\n---', 3);
+  const endIndex = content.indexOf("\n---", 3);
   if (endIndex === -1) {
-    return { summary: null, readWhen: [], error: 'unterminated front matter' };
+    return { summary: null, readWhen: [], error: "unterminated front matter" };
   }
 
   const frontMatter = content.slice(3, endIndex).trim();
-  const lines = frontMatter.split('\n');
+  const lines = frontMatter.split("\n");
 
   let summaryLine = null;
   const readWhen = [];
@@ -47,16 +47,16 @@ function extractMetadata(fullPath) {
   for (const rawLine of lines) {
     const line = rawLine.trim();
 
-    if (line.startsWith('summary:')) {
+    if (line.startsWith("summary:")) {
       summaryLine = line;
       collectingReadWhen = false;
       continue;
     }
 
-    if (line.startsWith('read_when:')) {
+    if (line.startsWith("read_when:")) {
       collectingReadWhen = true;
-      const inline = line.slice('read_when:'.length).trim();
-      if (inline.startsWith('[') && inline.endsWith(']')) {
+      const inline = line.slice("read_when:".length).trim();
+      if (inline.startsWith("[") && inline.endsWith("]")) {
         try {
           const parsed = JSON.parse(inline.replace(/'/g, '"'));
           if (Array.isArray(parsed)) {
@@ -73,10 +73,10 @@ function extractMetadata(fullPath) {
     }
 
     if (collectingReadWhen) {
-      if (line.startsWith('- ')) {
+      if (line.startsWith("- ")) {
         const hint = line.slice(2).trim();
         if (hint) readWhen.push(hint);
-      } else if (line === '') {
+      } else if (line === "") {
         // allow blank spacer lines inside list
       } else {
         collectingReadWhen = false;
@@ -85,20 +85,23 @@ function extractMetadata(fullPath) {
   }
 
   if (!summaryLine) {
-    return { summary: null, readWhen, error: 'summary key missing' };
+    return { summary: null, readWhen, error: "summary key missing" };
   }
 
-  const summaryValue = summaryLine.slice('summary:'.length).trim();
-  const normalized = summaryValue.replace(/^['"]|['"]$/g, '').replace(/\s+/g, ' ').trim();
+  const summaryValue = summaryLine.slice("summary:".length).trim();
+  const normalized = summaryValue
+    .replace(/^['"]|['"]$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 
   if (!normalized) {
-    return { summary: null, readWhen, error: 'summary is empty' };
+    return { summary: null, readWhen, error: "summary is empty" };
   }
 
   return { summary: normalized, readWhen };
 }
 
-console.log('Listing all markdown files in docs folder:');
+console.log("Listing all markdown files in docs folder:");
 
 const markdownFiles = walkMarkdownFiles(DOCS_DIR);
 
@@ -108,12 +111,14 @@ for (const relativePath of markdownFiles) {
   if (summary) {
     console.log(`${relativePath} - ${summary}`);
     if (readWhen.length > 0) {
-      console.log(`  Read when: ${readWhen.join('; ')}`);
+      console.log(`  Read when: ${readWhen.join("; ")}`);
     }
   } else {
-    const reason = error ? ` - [${error}]` : '';
+    const reason = error ? ` - [${error}]` : "";
     console.log(`${relativePath}${reason}`);
   }
 }
 
-console.log('\nReminder: keep docs up to date as behavior changes. When your task matches any "Read when" hint above (React hooks, cache directives, database work, tests, etc.), read that doc before coding, and suggest new coverage when it is missing.');
+console.log(
+  '\nReminder: keep docs up to date as behavior changes. When your task matches any "Read when" hint above (React hooks, cache directives, database work, tests, etc.), read that doc before coding, and suggest new coverage when it is missing.',
+);

--- a/Scripts/generate-llms.mjs
+++ b/Scripts/generate-llms.mjs
@@ -36,7 +36,9 @@ const lines = [
   productDescription,
   "",
   "Canonical documentation:",
-  ...pages.map((page) => "- " + page.title + ": " + pageUrl(page.rel) + (page.description ? " - " + page.description : "")),
+  ...pages.map(
+    (page) => "- " + page.title + ": " + pageUrl(page.rel) + (page.description ? " - " + page.description : ""),
+  ),
   "",
   "Source: " + source,
   "",
@@ -81,7 +83,10 @@ function pageUrl(rel) {
 }
 
 function textContent(value) {
-  return attr(value || "").replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+  return attr(value || "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function attr(value) {

--- a/Scripts/install_lint_tools.sh
+++ b/Scripts/install_lint_tools.sh
@@ -8,6 +8,10 @@ BIN_DIR="${TOOLS_DIR}/bin"
 
 SWIFTFORMAT_VERSION="0.61.1"
 SWIFTLINT_VERSION="0.65.0"
+OXLINT_VERSION="1.76.0"
+OXFMT_VERSION="0.61.0"
+OXC_APPS_RELEASE="1.76.0"
+TYPESCRIPT_VERSION="5.9.3"
 
 SWIFTFORMAT_SHA256_DARWIN="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"
 SWIFTLINT_SHA256_DARWIN="d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba6"
@@ -15,22 +19,40 @@ SWIFTFORMAT_SHA256_LINUX_X86_64="7bc8706e3fd51963f1f29eb99098ebdf482f3497fa527c6
 SWIFTLINT_SHA256_LINUX_X86_64="79306a34e5c7cc55a220cd108cbb861dcad5f10138dcdf261e2624ae8b0a486b"
 SWIFTFORMAT_SHA256_LINUX_ARM64="42a35b557a6d56975fba3a48e78d39ab5388c8faac65d4819f25d3e20c7504c0"
 SWIFTLINT_SHA256_LINUX_ARM64="12d3b84bc5b69ae13a99a5a5c79904f9ce25867f099f6368d0037854f9ee6c26"
+OXLINT_SHA256_DARWIN_X86_64="8ce24ce5ab9d2ba8177f33d69a21931cc42b6fcae3658abce9b89cbe3f35c449"
+OXLINT_SHA256_DARWIN_ARM64="71071f11d95e3ffc3185f46f29ebc69e099fb141016c2109e1f3580553646d61"
+OXLINT_SHA256_LINUX_X86_64="5a01b07e26311b749266794b02dc3f757498fb799e66b117d10c49ec842b59f0"
+OXLINT_SHA256_LINUX_ARM64="657f88fc484f0ba61bce1cb0c6ce247686d8e3e8e0b62cbc5020131b3852230e"
+OXFMT_SHA256_DARWIN_X86_64="38e17bbcd6a81744676ff3a6e4bdc1f22b34baed30f91e56be80a34a54d12fd2"
+OXFMT_SHA256_DARWIN_ARM64="dcb656524237ad33a0a5d46a836a2b6f67843e644a3098e4709de96b6305b1be"
+OXFMT_SHA256_LINUX_X86_64="91375457015624f93914744959795b40aa552bfc05d3c1c229186acf5bef4500"
+OXFMT_SHA256_LINUX_ARM64="e604e0db4aaee11cb203b094df12f8f12ff2c3b9507430a8044b4693abdad53a"
+TYPESCRIPT_SHA256="10e108c9cf7d5f2879053dff18515fb405abf2ccef63eaaf017d9c571687a1d3"
 
 log() { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 INSTALL_SWIFTFORMAT=false
 INSTALL_SWIFTLINT=false
+INSTALL_OXLINT=false
+INSTALL_OXFMT=false
+INSTALL_TYPESCRIPT=false
 
 if [[ "$#" -eq 0 ]]; then
   INSTALL_SWIFTFORMAT=true
   INSTALL_SWIFTLINT=true
+  INSTALL_OXLINT=true
+  INSTALL_OXFMT=true
+  INSTALL_TYPESCRIPT=true
 else
   for tool in "$@"; do
     case "$tool" in
       all)
         INSTALL_SWIFTFORMAT=true
         INSTALL_SWIFTLINT=true
+        INSTALL_OXLINT=true
+        INSTALL_OXFMT=true
+        INSTALL_TYPESCRIPT=true
         ;;
       swiftformat)
         INSTALL_SWIFTFORMAT=true
@@ -38,8 +60,17 @@ else
       swiftlint)
         INSTALL_SWIFTLINT=true
         ;;
+      oxlint)
+        INSTALL_OXLINT=true
+        ;;
+      oxfmt)
+        INSTALL_OXFMT=true
+        ;;
+      typescript)
+        INSTALL_TYPESCRIPT=true
+        ;;
       *)
-        fail "Unknown lint tool '${tool}'. Usage: $(basename "$0") [all|swiftformat|swiftlint]..."
+        fail "Unknown lint tool '${tool}'. Usage: $(basename "$0") [all|swiftformat|swiftlint|oxlint|oxfmt|typescript]..."
         ;;
     esac
   done
@@ -108,6 +139,65 @@ install_zip_binary() {
   rm -rf "$tmp_dir"
 }
 
+install_tar_binary() {
+  local label="$1"
+  local url="$2"
+  local expected_sha="$3"
+  local binary_name="$4"
+  local installed_name="$5"
+
+  local tmp_tar
+  tmp_tar="$(mktemp -t "${label}.XXXX")"
+  local tmp_dir
+  tmp_dir="$(mktemp -d -t "${label}.XXXX")"
+
+  log "==> Downloading ${label}"
+  download_file "$url" "$tmp_tar"
+
+  local actual_sha
+  actual_sha="$(sha256_value "$tmp_tar")"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    rm -f "$tmp_tar"
+    rm -rf "$tmp_dir"
+    fail "${label} SHA256 mismatch (expected ${expected_sha}, got ${actual_sha})"
+  fi
+
+  tar -xzf "$tmp_tar" -C "$tmp_dir"
+  if [[ ! -f "${tmp_dir}/${binary_name}" ]]; then
+    rm -f "$tmp_tar"
+    rm -rf "$tmp_dir"
+    fail "${label} binary '${binary_name}' not found in archive"
+  fi
+  install -m 0755 "${tmp_dir}/${binary_name}" "${BIN_DIR}/${installed_name}"
+
+  rm -f "$tmp_tar"
+  rm -rf "$tmp_dir"
+}
+
+install_typescript() {
+  local tmp_tar
+  tmp_tar="$(mktemp -t "typescript.XXXX")"
+  local tmp_dir
+  tmp_dir="$(mktemp -d -t "typescript.XXXX")"
+  local url="https://registry.npmjs.org/typescript/-/typescript-${TYPESCRIPT_VERSION}.tgz"
+
+  log "==> Downloading TypeScript ${TYPESCRIPT_VERSION}"
+  download_file "$url" "$tmp_tar"
+  local actual_sha
+  actual_sha="$(sha256_value "$tmp_tar")"
+  if [[ "$actual_sha" != "$TYPESCRIPT_SHA256" ]]; then
+    rm -f "$tmp_tar"
+    rm -rf "$tmp_dir"
+    fail "TypeScript ${TYPESCRIPT_VERSION} SHA256 mismatch (expected ${TYPESCRIPT_SHA256}, got ${actual_sha})"
+  fi
+
+  tar -xzf "$tmp_tar" -C "$tmp_dir"
+  rm -rf "${TOOLS_DIR}/typescript"
+  mv "${tmp_dir}/package" "${TOOLS_DIR}/typescript"
+  rm -f "$tmp_tar"
+  rm -rf "$tmp_dir"
+}
+
 mkdir -p "$BIN_DIR"
 
 swiftformat_installed() {
@@ -120,8 +210,26 @@ swiftlint_installed() {
     && [[ "$("${BIN_DIR}/swiftlint" version 2>/dev/null || true)" == "${SWIFTLINT_VERSION}" ]]
 }
 
+oxlint_installed() {
+  [[ -x "${BIN_DIR}/oxlint" ]] \
+    && [[ "$("${BIN_DIR}/oxlint" --version 2>/dev/null || true)" == "Version: ${OXLINT_VERSION}" ]]
+}
+
+oxfmt_installed() {
+  [[ -x "${BIN_DIR}/oxfmt" ]] \
+    && [[ "$("${BIN_DIR}/oxfmt" --version 2>/dev/null || true)" == "Version: ${OXFMT_VERSION}" ]]
+}
+
+typescript_installed() {
+  [[ -f "${TOOLS_DIR}/typescript/bin/tsc" ]] \
+    && [[ "$(node "${TOOLS_DIR}/typescript/bin/tsc" --version 2>/dev/null || true)" == "Version ${TYPESCRIPT_VERSION}" ]]
+}
+
 if { [[ "$INSTALL_SWIFTFORMAT" != true ]] || swiftformat_installed; } \
-  && { [[ "$INSTALL_SWIFTLINT" != true ]] || swiftlint_installed; }
+  && { [[ "$INSTALL_SWIFTLINT" != true ]] || swiftlint_installed; } \
+  && { [[ "$INSTALL_OXLINT" != true ]] || oxlint_installed; } \
+  && { [[ "$INSTALL_OXFMT" != true ]] || oxfmt_installed; } \
+  && { [[ "$INSTALL_TYPESCRIPT" != true ]] || typescript_installed; }
 then
   log "==> Requested lint tools already installed"
   exit 0
@@ -130,16 +238,44 @@ fi
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
+if [[ "$INSTALL_TYPESCRIPT" == true ]] && ! typescript_installed; then
+  command -v node >/dev/null 2>&1 || fail "Node.js is required to run TypeScript."
+  install_typescript
+fi
+
 case "$OS" in
   Darwin)
     SWIFTFORMAT_URL="https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip"
     SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/portable_swiftlint.zip"
+    case "$ARCH" in
+      x86_64)
+        OXC_TARGET="x86_64-apple-darwin"
+        OXLINT_SHA256="$OXLINT_SHA256_DARWIN_X86_64"
+        OXFMT_SHA256="$OXFMT_SHA256_DARWIN_X86_64"
+        ;;
+      arm64)
+        OXC_TARGET="aarch64-apple-darwin"
+        OXLINT_SHA256="$OXLINT_SHA256_DARWIN_ARM64"
+        OXFMT_SHA256="$OXFMT_SHA256_DARWIN_ARM64"
+        ;;
+      *)
+        fail "Unsupported macOS arch: ${ARCH}"
+        ;;
+    esac
 
     if [[ "$INSTALL_SWIFTFORMAT" == true ]] && ! swiftformat_installed; then
       install_zip_binary "SwiftFormat ${SWIFTFORMAT_VERSION}" "$SWIFTFORMAT_URL" "$SWIFTFORMAT_SHA256_DARWIN" "swiftformat"
     fi
     if [[ "$INSTALL_SWIFTLINT" == true ]] && ! swiftlint_installed; then
       install_zip_binary "SwiftLint ${SWIFTLINT_VERSION}" "$SWIFTLINT_URL" "$SWIFTLINT_SHA256_DARWIN" "swiftlint"
+    fi
+    if [[ "$INSTALL_OXLINT" == true ]] && ! oxlint_installed; then
+      OXLINT_URL="https://github.com/oxc-project/oxc/releases/download/apps_v${OXC_APPS_RELEASE}/oxlint-${OXC_TARGET}.tar.gz"
+      install_tar_binary "oxlint ${OXLINT_VERSION}" "$OXLINT_URL" "$OXLINT_SHA256" "oxlint-${OXC_TARGET}" "oxlint"
+    fi
+    if [[ "$INSTALL_OXFMT" == true ]] && ! oxfmt_installed; then
+      OXFMT_URL="https://github.com/oxc-project/oxc/releases/download/apps_v${OXC_APPS_RELEASE}/oxfmt-${OXC_TARGET}.tar.gz"
+      install_tar_binary "oxfmt ${OXFMT_VERSION}" "$OXFMT_URL" "$OXFMT_SHA256" "oxfmt-${OXC_TARGET}" "oxfmt"
     fi
     ;;
   Linux)
@@ -150,6 +286,9 @@ case "$OS" in
         SWIFTFORMAT_BINARY="swiftformat_linux"
         SWIFTFORMAT_SHA256="$SWIFTFORMAT_SHA256_LINUX_X86_64"
         SWIFTLINT_SHA256="$SWIFTLINT_SHA256_LINUX_X86_64"
+        OXC_TARGET="x86_64-unknown-linux-gnu"
+        OXLINT_SHA256="$OXLINT_SHA256_LINUX_X86_64"
+        OXFMT_SHA256="$OXFMT_SHA256_LINUX_X86_64"
         ;;
       aarch64|arm64)
         SWIFTFORMAT_URL="https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat_linux_aarch64.zip"
@@ -157,6 +296,9 @@ case "$OS" in
         SWIFTFORMAT_BINARY="swiftformat_linux_aarch64"
         SWIFTFORMAT_SHA256="$SWIFTFORMAT_SHA256_LINUX_ARM64"
         SWIFTLINT_SHA256="$SWIFTLINT_SHA256_LINUX_ARM64"
+        OXC_TARGET="aarch64-unknown-linux-gnu"
+        OXLINT_SHA256="$OXLINT_SHA256_LINUX_ARM64"
+        OXFMT_SHA256="$OXFMT_SHA256_LINUX_ARM64"
         ;;
       *)
         fail "Unsupported Linux arch: ${ARCH}"
@@ -174,6 +316,14 @@ case "$OS" in
     if [[ "$INSTALL_SWIFTLINT" == true ]] && ! swiftlint_installed; then
       install_zip_binary "SwiftLint ${SWIFTLINT_VERSION}" "$SWIFTLINT_URL" "$SWIFTLINT_SHA256" "swiftlint"
     fi
+    if [[ "$INSTALL_OXLINT" == true ]] && ! oxlint_installed; then
+      OXLINT_URL="https://github.com/oxc-project/oxc/releases/download/apps_v${OXC_APPS_RELEASE}/oxlint-${OXC_TARGET}.tar.gz"
+      install_tar_binary "oxlint ${OXLINT_VERSION}" "$OXLINT_URL" "$OXLINT_SHA256" "oxlint-${OXC_TARGET}" "oxlint"
+    fi
+    if [[ "$INSTALL_OXFMT" == true ]] && ! oxfmt_installed; then
+      OXFMT_URL="https://github.com/oxc-project/oxc/releases/download/apps_v${OXC_APPS_RELEASE}/oxfmt-${OXC_TARGET}.tar.gz"
+      install_tar_binary "oxfmt ${OXFMT_VERSION}" "$OXFMT_URL" "$OXFMT_SHA256" "oxfmt-${OXC_TARGET}" "oxfmt"
+    fi
     ;;
   *)
     fail "Unsupported OS: ${OS}"
@@ -186,4 +336,13 @@ if [[ "$INSTALL_SWIFTFORMAT" == true ]]; then
 fi
 if [[ "$INSTALL_SWIFTLINT" == true ]]; then
   "${BIN_DIR}/swiftlint" version
+fi
+if [[ "$INSTALL_OXLINT" == true ]]; then
+  "${BIN_DIR}/oxlint" --version
+fi
+if [[ "$INSTALL_OXFMT" == true ]]; then
+  "${BIN_DIR}/oxfmt" --version
+fi
+if [[ "$INSTALL_TYPESCRIPT" == true ]]; then
+  node "${TOOLS_DIR}/typescript/bin/tsc" --version
 fi

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -13,12 +13,28 @@ ensure_swiftlint() {
   "${ROOT_DIR}/Scripts/install_lint_tools.sh" swiftlint
 }
 
+ensure_oxlint() {
+  "${ROOT_DIR}/Scripts/install_lint_tools.sh" oxlint
+}
+
+ensure_oxfmt() {
+  "${ROOT_DIR}/Scripts/install_lint_tools.sh" oxfmt
+}
+
+ensure_typescript() {
+  "${ROOT_DIR}/Scripts/install_lint_tools.sh" typescript
+}
+
 check_codex_parser_hash() {
   "${ROOT_DIR}/Scripts/regenerate-codex-parser-hash.sh" --check
 }
 
 check_provider_manifests() {
   "${ROOT_DIR}/Scripts/regenerate-provider-manifests.sh" --check
+}
+
+check_plugin_javascript() {
+  "${ROOT_DIR}/Scripts/regenerate-plugin-js.sh" --check
 }
 
 check_package_product_paths() {
@@ -90,6 +106,7 @@ check_llms_index() {
 run_portable_checks() {
   check_codex_parser_hash
   check_provider_manifests
+  check_plugin_javascript
   check_package_product_paths
   check_package_strip
   check_package_signing
@@ -115,26 +132,74 @@ run_swiftlint() {
   "${BIN_DIR}/swiftlint" --strict
 }
 
+collect_javascript_files() {
+  JAVASCRIPT_FILES=("${ROOT_DIR}/docs/site.js")
+  local file
+  for file in "${ROOT_DIR}"/Scripts/*.mjs "${ROOT_DIR}"/Sources/CodexBarCore/Resources/Plugins/*.js \
+    "${ROOT_DIR}"/Sources/CodexBarCore/Resources/Plugins/*.ts
+  do
+    [[ -f "$file" ]] || continue
+    case "$(basename "$file")" in
+      sucrase-*.min.js) continue ;;
+    esac
+    JAVASCRIPT_FILES+=("$file")
+  done
+}
+
+run_oxfmt_check() {
+  ensure_oxfmt
+  collect_javascript_files
+  "${BIN_DIR}/oxfmt" --config "${ROOT_DIR}/.oxfmtrc.json" --check "${JAVASCRIPT_FILES[@]}"
+}
+
+run_oxlint() {
+  ensure_oxlint
+  collect_javascript_files
+  "${BIN_DIR}/oxlint" \
+    --config "${ROOT_DIR}/.oxlintrc.json" \
+    --deny-warnings \
+    --report-unused-disable-directives \
+    "${JAVASCRIPT_FILES[@]}"
+}
+
+run_typescript_check() {
+  ensure_typescript
+  node "${ROOT_DIR}/.build/lint-tools/typescript/bin/tsc" --project "${ROOT_DIR}/tsconfig.plugins.json"
+}
+
+run_javascript_checks() {
+  run_oxfmt_check
+  run_oxlint
+  run_typescript_check
+}
+
 cmd="${1:-lint}"
 
 case "$cmd" in
   lint)
     check_app_locales
     run_portable_checks
+    run_javascript_checks
     run_swiftformat_lint
     run_swiftlint
     ;;
   lint-linux)
     run_portable_checks
+    run_javascript_checks
     run_swiftlint
     ;;
   lint-macos)
     check_app_locales
+    run_javascript_checks
     run_swiftformat_lint
     ;;
   format)
     ensure_swiftformat
     "${BIN_DIR}/swiftformat" Sources Tests
+    ensure_oxfmt
+    collect_javascript_files
+    "${BIN_DIR}/oxfmt" --config "${ROOT_DIR}/.oxfmtrc.json" --write "${JAVASCRIPT_FILES[@]}"
+    "${ROOT_DIR}/Scripts/regenerate-plugin-js.sh" --write
     ;;
   *)
     printf 'Usage: %s [lint|lint-linux|lint-macos|format]\n' "$(basename "$0")" >&2

--- a/Scripts/regenerate-plugin-js.sh
+++ b/Scripts/regenerate-plugin-js.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_DIR="${ROOT_DIR}/Sources/CodexBarCore/Resources/Plugins"
+SUCRASE_FILE="${PLUGIN_DIR}/sucrase-3.35.1.min.js"
+OXFMT="${ROOT_DIR}/.build/lint-tools/bin/oxfmt"
+MODE="${1:-write}"
+
+case "$MODE" in
+  write | --write)
+    CHECK_ONLY=0
+    ;;
+  check | --check)
+    CHECK_ONLY=1
+    ;;
+  *)
+    echo "Usage: $0 [write|--write|check|--check]" >&2
+    exit 2
+    ;;
+esac
+
+count=0
+"${ROOT_DIR}/Scripts/install_lint_tools.sh" oxfmt >/dev/null
+for source in "${PLUGIN_DIR}"/*.ts; do
+  [[ -f "$source" ]] || continue
+  [[ "$source" == *.d.ts ]] && continue
+  output="${source%.ts}.js"
+  expected_dir="$(mktemp -d)"
+  expected="${expected_dir}/$(basename "$output")"
+  node "${ROOT_DIR}/Scripts/transpile-plugin-ts.mjs" "$source" "$SUCRASE_FILE" >"$expected"
+  "$OXFMT" --config "${ROOT_DIR}/.oxfmtrc.json" --write "$expected" >/dev/null
+  count=$((count + 1))
+
+  if [[ "$CHECK_ONLY" -eq 1 ]]; then
+    if ! cmp -s "$expected" "$output"; then
+      echo "error: ${output#${ROOT_DIR}/} is stale. Run Scripts/regenerate-plugin-js.sh and commit the result." >&2
+      if [[ -f "$output" ]]; then
+        diff -u "$output" "$expected" >&2 || true
+      else
+        diff -u /dev/null "$expected" >&2 || true
+      fi
+      rm -rf "$expected_dir"
+      exit 1
+    fi
+    rm -rf "$expected_dir"
+  else
+    mv "$expected" "$output"
+    rm -rf "$expected_dir"
+    echo "Updated ${output#${ROOT_DIR}/}"
+  fi
+done
+
+if [[ "$count" -eq 0 ]]; then
+  echo "error: no bundled TypeScript plugins found in ${PLUGIN_DIR#${ROOT_DIR}/}" >&2
+  exit 1
+fi
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+  echo "Bundled plugin JavaScript is current (${count} TypeScript source file(s))"
+fi

--- a/Scripts/transpile-plugin-ts.mjs
+++ b/Scripts/transpile-plugin-ts.mjs
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import vm from "node:vm";
+
+const [sourcePath, sucrasePath] = process.argv.slice(2);
+if (!sourcePath || !sucrasePath) {
+  console.error("Usage: transpile-plugin-ts.mjs <source.ts> <sucrase.min.js>");
+  process.exit(2);
+}
+
+const context = vm.createContext({
+  __codexbarTypeScriptSource: fs.readFileSync(sourcePath, "utf8"),
+});
+vm.runInContext(fs.readFileSync(sucrasePath, "utf8"), context, { filename: sucrasePath });
+const output = vm.runInContext(
+  "sucrase.transform(__codexbarTypeScriptSource, {transforms:['typescript']}).code",
+  context,
+  { filename: "<sucrase-transform>" },
+);
+process.stdout.write(output);

--- a/Sources/CodexBarCore/Resources/Plugins/clawrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/clawrouter.js
@@ -15,7 +15,7 @@ defineProvider({
 
   async fetchUsage(ctx) {
     let base = (ctx.settings.get("CLAWROUTER_BASE_URL") || "https://clawrouter.openclaw.ai").replace(/\/+$/, "");
-    if (!/\/v1$/.test(base)) base += "/v1";
+    if (!base.endsWith("/v1")) base += "/v1";
     const response = await ctx.http.get(`${base}/usage`);
     if (response.status === 401 || response.status === 403) {
       throw ctx.fail.authenticationExpired("ClawRouter rejected the API key. Check the key and its policy status.");
@@ -30,11 +30,18 @@ defineProvider({
     let payload;
     try {
       payload = JSON.parse(response.bodyText);
-    } catch (_) {
+    } catch {
       throw ctx.fail.parseFailure("Could not parse ClawRouter usage: response was not valid JSON");
     }
-    if (!payload || typeof payload !== "object" || Array.isArray(payload) ||
-        !payload.budget || !payload.usage || !payload.usage.summary || !Array.isArray(payload.usage.providers)) {
+    if (
+      !payload ||
+      typeof payload !== "object" ||
+      Array.isArray(payload) ||
+      !payload.budget ||
+      !payload.usage ||
+      !payload.usage.summary ||
+      !Array.isArray(payload.usage.providers)
+    ) {
       throw ctx.fail.parseFailure("Could not parse ClawRouter usage: response shape is invalid");
     }
 
@@ -54,7 +61,10 @@ defineProvider({
       if (!match) return null;
       let year = Number(match[1]);
       let month = Number(match[2]) + 1;
-      if (month === 13) { year += 1; month = 1; }
+      if (month === 13) {
+        year += 1;
+        month = 1;
+      }
       return ctx.date.iso(`${year}-${String(month).padStart(2, "0")}-01T00:00:00Z`);
     }
 
@@ -75,19 +85,21 @@ defineProvider({
     const totalTokens = integer(summary.totalTokens, "summary.totalTokens");
     const actualCost = micros(summary.actualCostMicros, "summary.actualCostMicros", false);
 
-    const providers = payload.usage.providers.map(item => {
-      if (!item || typeof item.provider !== "string") {
-        throw ctx.fail.parseFailure("Could not parse ClawRouter usage: provider name must be a string");
-      }
-      return {
-        provider: item.provider.trim() || "Unknown",
-        requests: integer(item.requestCount, "provider.requestCount"),
-        success: integer(item.successCount, "provider.successCount"),
-        errors: integer(item.errorCount, "provider.errorCount"),
-        tokens: integer(item.totalTokens, "provider.totalTokens"),
-        cost: micros(item.actualCostMicros, "provider.actualCostMicros", false),
-      };
-    }).sort((a, b) => b.cost - a.cost || b.requests - a.requests || a.provider.localeCompare(b.provider));
+    const providers = payload.usage.providers
+      .map((item) => {
+        if (!item || typeof item.provider !== "string") {
+          throw ctx.fail.parseFailure("Could not parse ClawRouter usage: provider name must be a string");
+        }
+        return {
+          provider: item.provider.trim() || "Unknown",
+          requests: integer(item.requestCount, "provider.requestCount"),
+          success: integer(item.successCount, "provider.successCount"),
+          errors: integer(item.errorCount, "provider.errorCount"),
+          tokens: integer(item.totalTokens, "provider.totalTokens"),
+          cost: micros(item.actualCostMicros, "provider.actualCostMicros", false),
+        };
+      })
+      .sort((a, b) => b.cost - a.cost || b.requests - a.requests || a.provider.localeCompare(b.provider));
 
     const result = {
       dataConfidence: "exact",
@@ -95,15 +107,25 @@ defineProvider({
         organization: `${providers.length} routed providers`,
         loginMethod: budget.configured ? "Managed monthly budget" : "Unmetered",
       },
-      details: [{
-        title: "Usage",
-        rows: [
-          { label: "Requests", value: String(requestCount), secondaryValue: `${successCount} succeeded · ${errorCount} failed` },
-          { label: "Tokens", value: String(totalTokens), secondaryValue: `${inputTokens} input · ${outputTokens} output` },
-          { label: "Actual cost", value: `$${actualCost.toFixed(6)}` },
-          { label: "Budget ledger", value: budget.ledger },
-        ],
-      }],
+      details: [
+        {
+          title: "Usage",
+          rows: [
+            {
+              label: "Requests",
+              value: String(requestCount),
+              secondaryValue: `${successCount} succeeded · ${errorCount} failed`,
+            },
+            {
+              label: "Tokens",
+              value: String(totalTokens),
+              secondaryValue: `${inputTokens} input · ${outputTokens} output`,
+            },
+            { label: "Actual cost", value: `$${actualCost.toFixed(6)}` },
+            { label: "Budget ledger", value: budget.ledger },
+          ],
+        },
+      ],
     };
 
     if (spent !== null && limit !== null) {
@@ -132,7 +154,7 @@ defineProvider({
       }
       result.details.push({
         title: "Routed providers",
-        rows: providers.slice(0, 20).map(item => ({
+        rows: providers.slice(0, 20).map((item) => ({
           label: item.provider,
           value: `${item.requests} requests`,
           secondaryValue: `$${item.cost.toFixed(6)} · ${item.tokens} tokens`,
@@ -141,7 +163,7 @@ defineProvider({
           kind: "bars",
           title: "Provider cost",
           unit: "USD",
-          points: visible.map(item => ({ label: item.provider, value: item.cost })),
+          points: visible.map((item) => ({ label: item.provider, value: item.cost })),
         },
       });
     }

--- a/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
+++ b/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
@@ -1,0 +1,172 @@
+type CodexBarJSONPrimitive = boolean | number | string | null;
+type CodexBarJSONValue = CodexBarJSONPrimitive | CodexBarJSONValue[] | { [key: string]: CodexBarJSONValue };
+
+type CodexBarEndpoint =
+  | string
+  | {
+      setting: string;
+      policy: "https" | "https-or-loopback-http";
+    };
+
+type CodexBarAuth =
+  | { type: "bearer" | "x-api-key"; secret: string }
+  | { type: "header"; header: string; secret: string }
+  | { type: "authorization-scheme"; scheme: string; secret: string };
+
+interface CodexBarSetting {
+  key: string;
+  title: string;
+  subtitle?: string;
+  type?: "plain" | "secure";
+}
+
+interface CodexBarRateWindow {
+  usedPercent: number;
+  windowMinutes?: number | null;
+  resetsAt?: Date | string | null;
+  resetDescription?: string | null;
+  nextRegenPercent?: number | null;
+}
+
+type CodexBarNamedRateWindow = { id: string; title: string } & (CodexBarRateWindow | { window: CodexBarRateWindow });
+
+interface CodexBarCostSnapshot {
+  used: number;
+  limit?: number | null;
+  currency: string;
+  period?: string | null;
+  resetsAt?: Date | string | null;
+  nextRegenAmount?: number | null;
+  balance?: number | null;
+}
+
+interface CodexBarIdentitySnapshot {
+  email?: string | null;
+  organization?: string | null;
+  loginMethod?: string | null;
+  accountID?: string | null;
+}
+
+interface CodexBarDetailRow {
+  label: string;
+  value: string;
+  secondaryValue?: string | null;
+}
+
+interface CodexBarDetailChart {
+  kind: "bars" | "line";
+  title?: string | null;
+  unit?: string | null;
+  points: Array<{ label: string; value: number }>;
+}
+
+interface CodexBarDetailSection {
+  title?: string | null;
+  rows: CodexBarDetailRow[];
+  chart?: CodexBarDetailChart | null;
+}
+
+interface CodexBarUsageSnapshot {
+  primary?: CodexBarRateWindow | null;
+  secondary?: CodexBarRateWindow | null;
+  tertiary?: CodexBarRateWindow | null;
+  extraWindows?: CodexBarNamedRateWindow[] | null;
+  cost?: CodexBarCostSnapshot | null;
+  identity?: CodexBarIdentitySnapshot | null;
+  subscriptionRenewsAt?: Date | string | null;
+  subscriptionExpiresAt?: Date | string | null;
+  dataConfidence?: "exact" | "estimated" | "percentOnly" | "unknown";
+  details?: CodexBarDetailSection[] | null;
+}
+
+interface CodexBarHTTPRequestOptions {
+  headers?: Readonly<Record<string, string>>;
+  timeoutSeconds?: number;
+}
+
+interface CodexBarHTTPResponse {
+  status: number;
+  headers: Readonly<Record<string, string>>;
+}
+
+interface CodexBarHTTPJSONResponse<T = unknown> extends CodexBarHTTPResponse {
+  json: T;
+}
+
+interface CodexBarHTTPTextResponse extends CodexBarHTTPResponse {
+  bodyText: string;
+}
+
+interface CodexBarPluginContext {
+  readonly http: {
+    getJSON<T = unknown>(url: string, options?: CodexBarHTTPRequestOptions): Promise<CodexBarHTTPJSONResponse<T>>;
+    get(url: string, options?: CodexBarHTTPRequestOptions): Promise<CodexBarHTTPTextResponse>;
+    postJSON<T = unknown>(
+      url: string,
+      options: CodexBarHTTPRequestOptions & { body: CodexBarJSONValue },
+    ): Promise<CodexBarHTTPJSONResponse<T>>;
+  };
+  readonly settings: {
+    get(key: string): string | null;
+    getSecret(key: string): string | null;
+  };
+  readonly browser: {
+    cookieHeader(domain: string): Promise<string>;
+  };
+  readonly html: {
+    metaContent(html: string, name: string): string | null;
+    matchFirst(html: string, regexSource: string, flags?: string): string | null;
+  };
+  readonly date: {
+    now(): Date;
+    iso(value: string): Date;
+    unixSeconds(value: number): Date;
+    unixMillis(value: number): Date;
+    nextDailyReset(timeZone: string, hour: number): Date;
+  };
+  readonly format: {
+    number(value: number, options?: { minimumFractionDigits?: number; maximumFractionDigits?: number }): string;
+    usd(value: number): string;
+    monthDay(value: Date | number | string): string;
+  };
+  readonly fail: Readonly<
+    Record<
+      | "authenticationExpired"
+      | "missingCredential"
+      | "permissionDenied"
+      | "rateLimited"
+      | "providerUnavailable"
+      | "parseFailure"
+      | "networkFailure"
+      | "apiFailure",
+      (message: unknown) => Error
+    >
+  >;
+  readonly env: {
+    readonly timeZone: string;
+  };
+  readonly cache: {
+    get<T = unknown>(key: string): T | undefined;
+    set(key: string, value: unknown, ttlSeconds: number): void;
+  };
+  readonly jwt: {
+    decode<T = unknown>(token: string): T;
+  };
+  log(...values: unknown[]): void;
+  pct(used: number, limit: number): number;
+  amountFromPercent(percent: number, limit: number): number;
+}
+
+interface CodexBarProviderDefinition {
+  id: string;
+  name: string;
+  icon?: { monogram?: string; tint?: string };
+  endpoints: CodexBarEndpoint[];
+  auth?: CodexBarAuth;
+  settings: CodexBarSetting[];
+  capabilities?: Array<"browser-cookies">;
+  cookieDomains?: string[];
+  fetchUsage(ctx: CodexBarPluginContext): CodexBarUsageSnapshot | Promise<CodexBarUsageSnapshot>;
+}
+
+declare function defineProvider(definition: CodexBarProviderDefinition): void;

--- a/Sources/CodexBarCore/Resources/Plugins/crof.ts
+++ b/Sources/CodexBarCore/Resources/Plugins/crof.ts
@@ -1,3 +1,9 @@
+type CrofPayload = {
+  credits: unknown;
+  requests_plan?: unknown;
+  usable_requests?: unknown;
+};
+
 defineProvider({
   id: "crof",
   name: "Crof",
@@ -15,7 +21,7 @@ defineProvider({
   async fetchUsage(ctx) {
     const response = await ctx.http.getJSON("https://crof.ai/usage_api/");
     if (response.status !== 200) throw new Error(`Crof API error: HTTP ${response.status}`);
-    const payload = response.json;
+    const payload = response.json as CrofPayload;
     if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
       throw new Error("Failed to parse Crof response: expected an object");
     }
@@ -23,7 +29,7 @@ defineProvider({
       throw new Error("Failed to parse Crof response: credits must be a number");
     }
 
-    function optionalNumber(value, field) {
+    function optionalNumber(value: unknown, field: string): number | null {
       if (value === null || value === undefined) return null;
       if (typeof value !== "number" || !Number.isFinite(value)) {
         throw new Error(`Failed to parse Crof response: ${field} must be a number`);

--- a/Sources/CodexBarCore/Resources/Plugins/deepgram.js
+++ b/Sources/CodexBarCore/Resources/Plugins/deepgram.js
@@ -15,7 +15,8 @@ defineProvider({
       if (status === 401) return ctx.fail.authenticationExpired("Deepgram API key is invalid or expired.");
       if (status === 403) {
         return ctx.fail.permissionDenied(
-          "Deepgram rejected access: The API key may not have access to the project or the Management API. HTTP 403");
+          "Deepgram rejected access: The API key may not have access to the project or the Management API. HTTP 403",
+        );
       }
       if (status === 429) return ctx.fail.rateLimited("Deepgram API error: HTTP 429");
       if (status >= 500) return ctx.fail.providerUnavailable(`Deepgram API error: HTTP ${status}`);
@@ -27,12 +28,12 @@ defineProvider({
       try {
         response = await ctx.http.get(url);
       } catch (error) {
-        throw ctx.fail.networkFailure(`Deepgram network error: ${error && error.message || error}`);
+        throw ctx.fail.networkFailure(`Deepgram network error: ${(error && error.message) || error}`);
       }
       if (response.status !== 200) throw classifyStatus(response.status);
       try {
         return JSON.parse(response.bodyText);
-      } catch (_) {
+      } catch {
         throw ctx.fail.parseFailure("Deepgram parse error: response was not valid JSON");
       }
     }
@@ -115,34 +116,37 @@ defineProvider({
     let start = null;
     let end = null;
     for (const project of projects) {
-      const payload = usagePayload(await getJSON(
-        `${base}/projects/${encodeURIComponent(project.project_id)}/usage/breakdown`));
+      const payload = usagePayload(
+        await getJSON(`${base}/projects/${encodeURIComponent(project.project_id)}/usage/breakdown`),
+      );
       if (payload.start && (!start || payload.start < start)) start = payload.start;
       if (payload.end && (!end || payload.end > end)) end = payload.end;
       for (const field of Object.keys(totals)) totals[field] += payload[field];
     }
 
-    const decimal = value => ctx.format.number(value, {
-      minimumFractionDigits: value === Math.floor(value) ? 0 : 1,
-      maximumFractionDigits: 1,
-    });
-    const integer = value => ctx.format.number(value, { maximumFractionDigits: 0 });
+    const decimal = (value) =>
+      ctx.format.number(value, {
+        minimumFractionDigits: value === Math.floor(value) ? 0 : 1,
+        maximumFractionDigits: 1,
+      });
+    const integer = (value) => ctx.format.number(value, { maximumFractionDigits: 0 });
     const rows = [{ label: "Requests", value: integer(totals.requests) }];
-    if (totals.hours || totals.totalHours) rows.push({
-      label: "Audio",
-      value: `${decimal(totals.hours)} hours`,
-      secondaryValue: `${decimal(totals.totalHours)} billable hours`,
-    });
+    if (totals.hours || totals.totalHours)
+      rows.push({
+        label: "Audio",
+        value: `${decimal(totals.hours)} hours`,
+        secondaryValue: `${decimal(totals.totalHours)} billable hours`,
+      });
     if (totals.agentHours) rows.push({ label: "Agent hours", value: decimal(totals.agentHours) });
-    if (totals.tokensIn || totals.tokensOut) rows.push({
-      label: "Tokens",
-      value: integer(totals.tokensIn + totals.tokensOut),
-    });
+    if (totals.tokensIn || totals.tokensOut)
+      rows.push({
+        label: "Tokens",
+        value: integer(totals.tokensIn + totals.tokensOut),
+      });
     if (totals.tts) rows.push({ label: "TTS characters", value: integer(totals.tts) });
     if (start && end) rows.push({ label: "Period", value: `${start} to ${end}` });
-    const loginMethod = projects.length > 1
-      ? `${projects.length} projects`
-      : `Project: ${projects[0].name || projects[0].project_id}`;
+    const loginMethod =
+      projects.length > 1 ? `${projects.length} projects` : `Project: ${projects[0].name || projects[0].project_id}`;
     return { identity: { loginMethod }, details: [{ title: "Usage summary", rows }] };
   },
 });

--- a/Sources/CodexBarCore/Resources/Plugins/manus.js
+++ b/Sources/CodexBarCore/Resources/Plugins/manus.js
@@ -10,34 +10,43 @@ defineProvider({
     const match = /(?:^|;\s*)session_id=([^;]+)/i.exec(cookies);
     if (!match) throw new Error("Manus session cookie is missing");
     const response = await ctx.http.postJSON("https://api.manus.im/user.v1.UserService/GetAvailableCredits", {
-      body: {}, headers: {
-        Authorization: `Bearer ${match[1]}`, Origin: "https://manus.im", Referer: "https://manus.im/",
+      body: {},
+      headers: {
+        Authorization: `Bearer ${match[1]}`,
+        Origin: "https://manus.im",
+        Referer: "https://manus.im/",
         "Connect-Protocol-Version": "1",
       },
     });
     if (response.status !== 200) throw new Error(`Manus API error: HTTP ${response.status}`);
     const root = response.json || {};
     const data = root.data || root.result || root.response || root.availableCredits || root;
-    const number = key => Number(data[key] || 0);
+    const number = (key) => Number(data[key] || 0);
     const total = number("totalCredits");
     const free = number("freeCredits");
     const monthly = number("proMonthlyCredits");
     const periodic = number("periodicCredits");
     const refresh = number("refreshCredits");
     const maxRefresh = number("maxRefreshCredits");
-    const format = value => ctx.format.number(Math.round(value), { maximumFractionDigits: 0 });
+    const format = (value) => ctx.format.number(Math.round(value), { maximumFractionDigits: 0 });
     return {
-      primary: monthly > 0 ? {
-        usedPercent: ctx.pct(monthly - periodic, monthly),
-        resetDescription: `Total ${format(total)} • Free ${format(free)}`,
-      } : undefined,
-      secondary: maxRefresh > 0 ? {
-        usedPercent: ctx.pct(maxRefresh - refresh, maxRefresh),
-        resetsAt: data.nextRefreshTime ? ctx.date.iso(data.nextRefreshTime) : undefined,
-        resetDescription: data.refreshInterval
-          ? `${String(data.refreshInterval).replace(/^./, value => value.toUpperCase())}: ${format(refresh)} / ${format(maxRefresh)}`
-          : `${format(refresh)} / ${format(maxRefresh)}`,
-      } : undefined,
+      primary:
+        monthly > 0
+          ? {
+              usedPercent: ctx.pct(monthly - periodic, monthly),
+              resetDescription: `Total ${format(total)} • Free ${format(free)}`,
+            }
+          : undefined,
+      secondary:
+        maxRefresh > 0
+          ? {
+              usedPercent: ctx.pct(maxRefresh - refresh, maxRefresh),
+              resetsAt: data.nextRefreshTime ? ctx.date.iso(data.nextRefreshTime) : undefined,
+              resetDescription: data.refreshInterval
+                ? `${String(data.refreshInterval).replace(/^./, (value) => value.toUpperCase())}: ${format(refresh)} / ${format(maxRefresh)}`
+                : `${format(refresh)} / ${format(maxRefresh)}`,
+            }
+          : undefined,
       identity: { loginMethod: `Balance: ${format(total)} credits` },
     };
   },

--- a/Sources/CodexBarCore/Resources/Plugins/openai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openai.js
@@ -71,8 +71,13 @@ defineProvider({
           const response = await ctx.http.getJSON(queryURL(path, range, groupBy, page));
           if (response.status !== 200) throw new Error(`OpenAI ${path} error: HTTP ${response.status}`);
           const body = response.json;
-          if (!body || typeof body !== "object" || Array.isArray(body) ||
-              !Array.isArray(body.data) || typeof body.has_more !== "boolean") {
+          if (
+            !body ||
+            typeof body !== "object" ||
+            Array.isArray(body) ||
+            !Array.isArray(body.data) ||
+            typeof body.has_more !== "boolean"
+          ) {
             throw new Error(`Failed to parse OpenAI ${path} page`);
           }
           buckets.push(...body.data);
@@ -94,15 +99,29 @@ defineProvider({
       const completionBuckets = await pages("/v1/organization/usage/completions", "model");
       const daily = new Map();
       function bucket(raw) {
-        if (!raw || typeof raw !== "object" || Array.isArray(raw) ||
-            !Number.isInteger(raw.start_time) || !Number.isInteger(raw.end_time) || !Array.isArray(raw.results)) {
+        if (
+          !raw ||
+          typeof raw !== "object" ||
+          Array.isArray(raw) ||
+          !Number.isInteger(raw.start_time) ||
+          !Number.isInteger(raw.end_time) ||
+          !Array.isArray(raw.results)
+        ) {
           throw new Error("Failed to parse OpenAI usage bucket");
         }
         let value = daily.get(raw.start_time);
         if (!value) {
           value = {
-            start: raw.start_time, end: raw.end_time, cost: 0, requests: 0,
-            input: 0, cached: 0, output: 0, tokens: 0, models: new Map(), lines: new Map(),
+            start: raw.start_time,
+            end: raw.end_time,
+            cost: 0,
+            requests: 0,
+            input: 0,
+            cached: 0,
+            output: 0,
+            tokens: 0,
+            models: new Map(),
+            lines: new Map(),
           };
           daily.set(raw.start_time, value);
         }
@@ -142,54 +161,76 @@ defineProvider({
         }
       }
       const days = Array.from(daily.values()).sort((a, b) => a.start - b.start);
-      const totals = days.reduce((sum, day) => {
-        sum.cost += day.cost; sum.requests += day.requests; sum.input += day.input;
-        sum.cached += day.cached; sum.output += day.output; sum.tokens += day.tokens;
-        return sum;
-      }, { cost: 0, requests: 0, input: 0, cached: 0, output: 0, tokens: 0 });
+      const totals = days.reduce(
+        (sum, day) => {
+          sum.cost += day.cost;
+          sum.requests += day.requests;
+          sum.input += day.input;
+          sum.cached += day.cached;
+          sum.output += day.output;
+          sum.tokens += day.tokens;
+          return sum;
+        },
+        { cost: 0, requests: 0, input: 0, cached: 0, output: 0, tokens: 0 },
+      );
       const models = new Map();
       const lines = new Map();
       for (const day of days) {
         for (const [modelName, value] of day.models) {
           const model = models.get(modelName) || { requests: 0, tokens: 0 };
-          model.requests += value.requests; model.tokens += value.tokens; models.set(modelName, model);
+          model.requests += value.requests;
+          model.tokens += value.tokens;
+          models.set(modelName, model);
         }
         for (const [line, cost] of day.lines) lines.set(line, (lines.get(line) || 0) + cost);
       }
-      const topModels = Array.from(models.entries()).sort((a, b) => b[1].tokens - a[1].tokens || a[0].localeCompare(b[0]));
+      const topModels = Array.from(models.entries()).sort(
+        (a, b) => b[1].tokens - a[1].tokens || a[0].localeCompare(b[0]),
+      );
       const topLines = Array.from(lines.entries()).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
       const chartDays = days.slice(-120);
       const summaryRows = [
         { label: "Spend", value: usd(totals.cost), secondaryValue: `Last ${historyDays} days` },
         { label: "Requests", value: numberText(totals.requests) },
-        { label: "Tokens", value: numberText(totals.tokens), secondaryValue: `${numberText(totals.input)} input · ${numberText(totals.output)} output` },
+        {
+          label: "Tokens",
+          value: numberText(totals.tokens),
+          secondaryValue: `${numberText(totals.input)} input · ${numberText(totals.output)} output`,
+        },
         { label: "Cached input", value: numberText(totals.cached) },
       ];
       if (days.length > chartDays.length) {
         summaryRows.push({ label: "Chart range", value: `Last ${chartDays.length} days` });
       }
-      const details = [{
-        title: "Usage summary",
-        rows: summaryRows,
-        chart: {
-          kind: "bars",
-          title: "Daily spend",
-          unit: "USD",
-          points: chartDays.map(day => ({ label: new Date(day.start * 1000).toISOString().slice(0, 10), value: day.cost })),
+      const details = [
+        {
+          title: "Usage summary",
+          rows: summaryRows,
+          chart: {
+            kind: "bars",
+            title: "Daily spend",
+            unit: "USD",
+            points: chartDays.map((day) => ({
+              label: new Date(day.start * 1000).toISOString().slice(0, 10),
+              value: day.cost,
+            })),
+          },
         },
-      }];
+      ];
       if (topModels.length) {
         details.push({
           title: "Models",
-          rows: topModels.slice(0, 24).map(item => ({
-            label: item[0], value: `${numberText(item[1].tokens)} tokens`, secondaryValue: `${item[1].requests} requests`,
+          rows: topModels.slice(0, 24).map((item) => ({
+            label: item[0],
+            value: `${numberText(item[1].tokens)} tokens`,
+            secondaryValue: `${item[1].requests} requests`,
           })),
         });
       }
       if (topLines.length) {
         details.push({
           title: "Line items",
-          rows: topLines.slice(0, 24).map(item => ({ label: item[0], value: usd(item[1]) })),
+          rows: topLines.slice(0, 24).map((item) => ({ label: item[0], value: usd(item[1]) })),
         });
       }
       const identity = { loginMethod: projectID ? `Admin API: ${projectID}` : "Admin API" };
@@ -208,10 +249,13 @@ defineProvider({
       const granted = finite(body.total_granted, "total_granted", false);
       const used = finite(body.total_used, "total_used", false);
       const available = finite(body.total_available, "total_available", false);
-      const futureExpiries = body.grants && Array.isArray(body.grants.data)
-        ? body.grants.data.map(item => item && finite(item.expires_at, "expires_at", true))
-          .filter(value => value !== null && value * 1000 > Date.now()).sort((a, b) => a - b)
-        : [];
+      const futureExpiries =
+        body.grants && Array.isArray(body.grants.data)
+          ? body.grants.data
+              .map((item) => item && finite(item.expires_at, "expires_at", true))
+              .filter((value) => value !== null && value * 1000 > Date.now())
+              .sort((a, b) => a - b)
+          : [];
       const resetsAt = futureExpiries.length ? ctx.date.unixSeconds(futureExpiries[0]) : null;
       const primary = {
         usedPercent: granted > 0 ? ctx.pct(used, granted) : available > 0 ? 0 : 100,
@@ -224,14 +268,16 @@ defineProvider({
         primary,
         cost,
         identity: { loginMethod: `API balance: ${usd(available)}` },
-        details: [{
-          title: "API credits",
-          rows: [
-            { label: "Available", value: usd(available) },
-            { label: "Used", value: usd(used) },
-            { label: "Granted", value: usd(granted) },
-          ],
-        }],
+        details: [
+          {
+            title: "API credits",
+            rows: [
+              { label: "Available", value: usd(available) },
+              { label: "Used", value: usd(used) },
+              { label: "Granted", value: usd(granted) },
+            ],
+          },
+        ],
       };
     }
   },

--- a/Sources/CodexBarCore/Resources/Plugins/openrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openrouter.js
@@ -35,7 +35,7 @@ defineProvider({
     let creditsPayload;
     try {
       creditsPayload = JSON.parse(creditsResponse.bodyText);
-    } catch (_) {
+    } catch {
       throw ctx.fail.parseFailure("Failed to parse OpenRouter response: response was not valid JSON");
     }
     const credits = creditsPayload && creditsPayload.data;
@@ -49,8 +49,10 @@ defineProvider({
     let keyData = null;
     let keyDegradation = null;
     const injectedOptionalTimeout = ctx.__codexbarOptionalRequestTimeoutSeconds;
-    const optionalRequestTimeoutSeconds = typeof injectedOptionalTimeout === "number" &&
-      Number.isFinite(injectedOptionalTimeout) ? injectedOptionalTimeout : 1;
+    const optionalRequestTimeoutSeconds =
+      typeof injectedOptionalTimeout === "number" && Number.isFinite(injectedOptionalTimeout)
+        ? injectedOptionalTimeout
+        : 1;
     function degradationReason(error) {
       const message = error && typeof error.message === "string" ? error.message : String(error);
       if (/timed out|-1001/i.test(message)) return "Request timed out";
@@ -63,18 +65,24 @@ defineProvider({
       });
       if (keyResponse.status !== 200) keyDegradation = `Request returned HTTP ${keyResponse.status}`;
       const keyPayload = keyResponse.status === 200 ? JSON.parse(keyResponse.bodyText) : null;
-      if (keyPayload && keyPayload.data && typeof keyPayload.data === "object" &&
-          !Array.isArray(keyPayload.data)) {
+      if (keyPayload && keyPayload.data && typeof keyPayload.data === "object" && !Array.isArray(keyPayload.data)) {
         const candidate = keyPayload.data;
-        for (const field of [
-          "limit", "limit_remaining", "usage", "usage_daily", "usage_weekly", "usage_monthly",
-        ]) finite(candidate[field], `key.${field}`, true);
-        if (candidate.limit_reset !== null && candidate.limit_reset !== undefined &&
-            typeof candidate.limit_reset !== "string") throw new TypeError("key.limit_reset must be a string");
-        if (candidate.rate_limit !== null && candidate.rate_limit !== undefined &&
-            (!candidate.rate_limit || typeof candidate.rate_limit !== "object" ||
-             !Number.isInteger(candidate.rate_limit.requests) ||
-             typeof candidate.rate_limit.interval !== "string")) {
+        for (const field of ["limit", "limit_remaining", "usage", "usage_daily", "usage_weekly", "usage_monthly"])
+          finite(candidate[field], `key.${field}`, true);
+        if (
+          candidate.limit_reset !== null &&
+          candidate.limit_reset !== undefined &&
+          typeof candidate.limit_reset !== "string"
+        )
+          throw new TypeError("key.limit_reset must be a string");
+        if (
+          candidate.rate_limit !== null &&
+          candidate.rate_limit !== undefined &&
+          (!candidate.rate_limit ||
+            typeof candidate.rate_limit !== "object" ||
+            !Number.isInteger(candidate.rate_limit.requests) ||
+            typeof candidate.rate_limit.interval !== "string")
+        ) {
           throw new TypeError("key.rate_limit is invalid");
         }
         keyData = candidate;
@@ -86,9 +94,13 @@ defineProvider({
 
     function resetWindowUsage(reset) {
       const windowKey =
-        reset === "daily" ? "usage_daily" :
-        reset === "weekly" ? "usage_weekly" :
-        reset === "monthly" ? "usage_monthly" : null;
+        reset === "daily"
+          ? "usage_daily"
+          : reset === "weekly"
+            ? "usage_weekly"
+            : reset === "monthly"
+              ? "usage_monthly"
+              : null;
       if (!windowKey) return null;
       return finite(keyData[windowKey], `key.${windowKey}`, true);
     }
@@ -121,15 +133,17 @@ defineProvider({
       }
     }
 
-    const currency = value => `$${Math.max(0, value).toFixed(2)}`;
-    const details = [{
-      title: "Credits",
-      rows: [
-        { label: "Remaining", value: currency(balance) },
-        { label: "Used", value: currency(totalUsage) },
-        { label: "Total added", value: currency(totalCredits) },
-      ],
-    }];
+    const currency = (value) => `$${Math.max(0, value).toFixed(2)}`;
+    const details = [
+      {
+        title: "Credits",
+        rows: [
+          { label: "Remaining", value: currency(balance) },
+          { label: "Used", value: currency(totalUsage) },
+          { label: "Total added", value: currency(totalCredits) },
+        ],
+      },
+    ];
 
     if (keyData) {
       const rows = [];
@@ -170,11 +184,13 @@ defineProvider({
     } else {
       details.push({
         title: "API key",
-        rows: [{
-          label: "API key budget",
-          value: "Unavailable right now",
-          secondaryValue: keyDegradation,
-        }],
+        rows: [
+          {
+            label: "API key budget",
+            value: "Unavailable right now",
+            secondaryValue: keyDegradation,
+          },
+        ],
       });
     }
 

--- a/Sources/CodexBarCore/Resources/Plugins/perplexity.js
+++ b/Sources/CodexBarCore/Resources/Plugins/perplexity.js
@@ -9,35 +9,66 @@ defineProvider({
     const cookie = await ctx.browser.cookieHeader("www.perplexity.ai");
     const response = await ctx.http.getJSON(
       "https://www.perplexity.ai/rest/billing/credits?version=2.18&source=default",
-      { headers: { Cookie: cookie, Origin: "https://www.perplexity.ai", Referer: "https://www.perplexity.ai/account/usage" } });
+      {
+        headers: {
+          Cookie: cookie,
+          Origin: "https://www.perplexity.ai",
+          Referer: "https://www.perplexity.ai/account/usage",
+        },
+      },
+    );
     if (response.status !== 200) throw new Error(`Perplexity API error: HTTP ${response.status}`);
     const data = response.json;
     const grants = data.credit_grants || data.creditGrants || [];
     const now = Date.now() / 1000;
-    const amount = grant => Number(grant.amount_cents ?? grant.amountCents ?? 0);
-    const recurring = grants.filter(grant => grant.type === "recurring").reduce((sum, grant) => sum + amount(grant), 0);
-    const promoGrants = grants.filter(grant => grant.type === "promotional" && Number(grant.expires_at_ts ?? grant.expiresAtTs ?? Infinity) > now);
+    const amount = (grant) => Number(grant.amount_cents ?? grant.amountCents ?? 0);
+    const recurring = grants
+      .filter((grant) => grant.type === "recurring")
+      .reduce((sum, grant) => sum + amount(grant), 0);
+    const promoGrants = grants.filter(
+      (grant) => grant.type === "promotional" && Number(grant.expires_at_ts ?? grant.expiresAtTs ?? Infinity) > now,
+    );
     const promo = promoGrants.reduce((sum, grant) => sum + amount(grant), 0);
-    const purchasedGrants = grants.filter(grant => grant.type === "purchased").reduce((sum, grant) => sum + amount(grant), 0);
-    const purchased = Math.max(purchasedGrants, Number(data.current_period_purchased_cents ?? data.currentPeriodPurchasedCents ?? 0));
+    const purchasedGrants = grants
+      .filter((grant) => grant.type === "purchased")
+      .reduce((sum, grant) => sum + amount(grant), 0);
+    const purchased = Math.max(
+      purchasedGrants,
+      Number(data.current_period_purchased_cents ?? data.currentPeriodPurchasedCents ?? 0),
+    );
     let remaining = Number(data.total_usage_cents ?? data.totalUsageCents ?? 0);
-    const recurringUsed = Math.min(remaining, recurring); remaining -= recurringUsed;
-    const purchasedUsed = Math.min(remaining, purchased); remaining -= purchasedUsed;
+    const recurringUsed = Math.min(remaining, recurring);
+    remaining -= recurringUsed;
+    const purchasedUsed = Math.min(remaining, purchased);
+    remaining -= purchasedUsed;
     const promoUsed = Math.min(remaining, promo);
     const renewal = Number(data.renewal_date_ts ?? data.renewalDateTs);
-    const promoExpiry = promoGrants.map(grant => Number(grant.expires_at_ts ?? grant.expiresAtTs)).filter(Number.isFinite).sort()[0];
-    const integer = value => String(Math.round(value));
+    const promoExpiry = promoGrants
+      .map((grant) => Number(grant.expires_at_ts ?? grant.expiresAtTs))
+      .filter(Number.isFinite)
+      .sort()[0];
+    const integer = (value) => String(Math.round(value));
     const promoDescription = `${integer(promoUsed)}/${integer(promo)} bonus`;
     return {
-      primary: recurring > 0 ? {
-        usedPercent: ctx.pct(recurringUsed, recurring), resetsAt: ctx.date.unixSeconds(renewal),
-        resetDescription: `${integer(recurringUsed)}/${integer(recurring)} credits`,
-      } : (promo > 0 || purchased > 0 ? undefined : {
-        usedPercent: 100, resetsAt: ctx.date.unixSeconds(renewal), resetDescription: "0/0 credits",
-      }),
+      primary:
+        recurring > 0
+          ? {
+              usedPercent: ctx.pct(recurringUsed, recurring),
+              resetsAt: ctx.date.unixSeconds(renewal),
+              resetDescription: `${integer(recurringUsed)}/${integer(recurring)} credits`,
+            }
+          : promo > 0 || purchased > 0
+            ? undefined
+            : {
+                usedPercent: 100,
+                resetsAt: ctx.date.unixSeconds(renewal),
+                resetDescription: "0/0 credits",
+              },
       secondary: {
         usedPercent: promo > 0 ? ctx.pct(promoUsed, promo) : 100,
-        resetDescription: promoExpiry ? `${promoDescription} · exp. ${ctx.format.monthDay(new Date(promoExpiry * 1000))}` : promoDescription,
+        resetDescription: promoExpiry
+          ? `${promoDescription} · exp. ${ctx.format.monthDay(new Date(promoExpiry * 1000))}`
+          : promoDescription,
       },
       tertiary: {
         usedPercent: purchased > 0 ? ctx.pct(purchasedUsed, purchased) : 100,

--- a/Sources/CodexBarCore/Resources/Plugins/poe.js
+++ b/Sources/CodexBarCore/Resources/Plugins/poe.js
@@ -3,12 +3,14 @@ defineProvider({
   name: "Poe",
   endpoints: ["https://api.poe.com"],
   auth: { type: "bearer", secret: "POE_API_KEY" },
-  settings: [{
-    key: "POE_API_KEY",
-    title: "API key",
-    subtitle: "Poe API key used for point balance and history.",
-    type: "secure",
-  }],
+  settings: [
+    {
+      key: "POE_API_KEY",
+      title: "API key",
+      subtitle: "Poe API key used for point balance and history.",
+      type: "secure",
+    },
+  ],
 
   async fetchUsage(ctx) {
     const balanceResponse = await ctx.http.getJSON("https://api.poe.com/usage/current_balance");
@@ -49,7 +51,7 @@ defineProvider({
       return null;
     }
     function timeString(date) {
-      const pad = value => String(value).padStart(2, "0");
+      const pad = (value) => String(value).padStart(2, "0");
       return `${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
     }
     function summaryRow(label, summary) {
@@ -73,8 +75,13 @@ defineProvider({
         if (response.status < 200 || response.status >= 300) throw new Error(`HTTP ${response.status}`);
         const root = response.json;
         if (!root || typeof root !== "object" || Array.isArray(root)) throw new Error("invalid history JSON");
-        const rows = Array.isArray(root.data) ? root.data :
-          Array.isArray(root.items) ? root.items : Array.isArray(root.results) ? root.results : [];
+        const rows = Array.isArray(root.data)
+          ? root.data
+          : Array.isArray(root.items)
+            ? root.items
+            : Array.isArray(root.results)
+              ? root.results
+              : [];
         for (const row of rows) {
           if (!row || typeof row !== "object" || Array.isArray(row)) continue;
           const date = entryDate(row.creation_time ?? row.timestamp ?? row.created_at);
@@ -82,20 +89,27 @@ defineProvider({
           const points = Math.max(0, optionalNumber(row.cost_points ?? row.points ?? row.point_cost, "points") ?? 0);
           const cost = optionalNumber(row.cost_usd ?? row.usd, "cost_usd");
           const model = typeof row.bot_name === "string" && row.bot_name.trim() ? row.bot_name.trim() : "unknown";
-          const usageType = typeof row.usage_type === "string" && row.usage_type.trim()
-            ? row.usage_type.trim() : "unknown";
+          const usageType =
+            typeof row.usage_type === "string" && row.usage_type.trim() ? row.usage_type.trim() : "unknown";
           entries.push({ date, points, cost, model, usageType });
         }
         const next = typeof root.next_cursor === "string" && root.next_cursor.trim() ? root.next_cursor.trim() : null;
-        cursor = next || (root.has_more === true && rows.length && typeof rows[rows.length - 1].query_id === "string"
-          ? rows[rows.length - 1].query_id.trim() : null);
+        cursor =
+          next ||
+          (root.has_more === true && rows.length && typeof rows[rows.length - 1].query_id === "string"
+            ? rows[rows.length - 1].query_id.trim()
+            : null);
         if (!cursor) break;
         const lastDate = rows.length
-          ? entryDate(rows[rows.length - 1].creation_time ?? rows[rows.length - 1].timestamp ?? rows[rows.length - 1].created_at)
+          ? entryDate(
+              rows[rows.length - 1].creation_time ??
+                rows[rows.length - 1].timestamp ??
+                rows[rows.length - 1].created_at,
+            )
           : null;
         if (lastDate && lastDate.getTime() < cutoff) break;
       }
-    } catch (_) {}
+    } catch {}
 
     const daily = new Map();
     const models = new Map();
@@ -105,29 +119,45 @@ defineProvider({
       const bucket = daily.get(day) || { points: 0, requests: 0, cost: 0, hasCost: false };
       bucket.points += entry.points;
       bucket.requests += 1;
-      if (entry.cost !== null) { bucket.cost += Math.max(0, entry.cost); bucket.hasCost = true; }
+      if (entry.cost !== null) {
+        bucket.cost += Math.max(0, entry.cost);
+        bucket.hasCost = true;
+      }
       daily.set(day, bucket);
       models.set(entry.model, (models.get(entry.model) || 0) + entry.points);
       types.set(entry.usageType, (types.get(entry.usageType) || 0) + entry.points);
     }
     const days = Array.from(daily.entries()).sort((a, b) => a[0].localeCompare(b[0]));
-    const summarize = count => days.slice(-count).reduce((sum, item) => {
-      sum.points += item[1].points;
-      sum.requests += item[1].requests;
-      if (item[1].hasCost) { sum.cost += item[1].cost; sum.hasCost = true; }
-      return sum;
-    }, { points: 0, requests: 0, cost: 0, hasCost: false });
+    const summarize = (count) =>
+      days.slice(-count).reduce(
+        (sum, item) => {
+          sum.points += item[1].points;
+          sum.requests += item[1].requests;
+          if (item[1].hasCost) {
+            sum.cost += item[1].cost;
+            sum.hasCost = true;
+          }
+          return sum;
+        },
+        { points: 0, requests: 0, cost: 0, hasCost: false },
+      );
     const seven = summarize(7);
     const thirty = summarize(30);
     const now = new Date(Date.now());
     const todayUTC = now.toISOString().slice(0, 10);
-    const todayEntries = entries.filter(entry => entry.date.toISOString().slice(0, 10) === todayUTC);
-    const today = todayEntries.reduce((sum, entry) => {
-      sum.points += entry.points;
-      sum.requests += 1;
-      if (entry.cost !== null) { sum.cost += Math.max(0, entry.cost); sum.hasCost = true; }
-      return sum;
-    }, { points: 0, requests: 0, cost: 0, hasCost: false });
+    const todayEntries = entries.filter((entry) => entry.date.toISOString().slice(0, 10) === todayUTC);
+    const today = todayEntries.reduce(
+      (sum, entry) => {
+        sum.points += entry.points;
+        sum.requests += 1;
+        if (entry.cost !== null) {
+          sum.cost += Math.max(0, entry.cost);
+          sum.hasCost = true;
+        }
+        return sum;
+      },
+      { points: 0, requests: 0, cost: 0, hasCost: false },
+    );
     const topModel = Array.from(models.entries()).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
     const topTypes = Array.from(types.entries()).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
     const rows = [];
@@ -136,20 +166,28 @@ defineProvider({
       rows.push(summaryRow("Today", today));
       rows.push(summaryRow("Last 7 days", seven));
       rows.push(summaryRow("Last 30 days", thirty));
-      if (topModel) rows.push({ label: "Top model", value: topModel[0], secondaryValue: `${compact(topModel[1])} points` });
+      if (topModel)
+        rows.push({ label: "Top model", value: topModel[0], secondaryValue: `${compact(topModel[1])} points` });
       if (topTypes.length) {
         rows.push({
           label: "Usage mix",
-          value: topTypes.slice(0, 2).map(item => `${item[0]}: ${compact(item[1])} points`).join(" · "),
+          value: topTypes
+            .slice(0, 2)
+            .map((item) => `${item[0]}: ${compact(item[1])} points`)
+            .join(" · "),
         });
       }
-      entries.slice().sort((a, b) => b.date - a.date).slice(0, 3).forEach((entry, index) => {
-        rows.push({
-          label: index === 0 ? "Recent activity" : timeString(entry.date),
-          value: index === 0 ? `${timeString(entry.date)} · ${entry.model}` : entry.model,
-          secondaryValue: `${compact(entry.points)} points`,
+      entries
+        .slice()
+        .sort((a, b) => b.date - a.date)
+        .slice(0, 3)
+        .forEach((entry, index) => {
+          rows.push({
+            label: index === 0 ? "Recent activity" : timeString(entry.date),
+            value: index === 0 ? `${timeString(entry.date)} · ${entry.model}` : entry.model,
+            secondaryValue: `${compact(entry.points)} points`,
+          });
         });
-      });
     }
     const section = { title: "Points", rows };
     if (days.length) {
@@ -157,7 +195,7 @@ defineProvider({
         kind: "bars",
         title: "Daily points",
         unit: "points",
-        points: days.map(item => ({ label: item[0], value: item[1].points })),
+        points: days.map((item) => ({ label: item[0], value: item[1].points })),
       };
     }
     const result = { details: [section], identity: {} };

--- a/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
+++ b/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
@@ -47,10 +47,10 @@
     networkFailure: "network-failure",
     apiFailure: "api-failure",
   });
-  const classifiedFailure = kind => message =>
-    new Error(`__CODEXBAR_FAILURE__:${kind}:${String(message)}`);
-  ctx.fail = Object.freeze(Object.fromEntries(
-    Object.entries(failureKinds).map(([name, kind]) => [name, classifiedFailure(kind)])));
+  const classifiedFailure = (kind) => (message) => new Error(`__CODEXBAR_FAILURE__:${kind}:${String(message)}`);
+  ctx.fail = Object.freeze(
+    Object.fromEntries(Object.entries(failureKinds).map(([name, kind]) => [name, classifiedFailure(kind)])),
+  );
 
   ctx.browser = Object.freeze({
     cookieHeader(domain) {
@@ -77,10 +77,19 @@
     },
   });
 
-  ctx.log = (...args) => host.log(args.map(value => {
-    if (typeof value === "string") return value;
-    try { return JSON.stringify(value); } catch (_) { return String(value); }
-  }).join(" "));
+  ctx.log = (...args) =>
+    host.log(
+      args
+        .map((value) => {
+          if (typeof value === "string") return value;
+          try {
+            return JSON.stringify(value);
+          } catch (_) {
+            return String(value);
+          }
+        })
+        .join(" "),
+    );
 
   ctx.cache = Object.freeze({
     get(key) {
@@ -108,7 +117,9 @@
   }
 
   ctx.format = Object.freeze({
-    number(value, options) { return formatNumber(value, options); },
+    number(value, options) {
+      return formatNumber(value, options);
+    },
     usd(value) {
       const numeric = Number(value);
       const sign = numeric < 0 ? "-$" : "$";
@@ -154,11 +165,21 @@
   const nowMillis = Number(ctx.__codexbarNowMillis);
   delete ctx.__codexbarNowMillis;
   ctx.date = Object.freeze({
-    now() { return parseDate(nowMillis); },
-    nowMillis() { return nowMillis; },
-    iso(value) { return parseDate(String(value)); },
-    unixSeconds(value) { return parseDate(Number(value) * 1000); },
-    unixMillis(value) { return parseDate(Number(value)); },
+    now() {
+      return parseDate(nowMillis);
+    },
+    nowMillis() {
+      return nowMillis;
+    },
+    iso(value) {
+      return parseDate(String(value));
+    },
+    unixSeconds(value) {
+      return parseDate(Number(value) * 1000);
+    },
+    unixMillis(value) {
+      return parseDate(Number(value));
+    },
     nextDailyReset(timeZone, hour) {
       const resetHour = Number(hour);
       if (!Number.isInteger(resetHour) || resetHour < 0 || resetHour > 23) {
@@ -180,4 +201,4 @@
   ctx.amountFromPercent = (percent, limit) => host.amountFromPercent(Number(percent), Number(limit));
 
   return ctx;
-})
+});

--- a/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
+++ b/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
@@ -1,3 +1,4 @@
+// oxlint-disable-next-line no-unused-expressions -- IIFE evaluated by the plugin engine for its side effects
 (function applyProviderPluginPrelude(ctx, host) {
   "use strict";
 
@@ -84,7 +85,7 @@
           if (typeof value === "string") return value;
           try {
             return JSON.stringify(value);
-          } catch (_) {
+          } catch {
             return String(value);
           }
         })

--- a/Sources/CodexBarCore/Resources/Plugins/qoder.js
+++ b/Sources/CodexBarCore/Resources/Plugins/qoder.js
@@ -12,11 +12,17 @@ defineProvider({
       const origin = `https://${site}`;
       const candidate = await ctx.http.getJSON(`${origin}/api/v2/me/usages/big_model_credits`, {
         headers: {
-          Cookie: cookie, Origin: origin, Referer: `${origin}/account/usage`,
-          "X-Requested-With": "XMLHttpRequest", "Bx-V": "2.5.35",
+          Cookie: cookie,
+          Origin: origin,
+          Referer: `${origin}/account/usage`,
+          "X-Requested-With": "XMLHttpRequest",
+          "Bx-V": "2.5.35",
         },
       });
-      if (candidate.status >= 200 && candidate.status < 300) { response = candidate; break; }
+      if (candidate.status >= 200 && candidate.status < 300) {
+        response = candidate;
+        break;
+      }
     }
     if (!response) throw new Error("Qoder credentials were rejected");
     const root = response.json || {};
@@ -28,15 +34,25 @@ defineProvider({
     const read = (value, camel, snake) => Number(value[camel] ?? value[snake]);
     const used = read(summary, "usedValue", "used_value") + (shared ? read(shared, "usedValue", "used_value") : 0);
     const total = read(summary, "limitValue", "limit_value") + (shared ? read(shared, "limitValue", "limit_value") : 0);
-    const percentage = shared ? ctx.pct(used, total) : Number(summary.usagePercentage ?? summary.usage_percentage ?? ctx.pct(used, total));
+    const percentage = shared
+      ? ctx.pct(used, total)
+      : Number(summary.usagePercentage ?? summary.usage_percentage ?? ctx.pct(used, total));
     const reset = root.nextResetAt ?? root.next_reset_at;
-    const resetDate = typeof reset === "number"
-      ? (reset > 10000000000 ? ctx.date.unixMillis(reset) : ctx.date.unixSeconds(reset))
-      : (reset ? ctx.date.iso(reset) : undefined);
-    const format = value => ctx.format.number(value, { maximumFractionDigits: Number.isInteger(value) ? 0 : 2 });
-    return { primary: {
-      usedPercent: Math.max(0, Math.min(100, percentage)), resetsAt: resetDate,
-      resetDescription: `${format(used)} / ${format(total)} credits`,
-    } };
+    const resetDate =
+      typeof reset === "number"
+        ? reset > 10000000000
+          ? ctx.date.unixMillis(reset)
+          : ctx.date.unixSeconds(reset)
+        : reset
+          ? ctx.date.iso(reset)
+          : undefined;
+    const format = (value) => ctx.format.number(value, { maximumFractionDigits: Number.isInteger(value) ? 0 : 2 });
+    return {
+      primary: {
+        usedPercent: Math.max(0, Math.min(100, percentage)),
+        resetsAt: resetDate,
+        resetDescription: `${format(used)} / ${format(total)} credits`,
+      },
+    };
   },
 });

--- a/Sources/CodexBarCore/Resources/Plugins/sub2api.js
+++ b/Sources/CodexBarCore/Resources/Plugins/sub2api.js
@@ -10,7 +10,7 @@ defineProvider({
   async fetchUsage(ctx) {
     let base = ctx.settings.get("SUB2API_BASE_URL").replace(/\/+$/, "");
     if (!/\/v1(?:\/usage)?$/.test(base)) base += "/v1";
-    if (!/\/usage$/.test(base)) base += "/usage";
+    if (!base.endsWith("/usage")) base += "/usage";
     const timezone = ctx.env.timeZone || "UTC";
     let response;
     try {
@@ -18,11 +18,12 @@ defineProvider({
         timeoutSeconds: 15,
       });
     } catch (error) {
-      throw ctx.fail.networkFailure(`sub2api network error: ${error && error.message || error}`);
+      throw ctx.fail.networkFailure(`sub2api network error: ${(error && error.message) || error}`);
     }
     if (response.status === 401 || response.status === 403) {
       throw ctx.fail.authenticationExpired(
-        "sub2api rejected the API key. Check that the key is active and assigned to a group.");
+        "sub2api rejected the API key. Check that the key is active and assigned to a group.",
+      );
     }
     if (response.status === 429) throw ctx.fail.rateLimited("sub2api API returned HTTP 429.");
     if (response.status >= 500) {
@@ -35,7 +36,7 @@ defineProvider({
     let data;
     try {
       data = JSON.parse(response.bodyText);
-    } catch (_) {
+    } catch {
       throw ctx.fail.parseFailure("Could not parse sub2api usage: response was not valid JSON");
     }
     if (!data || typeof data !== "object" || Array.isArray(data)) {
@@ -64,21 +65,24 @@ defineProvider({
     function parseDate(value, field) {
       const text = optional(value, field, "string");
       if (text === null) return undefined;
-      try { return ctx.date.iso(text); } catch (_) {
+      try {
+        return ctx.date.iso(text);
+      } catch {
         throw ctx.fail.parseFailure(`Could not parse sub2api usage: ${field} is not a valid date`);
       }
     }
 
-    const mode = optional(data.mode, "mode", "string") || "unknown";
+    optional(data.mode, "mode", "string");
     const isValid = optional(data.isValid, "isValid", "boolean");
-    const status = optional(data.status, "status", "string");
+    optional(data.status, "status", "string");
     const planName = optional(data.planName, "planName", "string");
     optional(data.remaining, "remaining", "number");
     const balance = optional(data.balance, "balance", "number");
     const rootUnit = optional(data.unit, "unit", "string");
     if (isValid === false) {
       throw ctx.fail.authenticationExpired(
-        "sub2api rejected the API key. Check that the key is active and assigned to a group.");
+        "sub2api rejected the API key. Check that the key is active and assigned to a group.",
+      );
     }
 
     let quota = null;
@@ -93,7 +97,7 @@ defineProvider({
         unit: optional(data.quota.unit, "quota.unit", "string"),
       };
     }
-    const unit = rootUnit || quota && quota.unit || "USD";
+    const unit = rootUnit || (quota && quota.unit) || "USD";
 
     let subscription = null;
     if (data.subscription !== null && data.subscription !== undefined) {
@@ -111,19 +115,22 @@ defineProvider({
       };
     }
 
-    const money = (value, valueUnit = "USD") => valueUnit.toUpperCase() === "USD"
-      ? `$${ctx.format.number(value, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })}`
-      : `${Number(value).toFixed(2)} ${valueUnit}`;
-    const amount = (used, limit, valueUnit = "USD") =>
-      `${money(used, valueUnit)} / ${money(limit, valueUnit)}`;
-    const window = (used, limit, minutes, valueUnit = "USD") => limit !== null && limit > 0 ? ({
-      usedPercent: ctx.pct(used, limit),
-      windowMinutes: minutes,
-      resetDescription: amount(used, limit, valueUnit),
-    }) : null;
+    const money = (value, valueUnit = "USD") =>
+      valueUnit.toUpperCase() === "USD"
+        ? `$${ctx.format.number(value, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })}`
+        : `${Number(value).toFixed(2)} ${valueUnit}`;
+    const amount = (used, limit, valueUnit = "USD") => `${money(used, valueUnit)} / ${money(limit, valueUnit)}`;
+    const window = (used, limit, minutes, valueUnit = "USD") =>
+      limit !== null && limit > 0
+        ? {
+            usedPercent: ctx.pct(used, limit),
+            windowMinutes: minutes,
+            resetDescription: amount(used, limit, valueUnit),
+          }
+        : null;
     let primary = null;
     let secondary = null;
     let tertiary = null;
@@ -200,7 +207,7 @@ defineProvider({
         secondaryValue: money(value.cost),
       });
     }
-    const expiresAt = subscription && subscription.expiresAt || parseDate(data.expires_at, "expires_at");
+    const expiresAt = (subscription && subscription.expiresAt) || parseDate(data.expires_at, "expires_at");
     return {
       primary,
       secondary,

--- a/Sources/CodexBarCore/Resources/Plugins/synthetic.js
+++ b/Sources/CodexBarCore/Resources/Plugins/synthetic.js
@@ -27,27 +27,73 @@ defineProvider({
 
     const labelKeys = ["name", "label", "type", "period", "scope", "title", "id"];
     const percentUsedKeys = [
-      "percentUsed", "usedPercent", "usagePercent", "usage_percent", "used_percent", "percent_used", "percent",
+      "percentUsed",
+      "usedPercent",
+      "usagePercent",
+      "usage_percent",
+      "used_percent",
+      "percent_used",
+      "percent",
     ];
-    const percentRemainingKeys = [
-      "percentRemaining", "remainingPercent", "remaining_percent", "percent_remaining",
-    ];
+    const percentRemainingKeys = ["percentRemaining", "remainingPercent", "remaining_percent", "percent_remaining"];
     const limitKeys = [
-      "limit", "messageLimit", "message_limit", "messages", "maxRequests", "max_requests", "requestLimit",
-      "request_limit", "quota", "max", "total", "capacity", "allowance",
+      "limit",
+      "messageLimit",
+      "message_limit",
+      "messages",
+      "maxRequests",
+      "max_requests",
+      "requestLimit",
+      "request_limit",
+      "quota",
+      "max",
+      "total",
+      "capacity",
+      "allowance",
     ];
     const usedKeys = [
-      "used", "usage", "usedMessages", "used_messages", "messagesUsed", "messages_used", "requests",
-      "requestCount", "request_count", "consumed", "spent",
+      "used",
+      "usage",
+      "usedMessages",
+      "used_messages",
+      "messagesUsed",
+      "messages_used",
+      "requests",
+      "requestCount",
+      "request_count",
+      "consumed",
+      "spent",
     ];
     const remainingKeys = ["remaining", "left", "available", "balance"];
     const resetKeys = [
-      "resetAt", "reset_at", "resetsAt", "resets_at", "renewAt", "renew_at", "renewsAt", "renews_at",
-      "nextTickAt", "next_tick_at", "nextRegenAt", "next_regen_at", "periodEnd", "period_end", "expiresAt",
-      "expires_at", "endAt", "end_at",
+      "resetAt",
+      "reset_at",
+      "resetsAt",
+      "resets_at",
+      "renewAt",
+      "renew_at",
+      "renewsAt",
+      "renews_at",
+      "nextTickAt",
+      "next_tick_at",
+      "nextRegenAt",
+      "next_regen_at",
+      "periodEnd",
+      "period_end",
+      "expiresAt",
+      "expires_at",
+      "endAt",
+      "end_at",
     ];
     const planKeys = [
-      "plan", "planName", "plan_name", "subscription", "subscriptionPlan", "tier", "package", "packageName",
+      "plan",
+      "planName",
+      "plan_name",
+      "subscription",
+      "subscriptionPlan",
+      "tier",
+      "package",
+      "packageName",
     ];
 
     function stringValue(value) {
@@ -88,7 +134,11 @@ defineProvider({
         if (number > 1000000000) return ctx.date.unixSeconds(number);
       }
       if (typeof value === "string") {
-        try { return ctx.date.iso(value); } catch (_) { return null; }
+        try {
+          return ctx.date.iso(value);
+        } catch {
+          return null;
+        }
       }
       return null;
     }
@@ -132,13 +182,35 @@ defineProvider({
       if (days !== null) return Math.round(days * 1440);
       const seconds = firstNumber(payload, ["windowSeconds", "window_seconds", "periodSeconds", "period_seconds"]);
       if (seconds !== null) return Math.round(seconds / 60);
-      const text = firstString(payload, ["window", "windowLabel", "window_label", "period", "periodLabel", "period_label"]);
+      const text = firstString(payload, [
+        "window",
+        "windowLabel",
+        "window_label",
+        "period",
+        "periodLabel",
+        "period_label",
+      ]);
       if (text === null) return null;
-      const match = text.toLowerCase().replace(/\s/g, "").match(/^([0-9]*\.?[0-9]+)(minutes?|mins?|m|hours?|hrs?|hr|h|days?|d)$/);
+      const match = text
+        .toLowerCase()
+        .replace(/\s/g, "")
+        .match(/^([0-9]*\.?[0-9]+)(minutes?|mins?|m|hours?|hrs?|hr|h|days?|d)$/);
       if (!match) return null;
-      const multipliers = { m: 1, min: 1, mins: 1, minute: 1, minutes: 1,
-        h: 60, hr: 60, hrs: 60, hour: 60, hours: 60,
-        d: 1440, day: 1440, days: 1440 };
+      const multipliers = {
+        m: 1,
+        min: 1,
+        mins: 1,
+        minute: 1,
+        minutes: 1,
+        h: 60,
+        hr: 60,
+        hrs: 60,
+        hour: 60,
+        hours: 60,
+        d: 1440,
+        day: 1440,
+        days: 1440,
+      };
       return Math.round(Number(match[1]) * multipliers[match[2]]);
     }
 
@@ -156,9 +228,14 @@ defineProvider({
     }
 
     function isQuota(payload) {
-      return payload && typeof payload === "object" && !Array.isArray(payload) &&
-        [limitKeys, usedKeys, remainingKeys, percentUsedKeys, percentRemainingKeys]
-          .some(keys => firstNumber(payload, keys) !== null);
+      return (
+        payload &&
+        typeof payload === "object" &&
+        !Array.isArray(payload) &&
+        [limitKeys, usedKeys, remainingKeys, percentUsedKeys, percentRemainingKeys].some(
+          (keys) => firstNumber(payload, keys) !== null,
+        )
+      );
     }
 
     function parseQuota(payload) {
@@ -189,9 +266,9 @@ defineProvider({
         const description = windowDescription(minutes);
         if (description !== null) window.resetDescription = description;
       }
-      const tickPercent = normalizedPercent(firstNumber(
-        payload,
-        ["tickPercent", "tick_percent", "nextTickPercent", "next_tick_percent"]));
+      const tickPercent = normalizedPercent(
+        firstNumber(payload, ["tickPercent", "tick_percent", "nextTickPercent", "next_tick_percent"]),
+      );
       if (tickPercent !== null) window.nextRegenPercent = tickPercent;
 
       const costLimit = firstCurrency(payload, ["maxCredits", "max_credits"]);
@@ -199,8 +276,12 @@ defineProvider({
       if (costLimit !== null) {
         const remaining = firstCurrency(payload, ["remainingCredits", "remaining_credits"]);
         const explicitUsed = firstCurrency(payload, ["usedCredits", "used_credits"]);
-        const used = explicitUsed !== null ? explicitUsed :
-          remaining !== null ? Math.max(0, costLimit - remaining) : ctx.amountFromPercent(usedPercent, costLimit);
+        const used =
+          explicitUsed !== null
+            ? explicitUsed
+            : remaining !== null
+              ? Math.max(0, costLimit - remaining)
+              : ctx.amountFromPercent(usedPercent, costLimit);
         cost = { used, limit: costLimit, currency: "USD", period: "Weekly" };
         if (resetsAt !== null) cost.resetsAt = resetsAt;
         const regen = firstCurrency(payload, ["nextRegenCredits", "next_regen_credits"]);
@@ -218,7 +299,9 @@ defineProvider({
       if (Array.isArray(candidate)) return candidate.flatMap(collect);
       if (!candidate || typeof candidate !== "object") return [];
       if (isQuota(candidate)) return [candidate];
-      return Object.keys(candidate).sort().flatMap(key => collect(candidate[key]));
+      return Object.keys(candidate)
+        .sort()
+        .flatMap((key) => collect(candidate[key]));
     }
 
     const data = root.data && typeof root.data === "object" ? root.data : null;
@@ -233,12 +316,22 @@ defineProvider({
 
     let parsed;
     if (slots.some(Boolean)) {
-      parsed = slots.map(value => value ? parseQuota(value) : null);
+      parsed = slots.map((value) => (value ? parseQuota(value) : null));
     } else {
       const candidates = [
-        root.quotas, root.quota, root.limits, root.usage, root.entries, root.subscription, root.data,
-        data && data.quotas, data && data.quota, data && data.limits, data && data.usage,
-        data && data.entries, data && data.subscription,
+        root.quotas,
+        root.quota,
+        root.limits,
+        root.usage,
+        root.entries,
+        root.subscription,
+        root.data,
+        data && data.quotas,
+        data && data.quota,
+        data && data.limits,
+        data && data.usage,
+        data && data.entries,
+        data && data.subscription,
       ];
       let values = [];
       for (const candidate of candidates) {
@@ -256,7 +349,7 @@ defineProvider({
       tertiary: parsed[2] ? parsed[2].window : null,
       identity: plan ? { loginMethod: plan } : {},
     };
-    const withCost = parsed.find(value => value && value.cost);
+    const withCost = parsed.find((value) => value && value.cost);
     if (withCost) snapshot.cost = withCost.cost;
     return snapshot;
   },

--- a/Sources/CodexBarCore/Resources/Plugins/t3chat.js
+++ b/Sources/CodexBarCore/Resources/Plugins/t3chat.js
@@ -7,29 +7,51 @@ defineProvider({
   cookieDomains: ["t3.chat"],
   async fetchUsage(ctx) {
     const cookie = await ctx.browser.cookieHeader("t3.chat");
-    const input = encodeURIComponent(JSON.stringify({ "0": { json: { sessionId: null }, meta: { values: { sessionId: ["undefined"] } } } }));
+    const input = encodeURIComponent(
+      JSON.stringify({ 0: { json: { sessionId: null }, meta: { values: { sessionId: ["undefined"] } } } }),
+    );
     const response = await ctx.http.get(`https://t3.chat/api/trpc/getCustomerData?batch=1&input=${input}`, {
       headers: {
-        Cookie: cookie, Origin: "https://t3.chat", Referer: "https://t3.chat/settings/customization",
-        "trpc-accept": "application/jsonl", "x-trpc-source": "web-client", "x-trpc-batch": "true",
+        Cookie: cookie,
+        Origin: "https://t3.chat",
+        Referer: "https://t3.chat/settings/customization",
+        "trpc-accept": "application/jsonl",
+        "x-trpc-source": "web-client",
+        "x-trpc-batch": "true",
       },
     });
     if (response.status !== 200) throw new Error(`T3 Chat API error: HTTP ${response.status}`);
     function find(value) {
       if (!value || typeof value !== "object") return null;
-      if ("usageFourHourPercentage" in value || "usageMonthPercentage" in value || (value.subscription && value.usageBand)) return value;
-      for (const child of Object.values(value)) { const found = find(child); if (found) return found; }
+      if (
+        "usageFourHourPercentage" in value ||
+        "usageMonthPercentage" in value ||
+        (value.subscription && value.usageBand)
+      )
+        return value;
+      for (const child of Object.values(value)) {
+        const found = find(child);
+        if (found) return found;
+      }
       return null;
     }
     let data = null;
     for (const line of response.bodyText.split(/\r?\n/)) {
-      try { data = find(JSON.parse(line)); } catch (_) {}
+      try {
+        data = find(JSON.parse(line));
+      } catch {}
       if (data) break;
     }
     if (!data) throw new Error("T3 Chat response is missing customer data");
-    const date = value => !value || value <= 0 ? undefined : (value > 10000000000 ? ctx.date.unixMillis(value) : ctx.date.unixSeconds(value));
-    const rawPlan = data.subscription && data.subscription.productName || data.subTier;
-    const plan = rawPlan && String(rawPlan).split("-").map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(" ");
+    const date = (value) =>
+      !value || value <= 0 ? undefined : value > 10000000000 ? ctx.date.unixMillis(value) : ctx.date.unixSeconds(value);
+    const rawPlan = (data.subscription && data.subscription.productName) || data.subTier;
+    const plan =
+      rawPlan &&
+      String(rawPlan)
+        .split("-")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ");
     return {
       primary: {
         usedPercent: Math.max(0, Math.min(100, Number(data.usageFourHourPercentage || 0))),
@@ -39,7 +61,8 @@ defineProvider({
       },
       secondary: {
         usedPercent: Math.max(0, Math.min(100, Number(data.usageMonthPercentage ?? data.usagePeriodPercentage ?? 0))),
-        resetsAt: date(data.subscription && data.subscription.currentPeriodEnd), resetDescription: "Overage",
+        resetsAt: date(data.subscription && data.subscription.currentPeriodEnd),
+        resetDescription: "Overage",
       },
       identity: { loginMethod: plan || undefined },
     };

--- a/Sources/CodexBarCore/Resources/Plugins/venice.js
+++ b/Sources/CodexBarCore/Resources/Plugins/venice.js
@@ -29,14 +29,16 @@ defineProvider({
 
     function optionalNumber(value, field) {
       if (value === null || value === undefined || value === "") return null;
-      const number = typeof value === "number" ? value :
-        typeof value === "string" ? Number(value.trim()) : Number.NaN;
+      const number = typeof value === "number" ? value : typeof value === "string" ? Number(value.trim()) : Number.NaN;
       if (!Number.isFinite(number)) throw new Error(`Failed to parse Venice response: ${field} must be numeric`);
       return number;
     }
 
-    if (payload.consumptionCurrency !== null && payload.consumptionCurrency !== undefined &&
-        typeof payload.consumptionCurrency !== "string") {
+    if (
+      payload.consumptionCurrency !== null &&
+      payload.consumptionCurrency !== undefined &&
+      typeof payload.consumptionCurrency !== "string"
+    ) {
       throw new Error("Failed to parse Venice response: consumptionCurrency must be a string");
     }
     const currency = payload.consumptionCurrency ? payload.consumptionCurrency.toUpperCase() : null;

--- a/Sources/CodexBarCore/Resources/Plugins/xai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/xai.js
@@ -15,10 +15,14 @@ defineProvider({
     const root = `https://management-api.x.ai/v1/billing/teams/${encodeURIComponent(team)}`;
     const balanceResponse = await ctx.http.getJSON(`${root}/prepaid/balance`);
     if (balanceResponse.status === 401 || balanceResponse.status === 403) {
-      throw ctx.fail.authenticationExpired("xAI rejected the Management API key. Create one in the xAI Console under Settings > Management Keys; inference API keys are not accepted.");
+      throw ctx.fail.authenticationExpired(
+        "xAI rejected the Management API key. Create one in the xAI Console under Settings > Management Keys; inference API keys are not accepted.",
+      );
     }
     if (balanceResponse.status === 404) {
-      throw ctx.fail.apiFailure("xAI returned 404 for this team. Check the team ID, and that the Management key belongs to the same team.");
+      throw ctx.fail.apiFailure(
+        "xAI returned 404 for this team. Check the team ID, and that the Management key belongs to the same team.",
+      );
     }
     if (balanceResponse.status === 429) {
       throw ctx.fail.rateLimited("xAI Management API rate limit exceeded. Usage will refresh on the next cycle.");
@@ -35,30 +39,42 @@ defineProvider({
     const start = new Date(now);
     start.setUTCDate(start.getUTCDate() - 29);
     start.setUTCHours(0, 0, 0, 0);
-    const timestamp = date => `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")} ${String(date.getUTCHours()).padStart(2, "0")}:${String(date.getUTCMinutes()).padStart(2, "0")}:${String(date.getUTCSeconds()).padStart(2, "0")}`;
+    const timestamp = (date) =>
+      `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")} ${String(date.getUTCHours()).padStart(2, "0")}:${String(date.getUTCMinutes()).padStart(2, "0")}:${String(date.getUTCSeconds()).padStart(2, "0")}`;
     let daily = [];
     let partial = false;
     try {
-      const usage = await ctx.http.postJSON(`${root}/usage`, { body: { analyticsRequest: {
-        timeRange: { startTime: timestamp(start), endTime: timestamp(now), timezone: "Etc/GMT" },
-        timeUnit: "TIME_UNIT_DAY", values: [{ name: "usd", aggregation: "AGGREGATION_SUM" }],
-        groupBy: [], filters: [],
-      } } });
+      const usage = await ctx.http.postJSON(`${root}/usage`, {
+        body: {
+          analyticsRequest: {
+            timeRange: { startTime: timestamp(start), endTime: timestamp(now), timezone: "Etc/GMT" },
+            timeUnit: "TIME_UNIT_DAY",
+            values: [{ name: "usd", aggregation: "AGGREGATION_SUM" }],
+            groupBy: [],
+            filters: [],
+          },
+        },
+      });
       if (usage.status === 401 || usage.status === 403) {
-        throw ctx.fail.authenticationExpired("xAI rejected the Management API key. Create one in the xAI Console under Settings > Management Keys; inference API keys are not accepted.");
+        throw ctx.fail.authenticationExpired(
+          "xAI rejected the Management API key. Create one in the xAI Console under Settings > Management Keys; inference API keys are not accepted.",
+        );
       }
       if (usage.status >= 200 && usage.status < 300) {
         const totals = {};
-        for (const series of usage.json.timeSeries || []) for (const point of series.dataPoints || []) {
-          const date = new Date(point.timestamp);
-          const value = (point.values || [0])[0] || 0;
-          if (!Number.isFinite(date.getTime()) || typeof value !== "number" || !Number.isFinite(value)) {
-            throw new Error("invalid xAI usage history");
+        for (const series of usage.json.timeSeries || [])
+          for (const point of series.dataPoints || []) {
+            const date = new Date(point.timestamp);
+            const value = (point.values || [0])[0] || 0;
+            if (!Number.isFinite(date.getTime()) || typeof value !== "number" || !Number.isFinite(value)) {
+              throw new Error("invalid xAI usage history");
+            }
+            const day = date.toISOString().slice(0, 10);
+            totals[day] = (totals[day] || 0) + value;
           }
-          const day = date.toISOString().slice(0, 10);
-          totals[day] = (totals[day] || 0) + value;
-        }
-        daily = Object.keys(totals).sort().map(day => ({ label: day, value: totals[day] }));
+        daily = Object.keys(totals)
+          .sort()
+          .map((day) => ({ label: day, value: totals[day] }));
         partial = usage.json.limitReached === true;
       }
     } catch (error) {
@@ -68,17 +84,19 @@ defineProvider({
       cost: { used: balance, currency: "USD", period: "Prepaid credits" },
       identity: { loginMethod: "Management API" },
       dataConfidence: partial ? "estimated" : "exact",
-      details: [{
-        title: "Billing summary",
-        rows: [
-          { label: "Prepaid balance", value: `$${balance.toFixed(2)}` },
-          {
-            label: partial ? "Last 30 days (partial)" : "Last 30 days",
-            value: `$${daily.reduce((sum, point) => sum + point.value, 0).toFixed(2)}`,
-          },
-        ],
-        chart: daily.length ? { kind: "bars", title: "Daily spend", unit: "USD", points: daily } : undefined,
-      }],
+      details: [
+        {
+          title: "Billing summary",
+          rows: [
+            { label: "Prepaid balance", value: `$${balance.toFixed(2)}` },
+            {
+              label: partial ? "Last 30 days (partial)" : "Last 30 days",
+              value: `$${daily.reduce((sum, point) => sum + point.value, 0).toFixed(2)}`,
+            },
+          ],
+          chart: daily.length ? { kind: "bars", title: "Daily spend", unit: "USD", points: daily } : undefined,
+        },
+      ],
     };
   },
 });

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -25,19 +25,16 @@ defineProvider({
     const project = ctx.settings.get("Z_AI_PROJECT");
     if (region !== "global" && region !== "bigmodel-cn") throw new Error("Unsupported z.ai region");
     if (scope !== "personal" && scope !== "team") throw new Error("Unsupported z.ai usage scope");
-    if (scope === "team" && (!organization || !project)) throw new Error("z.ai team scope needs organization and project");
+    if (scope === "team" && (!organization || !project))
+      throw new Error("z.ai team scope needs organization and project");
     const base = region === "bigmodel-cn" ? "https://open.bigmodel.cn" : "https://api.z.ai";
-    const quotaEndpoint = ctx.settings.get("Z_AI_QUOTA_ENDPOINT") ||
-      `${base}/api/monitor/usage/quota/limit`;
-    const modelUsageEndpoint = ctx.settings.get("Z_AI_MODEL_USAGE_ENDPOINT") ||
-      `${base}/api/monitor/usage/model-usage`;
-    const headers = scope === "team"
-      ? { "Bigmodel-Organization": organization, "Bigmodel-Project": project }
-      : {};
+    const quotaEndpoint = ctx.settings.get("Z_AI_QUOTA_ENDPOINT") || `${base}/api/monitor/usage/quota/limit`;
+    const modelUsageEndpoint = ctx.settings.get("Z_AI_MODEL_USAGE_ENDPOINT") || `${base}/api/monitor/usage/model-usage`;
+    const headers = scope === "team" ? { "Bigmodel-Organization": organization, "Bigmodel-Project": project } : {};
     function withType(url, value) {
       const parts = String(url).split("?");
       const query = parts.length > 1 ? parts.slice(1).join("?").split("&").filter(Boolean) : [];
-      const filtered = query.filter(item => decodeURIComponent(item.split("=", 1)[0]) !== "type");
+      const filtered = query.filter((item) => decodeURIComponent(item.split("=", 1)[0]) !== "type");
       filtered.push(`type=${value}`);
       return `${parts[0]}?${filtered.join("&")}`;
     }
@@ -58,9 +55,15 @@ defineProvider({
       return value;
     }
     function parseLimit(raw) {
-      if (!raw || typeof raw !== "object" || Array.isArray(raw) ||
-          typeof raw.type !== "string" || !Number.isInteger(raw.unit) ||
-          !Number.isInteger(raw.number) || !Number.isInteger(raw.percentage)) {
+      if (
+        !raw ||
+        typeof raw !== "object" ||
+        Array.isArray(raw) ||
+        typeof raw.type !== "string" ||
+        !Number.isInteger(raw.unit) ||
+        !Number.isInteger(raw.number) ||
+        !Number.isInteger(raw.percentage)
+      ) {
         throw new Error("Failed to parse z.ai limit entry");
       }
       if (raw.type !== "TOKENS_LIMIT" && raw.type !== "TIME_LIMIT" && raw.type !== "CREDIT_LIMIT") return null;
@@ -101,7 +104,11 @@ defineProvider({
       const parts = [];
       if (limit.usage !== null) parts.push(`${limit.usage} limit`);
       if (limit.remaining !== null) parts.push(`${limit.remaining} remaining`);
-      return { label, value: `${limit.percent.toFixed(limit.percent % 1 ? 1 : 0)}% used`, secondaryValue: parts.join(" · ") || undefined };
+      return {
+        label,
+        value: `${limit.percent.toFixed(limit.percent % 1 ? 1 : 0)}% used`,
+        secondaryValue: parts.join(" · ") || undefined,
+      };
     }
     // Mirrors UsageFormatter.resetCountdownDescription so the row reads like native reset text.
     function countdownText(millis) {
@@ -130,8 +137,9 @@ defineProvider({
       const day = now.getUTCDay();
       const hour = now.getUTCHours();
       const isPeak = day >= 1 && day <= 5 && hour >= PEAK_START && hour < PEAK_END;
-      const boundary = new Date(Date.UTC(
-        now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), isPeak ? PEAK_END : PEAK_START));
+      const boundary = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), isPeak ? PEAK_END : PEAK_START),
+      );
       if (!isPeak) {
         if (hour >= PEAK_START) boundary.setUTCDate(boundary.getUTCDate() + 1);
         while (boundary.getUTCDay() === 0 || boundary.getUTCDay() === 6) {
@@ -147,9 +155,10 @@ defineProvider({
     }
 
     const limits = root.data.limits.map(parseLimit).filter(Boolean);
-    const tokenLimits = limits.filter(item => item.raw.type === "TOKENS_LIMIT" || item.raw.type === "CREDIT_LIMIT")
+    const tokenLimits = limits
+      .filter((item) => item.raw.type === "TOKENS_LIMIT" || item.raw.type === "CREDIT_LIMIT")
       .sort((a, b) => (a.windowMinutes || Number.MAX_SAFE_INTEGER) - (b.windowMinutes || Number.MAX_SAFE_INTEGER));
-    const timeLimit = limits.filter(item => item.raw.type === "TIME_LIMIT").pop() || null;
+    const timeLimit = limits.filter((item) => item.raw.type === "TIME_LIMIT").pop() || null;
     const tokenLimit = tokenLimits.length ? tokenLimits[tokenLimits.length - 1] : null;
     const sessionLimit = tokenLimits.length >= 2 ? tokenLimits[0] : null;
     const primaryLimit = sessionLimit || tokenLimit || timeLimit;
@@ -162,9 +171,18 @@ defineProvider({
     if ((tokenLimit || sessionLimit) && timeLimit) {
       result.extraWindows = [{ id: "zai-mcp", title: "MCP", window: window(timeLimit) }];
     }
-    if (tokenLimit) result.details[0].rows.push(limitRow(tokenLimit.raw.type === "CREDIT_LIMIT" ? "Credit quota" : "Token quota", tokenLimit));
-    if (sessionLimit) result.details[0].rows.push(limitRow(sessionLimit.raw.type === "CREDIT_LIMIT" ? "Session credit quota" : "Session token quota", sessionLimit));
-    const hasCreditLimit = [tokenLimit, sessionLimit].some(item => item && item.raw.type === "CREDIT_LIMIT");
+    if (tokenLimit)
+      result.details[0].rows.push(
+        limitRow(tokenLimit.raw.type === "CREDIT_LIMIT" ? "Credit quota" : "Token quota", tokenLimit),
+      );
+    if (sessionLimit)
+      result.details[0].rows.push(
+        limitRow(
+          sessionLimit.raw.type === "CREDIT_LIMIT" ? "Session credit quota" : "Session token quota",
+          sessionLimit,
+        ),
+      );
+    const hasCreditLimit = [tokenLimit, sessionLimit].some((item) => item && item.raw.type === "CREDIT_LIMIT");
     if (hasCreditLimit) result.details[0].rows.push(quotaRateRow());
     if (timeLimit) {
       result.details[0].rows.push(limitRow("MCP quota", timeLimit));
@@ -174,8 +192,9 @@ defineProvider({
         }
       }
     }
-    const plan = [root.data.planName, root.data.plan, root.data.plan_type, root.data.packageName, root.data.level]
-      .find(value => typeof value === "string" && value.trim());
+    const plan = [root.data.planName, root.data.plan, root.data.plan_type, root.data.packageName, root.data.level].find(
+      (value) => typeof value === "string" && value.trim(),
+    );
     if (plan) result.identity.loginMethod = plan.trim();
 
     async function modelUsage(daysBack) {
@@ -185,12 +204,14 @@ defineProvider({
       start.setDate(start.getDate() - Math.max(1, daysBack));
       const rangeEnd = new Date(end);
       rangeEnd.setMinutes(59, 59, 0);
-      const pad = value => String(value).padStart(2, "0");
-      const stamp = date => `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
+      const pad = (value) => String(value).padStart(2, "0");
+      const stamp = (date) =>
+        `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
         `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
       const type = scope === "team" ? "&type=3" : "";
       const modelUsageBase = modelUsageEndpoint.split("?", 1)[0];
-      const url = `${modelUsageBase}?startTime=${encodeURIComponent(stamp(start))}` +
+      const url =
+        `${modelUsageBase}?startTime=${encodeURIComponent(stamp(start))}` +
         `&endTime=${encodeURIComponent(stamp(rangeEnd))}${type}`;
       const response = await ctx.http.getJSON(url, { headers });
       if (response.status !== 200) throw new Error(`HTTP ${response.status}`);
@@ -199,30 +220,39 @@ defineProvider({
       const data = body.data || {};
       const labels = Array.isArray(data.x_time) ? data.x_time : [];
       const models = Array.isArray(data.modelDataList) ? data.modelDataList : [];
-      const points = labels.map((label, index) => {
-        let total = 0;
-        for (const model of models) {
-          const value = model && Array.isArray(model.tokensUsage) ? model.tokensUsage[index] : null;
-          if (Number.isInteger(value) && value > 0) total += value;
-        }
-        return { label: String(label), value: total };
-      }).filter(point => point.value > 0);
-      const totals = models.map(model => ({
-        name: model && typeof model.modelName === "string" ? model.modelName : "Unknown",
-        tokens: model && Array.isArray(model.tokensUsage)
-          ? model.tokensUsage.reduce((sum, value) => sum + (Number.isInteger(value) && value > 0 ? value : 0), 0)
-          : 0,
-      })).filter(item => item.tokens > 0).sort((a, b) => b.tokens - a.tokens || a.name.localeCompare(b.name));
+      const points = labels
+        .map((label, index) => {
+          let total = 0;
+          for (const model of models) {
+            const value = model && Array.isArray(model.tokensUsage) ? model.tokensUsage[index] : null;
+            if (Number.isInteger(value) && value > 0) total += value;
+          }
+          return { label: String(label), value: total };
+        })
+        .filter((point) => point.value > 0);
+      const totals = models
+        .map((model) => ({
+          name: model && typeof model.modelName === "string" ? model.modelName : "Unknown",
+          tokens:
+            model && Array.isArray(model.tokensUsage)
+              ? model.tokensUsage.reduce((sum, value) => sum + (Number.isInteger(value) && value > 0 ? value : 0), 0)
+              : 0,
+        }))
+        .filter((item) => item.tokens > 0)
+        .sort((a, b) => b.tokens - a.tokens || a.name.localeCompare(b.name));
       return { points, totals };
     }
 
-    for (const [days, title] of [[1, "Hourly tokens"], [30, "Daily tokens"]]) {
+    for (const [days, title] of [
+      [1, "Hourly tokens"],
+      [30, "Daily tokens"],
+    ]) {
       try {
         const usage = await modelUsage(days);
         if (usage.points.length) {
           result.details.push({
             title,
-            rows: usage.totals.slice(0, 20).map(item => ({ label: item.name, value: String(item.tokens) })),
+            rows: usage.totals.slice(0, 20).map((item) => ({ label: item.name, value: String(item.tokens) })),
             chart: { kind: "bars", title, unit: "tokens", points: usage.points },
           });
         }

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -256,7 +256,7 @@ defineProvider({
             chart: { kind: "bars", title, unit: "tokens", points: usage.points },
           });
         }
-      } catch (_) {}
+      } catch {}
     }
     return result;
   },

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -164,6 +164,15 @@ and 120 characters per detail string. Wrong types and limit violations fail the 
 
 ## TypeScript
 
+[`codexbar-plugin.d.ts`](../Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts) is the canonical authoring
+contract for `defineProvider`, the `ctx` host API, manifests, and usage snapshots. Bundled plugins may use that contract
+directly as `.ts` sources. `Scripts/regenerate-plugin-js.sh` transpiles them with the vendored Sucrase build into
+committed sibling `.js` files; the runtime continues to load only those JavaScript files, so bundled TypeScript has no
+runtime compilation cost. `make check` verifies both the TypeScript contract and generated-file freshness.
+
+For bundled-plugin work, run `make format` after editing TypeScript so the committed JavaScript is regenerated. Do not
+edit a generated sibling `.js` file directly.
+
 TypeScript files are transpiled by the selected plugin engine with the bundled Sucrase 3.35.1 build using its
 `typescript` transform. Use ordinary
 type syntax but no module imports, JSX, decorators, or runtime TypeScript features that require module resolution.

--- a/docs/site.js
+++ b/docs/site.js
@@ -1,11 +1,10 @@
-import { localeCatalog, localeMessages } from './site-locales.mjs';
+import { localeCatalog, localeMessages } from "./site-locales.mjs";
 
 const root = document.documentElement;
 let activeMessages = localeMessages.en;
 
 const HERO_MOBILE_MAX = 768;
 const HERO_TABLET_MAX = 1023;
-const HERO_DESKTOP_MIN = 1024;
 const MOCKUP_SCREEN_MARGIN_RIGHT = 50;
 const MOCKUP_SCREEN_MARGIN_RIGHT_TABLET = 15;
 const MOCKUP_ARTBOARD_RATIO = 1.18;
@@ -62,7 +61,7 @@ function getMenubarRenderedHeightPx() {
 
 function getPanelBasePx() {
   const menubar = getMenubarComputed();
-  const menubarHeight = (menubar.topPx - HERO_FIGMA_SCREEN.paddingTop) + getMenubarRenderedHeightPx();
+  const menubarHeight = menubar.topPx - HERO_FIGMA_SCREEN.paddingTop + getMenubarRenderedHeightPx();
   return {
     topPx: HERO_FIGMA_SCREEN.paddingTop + menubarHeight + HERO_FIGMA_PANEL.gapBelowMenubar,
     rightPx: HERO_FIGMA_SCREEN.paddingRight + HERO_FIGMA_PANEL.insetBeyondPaddingRight,
@@ -164,24 +163,24 @@ function getHudDefaultsFromGeometry() {
   const tabletPanel = getTabletPanelComputed();
   const mobilePanel = getMobilePanelComputed();
   return {
-    '--hud-anchor-top': menubar.anchorTop,
-    '--hud-margin-right': menubar.marginRight,
-    '--menubar-scale': String(menubar.scale),
-    '--mobile-hud-anchor-top': menubar.anchorTop,
-    '--mobile-hud-margin-right': menubar.marginRight,
-    '--mobile-menubar-scale': String(menubar.mobileScale),
-    '--hud-panel-top': panel.panelTop,
-    '--hud-panel-margin-right': panel.panelMarginRight,
-    '--hud-panel-width': panel.panelWidth,
-    '--popover-scale': String(panel.scale),
-    '--tablet-hud-panel-top': tabletPanel.panelTop,
-    '--tablet-hud-panel-margin-right': tabletPanel.panelMarginRight,
-    '--tablet-hud-panel-width': tabletPanel.panelWidth,
-    '--tablet-popover-scale': String(tabletPanel.scale),
-    '--mobile-hud-panel-top': mobilePanel.panelTop,
-    '--mobile-hud-panel-margin-right': mobilePanel.panelMarginRight,
-    '--mobile-hud-panel-width': mobilePanel.panelWidth,
-    '--mobile-popover-scale': String(mobilePanel.scale),
+    "--hud-anchor-top": menubar.anchorTop,
+    "--hud-margin-right": menubar.marginRight,
+    "--menubar-scale": String(menubar.scale),
+    "--mobile-hud-anchor-top": menubar.anchorTop,
+    "--mobile-hud-margin-right": menubar.marginRight,
+    "--mobile-menubar-scale": String(menubar.mobileScale),
+    "--hud-panel-top": panel.panelTop,
+    "--hud-panel-margin-right": panel.panelMarginRight,
+    "--hud-panel-width": panel.panelWidth,
+    "--popover-scale": String(panel.scale),
+    "--tablet-hud-panel-top": tabletPanel.panelTop,
+    "--tablet-hud-panel-margin-right": tabletPanel.panelMarginRight,
+    "--tablet-hud-panel-width": tabletPanel.panelWidth,
+    "--tablet-popover-scale": String(tabletPanel.scale),
+    "--mobile-hud-panel-top": mobilePanel.panelTop,
+    "--mobile-hud-panel-margin-right": mobilePanel.panelMarginRight,
+    "--mobile-hud-panel-width": mobilePanel.panelWidth,
+    "--mobile-popover-scale": String(mobilePanel.scale),
   };
 }
 
@@ -195,12 +194,12 @@ const HERO_DESKTOP_ANCHOR = {
   tabletMockupScale: 1.2,
 };
 
-const HERO_LAYOUT_VARS = ['--mockup-x', '--mockup-y', '--tablet-mockup-x', '--tablet-mockup-stage-height'];
+const HERO_LAYOUT_VARS = ["--mockup-x", "--mockup-y", "--tablet-mockup-x", "--tablet-mockup-stage-height"];
 
 function readRootPx(name, fallback) {
   const raw = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
   if (!raw) return fallback;
-  if (raw.endsWith('rem')) {
+  if (raw.endsWith("rem")) {
     const rootFont = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
     const rem = Number.parseFloat(raw);
     return Number.isFinite(rem) && Number.isFinite(rootFont) ? rem * rootFont : fallback;
@@ -210,16 +209,16 @@ function readRootPx(name, fallback) {
 }
 
 function computeTabletStageHeight(width) {
-  const headerPx = readRootPx('--header-height', 64);
+  const headerPx = readRootPx("--header-height", 64);
   const tuneWidth = HERO_DESKTOP_ANCHOR.tabletTuneWidth;
   const baseWidth = getMockupBaseWidth(width, tuneWidth);
   const artboardHeight = baseWidth * (3239 / 6111);
   const scale = getMockupEffectiveScale(width, { tablet: true });
   const scaledHeight = artboardHeight * scale;
-  const mockupY = readRootNumber('--tablet-mockup-y', 13);
+  const mockupY = readRootNumber("--tablet-mockup-y", 13);
   const mockupBottom = headerPx + mockupY + scaledHeight;
-  const panelTop = readRootPercent('--tablet-hud-panel-top', 9.5);
-  const panelScale = readRootNumber('--tablet-popover-scale', 1.35);
+  const panelTop = readRootPercent("--tablet-hud-panel-top", 9.5);
+  const panelScale = readRootNumber("--tablet-popover-scale", 1.35);
   const panelApproxHeight = scaledHeight * 0.36 * panelScale;
   const panelBottom = headerPx + mockupY + scaledHeight * panelTop + panelApproxHeight;
 
@@ -244,7 +243,7 @@ function readRootNumber(name, fallback) {
 function readRootPercent(name, fallbackPercent) {
   const raw = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
   if (!raw) return fallbackPercent / 100;
-  if (raw.endsWith('%')) {
+  if (raw.endsWith("%")) {
     const value = Number.parseFloat(raw);
     return Number.isFinite(value) ? value / 100 : fallbackPercent / 100;
   }
@@ -256,8 +255,8 @@ function getMockupEffectiveScale(width, { tablet = false } = {}) {
   const tuneWidth = tablet ? HERO_DESKTOP_ANCHOR.tabletTuneWidth : HERO_DESKTOP_ANCHOR.width;
   const fluidMax = tablet ? HERO_DESKTOP_ANCHOR.tabletFluidMax : HERO_DESKTOP_ANCHOR.fluidMax;
   const scale = tablet
-    ? readRootNumber('--tablet-mockup-scale', HERO_DESKTOP_ANCHOR.tabletMockupScale)
-    : readRootNumber('--mockup-scale', HERO_DESKTOP_ANCHOR.mockupScale);
+    ? readRootNumber("--tablet-mockup-scale", HERO_DESKTOP_ANCHOR.tabletMockupScale)
+    : readRootNumber("--mockup-scale", HERO_DESKTOP_ANCHOR.mockupScale);
   if (width >= tuneWidth) return scale;
   return scale * getHeroFluidFactor(width, tuneWidth, fluidMax);
 }
@@ -266,7 +265,7 @@ function computeMockupX(width, { tablet = false } = {}) {
   const tuneWidth = tablet ? HERO_DESKTOP_ANCHOR.tabletTuneWidth : HERO_DESKTOP_ANCHOR.width;
   const scaledWidth = getMockupBaseWidth(width, tuneWidth) * getMockupEffectiveScale(width, { tablet });
   const marginRight = tablet ? MOCKUP_SCREEN_MARGIN_RIGHT_TABLET : MOCKUP_SCREEN_MARGIN_RIGHT;
-  const baseX = (width / 2) - marginRight - (scaledWidth / 2);
+  const baseX = width / 2 - marginRight - scaledWidth / 2;
   return tablet ? baseX + HERO_TABLET_MOCKUP_X_CORRECTION : baseX;
 }
 
@@ -276,8 +275,8 @@ function getMobileStageWidth(viewportWidth) {
 
 function computeMobileMockupOffsetX(viewportWidth) {
   const stageWidth = getMobileStageWidth(viewportWidth);
-  const scale = readRootNumber('--mobile-mockup-scale', HERO_MOBILE_MOCKUP_TUNE_SCALE);
-  const widthPct = readRootNumber('--mobile-mockup-width', 251) / 100;
+  const scale = readRootNumber("--mobile-mockup-scale", HERO_MOBILE_MOCKUP_TUNE_SCALE);
+  const widthPct = readRootNumber("--mobile-mockup-width", 251) / 100;
   const scaledWidth = stageWidth * widthPct * scale;
   const scaleNudge = (HERO_MOBILE_MOCKUP_TUNE_SCALE - scale) * scaledWidth * 0.5;
   return Math.round((HERO_MOBILE_MOCKUP_X_CORRECTION + scaleNudge) * 100) / 100;
@@ -302,48 +301,46 @@ function applyHeroDesktopLayout() {
   const root = document.documentElement;
   const isTablet = width > HERO_MOBILE_MAX && width <= HERO_TABLET_MAX;
   const marginRight = isTablet ? MOCKUP_SCREEN_MARGIN_RIGHT_TABLET : MOCKUP_SCREEN_MARGIN_RIGHT;
-  root.style.setProperty('--mockup-screen-margin-right', `${marginRight}px`);
+  root.style.setProperty("--mockup-screen-margin-right", `${marginRight}px`);
 
   if (width <= HERO_MOBILE_MAX) {
     clearHeroDesktopLayout();
-    root.style.setProperty('--mobile-mockup-offset-x', `${computeMobileMockupOffsetX(width)}px`);
+    root.style.setProperty("--mobile-mockup-offset-x", `${computeMobileMockupOffsetX(width)}px`);
     return;
   }
 
-  root.style.removeProperty('--mobile-mockup-offset-x');
+  root.style.removeProperty("--mobile-mockup-offset-x");
 
   const mockupX = Math.round(computeMockupX(width, { tablet: isTablet }) * 100) / 100;
 
   if (width <= HERO_TABLET_MAX) {
-    root.style.setProperty('--tablet-mockup-x', `${mockupX}px`);
-    root.style.setProperty('--tablet-mockup-y', `${readRootNumber('--tablet-mockup-y', 13)}px`);
-    root.style.setProperty('--tablet-mockup-stage-height', `${computeTabletStageHeight(width)}px`);
-    root.style.removeProperty('--mockup-x');
-    root.style.removeProperty('--mockup-y');
+    root.style.setProperty("--tablet-mockup-x", `${mockupX}px`);
+    root.style.setProperty("--tablet-mockup-y", `${readRootNumber("--tablet-mockup-y", 13)}px`);
+    root.style.setProperty("--tablet-mockup-stage-height", `${computeTabletStageHeight(width)}px`);
+    root.style.removeProperty("--mockup-x");
+    root.style.removeProperty("--mockup-y");
     return;
   }
 
-  root.style.setProperty('--mockup-x', `${mockupX}px`);
-  root.style.setProperty('--mockup-y', `${HERO_DESKTOP_ANCHOR.mockupY}px`);
-  root.style.removeProperty('--tablet-mockup-x');
-  root.style.removeProperty('--tablet-mockup-y');
-  root.style.removeProperty('--tablet-mockup-stage-height');
+  root.style.setProperty("--mockup-x", `${mockupX}px`);
+  root.style.setProperty("--mockup-y", `${HERO_DESKTOP_ANCHOR.mockupY}px`);
+  root.style.removeProperty("--tablet-mockup-x");
+  root.style.removeProperty("--tablet-mockup-y");
+  root.style.removeProperty("--tablet-mockup-stage-height");
 }
 
 applyHudGeometryDefaults();
 applyHeroDesktopLayout();
 
-window.addEventListener('resize', applyHeroDesktopLayout);
-window.visualViewport?.addEventListener('resize', applyHeroDesktopLayout);
+window.addEventListener("resize", applyHeroDesktopLayout);
+window.visualViewport?.addEventListener("resize", applyHeroDesktopLayout);
 
-const themeMedia = window.matchMedia('(prefers-color-scheme: dark)');
-const themeToggle = document.querySelector('#theme-toggle');
-const themeNames = { system: 'System', light: 'Light', dark: 'Dark' };
+const themeMedia = window.matchMedia("(prefers-color-scheme: dark)");
+const themeToggle = document.querySelector("#theme-toggle");
+const themeNames = { system: "System", light: "Light", dark: "Dark" };
 
 function applyThemePreference(preference, persist = true) {
-  const resolvedTheme = preference === 'system'
-    ? (themeMedia.matches ? 'dark' : 'light')
-    : preference;
+  const resolvedTheme = preference === "system" ? (themeMedia.matches ? "dark" : "light") : preference;
 
   root.dataset.theme = resolvedTheme;
   root.dataset.themePreference = preference;
@@ -353,51 +350,51 @@ function applyThemePreference(preference, persist = true) {
 
   if (persist) {
     try {
-      localStorage.setItem('codexbar-theme', preference);
-    } catch (_) {}
+      localStorage.setItem("codexbar-theme", preference);
+    } catch {}
   }
 }
 
 function updateThemeToggleLabel() {
-  const nextTheme = root.dataset.theme === 'dark' ? 'light' : 'dark';
-  const label = message(nextTheme === 'dark' ? 'theme.toDark' : 'theme.toLight');
-  themeToggle.setAttribute('aria-label', label);
+  const nextTheme = root.dataset.theme === "dark" ? "light" : "dark";
+  const label = message(nextTheme === "dark" ? "theme.toDark" : "theme.toLight");
+  themeToggle.setAttribute("aria-label", label);
   themeToggle.title = label;
 }
 
-themeToggle.addEventListener('click', () => {
-  const nextPreference = root.dataset.theme === 'dark' ? 'light' : 'dark';
+themeToggle.addEventListener("click", () => {
+  const nextPreference = root.dataset.theme === "dark" ? "light" : "dark";
   applyThemePreference(nextPreference);
 });
 
-themeMedia.addEventListener('change', () => {
-  if (root.dataset.themePreference === 'system') applyThemePreference('system', false);
+themeMedia.addEventListener("change", () => {
+  if (root.dataset.themePreference === "system") applyThemePreference("system", false);
 });
 
-applyThemePreference(root.dataset.themePreference || 'system', false);
+applyThemePreference(root.dataset.themePreference || "system", false);
 
 const languageShortNames = {
-  en: 'EN',
-  'zh-CN': '简',
-  'zh-TW': '繁',
-  'ja-JP': 'JA',
-  es: 'ES',
-  'pt-BR': 'PT',
-  ko: 'KO',
-  de: 'DE',
-  fr: 'FR',
-  ar: 'AR',
-  it: 'IT',
-  vi: 'VI',
-  nl: 'NL',
-  tr: 'TR',
-  uk: 'UK',
-  id: 'ID',
-  pl: 'PL',
-  fa: 'FA',
-  th: 'TH',
-  ca: 'CA',
-  sv: 'SV',
+  en: "EN",
+  "zh-CN": "简",
+  "zh-TW": "繁",
+  "ja-JP": "JA",
+  es: "ES",
+  "pt-BR": "PT",
+  ko: "KO",
+  de: "DE",
+  fr: "FR",
+  ar: "AR",
+  it: "IT",
+  vi: "VI",
+  nl: "NL",
+  tr: "TR",
+  uk: "UK",
+  id: "ID",
+  pl: "PL",
+  fa: "FA",
+  th: "TH",
+  ca: "CA",
+  sv: "SV",
 };
 const languages = localeCatalog.map((language) => ({
   ...language,
@@ -406,48 +403,54 @@ const languages = localeCatalog.map((language) => ({
   label: language.name,
 }));
 const supportedLanguages = new Set(languages.map((language) => language.id));
-const rtlLanguages = new Set(localeCatalog.filter((language) => language.direction === 'rtl').map((language) => language.code));
+const rtlLanguages = new Set(
+  localeCatalog.filter((language) => language.direction === "rtl").map((language) => language.code),
+);
 const localeAliases = {
-  'zh-cn': 'zh-CN',
-  'zh-hans': 'zh-CN',
-  'zh-hant': 'zh-TW',
-  'zh-hk': 'zh-TW',
-  'zh-tw': 'zh-TW',
-  ja: 'ja-JP',
-  pt: 'pt-BR',
-  'pt-br': 'pt-BR',
+  "zh-cn": "zh-CN",
+  "zh-hans": "zh-CN",
+  "zh-hant": "zh-TW",
+  "zh-hk": "zh-TW",
+  "zh-tw": "zh-TW",
+  ja: "ja-JP",
+  pt: "pt-BR",
+  "pt-br": "pt-BR",
 };
-const languageStorageKey = 'codexbar-language';
-const languagePicker = document.querySelector('#language-picker');
-const languageTrigger = document.querySelector('#language-picker-trigger');
-const languageMenu = document.querySelector('#language-picker-menu');
-const languageList = document.querySelector('#language-picker-list');
-const languageShort = document.querySelector('[data-lang-short]');
+const languageStorageKey = "codexbar-language";
+const languagePicker = document.querySelector("#language-picker");
+const languageTrigger = document.querySelector("#language-picker-trigger");
+const languageMenu = document.querySelector("#language-picker-menu");
+const languageList = document.querySelector("#language-picker-list");
+const languageShort = document.querySelector("[data-lang-short]");
 
 function normalizeLocale(value) {
   if (!value) return null;
   const lower = value.toLowerCase();
   if (localeAliases[lower]) return localeAliases[lower];
-  return languages.find((language) => language.id.toLowerCase() === lower || lower.startsWith(`${language.id.toLowerCase()}-`))?.id || null;
+  return (
+    languages.find(
+      (language) => language.id.toLowerCase() === lower || lower.startsWith(`${language.id.toLowerCase()}-`),
+    )?.id || null
+  );
 }
 
 function selectedLocale() {
   try {
-    const queryLocale = normalizeLocale(new URLSearchParams(location.search).get('lang'));
+    const queryLocale = normalizeLocale(new URLSearchParams(location.search).get("lang"));
     if (queryLocale) return queryLocale;
     const storedLocale = normalizeLocale(localStorage.getItem(languageStorageKey));
     if (storedLocale) return storedLocale;
-  } catch (_) {}
+  } catch {}
 
   for (const language of navigator.languages || [navigator.language]) {
     const locale = normalizeLocale(language);
     if (locale) return locale;
   }
-  return 'en';
+  return "en";
 }
 
 let activeLanguage = selectedLocale();
-if (!supportedLanguages.has(activeLanguage)) activeLanguage = 'en';
+if (!supportedLanguages.has(activeLanguage)) activeLanguage = "en";
 
 function message(key) {
   return activeMessages[key] || localeMessages.en[key] || key;
@@ -461,41 +464,41 @@ function applyAttributeMessages(dataAttribute, targetAttribute) {
 
 function richToken(name) {
   const codeTokens = {
-    cask: 'brew install --cask steipete/tap/codexbar',
-    codexbar: 'codexbar',
-    linuxCommand: 'brew install steipete/tap/codexbar',
-    upgrade: 'brew upgrade',
+    cask: "brew install --cask steipete/tap/codexbar",
+    codexbar: "codexbar",
+    linuxCommand: "brew install steipete/tap/codexbar",
+    upgrade: "brew upgrade",
   };
   if (codeTokens[name]) {
-    const code = document.createElement('code');
-    code.className = 'inline-code';
+    const code = document.createElement("code");
+    code.className = "inline-code";
     code.textContent = codeTokens[name];
     return code;
   }
-  if (name === 'releases') {
-    const link = document.createElement('a');
-    link.className = 'text-link';
-    link.href = 'https://github.com/steipete/CodexBar/releases';
-    link.textContent = 'GitHub Releases';
+  if (name === "releases") {
+    const link = document.createElement("a");
+    link.className = "text-link";
+    link.href = "https://github.com/steipete/CodexBar/releases";
+    link.textContent = "GitHub Releases";
     return link;
   }
-  if (name === 'issue') {
-    const link = document.createElement('a');
-    link.className = 'text-link';
-    link.href = 'https://github.com/steipete/CodexBar/issues/12';
-    link.textContent = 'issue #12';
+  if (name === "issue") {
+    const link = document.createElement("a");
+    link.className = "text-link";
+    link.href = "https://github.com/steipete/CodexBar/issues/12";
+    link.textContent = "issue #12";
     return link;
   }
-  if (name === 'mobileBreak') {
-    return document.createElement('br');
+  if (name === "mobileBreak") {
+    return document.createElement("br");
   }
-  if (name === 'break') {
+  if (name === "break") {
     const wrapper = document.createDocumentFragment();
-    const space = document.createElement('span');
-    space.className = 'inline sm:hidden';
-    space.textContent = ' ';
-    const br = document.createElement('br');
-    br.className = 'hidden sm:block';
+    const space = document.createElement("span");
+    space.className = "inline sm:hidden";
+    space.textContent = " ";
+    const br = document.createElement("br");
+    br.className = "hidden sm:block";
     wrapper.append(space, br);
     return wrapper;
   }
@@ -518,34 +521,34 @@ function renderRichMessage(element, value) {
 }
 
 function applyLanguageMessages() {
-  activeMessages = { ...localeMessages.en, ...(localeMessages[activeLanguage] || {}) };
+  activeMessages = { ...localeMessages.en, ...localeMessages[activeLanguage] };
   root.lang = activeLanguage;
-  root.dir = rtlLanguages.has(activeLanguage) ? 'rtl' : 'ltr';
+  root.dir = rtlLanguages.has(activeLanguage) ? "rtl" : "ltr";
   root.dataset.locale = activeLanguage;
-  document.title = message('meta.title');
-  document.querySelector('meta[name="description"]')?.setAttribute('content', message('meta.description'));
-  document.querySelector('meta[property="og:description"]')?.setAttribute('content', message('meta.ogDescription'));
-  document.querySelectorAll('[data-i18n]').forEach((element) => {
+  document.title = message("meta.title");
+  document.querySelector('meta[name="description"]')?.setAttribute("content", message("meta.description"));
+  document.querySelector('meta[property="og:description"]')?.setAttribute("content", message("meta.ogDescription"));
+  document.querySelectorAll("[data-i18n]").forEach((element) => {
     element.textContent = message(element.dataset.i18n);
   });
-  document.querySelectorAll('[data-i18n-rich]').forEach((element) => {
+  document.querySelectorAll("[data-i18n-rich]").forEach((element) => {
     renderRichMessage(element, message(element.dataset.i18nRich));
   });
-  applyAttributeMessages('data-i18n-aria-label', 'aria-label');
-  applyAttributeMessages('data-i18n-title', 'title');
-  applyAttributeMessages('data-i18n-alt', 'alt');
+  applyAttributeMessages("data-i18n-aria-label", "aria-label");
+  applyAttributeMessages("data-i18n-title", "title");
+  applyAttributeMessages("data-i18n-alt", "alt");
   updateThemeToggleLabel();
 }
 
 function renderLanguageMenu() {
   languageList.replaceChildren();
   languages.forEach((language) => {
-    const option = document.createElement('button');
-    option.type = 'button';
-    option.className = 'language-option button-press';
-    option.role = 'option';
+    const option = document.createElement("button");
+    option.type = "button";
+    option.className = "language-option button-press";
+    option.role = "option";
     option.dataset.lang = language.id;
-    option.setAttribute('aria-selected', String(language.id === activeLanguage));
+    option.setAttribute("aria-selected", String(language.id === activeLanguage));
     option.tabIndex = language.id === activeLanguage ? 0 : -1;
     option.innerHTML = `
       <svg viewBox="0 0 18 18" fill="none" aria-hidden="true">
@@ -553,7 +556,7 @@ function renderLanguageMenu() {
       </svg>
       <span>${language.label}</span>
     `;
-    option.addEventListener('click', () => selectLanguage(language.id));
+    option.addEventListener("click", () => selectLanguage(language.id));
     languageList.append(option);
   });
 }
@@ -565,14 +568,14 @@ function updateLanguageUi() {
   applyLanguageMessages();
   languageList.querySelectorAll('[role="option"]').forEach((option) => {
     const selected = option.dataset.lang === activeLanguage;
-    option.setAttribute('aria-selected', String(selected));
+    option.setAttribute("aria-selected", String(selected));
     option.tabIndex = selected ? 0 : -1;
   });
 }
 
 function setLanguageMenuOpen(open, { focusOption = false, restoreFocus = false } = {}) {
   languageMenu.hidden = !open;
-  languageTrigger.setAttribute('aria-expanded', String(open));
+  languageTrigger.setAttribute("aria-expanded", String(open));
   if (open && focusOption) {
     languageList.querySelector('[aria-selected="true"]')?.focus();
   } else if (!open && restoreFocus) {
@@ -585,9 +588,9 @@ function selectLanguage(languageId) {
   try {
     localStorage.setItem(languageStorageKey, languageId);
     const url = new URL(location.href);
-    url.searchParams.set('lang', languageId);
-    history.replaceState(null, '', url);
-  } catch (_) {}
+    url.searchParams.set("lang", languageId);
+    history.replaceState(null, "", url);
+  } catch {}
   updateLanguageUi();
   setLanguageMenuOpen(false, { restoreFocus: true });
 }
@@ -595,122 +598,125 @@ function selectLanguage(languageId) {
 renderLanguageMenu();
 updateLanguageUi();
 
-languageTrigger.addEventListener('click', () => {
+languageTrigger.addEventListener("click", () => {
   setLanguageMenuOpen(languageMenu.hidden, { focusOption: languageMenu.hidden });
 });
 
-languageTrigger.addEventListener('keydown', (event) => {
-  if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+languageTrigger.addEventListener("keydown", (event) => {
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
   event.preventDefault();
   setLanguageMenuOpen(true, { focusOption: true });
 });
 
-languageList.addEventListener('keydown', (event) => {
+languageList.addEventListener("keydown", (event) => {
   const options = [...languageList.querySelectorAll('[role="option"]')];
   const currentIndex = Math.max(0, options.indexOf(document.activeElement));
   let nextIndex;
-  if (event.key === 'ArrowDown') nextIndex = (currentIndex + 1) % options.length;
-  if (event.key === 'ArrowUp') nextIndex = (currentIndex - 1 + options.length) % options.length;
-  if (event.key === 'Home') nextIndex = 0;
-  if (event.key === 'End') nextIndex = options.length - 1;
+  if (event.key === "ArrowDown") nextIndex = (currentIndex + 1) % options.length;
+  if (event.key === "ArrowUp") nextIndex = (currentIndex - 1 + options.length) % options.length;
+  if (event.key === "Home") nextIndex = 0;
+  if (event.key === "End") nextIndex = options.length - 1;
   if (nextIndex === undefined) return;
   event.preventDefault();
   options[nextIndex]?.focus();
 });
 
-document.addEventListener('click', (event) => {
+document.addEventListener("click", (event) => {
   if (!languagePicker.contains(event.target)) setLanguageMenuOpen(false);
 });
 
-document.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape' && !languageMenu.hidden) {
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && !languageMenu.hidden) {
     event.preventDefault();
     setLanguageMenuOpen(false, { restoreFocus: true });
   }
 });
 
-const providerSection = document.querySelector('[data-provider-section]');
-const providerCards = providerSection.querySelectorAll('.provider-card:not([hidden])');
+const providerSection = document.querySelector("[data-provider-section]");
+const providerCards = providerSection.querySelectorAll(".provider-card:not([hidden])");
 providerCards.forEach((card, index) => {
-  card.classList.add('provider-reveal');
-  card.style.setProperty('--reveal-delay', `${80 + Math.min(index, 12) * 24}ms`);
+  card.classList.add("provider-reveal");
+  card.style.setProperty("--reveal-delay", `${80 + Math.min(index, 12) * 24}ms`);
 });
 
-const revealSection = (section) => section.classList.add('is-revealed');
+const revealSection = (section) => section.classList.add("is-revealed");
 
-if ('IntersectionObserver' in window) {
-  const revealObserver = new IntersectionObserver((entries, observer) => {
-    entries.forEach((entry) => {
-      if (!entry.isIntersecting) return;
-      revealSection(entry.target);
-      observer.unobserve(entry.target);
-    });
-  }, { threshold: 0.01, rootMargin: '0px 0px -8% 0px' });
+if ("IntersectionObserver" in window) {
+  const revealObserver = new IntersectionObserver(
+    (entries, observer) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        revealSection(entry.target);
+        observer.unobserve(entry.target);
+      });
+    },
+    { threshold: 0.01, rootMargin: "0px 0px -8% 0px" },
+  );
 
-  [providerSection, ...document.querySelectorAll('[data-scroll-section]')].forEach((section) => {
+  [providerSection, ...document.querySelectorAll("[data-scroll-section]")].forEach((section) => {
     revealObserver.observe(section);
   });
 } else {
   revealSection(providerSection);
-  document.querySelectorAll('[data-scroll-section]').forEach(revealSection);
+  document.querySelectorAll("[data-scroll-section]").forEach(revealSection);
 }
 
-document.querySelectorAll('.mac-widget-gallery-wrap').forEach((wrap) => {
-  const gallery = wrap.querySelector('.mac-widget-gallery');
+document.querySelectorAll(".mac-widget-gallery-wrap").forEach((wrap) => {
+  const gallery = wrap.querySelector(".mac-widget-gallery");
   if (!gallery) return;
 
   const syncScrollFade = () => {
     const overflows = gallery.scrollHeight > gallery.clientHeight + 1;
     const atBottom = gallery.scrollTop + gallery.clientHeight >= gallery.scrollHeight - 2;
-    wrap.classList.toggle('has-scroll-fade', overflows && !atBottom);
+    wrap.classList.toggle("has-scroll-fade", overflows && !atBottom);
   };
 
-  gallery.addEventListener('scroll', syncScrollFade, { passive: true });
-  window.addEventListener('resize', syncScrollFade);
-  if ('ResizeObserver' in window) {
+  gallery.addEventListener("scroll", syncScrollFade, { passive: true });
+  window.addEventListener("resize", syncScrollFade);
+  if ("ResizeObserver" in window) {
     new ResizeObserver(syncScrollFade).observe(gallery);
   }
   syncScrollFade();
 });
 
-const mockupStage = document.querySelector('#mockup-stage');
-const menubarItems = mockupStage.querySelectorAll('.system-menubar > *');
+const mockupStage = document.querySelector("#mockup-stage");
+const menubarItems = mockupStage.querySelectorAll(".system-menubar > *");
 const heroRootStyles = getComputedStyle(document.documentElement);
 const readHeroMs = (name) => Number.parseFloat(heroRootStyles.getPropertyValue(name)) || 0;
-const menubarStartDelay = readHeroMs('--hero-menubar-start');
-const menubarWaveGap = readHeroMs('--hero-menubar-wave');
-const reducedHeroMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+const menubarStartDelay = readHeroMs("--hero-menubar-start");
+const menubarWaveGap = readHeroMs("--hero-menubar-wave");
+const reducedHeroMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 const lastMenubarItemDelay = Math.max(0, menubarItems.length - 1) * menubarWaveGap;
-const markStartDelay = menubarStartDelay + lastMenubarItemDelay + readHeroMs('--hero-mark-after-menubar');
-const popoverStartDelay = markStartDelay + readHeroMs('--hero-popover-after-mark');
+const markStartDelay = menubarStartDelay + lastMenubarItemDelay + readHeroMs("--hero-mark-after-menubar");
+const popoverStartDelay = markStartDelay + readHeroMs("--hero-popover-after-mark");
 
 menubarItems.forEach((item, index) => {
-  item.style.setProperty('--menubar-enter-delay', `${reducedHeroMotion ? 0 : index * menubarWaveGap}ms`);
+  item.style.setProperty("--menubar-enter-delay", `${reducedHeroMotion ? 0 : index * menubarWaveGap}ms`);
 });
 
 const animatePopoverDetails = () => {
-  mockupStage.querySelectorAll('.usage-meter').forEach((meter, index) => {
-    meter.style.setProperty('--meter-delay', `${reducedHeroMotion ? 0 : 70 + index * 70}ms`);
+  mockupStage.querySelectorAll(".usage-meter").forEach((meter, index) => {
+    meter.style.setProperty("--meter-delay", `${reducedHeroMotion ? 0 : 70 + index * 70}ms`);
   });
-  mockupStage.querySelectorAll('.usage-chart i').forEach((bar, index) => {
-    bar.style.setProperty('--bar-delay', `${reducedHeroMotion ? 0 : 120 + index * 6}ms`);
+  mockupStage.querySelectorAll(".usage-chart i").forEach((bar, index) => {
+    bar.style.setProperty("--bar-delay", `${reducedHeroMotion ? 0 : 120 + index * 6}ms`);
   });
-  mockupStage.classList.add('is-animated');
+  mockupStage.classList.add("is-animated");
 };
 
 if (reducedHeroMotion) {
-  mockupStage.classList.add('is-menubar-entered', 'is-mark-animated');
+  mockupStage.classList.add("is-menubar-entered", "is-mark-animated");
   animatePopoverDetails();
 } else {
-  window.setTimeout(() => mockupStage.classList.add('is-menubar-entered'), menubarStartDelay);
-  window.setTimeout(() => mockupStage.classList.add('is-mark-animated'), markStartDelay);
+  window.setTimeout(() => mockupStage.classList.add("is-menubar-entered"), menubarStartDelay);
+  window.setTimeout(() => mockupStage.classList.add("is-mark-animated"), markStartDelay);
   window.setTimeout(animatePopoverDetails, popoverStartDelay);
 }
 
-const brewCopyButton = document.querySelector('#brew-copy');
-const brewCopyLabel = brewCopyButton?.querySelector('[data-brew-label]');
-const brewCopyIcon = brewCopyButton?.querySelector('[data-brew-icon]');
-const brewCopyStatus = brewCopyButton?.querySelector('[data-brew-status]');
+const brewCopyButton = document.querySelector("#brew-copy");
+const brewCopyLabel = brewCopyButton?.querySelector("[data-brew-label]");
+const brewCopyIcon = brewCopyButton?.querySelector("[data-brew-icon]");
+const brewCopyStatus = brewCopyButton?.querySelector("[data-brew-status]");
 let brewCopyResetTimer;
 
 async function copyBrewCommand() {
@@ -719,19 +725,19 @@ async function copyBrewCommand() {
 
   try {
     await navigator.clipboard.writeText(command);
-  } catch (_) {
+  } catch {
     return;
   }
 
   window.clearTimeout(brewCopyResetTimer);
-  brewCopyIcon.dataset.copied = 'true';
-  brewCopyStatus.textContent = message('clipboard.copied');
-  brewCopyButton.setAttribute('aria-label', message('clipboard.copied'));
+  brewCopyIcon.dataset.copied = "true";
+  brewCopyStatus.textContent = message("clipboard.copied");
+  brewCopyButton.setAttribute("aria-label", message("clipboard.copied"));
   brewCopyResetTimer = window.setTimeout(() => {
     delete brewCopyIcon.dataset.copied;
-    brewCopyStatus.textContent = '';
-    brewCopyButton.setAttribute('aria-label', message('clipboard.copyBrew'));
+    brewCopyStatus.textContent = "";
+    brewCopyButton.setAttribute("aria-label", message("clipboard.copyBrew"));
   }, 1500);
 }
 
-brewCopyButton?.addEventListener('click', copyBrewCommand);
+brewCopyButton?.addEventListener("click", copyBrewCommand);

--- a/tsconfig.plugins.json
+++ b/tsconfig.plugins.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": [
+    "Sources/CodexBarCore/Resources/Plugins/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the JavaScript/TypeScript toolchain for bundled provider plugins:

- **oxlint 1.76.0 + oxfmt 0.61.0**, pinned with per-platform SHA-256 checksums in Scripts/install_lint_tools.sh, wired into `make format`, both lint paths, and CI. All plugin files formatted; 20 lint findings fixed (one reasoned suppression on the prelude IIFE).
- **Typed plugin contract**: `codexbar-plugin.d.ts` covering `defineProvider` and the full `ctx` surface, enforced by pinned `tsc --noEmit` and referenced from docs/plugins.md as the canonical third-party authoring contract.
- **TypeScript authoring pipeline** for bundled plugins: `Scripts/regenerate-plugin-js.sh` transpiles committed `.ts` → committed `.js` via the vendored Sucrase, with a CI freshness check (regenerate-provider-manifests precedent). Proof: crof authored as `crof.ts`, generated `crof.js` byte-identical, goldens 7/7.

Local full-suite note: the machine is currently under load-average ~78 from an unrelated process storm; the single failing local test (BoundedChildProcessProofTests wall-clock) is untouched by this diff — CI is the timing arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
