### PR TITLE
Publish Codex quota before optional enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.1 — Unreleased
 
 ### Fixed
+- Codex: publish refreshed core quota immediately while optional Credits and OpenAI Web enrichment continues, without unfreezing cards whose layout still needs reconciliation (#2799). Thanks @Yuxin-Qiao!
 - Menu bar: keep DeepSeek balances compact and consistent between saved custom layouts and their live editor preview (#2638). Thanks @Yuxin-Qiao!
 - Settings: show CodexBar in the Dock while Settings or an update dialog is open, so Check for Updates and new-version prompts reliably appear in front.
 - Claude CLI: let explicit CLI usage and Auto fallback delegate authentication to the installed Claude executable, so an unavailable browser session no longer masks usable reduced-fidelity CLI usage.

--- a/Sources/CodexBar/MenuCardRefreshMonitor.swift
+++ b/Sources/CodexBar/MenuCardRefreshMonitor.swift
@@ -22,6 +22,9 @@ final class MenuCardRefreshMonitor {
     /// refreshing one provider does not stall or unfreeze another.
     private var manualRefreshProviders: Set<ProviderInstanceID> = []
     private var frozenManualRefreshModels: [ProviderInstanceID: UsageMenuCardView.Model] = [:]
+    /// Core models published before optional enrichment finishes. These keep an already-hosted card on the
+    /// refreshed quota if a later enrichment step temporarily changes the model's tracked layout.
+    private var publishedManualRefreshModels: [ProviderInstanceID: UsageMenuCardView.Model] = [:]
 
     /// True while any manual refresh (global or per-provider) is running.
     var isManualRefreshInFlight: Bool {
@@ -55,16 +58,38 @@ final class MenuCardRefreshMonitor {
         if let provider {
             self.manualRefreshProviders.remove(provider.instanceID)
             self.frozenManualRefreshModels[provider.instanceID] = nil
+            self.publishedManualRefreshModels[provider.instanceID] = nil
         } else {
             self.globalManualRefreshInFlight = false
             self.frozenManualRefreshModels.removeAll(keepingCapacity: true)
+            self.publishedManualRefreshModels.removeAll(keepingCapacity: true)
         }
+    }
+
+    /// Ends a provider-scoped refresh only when the hosted card can adopt the resolved model without a rebuild.
+    /// The published model stays pinned as a compatible fallback until the caller reaches its final reconciliation.
+    @discardableResult
+    func publishResolvedModelIfCompatible(for provider: UsageProvider) -> Bool {
+        let instanceID = provider.instanceID
+        guard self.manualRefreshProviders.contains(instanceID),
+              let frozen = self.frozenManualRefreshModels[instanceID],
+              let resolved = self.resolveModel(provider),
+              frozen.hasCompatibleTrackedLayout(with: resolved)
+        else {
+            return false
+        }
+
+        self.manualRefreshProviders.remove(instanceID)
+        self.frozenManualRefreshModels[instanceID] = nil
+        self.publishedManualRefreshModels[instanceID] = resolved
+        return true
     }
 
     func resetManualRefresh() {
         self.globalManualRefreshInFlight = false
         self.manualRefreshProviders.removeAll(keepingCapacity: true)
         self.frozenManualRefreshModels.removeAll(keepingCapacity: true)
+        self.publishedManualRefreshModels.removeAll(keepingCapacity: true)
     }
 
     func isManualRefreshInFlight(for provider: UsageProvider) -> Bool {
@@ -91,12 +116,17 @@ final class MenuCardRefreshMonitor {
             return fallback
         }
 
-        guard let resolved = self.resolveModel(provider),
-              fallback.hasCompatibleTrackedLayout(with: resolved)
-        else {
-            return fallback
+        if let resolved = self.resolveModel(provider),
+           fallback.hasCompatibleTrackedLayout(with: resolved)
+        {
+            return resolved
         }
-        return resolved
+        if let published = self.publishedManualRefreshModels[provider.instanceID],
+           fallback.hasCompatibleTrackedLayout(with: published)
+        {
+            return published
+        }
+        return fallback
     }
 
     func subtitle(

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -79,9 +79,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             let refreshStartedAt = Date()
             await self.store.refreshProvider(provider)
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
-            // Provider-scoped Codex refreshes continue with optional credits and OpenAI Web enrichment below.
-            // Publish the core quota snapshot to the already-open card before those slower best-effort stages
-            // run, matching the foreground/background split used by the all-provider refresh path.
+            // Provider-specific by design: Codex publishes the core quota snapshot to the already-open card
+            // before its optional credits and OpenAI Web enrichment stages below, matching the all-provider
+            // foreground/background split used by the full refresh path.
             if provider == .codex {
                 self.menuCardRefreshMonitor.endManualRefresh(for: provider)
             }

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -79,11 +79,11 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             let refreshStartedAt = Date()
             await self.store.refreshProvider(provider)
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
-            // Provider-specific by design: Codex publishes the core quota snapshot to the already-open card
-            // before its optional credits and OpenAI Web enrichment stages below, matching the all-provider
-            // foreground/background split used by the full refresh path.
+            // Provider-specific by design: Codex publishes a compatible core quota model before its optional
+            // credits and OpenAI Web enrichment stages below. Incompatible cards remain frozen until the final
+            // menu reconciliation, so they never lose their loading state while still showing the old layout.
             if provider == .codex {
-                self.menuCardRefreshMonitor.endManualRefresh(for: provider)
+                self.menuCardRefreshMonitor.publishResolvedModelIfCompatible(for: provider)
             }
             await self.store.refreshProviderStatus(provider)
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -79,6 +79,12 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             let refreshStartedAt = Date()
             await self.store.refreshProvider(provider)
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+            // Provider-scoped Codex refreshes continue with optional credits and OpenAI Web enrichment below.
+            // Publish the core quota snapshot to the already-open card before those slower best-effort stages
+            // run, matching the foreground/background split used by the all-provider refresh path.
+            if provider == .codex {
+                self.menuCardRefreshMonitor.endManualRefresh(for: provider)
+            }
             await self.store.refreshProviderStatus(provider)
             guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
             await self.store.refreshTokenUsageNow(for: provider, force: true)

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2363,7 +2363,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 371,
+            line: 377,
             anchor: "if provider == .qoder {",
             expectedProviderIDs: ["claude", "qoder"],
             expectedReferenceCount: 3,
@@ -2371,7 +2371,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 441,
+            line: 447,
             anchor: "?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledFirstPartyProviders().first)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 4,
@@ -2379,7 +2379,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 462,
+            line: 468,
             anchor: "?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledFirstPartyProviders().first)",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 4,
@@ -2387,7 +2387,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 535,
+            line: 541,
             anchor: "?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2395,7 +2395,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 594,
+            line: 600,
             anchor: "self.lazyStatusItem(for: provider ?? .codex)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2403,7 +2403,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 698,
+            line: 704,
             anchor: "return .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -434,6 +434,149 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
+    func `refresh monitor publishes compatible core and pins it until final reconciliation`() throws {
+        let settings = self.makeSettings()
+        self.enableOnly([.codex], settings: settings)
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        let monitor = controller.menuCardRefreshMonitor
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now)
+        let frozen = try #require(controller.menuCardModel(for: .codex))
+        monitor.beginManualRefresh(frozenModels: [.codex: frozen], provider: .codex)
+        defer { monitor.endManualRefresh(for: .codex) }
+
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 40,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now.addingTimeInterval(1))
+        let core = try #require(controller.menuCardModel(for: .codex))
+
+        #expect(monitor.publishResolvedModelIfCompatible(for: .codex))
+        #expect(!monitor.isManualRefreshInFlight(for: .codex))
+        #expect(monitor.model(for: .codex, fallback: frozen).metrics.map(\.percent) == core.metrics.map(\.percent))
+
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 40,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 70,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(7200),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(2))
+        let enriched = try #require(controller.menuCardModel(for: .codex))
+        let visibleBeforeReconciliation = monitor.model(for: .codex, fallback: frozen)
+        let visibleAfterReconciliation = monitor.model(for: .codex, fallback: enriched)
+
+        #expect(visibleBeforeReconciliation.metrics.map(\.percent) == core.metrics.map(\.percent))
+        #expect(visibleAfterReconciliation.metrics.map(\.percent) == enriched.metrics.map(\.percent))
+        if ProcessInfo.processInfo.environment["CODEXBAR_REFRESH_PROBE"] == "1" {
+            print(
+                "CODEXBAR_REFRESH_PROBE compatible-layout-shift refreshing=false pinned=" +
+                    "\(visibleBeforeReconciliation.metrics.first?.percentLabel ?? "none") " +
+                    "reconciledRows=\(visibleAfterReconciliation.metrics.count)")
+        }
+    }
+
+    @Test
+    func `refresh monitor keeps incompatible core frozen until reconciliation`() throws {
+        let settings = self.makeSettings()
+        self.enableOnly([.codex], settings: settings)
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        let monitor = controller.menuCardRefreshMonitor
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 15,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now)
+        let frozen = try #require(controller.menuCardModel(for: .codex))
+        monitor.beginManualRefresh(frozenModels: [.codex: frozen], provider: .codex)
+        defer { monitor.endManualRefresh(for: .codex) }
+
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 45,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 65,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(7200),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(1))
+        let refreshed = try #require(controller.menuCardModel(for: .codex))
+
+        #expect(!monitor.publishResolvedModelIfCompatible(for: .codex))
+        #expect(monitor.isManualRefreshInFlight(for: .codex))
+        #expect(monitor.subtitle(
+            for: .codex,
+            fallback: MenuCardLiveSubtitle(text: "old", style: .info)).style == .loading)
+        #expect(monitor.model(for: .codex, fallback: frozen).metrics.map(\.percent) == frozen.metrics.map(\.percent))
+
+        monitor.endManualRefresh(for: .codex)
+        let reconciled = monitor.model(for: .codex, fallback: refreshed)
+        #expect(!monitor.isManualRefreshInFlight(for: .codex))
+        #expect(reconciled.metrics.map(\.percent) == refreshed.metrics.map(\.percent))
+        if ProcessInfo.processInfo.environment["CODEXBAR_REFRESH_PROBE"] == "1" {
+            print(
+                "CODEXBAR_REFRESH_PROBE incompatible coreRows=\(refreshed.metrics.count) " +
+                    "blockedState=refreshing reconciledState=published")
+        }
+    }
+
+    @Test
+    func `refresh monitor publishes compatible core error honestly`() throws {
+        let settings = self.makeSettings()
+        self.enableOnly([.codex], settings: settings)
+        let controller = self.makeController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        let monitor = controller.menuCardRefreshMonitor
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now)
+        let frozen = try #require(controller.menuCardModel(for: .codex))
+        monitor.beginManualRefresh(frozenModels: [.codex: frozen], provider: .codex)
+        defer { monitor.endManualRefresh(for: .codex) }
+
+        controller.store.errors[.codex] = "Synthetic core refresh failure"
+
+        #expect(monitor.publishResolvedModelIfCompatible(for: .codex))
+        #expect(!monitor.isManualRefreshInFlight(for: .codex))
+        let subtitle = monitor.subtitle(
+            for: .codex,
+            fallback: MenuCardLiveSubtitle(text: "old", style: .info))
+        #expect(subtitle.style == .error)
+        #expect(monitor.model(for: .codex, fallback: frozen).metrics.map(\.percent) == frozen.metrics.map(\.percent))
+    }
+
+    @Test
     func `manual refresh keeps frozen quota even if menu rebuilds before completion`() throws {
         let settings = self.makeSettings()
         let controller = self.makeController(settings: settings)

--- a/Tests/CodexBarTests/StatusMenuScopedCodexRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuScopedCodexRefreshTests.swift
@@ -44,74 +44,129 @@ private final class ScopedRefreshGate {
 @Suite(.serialized)
 struct StatusMenuScopedCodexRefreshTests {
     @Test
-    func `scoped refresh publishes quota before dashboard enrichment completes`() async {
+    func `scoped refresh publishes compatible quota before dashboard enrichment completes`() async throws {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.statusChecksEnabled = false
         settings.costUsageEnabled = false
+        settings.showOptionalCreditsAndExtraUsage = true
         settings.openAIWebAccessEnabled = true
         settings.codexCookieSource = .manual
         settings.codexCookieHeader = "session=fixture"
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "fixture@example.com",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "fixture@example.com"))
+        settings.codexActiveSource = .liveSystem
         self.enableOnlyCodex(settings)
+        defer { settings._test_liveSystemCodexAccount = nil }
 
-        let account = AccountInfo(email: "test@example.com", plan: "pro")
+        let account = AccountInfo(email: "fixture@example.com", plan: "pro")
+        let environment = Self.isolatedEnvironment()
+        let fetcher = UsageFetcher(environment: environment)
         let store = UsageStore(
-            fetcher: UsageFetcher(),
+            fetcher: fetcher,
             browserDetection: BrowserDetection(cacheTTL: 0),
-            settings: settings)
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: environment)
         store.accountInfoCache[.codex] = UsageStore.AccountInfoCacheEntry(
             account: account,
             configRevision: settings.configRevision,
             expiresAt: .distantFuture)
-        let controller = StatusItemController(
+        let initialUpdatedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        store.snapshots[.codex] = Self.snapshot(usedPercent: 12, updatedAt: initialUpdatedAt)
+
+        try await withStatusItemControllerForTesting(
             store: store,
             settings: settings,
-            account: account,
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: .system)
-        let dashboardStarted = ScopedRefreshGate()
-        let releaseDashboard = ScopedRefreshGate()
+            fetcher: fetcher,
+            account: account)
+        { controller in
+            let creditsStarted = ScopedRefreshGate()
+            let releaseCredits = ScopedRefreshGate()
+            let monitor = controller.menuCardRefreshMonitor
+            let frozen = try #require(controller.menuCardModel(for: .codex))
+            var coreModel: UsageMenuCardView.Model?
+            var creditsLoaderCalls = 0
+            var dashboardLoaderCalls = 0
 
-        store._test_providerRefreshOverride = { provider in
-            #expect(provider == .codex)
-        }
-        store._test_codexCreditsLoaderOverride = {
-            CreditsSnapshot(remaining: 25, events: [], updatedAt: Date())
-        }
-        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
-            dashboardStarted.resume()
-            await releaseDashboard.wait()
-            return OpenAIDashboardSnapshot(
-                signedInEmail: account.email,
-                codeReviewRemainingPercent: 95,
-                creditEvents: [],
-                dailyBreakdown: [],
-                usageBreakdown: [],
-                creditsPurchaseURL: nil,
-                creditsRemaining: 25,
-                accountPlan: "Pro",
-                updatedAt: Date())
-        }
-        defer {
-            releaseDashboard.resume()
-            store._test_providerRefreshOverride = nil
-            store._test_codexCreditsLoaderOverride = nil
-            store._test_openAIDashboardLoaderOverride = nil
-        }
+            store._test_providerRefreshOverride = { provider in
+                #expect(provider == .codex)
+                store.snapshots[.codex] = Self.snapshot(
+                    usedPercent: 37,
+                    updatedAt: initialUpdatedAt.addingTimeInterval(60))
+                store.errors[.codex] = nil
+                coreModel = controller.menuCardModel(for: .codex)
+            }
+            store._test_codexCreditsLoaderOverride = {
+                creditsLoaderCalls += 1
+                if creditsLoaderCalls == 1 {
+                    creditsStarted.resume()
+                    await releaseCredits.wait()
+                }
+                return CreditsSnapshot(remaining: 25, events: [], updatedAt: Date())
+            }
+            store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
+                dashboardLoaderCalls += 1
+                return OpenAIDashboardSnapshot(
+                    signedInEmail: account.email,
+                    codeReviewRemainingPercent: 95,
+                    creditEvents: [],
+                    dailyBreakdown: [],
+                    usageBreakdown: [],
+                    creditsPurchaseURL: nil,
+                    creditsRemaining: 25,
+                    accountPlan: "Pro",
+                    updatedAt: Date())
+            }
+            defer {
+                releaseCredits.resume()
+                monitor.endManualRefresh(for: .codex)
+                store._test_providerRefreshOverride = nil
+                store._test_codexCreditsLoaderOverride = nil
+                store._test_openAIDashboardLoaderOverride = nil
+            }
 
-        controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [:], provider: .codex)
-        let refreshTask = Task { @MainActor in
-            await controller.performStoreRefresh(
-                for: .codex,
-                refreshOpenMenusWhenComplete: false,
-                interaction: .userInitiated)
-        }
-        #expect(await dashboardStarted.waitUntilSignaled())
-        #expect(!controller.menuCardRefreshMonitor.isManualRefreshInFlight(for: .codex))
+            monitor.beginManualRefresh(frozenModels: [.codex: frozen], provider: .codex)
+            let refreshTask = Task { @MainActor in
+                await controller.performStoreRefresh(
+                    for: .codex,
+                    refreshOpenMenusWhenComplete: false,
+                    interaction: .userInitiated)
+            }
+            let enrichmentDidStart = await creditsStarted.waitUntilSignaled()
+            #expect(enrichmentDidStart)
+            guard enrichmentDidStart else {
+                await refreshTask.value
+                return
+            }
 
-        releaseDashboard.resume()
-        await refreshTask.value
+            let expectedCore = try #require(coreModel)
+            let visibleWhileBlocked = monitor.model(for: .codex, fallback: frozen)
+            #expect(!monitor.isManualRefreshInFlight(for: .codex))
+            #expect(visibleWhileBlocked.metrics.map(\.percent) == expectedCore.metrics.map(\.percent))
+            #expect(visibleWhileBlocked.metrics.map(\.percent) != frozen.metrics.map(\.percent))
+            self.emitProbe(
+                "compatible enrichment=blocked refreshing=false before=" +
+                    "\(frozen.metrics.first?.percentLabel ?? "none") core=" +
+                    "\(visibleWhileBlocked.metrics.first?.percentLabel ?? "none")")
+
+            releaseCredits.resume()
+            await refreshTask.value
+
+            let finalModel = try #require(controller.menuCardModel(for: .codex))
+            let visibleAfterEnrichment = monitor.model(for: .codex, fallback: finalModel)
+            #expect(store.credits?.remaining == 25)
+            #expect(store.openAIDashboard?.creditsRemaining == 25)
+            #expect(creditsLoaderCalls >= 1)
+            #expect(dashboardLoaderCalls >= 1)
+            #expect(visibleAfterEnrichment.hasCompatibleTrackedLayout(with: finalModel))
+            self.emitProbe(
+                "compatible enrichment=complete credits=\(store.credits?.remaining ?? -1) " +
+                    "dashboardCredits=\(store.openAIDashboard?.creditsRemaining ?? -1)")
+        }
     }
 
     @Test
@@ -130,52 +185,51 @@ struct StatusMenuScopedCodexRefreshTests {
             account: account,
             configRevision: settings.configRevision,
             expiresAt: .distantFuture)
-        let controller = StatusItemController(
+        await withStatusItemControllerForTesting(
             store: store,
             settings: settings,
-            account: account,
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: .system)
+            fetcher: fetcher,
+            account: account)
+        { controller in
+            var providerRefreshes = 0
+            store._test_providerRefreshOverride = { provider in
+                #expect(provider == .codex)
+                providerRefreshes += 1
+            }
+            store._test_tokenUsageRefreshOverride = { _, _ in }
+            store._test_codexCreditsLoaderOverride = {
+                CreditsSnapshot(remaining: 25, events: [], updatedAt: Date())
+            }
+            store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
+                throw OpenAIDashboardFetcher.FetchError.loginRequired
+            }
+            store._test_openAIDashboardCookieImportOverride = { targetEmail, _, _, _, _ in
+                OpenAIDashboardBrowserCookieImporter.ImportResult(
+                    sourceLabel: "Chrome",
+                    cookieCount: 2,
+                    signedInEmail: targetEmail,
+                    matchesCodexEmail: true)
+            }
+            defer {
+                store._test_providerRefreshOverride = nil
+                store._test_tokenUsageRefreshOverride = nil
+                store._test_codexCreditsLoaderOverride = nil
+                store._test_openAIDashboardLoaderOverride = nil
+                store._test_openAIDashboardCookieImportOverride = nil
+            }
 
-        var providerRefreshes = 0
-        store._test_providerRefreshOverride = { provider in
-            #expect(provider == .codex)
-            providerRefreshes += 1
-        }
-        store._test_tokenUsageRefreshOverride = { _, _ in }
-        store._test_codexCreditsLoaderOverride = {
-            CreditsSnapshot(remaining: 25, events: [], updatedAt: Date())
-        }
-        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
-            throw OpenAIDashboardFetcher.FetchError.loginRequired
-        }
-        store._test_openAIDashboardCookieImportOverride = { targetEmail, _, _, _, _ in
-            OpenAIDashboardBrowserCookieImporter.ImportResult(
-                sourceLabel: "Chrome",
-                cookieCount: 2,
-                signedInEmail: targetEmail,
-                matchesCodexEmail: true)
-        }
+            await controller.performStoreRefresh(
+                for: .codex,
+                refreshOpenMenusWhenComplete: false,
+                interaction: .userInitiated)
 
-        await controller.performStoreRefresh(
-            for: .codex,
-            refreshOpenMenusWhenComplete: false,
-            interaction: .userInitiated)
-
-        #expect(store.openAIDashboardRequiresLogin)
-        #expect(providerRefreshes == 2)
+            #expect(store.openAIDashboardRequiresLogin)
+            #expect(providerRefreshes == 2)
+        }
     }
 
     private func makeSettings() -> SettingsStore {
-        let suite = "StatusMenuScopedCodexRefreshTests-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        return SettingsStore(
-            userDefaults: defaults,
-            configStore: testConfigStore(suiteName: suite),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+        testSettingsStore(suiteName: "StatusMenuScopedCodexRefreshTests")
     }
 
     private func enableOnlyCodex(_ settings: SettingsStore) {
@@ -183,5 +237,43 @@ struct StatusMenuScopedCodexRefreshTests {
             guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
             settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
         }
+    }
+
+    private static func isolatedEnvironment() -> [String: String] {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        return [
+            "HOME": root.path,
+            "CODEX_HOME": root.appendingPathComponent(".codex", isDirectory: true).path,
+            "XDG_CONFIG_HOME": root.appendingPathComponent(".config", isDirectory: true).path,
+        ]
+    }
+
+    private static func snapshot(
+        usedPercent: Double,
+        secondaryUsedPercent: Double? = nil,
+        updatedAt: Date) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: 300,
+                resetsAt: updatedAt.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: secondaryUsedPercent.map { percent in
+                RateWindow(
+                    usedPercent: percent,
+                    windowMinutes: 10080,
+                    resetsAt: updatedAt.addingTimeInterval(7200),
+                    resetDescription: nil)
+            },
+            updatedAt: updatedAt)
+    }
+
+    private func emitProbe(_ line: String) {
+        guard ProcessInfo.processInfo.environment["CODEXBAR_REFRESH_PROBE"] == "1" else { return }
+        let data = Data("CODEXBAR_REFRESH_PROBE \(line)\n".utf8)
+        FileHandle.standardError.write(data)
     }
 }

--- a/Tests/CodexBarTests/StatusMenuScopedCodexRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuScopedCodexRefreshTests.swift
@@ -4,8 +4,116 @@ import Testing
 @testable import CodexBar
 
 @MainActor
+private final class ScopedRefreshGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        if self.isOpen {
+            self.isOpen = false
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func resume() {
+        if let continuation = self.continuation {
+            continuation.resume()
+            self.continuation = nil
+        } else {
+            self.isOpen = true
+        }
+    }
+
+    func waitUntilSignaled(timeout: Duration = .seconds(5)) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while !self.isOpen {
+            if ContinuousClock.now >= deadline {
+                return false
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        self.isOpen = false
+        return true
+    }
+}
+
+@MainActor
 @Suite(.serialized)
 struct StatusMenuScopedCodexRefreshTests {
+    @Test
+    func `scoped refresh publishes quota before dashboard enrichment completes`() async {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.costUsageEnabled = false
+        settings.openAIWebAccessEnabled = true
+        settings.codexCookieSource = .manual
+        settings.codexCookieHeader = "session=fixture"
+        self.enableOnlyCodex(settings)
+
+        let account = AccountInfo(email: "test@example.com", plan: "pro")
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        store.accountInfoCache[.codex] = UsageStore.AccountInfoCacheEntry(
+            account: account,
+            configRevision: settings.configRevision,
+            expiresAt: .distantFuture)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: account,
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        let dashboardStarted = ScopedRefreshGate()
+        let releaseDashboard = ScopedRefreshGate()
+
+        store._test_providerRefreshOverride = { provider in
+            #expect(provider == .codex)
+        }
+        store._test_codexCreditsLoaderOverride = {
+            CreditsSnapshot(remaining: 25, events: [], updatedAt: Date())
+        }
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
+            dashboardStarted.resume()
+            await releaseDashboard.wait()
+            return OpenAIDashboardSnapshot(
+                signedInEmail: account.email,
+                codeReviewRemainingPercent: 95,
+                creditEvents: [],
+                dailyBreakdown: [],
+                usageBreakdown: [],
+                creditsPurchaseURL: nil,
+                creditsRemaining: 25,
+                accountPlan: "Pro",
+                updatedAt: Date())
+        }
+        defer {
+            releaseDashboard.resume()
+            store._test_providerRefreshOverride = nil
+            store._test_codexCreditsLoaderOverride = nil
+            store._test_openAIDashboardLoaderOverride = nil
+        }
+
+        controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [:], provider: .codex)
+        let refreshTask = Task { @MainActor in
+            await controller.performStoreRefresh(
+                for: .codex,
+                refreshOpenMenusWhenComplete: false,
+                interaction: .userInitiated)
+        }
+        #expect(await dashboardStarted.waitUntilSignaled())
+        #expect(!controller.menuCardRefreshMonitor.isManualRefreshInFlight(for: .codex))
+
+        releaseDashboard.resume()
+        await refreshTask.value
+    }
+
     @Test
     func `scoped refresh reconciles usage after dashboard login expires`() async {
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -171,13 +171,14 @@ func withStatusItemControllerForTesting<T>(
     store: UsageStore,
     settings: SettingsStore,
     fetcher: UsageFetcher,
+    account: AccountInfo? = nil,
     statusBar: NSStatusBar = .system,
     operation: (StatusItemController) throws -> T) rethrows -> T
 {
     let controller = StatusItemController(
         store: store,
         settings: settings,
-        account: fetcher.loadAccountInfo(),
+        account: account ?? fetcher.loadAccountInfo(),
         updater: DisabledUpdaterController(),
         preferencesSelection: PreferencesSelection(),
         statusBar: statusBar)
@@ -191,13 +192,14 @@ func withStatusItemControllerForTesting<T>(
     store: UsageStore,
     settings: SettingsStore,
     fetcher: UsageFetcher,
+    account: AccountInfo? = nil,
     statusBar: NSStatusBar = .system,
     operation: (StatusItemController) async throws -> T) async rethrows -> T
 {
     let controller = StatusItemController(
         store: store,
         settings: settings,
-        account: fetcher.loadAccountInfo(),
+        account: account ?? fetcher.loadAccountInfo(),
         updater: DisabledUpdaterController(),
         preferencesSelection: PreferencesSelection(),
         statusBar: statusBar)


### PR DESCRIPTION
## Summary

- publish newly fetched Codex core quota to an already-open card before optional Credits and OpenAI Web enrichment finishes
- keep layout-incompatible cards honestly refreshing until the existing final menu reconciliation
- pin the compatible core model so a later enrichment layout change cannot make the open card regress to stale quota
- release every test-created AppKit status item through the repository cleanup wrapper

## Root cause

Provider-scoped Codex refreshes kept the card frozen through core usage, status, token cost, Credits, and dashboard work. The original patch ended that freeze after core usage, but `MenuCardRefreshMonitor` correctly rejects a live model whose tracked layout differs from the already-hosted card. Clearing the monitor unconditionally therefore removed “Refreshing…” while leaving the old or empty fallback visible.

The monitor now owns the early-publication decision. It ends the provider-scoped loading state only when the frozen and resolved models have compatible tracked layouts, retains the published core model through the enrichment tail, and leaves incompatible cards frozen until the controller’s existing final reconciliation. Provider/account authority and the optional enrichment sequence are unchanged.

The original sequencing fixture also retained its system status item and blocked every Credits retry. It now uses the cleanup wrapper and deliberately blocks only the first enrichment call, allowing legitimate account-reconciliation retries to finish.

## Synthetic behavior proof

No provider credentials, network access, or personal data were used. A compiled production-controller seam emitted this deterministic operator trace:

```text
CODEXBAR_REFRESH_PROBE compatible enrichment=blocked refreshing=false before=88% left core=63% left
CODEXBAR_REFRESH_PROBE compatible enrichment=complete credits=25.0 dashboardCredits=25.0
CODEXBAR_REFRESH_PROBE compatible-layout-shift refreshing=false pinned=60% left reconciledRows=2
CODEXBAR_REFRESH_PROBE incompatible coreRows=2 blockedState=refreshing reconciledState=published
```

The three trace cases passed. A screenshot probe was not added because producing a signed visual fixture for these synthetic states would require product-only credential/menu plumbing; the controller trace exercises the same production monitor boundary directly.

## Validation

- `swift test --filter StatusMenuScopedCodexRefreshTests` — 2 tests passed; the former headless hang is gone
- `swift test --filter StatusMenuPersistentRefreshTests` — 43 tests passed
- focused compatible, incompatible, core-error, blocked-enrichment, and final-publication cases passed
- `make check` — passed; SwiftFormat and SwiftLint reported no issues
- `make test` — all 833 selections passed in 70/70 groups, with no retries or timeouts
- final Codex autoreview of the full branch against `origin/main` — clean, no accepted/actionable findings
