### PR TITLE
test: make CLIServeRouter refresh stand-ins uncancellable so timeout paths are deterministic

### DIFF
--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -633,7 +633,7 @@ struct CLIServeRouterTests {
                         requestTimeout: 0.01)
                     {
                         _ = await counter.increment()
-                        try? await Task.sleep(nanoseconds: 5_000_000_000)
+                        await Self.hangPastRequestDeadline()
                         return Self.response("[{\"provider\":\"codex\"}]")
                     }
                 }
@@ -727,7 +727,7 @@ struct CLIServeRouterTests {
             requestTimeout: 0.01)
         {
             _ = await counter.increment()
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            await Self.hangPastRequestDeadline()
             return Self.response("[{\"provider\":\"codex\",\"call\":2}]")
         }
 
@@ -785,7 +785,7 @@ struct CLIServeRouterTests {
             refreshInterval: 0.01,
             requestTimeout: 0.01)
         {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            await Self.hangPastRequestDeadline()
             return Self.response(#"[{"provider":"codex","call":3}]"#)
         }
         let timeoutRows = try Self.jsonRows(timedOut)
@@ -929,7 +929,7 @@ struct CLIServeRouterTests {
             refreshInterval: 0.05,
             requestTimeout: 0.01)
         {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            await Self.hangPastRequestDeadline()
             return Self.response("[]")
         }
         #expect(timedOut.status == .gatewayTimeout)
@@ -972,7 +972,7 @@ struct CLIServeRouterTests {
             refreshInterval: 0.05,
             requestTimeout: 0.01)
         {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            await Self.hangPastRequestDeadline()
             return Self.response("[]")
         }
         #expect(timedOut.status == .gatewayTimeout)
@@ -1258,7 +1258,7 @@ struct CLIServeRouterTests {
             refreshInterval: 0.05,
             requestTimeout: 0.01)
         {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            await Self.hangPastRequestDeadline()
             return Self.response(
                 #"[{"provider":"codex","account":"shared","call":3}]"#,
                 usageCacheKeys: ["account-2"])
@@ -1388,7 +1388,7 @@ struct CLIServeRouterTests {
             refreshInterval: 0.05,
             requestTimeout: 0.01)
         {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            await Self.hangPastRequestDeadline()
             return Self.response(
                 #"[{"provider":"antigravity","account":"second@example.com","call":2}]"#,
                 usageCacheKeys: [nil])
@@ -1426,7 +1426,7 @@ struct CLIServeRouterTests {
             refreshInterval: 0.05,
             requestTimeout: 0.01)
         {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            await Self.hangPastRequestDeadline()
             return Self.response("[]", usageCacheKeys: [])
         }
         #expect(timedOut.status == .gatewayTimeout)
@@ -1537,6 +1537,15 @@ struct CLIServeRouterTests {
             Issue.record("Expected \(expected)")
         case let .failure(error):
             #expect(error == expected)
+        }
+    }
+
+    /// A refresh stand-in that outlives any request deadline. Deliberately uncancellable:
+    /// `try? await Task.sleep` returns immediately once the coordinator cancels the timed-out
+    /// operation, and that salvaged "real" response then races (and can beat) the timeout value.
+    private static func hangPastRequestDeadline() async {
+        await withUnsafeContinuation { continuation in
+            DispatchQueue.global().asyncAfter(deadline: .now() + 5) { continuation.resume() }
         }
     }
 


### PR DESCRIPTION
Fixes the last macOS CI failure on main (CLIServeRouterTests "cost refresh keeps fresh providers while replacing timed out rows", failing at lines 792-793 with `codex call → 3` / `claude → nil`).

Mechanism: the tests fake a hung refresh with `try? await Task.sleep(5s)`. When the serve coordinator cancels the operation at the request deadline, `try?` swallows the cancellation and the closure returns its "real" response immediately — that salvaged response races the timeout value, and on loaded CI machines it wins, gets committed, and clobbers the cached stale rows the assertions expect. A real provider fetch surfaces cancellation as an error, so this is a test-double artifact, not a production behavior bug.

Fix: replace all eight cancellation-cooperating sleeps with an uncancellable `hangPastRequestDeadline()` helper (continuation resumed via `asyncAfter`), so a timed-out refresh deterministically stays hung past the deadline. Suite runs 5x locally at unchanged duration (~3s), all green.

Observation for a possible follow-up: the coordinator currently accepts a post-cancellation operation value if it completes before the timeout value is selected. If "deadline means deadline" should hold even for misbehaving sources, `operations.value` could ignore completions after the deadline — left out of this test-only change.

With this, main should be fully green: SIGTRAP fixed in #2792, PTY bound in #2795, this closes the last flake.
