### PR TITLE
fix: derive QuickJS JS stack limit from the worker stack size

### DIFF
--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -19,8 +19,19 @@ private enum QuickJSHostFunction: Int32 {
 }
 
 enum QuickJSRuntimeLimits {
-    /// Leave ample native-stack headroom for Swift entry frames and QuickJS's stack-overflow error construction.
-    static let nativeStackSizeBytes = 4 * 1024 * 1024
+    /// The dedicated worker thread's native stack. Sized far above the JavaScript budget so even a deep
+    /// Swift async/test baseline at the point JavaScript begins still leaves several MiB of physical stack.
+    static let nativeStackSizeBytes = 8 * 1024 * 1024
+
+    /// The JavaScript stack budget must sit well below the native stack it runs on, or QuickJS's overflow
+    /// guard fires with too little native headroom left to *construct* the RangeError and the throw path
+    /// itself faults (a hard crash observed only on CI runners with deep baseline frames; the guard is
+    /// unreliable at thin margins — quickjs-ng/zipline#1130 class). Deriving the JS limit as a quarter of
+    /// the actual worker stack makes the invariant hold for any stack size, including deliberately small
+    /// ones, so a misconfigured or starved thread throws cleanly instead of crashing.
+    static func javaScriptStackLimitBytes(workerStackSizeBytes: Int) -> Int {
+        max(64 * 1024, workerStackSizeBytes / 4)
+    }
 }
 
 private func quickJSHostCallback(
@@ -142,7 +153,6 @@ private final class QuickJSPluginValue: ProviderPluginValue {
 
 final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendable {
     static let memoryLimitBytes = 64 * 1024 * 1024
-    static let stackLimitBytes = 1 * 1024 * 1024
 
     static func transpileTypeScript(source: String, sucraseSource: String) throws -> String {
         try QuickJSTypeScriptTranspiler.transpile(source: source, sucraseSource: sucraseSource)
@@ -205,7 +215,9 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
                 throw ProviderPluginError.load("QuickJS could not create a runtime")
             }
             JS_SetMemoryLimit(runtime, Self.memoryLimitBytes)
-            JS_SetMaxStackSize(runtime, Self.stackLimitBytes)
+            JS_SetMaxStackSize(
+                runtime,
+                QuickJSRuntimeLimits.javaScriptStackLimitBytes(workerStackSizeBytes: workerStackSizeBytes))
             guard let context = JS_NewContext(runtime) else {
                 JS_FreeRuntime(runtime)
                 throw ProviderPluginError.load("QuickJS could not create a context")

--- a/Sources/CodexBarCore/Plugins/QuickJSTypeScriptTranspiler.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSTypeScriptTranspiler.swift
@@ -48,7 +48,10 @@ enum QuickJSTypeScriptTranspiler {
             throw ProviderPluginError.load("QuickJS could not create a TypeScript transpiler runtime")
         }
         JS_SetMemoryLimit(runtime, QuickJSProviderPluginEngine.memoryLimitBytes)
-        JS_SetMaxStackSize(runtime, QuickJSProviderPluginEngine.stackLimitBytes)
+        JS_SetMaxStackSize(
+            runtime,
+            QuickJSRuntimeLimits.javaScriptStackLimitBytes(
+                workerStackSizeBytes: QuickJSRuntimeLimits.nativeStackSizeBytes))
         guard let context = JS_NewContext(runtime) else {
             JS_FreeRuntime(runtime)
             throw ProviderPluginError.load("QuickJS could not create a TypeScript transpiler context")

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -553,12 +553,10 @@ struct ProviderPluginRuntimeTests {
 
     @Test
     func `QuickJS engine reports recursion beyond its JavaScript stack limit`() async throws {
-        // Production geometry only: QuickJS's overflow guard is unreliable when the native
-        // margin above the JS limit is thin (macOS crashes instead of throwing — see the
-        // quickjs-ng/zipline reports), so a deliberately starved worker stack turns this
-        // test into a layout-lottery process crash on CI runners. The default 4 MiB worker
-        // with the 1 MiB JS limit leaves 3 MiB of margin for the guard and throw path while
-        // still proving the semantics: over-limit recursion yields a clean script error.
+        // Deliberately starved worker geometry: with a fixed JS stack limit this crashed the process
+        // (guard fires with too little native left to build the RangeError — the quickjs-ng/zipline#1130
+        // class). The derived limit (a quarter of the worker stack) makes the invariant hold at any size,
+        // so even a 512 KiB thread throws a clean script error instead of overrunning the guard page.
         let engine = try Self.quickJSEngine(
             source: Self.plugin(fetchBody: """
             function recurse(depth) {
@@ -566,7 +564,7 @@ struct ProviderPluginRuntimeTests {
             }
             return { primary: { usedPercent: recurse(100000) } };
             """),
-            workerStackSizeBytes: QuickJSRuntimeLimits.nativeStackSizeBytes)
+            workerStackSizeBytes: 512 * 1024)
 
         do {
             _ = try await Self.fetchUsage(engine: engine)


### PR DESCRIPTION
## The QuickJS CI crash: actual root cause

`JS_SetMaxStackSize` received a fixed 1 MiB budget regardless of the native thread it ran on. On CI's macOS runners the Swift async/swift-testing baseline consumes enough of the 4 MiB worker stack that, once JavaScript spends its 1 MiB, too little native stack remains for QuickJS to **construct** the stack-overflow `RangeError` — so the throw path itself faults (signal 5, no CodexBar frames). This is the quickjs-ng/zipline#1130 "guard is unreliable at thin margins" class, which is why it reproduced only on runners with deeper baseline frames and never on a dev Mac.

**Fix:** derive the JS limit as a quarter of the *actual* worker stack, so the invariant holds at any thread size, and grow the production worker to 8 MiB (~7 MiB native headroom).

The regression test now runs at a deliberately starved **512 KiB** geometry — which crashed the fixed-limit code deterministically and throws a clean script error under the derived limit.

Supersedes #2793 (that branch got tangled with unrelated rebase content; this is the same 3-file change applied to a clean main).

Proof: make check clean, full plugin target 70/70, starved-geometry regression 3/3, CI's exact sharded harness green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
