### PR TITLE
fix: prevent QuickJS worker executor-isolation traps (refs #2778)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Runner info
-        run: printf 'macOS %s | %s\n' "$(sw_vers -productVersion)" "$(sysctl -n machdep.cpu.brand_string)"
+        run: |
+          printf 'macOS %s | %s\n' "$(sw_vers -productVersion)" "$(sysctl -n machdep.cpu.brand_string)"
+          defaults write com.apple.CrashReporter DialogType server
 
       - name: Select Xcode 26.3 or 26.2
         run: |
@@ -162,8 +164,6 @@ jobs:
       - name: Swift Test
         # Keep small batches to reduce SwiftPM process overhead without returning to one aggregate run.
         timeout-minutes: 50
-        env:
-          SWIFT_BACKTRACE: enable=yes,format=friendly
         run: |
           CODEXBAR_TEST_GROUP_SIZE=4 \
             CODEXBAR_TEST_SUITE_TIMEOUT=120 \
@@ -172,11 +172,35 @@ jobs:
             CODEXBAR_TEST_SHARD_COUNT=${{ matrix.shard-count }} \
             ./Scripts/test.sh
 
+      - name: Prepare plugin crash backtraces
+        if: ${{ always() && matrix.shard-index == 0 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test_binary="$(find .build -type f \
+            -path '*/CodexBarPackageTests.xctest/Contents/MacOS/CodexBarPackageTests' \
+            -print -quit)"
+          [[ -n "$test_binary" ]]
+          test_bundle="${test_binary%/Contents/MacOS/CodexBarPackageTests}"
+          entitlements="$RUNNER_TEMP/swift-test-backtrace-entitlements.plist"
+          plutil -create xml1 "$entitlements"
+          plutil -insert com.apple.security.get-task-allow -bool true "$entitlements"
+          codesign --force --sign - --entitlements "$entitlements" "$test_bundle"
+          codesign --display --entitlements :- "$test_bundle"
+
       - name: Provider plugin engine A/B goldens
         if: ${{ matrix.shard-index == 0 }}
         env:
-          SWIFT_BACKTRACE: enable=yes,format=friendly
+          SWIFT_BACKTRACE: enable=yes,preset=friendly,warnings=suppressed
         run: ./Scripts/test-plugin-engines.sh
+
+      - name: Rerun trapped plugin group with backtraces
+        if: ${{ failure() && matrix.shard-index == 0 }}
+        env:
+          SWIFT_BACKTRACE: enable=yes,preset=friendly,warnings=suppressed
+        run: >-
+          swift test --skip-build --no-parallel
+          --filter 'ProviderPluginParityTests|ProviderPluginRuntimeTests|Sub2APIPluginGoldenTests|UserProviderPluginPortableTests'
 
       - name: Collect crash reports on failure
         if: ${{ failure() }}
@@ -185,6 +209,10 @@ jobs:
           set -uo pipefail
           reports="$HOME/Library/Logs/DiagnosticReports"
           found=0
+          for _ in {1..10}; do
+            find "$reports" -name '*.ips' -newer .git/HEAD -print -quit 2>/dev/null | grep -q . && break
+            sleep 1
+          done
           if [[ -d "$reports" ]]; then
             while IFS= read -r file; do
               found=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Runner info
+        run: printf 'macOS %s | %s\n' "$(sw_vers -productVersion)" "$(sysctl -n machdep.cpu.brand_string)"
+
       - name: Select Xcode 26.3 or 26.2
         run: |
           set -euo pipefail
@@ -159,6 +162,8 @@ jobs:
       - name: Swift Test
         # Keep small batches to reduce SwiftPM process overhead without returning to one aggregate run.
         timeout-minutes: 50
+        env:
+          SWIFT_BACKTRACE: enable=yes,format=friendly
         run: |
           CODEXBAR_TEST_GROUP_SIZE=4 \
             CODEXBAR_TEST_SUITE_TIMEOUT=120 \
@@ -169,6 +174,8 @@ jobs:
 
       - name: Provider plugin engine A/B goldens
         if: ${{ matrix.shard-index == 0 }}
+        env:
+          SWIFT_BACKTRACE: enable=yes,format=friendly
         run: ./Scripts/test-plugin-engines.sh
 
       - name: Collect crash reports on failure
@@ -187,6 +194,13 @@ jobs:
             done < <(find "$reports" \( -name '*.ips' -o -name '*.crash' \) -newer .git/HEAD -print 2>/dev/null | head -5)
           fi
           [[ "$found" == 1 ]] || echo "no fresh crash reports under $reports"
+
+      - name: Upload crash reports on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: quickjs-crash-reports-${{ matrix.shard-index }}
+          path: ~/Library/Logs/DiagnosticReports/*.ips
 
       - name: Summarize macOS shard
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,22 +172,6 @@ jobs:
             CODEXBAR_TEST_SHARD_COUNT=${{ matrix.shard-count }} \
             ./Scripts/test.sh
 
-      - name: Prepare plugin crash backtraces
-        if: ${{ always() && matrix.shard-index == 0 }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          test_binary="$(find .build -type f \
-            -path '*/CodexBarPackageTests.xctest/Contents/MacOS/CodexBarPackageTests' \
-            -print -quit)"
-          [[ -n "$test_binary" ]]
-          test_bundle="${test_binary%/Contents/MacOS/CodexBarPackageTests}"
-          entitlements="$RUNNER_TEMP/swift-test-backtrace-entitlements.plist"
-          plutil -create xml1 "$entitlements"
-          plutil -insert com.apple.security.get-task-allow -bool true "$entitlements"
-          codesign --force --sign - --entitlements "$entitlements" "$test_bundle"
-          codesign --display --entitlements :- "$test_bundle"
-
       - name: Provider plugin engine A/B goldens
         if: ${{ matrix.shard-index == 0 }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fireworks: track 30-day rated billing spend with an API key and account slug (#2687). Thanks @x0mh0x!
 
 ### Fixed
+- Provider plugins: keep QuickJS worker jobs nonisolated from their callers, preventing Swift 6.2 macOS builds from trapping when the dedicated worker thread starts (refs #2778).
 - Plugins: the QuickJS HTTP/cookie bridge now starts a request's per-call timeout when the transport actually begins executing instead of when it is scheduled, so short deadlines (like OpenRouter's one-second key fast join) no longer fire spuriously under CPU load (refs #2778).
 - Codex: preserve recently modified cost-cache sessions across complete local calendar-day windows, avoiding needless rediscovery and rescans (#2764). Thanks @Yuxin-Qiao!
 - Codex: price persisted usage from token classes when reports are read, so a cold rebuild racing the models.dev catalog can no longer permanently bake fallback rates into SQLite (#2772).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fireworks: track 30-day rated billing spend with an API key and account slug (#2687). Thanks @x0mh0x!
 
 ### Fixed
-- Provider plugins: keep QuickJS worker jobs nonisolated from their callers, preventing Swift 6.2 macOS builds from trapping when the dedicated worker thread starts (refs #2778).
+- Provider plugins: use statically nonisolated thread entry points for QuickJS workers and TypeScript transpilation, preventing Swift 6.2 macOS builds from trapping on inherited executor checks (refs #2778).
 - Plugins: the QuickJS HTTP/cookie bridge now starts a request's per-call timeout when the transport actually begins executing instead of when it is scheduled, so short deadlines (like OpenRouter's one-second key fast join) no longer fire spuriously under CPU load (refs #2778).
 - Codex: preserve recently modified cost-cache sessions across complete local calendar-day windows, avoiding needless rediscovery and rescans (#2764). Thanks @Yuxin-Qiao!
 - Codex: price persisted usage from token classes when reports are read, so a cold rebuild racing the models.dev catalog can no longer permanently bake fallback rates into SQLite (#2772).

--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -162,6 +162,52 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
         let expiresAt: Date
     }
 
+    private final class Teardown: @unchecked Sendable {
+        let runtime: OpaquePointer
+        let context: OpaquePointer
+        let definition: JSValue?
+        let applyPrelude: JSValue?
+        let fetchUsage: JSValue?
+        let watchdog: OpaquePointer?
+
+        init(
+            runtime: OpaquePointer,
+            context: OpaquePointer,
+            definition: JSValue?,
+            applyPrelude: JSValue?,
+            fetchUsage: JSValue?,
+            watchdog: OpaquePointer?)
+        {
+            self.runtime = runtime
+            self.context = context
+            self.definition = definition
+            self.applyPrelude = applyPrelude
+            self.fetchUsage = fetchUsage
+            self.watchdog = watchdog
+        }
+
+        func run() {
+            if let definition {
+                cqjs_free_value(self.context, definition)
+            }
+            if let applyPrelude {
+                cqjs_free_value(self.context, applyPrelude)
+            }
+            if let fetchUsage {
+                cqjs_free_value(self.context, fetchUsage)
+            }
+            if let watchdog {
+                cqjs_watchdog_disarm(watchdog)
+            }
+            // The runtime retains the interrupt-handler opaque pointer until it is freed.
+            JS_FreeContext(self.context)
+            JS_FreeRuntime(self.runtime)
+            if let watchdog {
+                cqjs_watchdog_destroy(watchdog)
+            }
+        }
+    }
+
     // @unchecked Sendable is safe because every mutable engine field and QuickJS API call is confined
     // to this serial worker. requestInterrupt() is the watchdog's explicitly thread-safe escape hatch.
     private let worker: QuickJSSerialWorker
@@ -242,36 +288,17 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
     }
 
     deinit {
-        let runtime = self.runtime
-        let context = self.context
-        let definition = self.definition
-        let applyPrelude = self.applyPrelude
-        let fetchUsage = self.fetchUsage
-        let watchdog = self.watchdog
-        let teardown = {
-            if let definition {
-                cqjs_free_value(context, definition)
-            }
-            if let applyPrelude {
-                cqjs_free_value(context, applyPrelude)
-            }
-            if let fetchUsage {
-                cqjs_free_value(context, fetchUsage)
-            }
-            if let watchdog {
-                cqjs_watchdog_disarm(watchdog)
-            }
-            // The runtime retains the interrupt-handler opaque pointer until it is freed.
-            JS_FreeContext(context)
-            JS_FreeRuntime(runtime)
-            if let watchdog {
-                cqjs_watchdog_destroy(watchdog)
-            }
-        }
+        let teardown = Teardown(
+            runtime: self.runtime,
+            context: self.context,
+            definition: self.definition,
+            applyPrelude: self.applyPrelude,
+            fetchUsage: self.fetchUsage,
+            watchdog: self.watchdog)
         if self.worker.isCurrentThread {
-            teardown()
+            teardown.run()
         } else {
-            try? self.worker.sync(teardown)
+            try? self.worker.sync { teardown.run() }
         }
         self.worker.shutdown()
     }
@@ -938,7 +965,8 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
 }
 
 private final class QuickJSSerialWorker: @unchecked Sendable {
-    typealias Job = () -> Void
+    /// Jobs must not retain the caller's executor isolation when the dedicated thread invokes them.
+    typealias Job = @Sendable () -> Void
 
     private final class State: @unchecked Sendable {
         private let condition = NSCondition()
@@ -1017,7 +1045,7 @@ private final class QuickJSSerialWorker: @unchecked Sendable {
         precondition(self.state.enqueue(operation), "QuickJS worker accepted work after shutdown")
     }
 
-    func sync<Value: Sendable>(_ operation: @escaping () throws -> Value) throws -> Value {
+    func sync<Value: Sendable>(_ operation: @escaping @Sendable () throws -> Value) throws -> Value {
         if self.isCurrentThread {
             return try operation()
         }

--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -1014,22 +1014,37 @@ private final class QuickJSSerialWorker: @unchecked Sendable {
             }
             self.condition.unlock()
         }
+
+        func run() {
+            defer { self.markStopped() }
+            while let job = self.next() {
+                job()
+            }
+        }
+    }
+
+    private final class WorkerThread: Thread {
+        private let state: State
+
+        init(state: State, name: String, stackSizeBytes: Int) {
+            self.state = state
+            super.init()
+            self.name = name
+            self.stackSize = stackSizeBytes
+        }
+
+        override func main() {
+            self.state.run()
+        }
     }
 
     private let state: State
-    private let thread: Thread
+    private let thread: WorkerThread
 
     init(name: String, stackSizeBytes: Int) {
         let state = State()
         self.state = state
-        self.thread = Thread {
-            defer { state.markStopped() }
-            while let job = state.next() {
-                job()
-            }
-        }
-        self.thread.name = name
-        self.thread.stackSize = stackSizeBytes
+        self.thread = WorkerThread(state: state, name: name, stackSizeBytes: stackSizeBytes)
         self.thread.start()
     }
 

--- a/Sources/CodexBarCore/Plugins/QuickJSTypeScriptTranspiler.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSTypeScriptTranspiler.swift
@@ -2,16 +2,33 @@ import CQuickJS
 import Foundation
 
 enum QuickJSTypeScriptTranspiler {
-    static func transpile(source: String, sucraseSource: String) throws -> String {
-        let box = QuickJSBlockingResult<String>()
-        let thread = Thread {
-            box.finish(Result {
-                try self.transpileOnCurrentThread(source: source, sucraseSource: sucraseSource)
+    private final class TranspilerThread: Thread {
+        private let source: String
+        private let sucraseSource: String
+        private let box: QuickJSBlockingResult<String>
+
+        init(source: String, sucraseSource: String, box: QuickJSBlockingResult<String>) {
+            self.source = source
+            self.sucraseSource = sucraseSource
+            self.box = box
+            super.init()
+            // Dispatch/Swift cooperative workers can have less native stack than QuickJS's 2 MiB limit.
+            self.stackSize = QuickJSRuntimeLimits.nativeStackSizeBytes
+            self.name = "CodexBar QuickJS TypeScript transpiler"
+        }
+
+        override func main() {
+            self.box.finish(Result {
+                try QuickJSTypeScriptTranspiler.transpileOnCurrentThread(
+                    source: self.source,
+                    sucraseSource: self.sucraseSource)
             })
         }
-        // Dispatch/Swift cooperative workers can have less native stack than QuickJS's 2 MiB limit.
-        thread.stackSize = QuickJSRuntimeLimits.nativeStackSizeBytes
-        thread.name = "CodexBar QuickJS TypeScript transpiler"
+    }
+
+    static func transpile(source: String, sucraseSource: String) throws -> String {
+        let box = QuickJSBlockingResult<String>()
+        let thread = TranspilerThread(source: source, sucraseSource: sucraseSource, box: box)
         thread.start()
 
         let deadline = Date().addingTimeInterval(ProviderPluginRuntime.defaultTimeout + 1)


### PR DESCRIPTION
## Root cause

The macOS 26 runner's Swift 6.2.4 runtime traps when the dedicated QuickJS thread invokes a block-based thread entry closure that retained its caller's executor isolation. The crash artifact identifies the `CodexBar QuickJS provider plugin` thread and this frame chain:

```
_dispatch_assert_queue_fail
_swift_task_checkIsolatedSwift
closure #1 in QuickJSSerialWorker.init(name:stackSizeBytes:)
```

This is a Swift concurrency isolation failure at the serial-worker boundary, not a QuickJS JIT, executable-memory, or library-validation failure.

## Fix

- replace block-based QuickJS thread entries with `Thread` subclasses whose `main()` methods are statically nonisolated
- apply the same fix to the one-shot QuickJS TypeScript transpiler thread
- keep every queued worker job and synchronous operation explicitly `@Sendable`
- carry opaque QuickJS teardown state in an unchecked-Sendable holder while preserving worker-thread confinement
- retain the runner crash/backtrace diagnostics that produced the IPS evidence

## Proof

- exact affected plugin group: 49/49 passed
- full local suite after the final fix: 828 selections, 69/69 groups passed; zero retries or timeouts
- `make check`: clean
- autoreview: clean

Refs #2778.
