### PR TITLE
fix: run QuickJS worker and transpiler on Thread subclasses to avoid SDK-inferred MainActor block isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fireworks: track 30-day rated billing spend with an API key and account slug (#2687). Thanks @x0mh0x!
 
 ### Fixed
+- Plugins: run the QuickJS worker and TypeScript transpiler on Thread subclasses instead of Thread(block:) closures — binaries built with the Xcode 26.3 SDK inferred @MainActor on those blocks, and macOS runtimes that enforce dynamic isolation crashed (SIGTRAP) on the first plugin fetch; this was the deterministic macOS CI shard crash since #2775 and could crash shipped builds at runtime.
 - Plugins: the QuickJS HTTP/cookie bridge now starts a request's per-call timeout when the transport actually begins executing instead of when it is scheduled, so short deadlines (like OpenRouter's one-second key fast join) no longer fire spuriously under CPU load (refs #2778).
 - Codex: preserve recently modified cost-cache sessions across complete local calendar-day windows, avoiding needless rediscovery and rescans (#2764). Thanks @Yuxin-Qiao!
 - Codex: price persisted usage from token classes when reports are read, so a cold rebuild racing the models.dev catalog can no longer permanently bake fallback rates into SQLite (#2772).

--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -988,18 +988,32 @@ private final class QuickJSSerialWorker: @unchecked Sendable {
         }
     }
 
+    /// A Thread subclass with an overridden main() instead of Thread(block:): the block closure
+    /// picks up @MainActor inference under some SDKs (Xcode 26.3), and the embedded executor
+    /// check then traps on the first job when the OS runtime enforces isolation dynamically.
+    private final class WorkerThread: Thread {
+        private let state: State
+
+        init(state: State) {
+            self.state = state
+            super.init()
+        }
+
+        override func main() {
+            defer { self.state.markStopped() }
+            while let job = self.state.next() {
+                job()
+            }
+        }
+    }
+
     private let state: State
-    private let thread: Thread
+    private let thread: WorkerThread
 
     init(name: String, stackSizeBytes: Int) {
         let state = State()
         self.state = state
-        self.thread = Thread {
-            defer { state.markStopped() }
-            while let job = state.next() {
-                job()
-            }
-        }
+        self.thread = WorkerThread(state: state)
         self.thread.name = name
         self.thread.stackSize = stackSizeBytes
         self.thread.start()

--- a/Sources/CodexBarCore/Plugins/QuickJSTypeScriptTranspiler.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSTypeScriptTranspiler.swift
@@ -2,13 +2,33 @@ import CQuickJS
 import Foundation
 
 enum QuickJSTypeScriptTranspiler {
-    static func transpile(source: String, sucraseSource: String) throws -> String {
-        let box = QuickJSBlockingResult<String>()
-        let thread = Thread {
-            box.finish(Result {
-                try self.transpileOnCurrentThread(source: source, sucraseSource: sucraseSource)
+    /// A Thread subclass with an overridden main() instead of Thread(block:): the block closure
+    /// picks up @MainActor inference under some SDKs (Xcode 26.3), and the embedded executor
+    /// check then traps off-main when the OS runtime enforces isolation dynamically.
+    private final class TranspileThread: Thread {
+        private let box: QuickJSBlockingResult<String>
+        private let source: String
+        private let sucraseSource: String
+
+        init(box: QuickJSBlockingResult<String>, source: String, sucraseSource: String) {
+            self.box = box
+            self.source = source
+            self.sucraseSource = sucraseSource
+            super.init()
+        }
+
+        override func main() {
+            self.box.finish(Result {
+                try QuickJSTypeScriptTranspiler.transpileOnCurrentThread(
+                    source: self.source,
+                    sucraseSource: self.sucraseSource)
             })
         }
+    }
+
+    static func transpile(source: String, sucraseSource: String) throws -> String {
+        let box = QuickJSBlockingResult<String>()
+        let thread = TranspileThread(box: box, source: source, sucraseSource: sucraseSource)
         // Dispatch/Swift cooperative workers can have less native stack than QuickJS's 2 MiB limit.
         thread.stackSize = QuickJSRuntimeLimits.nativeStackSizeBytes
         thread.name = "CodexBar QuickJS TypeScript transpiler"


### PR DESCRIPTION
## Summary

Since #2775, both macOS CI shards crashed deterministically with signal 5 (SIGTRAP) the moment a `CodexBarPluginTests` group executed its first QuickJS plugin fetch — while the same binary path passed everywhere locally. Diagnosis (via CI core dumps + lldb on the runner, then `SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=1`):

> `warning: data race detected: @MainActor function at CodexBarCore/QuickJSProviderPluginEngine.swift:997 was not called on the main thread`

The `Thread { ... }` body closures of the QuickJS serial worker (and the TypeScript transpiler) pick up **@MainActor inference when compiled against the Xcode 26.3 SDK**, which embeds a dynamic executor check at closure entry. On macOS runtimes that enforce dynamic isolation (the `macos-26` runner image), the check trips `dispatch_assert_queue` and traps on the first enqueued job. Local machines on Xcode 26.6 never emit the check, so the crash was invisible in development — and #2775's stack-size mitigation was chasing a different mechanism. Because release builds also use Xcode 26.3/26.2, shipped binaries carried the same latent crash.

## Fix

Replace both `Thread(block:)` closures with `Thread` subclasses overriding `main()` — a plain nonisolated method with no closure isolation inference to poison. No behavioral change; worker loop, shutdown signaling, stack size, and naming preserved.

## Proof

- Diagnostic run on the fixed code, `macos-26` + Xcode 26.3, default (fatal) enforcement: both previously-crashing groups pass (8/8 ProviderPluginParityTests, 13/13 ProviderPluginDetailsParityTests group), `/cores` empty, zero signal-5s (run 31284805832).
- Local: full `CodexBarPluginTests` target 70/70; lint clean; autoreview clean.
- This PR's own `swift-test-macos` shards are the final gate.

Fixes the macOS CI redness on main since #2775. Refs #2778 (sibling flake fixed in #2784).
