### PR TITLE
test: harden three load-sensitive flaky tests

### DIFF
--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -706,30 +706,45 @@ struct CLIServeRouterTests {
 
     @Test
     func `cost refresh timeout serves the last good payload`() async throws {
-        let cache = CLIServeResponseCache()
+        let deadline = ServeListeningSignal()
+        let releaseSource = ServeListeningSignal()
+        defer { releaseSource.signal() }
+        let operations = CLIServeOperationCoordinator<CLIServeCoordinatedResponse>(
+            sleepUntil: { _ in await deadline.wait() })
+        let cache = CLIServeResponseCache(operations: operations)
         let counter = ServeTestCounter()
 
         let first = await CodexBarCLI.cachedServeResponse(
             key: "cost:",
             cache: cache,
             refreshInterval: 0.01,
-            requestTimeout: 1)
+            requestTimeout: 0)
         {
             let call = await counter.increment()
             return Self.response("[{\"provider\":\"codex\",\"call\":\(call)}]")
         }
-        try? await Task.sleep(nanoseconds: 30_000_000)
+        // Expire the fresh entry without relying on the scheduler to wake a TTL sleep promptly.
+        let cacheKey = CodexBarCLI.serveCacheKey(operationKey: "cost:", configToken: "")
+        _ = await cache.cachedResponse(for: cacheKey, now: Date().addingTimeInterval(1))
+        #expect(await cache.cachedEntryCount() == 0)
 
-        let timedOut = await CodexBarCLI.cachedServeResponse(
-            key: "cost:",
-            cache: cache,
-            refreshInterval: 0.01,
-            requestTimeout: 0.01)
-        {
-            _ = await counter.increment()
-            await Self.hangPastRequestDeadline()
-            return Self.response("[{\"provider\":\"codex\",\"call\":2}]")
+        let sourceEntered = ServeListeningSignal()
+        let request = Task {
+            await CodexBarCLI.cachedServeResponse(
+                key: "cost:",
+                cache: cache,
+                refreshInterval: 0.01,
+                requestTimeout: 30)
+            {
+                let call = await counter.increment()
+                sourceEntered.signal()
+                await releaseSource.wait()
+                return Self.response("[{\"provider\":\"codex\",\"call\":\(call)}]")
+            }
         }
+        await sourceEntered.wait()
+        deadline.signal()
+        let timedOut = await request.value
 
         #expect(timedOut.status == .ok)
         let firstRows = try Self.jsonRows(first)
@@ -739,6 +754,12 @@ struct CLIServeRouterTests {
         #expect(firstRows.first?["call"] as? Int == 1)
         #expect(timedOutRows.first?["call"] as? Int == 1)
         #expect(await counter.current() == 2)
+
+        releaseSource.signal()
+        for _ in 0..<1000 where await operations.snapshot().operationCount != 0 {
+            await Task.yield()
+        }
+        #expect(await operations.snapshot().operationCount == 0)
     }
 
     @Test

--- a/Tests/CodexBarTests/CostUsageStoreScaleProofTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreScaleProofTests.swift
@@ -79,10 +79,10 @@ struct CostUsageStoreScaleProofTests {
 
         // Generous gates so CI hardware variance does not flake; these catch order-of-magnitude
         // regressions (e.g. accidental full rewrites or missing indexes) rather than jitter.
-        #expect(Self.milliseconds(bulkElapsed) < 120_000)
-        #expect(Self.milliseconds(pruneElapsed) < 2000)
-        #expect(Self.milliseconds(reportElapsed) < 1000)
-        #expect(Self.milliseconds(snapshotElapsed) < 10000)
+        #expect(bulkElapsed < Self.timingBudget(.seconds(120)))
+        #expect(pruneElapsed < Self.timingBudget(.seconds(2)))
+        #expect(reportElapsed < Self.timingBudget(.seconds(1)))
+        #expect(snapshotElapsed < Self.timingBudget(.seconds(10)))
         #expect(bulkFileBytes < 300 * 1_048_576)
     }
 
@@ -140,7 +140,7 @@ struct CostUsageStoreScaleProofTests {
 
         print("[scale-proof] window prune 500 -> \(survivors) files: \(Self.milliseconds(pruneElapsed)) ms, ")
         print("[scale-proof] db file \(beforeBytes / 1_048_576) -> \(afterBytes / 1_048_576) MiB")
-        #expect(Self.milliseconds(pruneElapsed) < 5000)
+        #expect(pruneElapsed < Self.timingBudget(.seconds(5)))
     }
 
     @Test
@@ -173,8 +173,8 @@ struct CostUsageStoreScaleProofTests {
         print("[scale-proof] 100 MiB blob write: \(Self.milliseconds(writeElapsed)) ms, ")
         print("[scale-proof] db file after 100 MiB blob: \(persistedBytes / 1_048_576) MiB")
         print("[scale-proof] 100 MiB blob read: \(Self.milliseconds(readElapsed)) ms")
-        #expect(Self.milliseconds(writeElapsed) < 5000)
-        #expect(Self.milliseconds(readElapsed) < 5000)
+        #expect(writeElapsed < Self.timingBudget(.seconds(5)))
+        #expect(readElapsed < Self.timingBudget(.seconds(5)))
         // Keep the persisted representation bounded so a second whole-artifact copy cannot
         // hide behind a successful round trip.
         #expect(persistedBytes < 256 * 1_048_576)
@@ -184,6 +184,10 @@ struct CostUsageStoreScaleProofTests {
 // MARK: - Helpers
 
 extension CostUsageStoreScaleProofTests {
+    private static func timingBudget(_ budget: Duration) -> Duration {
+        TestTimingBudget.scaled(budget)
+    }
+
     private static func dayString(
         daysAgo: Int,
         calendar: Calendar,

--- a/Tests/CodexBarTests/CostUsageStoreScaleProofTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreScaleProofTests.swift
@@ -173,8 +173,18 @@ struct CostUsageStoreScaleProofTests {
         print("[scale-proof] 100 MiB blob write: \(Self.milliseconds(writeElapsed)) ms, ")
         print("[scale-proof] db file after 100 MiB blob: \(persistedBytes / 1_048_576) MiB")
         print("[scale-proof] 100 MiB blob read: \(Self.milliseconds(readElapsed)) ms")
-        #expect(writeElapsed < Self.timingBudget(.seconds(5)))
-        #expect(readElapsed < Self.timingBudget(.seconds(5)))
+        // The 100 MiB round trip is by far the heaviest single I/O operation in the suite and the
+        // shared CI scaler was calibrated against much lighter work (see TestTimingBudget), so the
+        // nominal budget carries the headroom here. A healthy write measures ~8.5s on an idle
+        // 32-core machine and ~6-8s on a busy one, which is why the previous 5s ceiling failed
+        // even without contention. 30s stays an order-of-magnitude gate against that real
+        // baseline: quadratic buffering or a full rewrite still trips it.
+        //
+        // No wall-clock gate survives a pathologically oversubscribed host — at two spinning
+        // burners per core this write degrades to 67-171s, which is indistinguishable from a
+        // genuine regression. The byte assertion below is the load-independent correctness check.
+        #expect(writeElapsed < Self.timingBudget(.seconds(30)))
+        #expect(readElapsed < Self.timingBudget(.seconds(30)))
         // Keep the persisted representation bounded so a second whole-artifact copy cannot
         // hide behind a successful round trip.
         #expect(persistedBytes < 256 * 1_048_576)

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -589,15 +589,15 @@ struct ProviderPluginRuntimeTests {
             if (ctx.settings.getSecret("TEST_KEY") === "hang") while (true) {}
             return { primary: { usedPercent: 7 } };
             """),
-            timeout: 0.15)
+            timeout: 5)
         let start = Date()
 
         await #expect(throws: ProviderPluginError.self) {
             _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "hang"])
         }
-        // The 0.15s watchdog must fire promptly rather than wait out the hang; allow generous
-        // headroom for loaded CI runners (observed 1.66s on ARM64 under contention).
-        #expect(Date().timeIntervalSince(start) < 5)
+        // This ceiling only proves the watchdog interrupted the infinite loop instead of hanging
+        // forever. The runtime timeout itself leaves fresh-worker compilation ample scheduler headroom.
+        #expect(Date().timeIntervalSince(start) < 30)
 
         let recovered = try await runtime.fetchUsage(secrets: ["TEST_KEY": "ok"])
         #expect(recovered.primary?.usedPercent == 7)


### PR DESCRIPTION
Three timing-sensitive tests passed in local isolation but flaked on loaded CI runners. Each is hardened here without weakening what it proves.

## 1. Router: `cost refresh timeout serves the last good payload`

The test simulated a slow cost refresh with `try? await Task.sleep(nanoseconds: 5_000_000_000)`. When the request deadline fires, `CLIServeOperationCoordinator.timeoutActive` cancels the source task — and a cancelled `Task.sleep` throws immediately, with `try?` swallowing it. The "slow" closure therefore returned its `call:2` payload right away. That late result is then committed *by design* (`sourceProduced` deliberately keeps slot ownership through `accept` so timed-out work still lands), overwriting the cached last-good entry. The test's own read of last-good was racing that commit, which is exactly the `call == 2` seen at line 740.

This is a test race, not a product race — the coordinator behaves as documented.

The fix makes the whole sequence deterministic by injecting the coordinator's existing `sleepUntil` seam so the deadline fires exactly when the test says. The source signals on entry and then blocks on a continuation the test releases only after the assertions, so no abandoned work can commit mid-assertion. Every timing sleep is gone, and a teardown drain asserts the coordinator leaks no operations.

Reproduced 6/20 on unmodified code under load; 20/20 after the fix.

## 2. Plugin runtime: `hung script times out and next fetch uses a fresh context`

A single 0.15s runtime-wide timeout served two different jobs: interrupting the infinite loop, *and* bounding the recovery fetch. Recovery has to build a fresh worker (the hung one is discarded), compile the plugin, and cross a thread hop — under contention that exceeds 150 ms on scheduler jitter alone, so a trivial script "timed out".

The watchdog budget moves to 5s, which only needs to be much shorter than the hang, and the elapsed-time assertion is relaxed to a 30s "did not hang forever" ceiling with a comment saying that is all it proves. Both properties still hold: the hang is interrupted, and the next fetch on the same runtime succeeds on a fresh context.

Honest caveat: this one **did not reproduce** on the baseline (10/10 on both engines), so the change rests on the mechanism above rather than on a captured failure. It is 20/20 after, on both QuickJS and JSC.

## 3. Scale proof: 100 MiB blob round trip

The duration gates throughout the file now scale through the repo's existing `TestTimingBudget` CI scaler. Byte gates are deliberately left fixed — they are correctness bounds, not timing bounds.

The 100 MiB write needed more than the shared 3x factor. Measuring the idle baseline showed the real problem: a healthy write is **~8.5s on an idle 32-core machine**, so the original 5s ceiling was under-set for the operation's genuine cost and failed without any contention at all. The 3x scaler alone would have left under 2x margin. Its nominal budget is therefore raised to 30s, which against a real ~8.5s baseline is still an order-of-magnitude gate: quadratic buffering or a full rewrite trips it.

Also documented in the test: no wall-clock gate survives a pathologically oversubscribed host. At two spinning burners per core this write degrades to 67-171s, indistinguishable from a genuine regression. The byte assertion is the load-independent correctness check.

## Proof

Load induced with two spinning burners per core (64 on 32 cores) for the first two; the scale proof uses 64 workers at ~25% duty, modelling a busy runner rather than a pathological one.

| Test | Result under load |
| --- | --- |
| Router timeout | 20/20 |
| Plugin timeout (QuickJS) | 10/10 |
| Plugin timeout (JSC) | 10/10 |
| 100 MiB blob round trip | 5/5, writes 5.8-8.4s vs 90s gate |

Full `CostUsageStoreScaleProofTests` suite passes. `make check` is clean (0 violations across 1,827 files). Codex autoreview returned no actionable findings.

No product code changed. No changelog entry: test-only.
