### PR TITLE
debug: capture QuickJS SIGTRAP backtrace on CI (do not merge)

### DIFF
--- a/.github/workflows/debug-quickjs-trap.yml
+++ b/.github/workflows/debug-quickjs-trap.yml
@@ -1,0 +1,62 @@
+name: Debug QuickJS trap
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  debug-quickjs-trap:
+    if: github.head_ref == 'debug/quickjs-sigtrap-ci'
+    runs-on: macos-26
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Select Xcode 26.3 or 26.2
+        run: |
+          set -euo pipefail
+          for candidate in /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app; do
+            if [[ -d "$candidate" ]]; then
+              sudo xcode-select -s "${candidate}/Contents/Developer"
+              echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
+              break
+            fi
+          done
+          /usr/bin/xcodebuild -version
+
+      - name: Build tests
+        run: swift build --build-tests
+
+      - name: Enable core dumps
+        run: |
+          sudo mkdir -p /cores
+          sudo chmod 1777 /cores
+          sysctl kern.corefile kern.coredump || true
+
+      - name: Run crashing group (cores enabled)
+        run: |
+          set -x
+          ulimit -c unlimited
+          swift test --skip-build --no-parallel --filter '(^CodexBarPluginTests\.ProviderPluginParityTests/)' || true
+          swift test --skip-build --no-parallel --filter '(^CodexBarPluginTests\.ProviderPluginDetailsParityTests/)' || true
+
+      - name: Backtrace cores
+        run: |
+          set -x
+          ls -la /cores || true
+          for c in /cores/core.*; do
+            [ -e "$c" ] || continue
+            lldb -c "$c" --batch -o "thread backtrace all" -o quit || true
+          done
+
+      - name: Dump crash reports (patient)
+        run: |
+          sleep 45
+          reports="$HOME/Library/Logs/DiagnosticReports"
+          ls -la "$reports" || true
+          for f in "$reports"/*; do
+            [ -e "$f" ] || continue
+            echo "::group::$(basename "$f")"
+            cat "$f" || true
+            echo "::endgroup::"
+          done

--- a/.github/workflows/debug-quickjs-trap.yml
+++ b/.github/workflows/debug-quickjs-trap.yml
@@ -49,9 +49,15 @@ jobs:
             lldb -c "$c" --batch -o "thread backtrace all" -o quit || true
           done
 
+      - name: Retry with executor checks logged (not fatal)
+        run: |
+          set -x
+          SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=1 SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy \
+            swift test --skip-build --no-parallel --filter '(^CodexBarPluginTests\.ProviderPluginParityTests/)' || true
+
       - name: Dump crash reports (patient)
         run: |
-          sleep 45
+          sleep 90
           reports="$HOME/Library/Logs/DiagnosticReports"
           ls -la "$reports" || true
           for f in "$reports"/*; do

--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -988,18 +988,32 @@ private final class QuickJSSerialWorker: @unchecked Sendable {
         }
     }
 
+    /// A Thread subclass with an overridden main() instead of Thread(block:): the block closure
+    /// picks up @MainActor inference under some SDKs (Xcode 26.3), and the embedded executor
+    /// check then traps on the first job when the OS runtime enforces isolation dynamically.
+    private final class WorkerThread: Thread {
+        private let state: State
+
+        init(state: State) {
+            self.state = state
+            super.init()
+        }
+
+        override func main() {
+            defer { self.state.markStopped() }
+            while let job = self.state.next() {
+                job()
+            }
+        }
+    }
+
     private let state: State
-    private let thread: Thread
+    private let thread: WorkerThread
 
     init(name: String, stackSizeBytes: Int) {
         let state = State()
         self.state = state
-        self.thread = Thread {
-            defer { state.markStopped() }
-            while let job = state.next() {
-                job()
-            }
-        }
+        self.thread = WorkerThread(state: state)
         self.thread.name = name
         self.thread.stackSize = stackSizeBytes
         self.thread.start()

--- a/Sources/CodexBarCore/Plugins/QuickJSTypeScriptTranspiler.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSTypeScriptTranspiler.swift
@@ -2,13 +2,33 @@ import CQuickJS
 import Foundation
 
 enum QuickJSTypeScriptTranspiler {
-    static func transpile(source: String, sucraseSource: String) throws -> String {
-        let box = QuickJSBlockingResult<String>()
-        let thread = Thread {
-            box.finish(Result {
-                try self.transpileOnCurrentThread(source: source, sucraseSource: sucraseSource)
+    /// A Thread subclass with an overridden main() instead of Thread(block:): the block closure
+    /// picks up @MainActor inference under some SDKs (Xcode 26.3), and the embedded executor
+    /// check then traps off-main when the OS runtime enforces isolation dynamically.
+    private final class TranspileThread: Thread {
+        private let box: QuickJSBlockingResult<String>
+        private let source: String
+        private let sucraseSource: String
+
+        init(box: QuickJSBlockingResult<String>, source: String, sucraseSource: String) {
+            self.box = box
+            self.source = source
+            self.sucraseSource = sucraseSource
+            super.init()
+        }
+
+        override func main() {
+            self.box.finish(Result {
+                try QuickJSTypeScriptTranspiler.transpileOnCurrentThread(
+                    source: self.source,
+                    sucraseSource: self.sucraseSource)
             })
         }
+    }
+
+    static func transpile(source: String, sucraseSource: String) throws -> String {
+        let box = QuickJSBlockingResult<String>()
+        let thread = TranspileThread(box: box, source: source, sucraseSource: sucraseSource)
         // Dispatch/Swift cooperative workers can have less native stack than QuickJS's 2 MiB limit.
         thread.stackSize = QuickJSRuntimeLimits.nativeStackSizeBytes
         thread.name = "CodexBar QuickJS TypeScript transpiler"


### PR DESCRIPTION
Temporary diagnostic PR — DO NOT MERGE.

Captures a backtrace for the macOS shard SIGTRAP that has been failing main since #2775 (first QuickJS plugin fetch in CodexBarPluginTests groups dies with signal 5; not reproducible locally on the same macOS 26 / Xcode 26.3 stack). Enables core dumps, runs the two crashing groups, backtraces any core with lldb, and dumps DiagnosticReports after a settle delay.
