### PR TITLE
test: make CLIServe cache timing deterministic

### DIFF
--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -227,9 +227,14 @@ struct ServeCostCollectionContext: Sendable {
 actor CLIServeResponseCache {
     static let maximumStaleTTL: TimeInterval = 3600
     nonisolated let operations: CLIServeOperationCoordinator<CLIServeCoordinatedResponse>
+    nonisolated let wallClock: @Sendable () -> Date
 
-    init(operations: CLIServeOperationCoordinator<CLIServeCoordinatedResponse> = CLIServeOperationCoordinator()) {
+    init(
+        operations: CLIServeOperationCoordinator<CLIServeCoordinatedResponse> = CLIServeOperationCoordinator(),
+        wallClock: @escaping @Sendable () -> Date = { Date() })
+    {
         self.operations = operations
+        self.wallClock = wallClock
     }
 
     private struct Entry {
@@ -1100,7 +1105,7 @@ extension CodexBarCLI {
         let cacheKey = Self.serveCacheKey(
             operationKey: request.key,
             configToken: request.configFingerprint)
-        if let response = await cache.cachedResponse(for: cacheKey, now: Date()) {
+        if let response = await cache.cachedResponse(for: cacheKey, now: cache.wallClock()) {
             return response
         }
 
@@ -1111,7 +1116,7 @@ extension CodexBarCLI {
            let stale = await cache.staleResponseForRevalidation(
                for: cacheKey,
                staleTTL: policy.staleTTL,
-               now: Date())
+               now: cache.wallClock())
         {
             Task.detached {
                 _ = await Self.refreshServeResponse(
@@ -1150,12 +1155,12 @@ extension CodexBarCLI {
                     fetched.response,
                     for: cacheKey,
                     policy: policy,
-                    now: Date(),
+                    now: cache.wallClock(),
                     shouldCache: Self.shouldCacheServeResponse(fetched.response))
                 return CLIServeCoordinatedResponse(response: committed, isCommitted: true)
             },
             operation: {
-                if let response = await cache.cachedResponse(for: cacheKey, now: Date()) {
+                if let response = await cache.cachedResponse(for: cacheKey, now: cache.wallClock()) {
                     return CLIServeCoordinatedResponse(response: response, isCommitted: false)
                 }
                 let response = await makeResponse()
@@ -1171,7 +1176,7 @@ extension CodexBarCLI {
             outcome.response,
             for: cacheKey,
             policy: policy,
-            now: Date(),
+            now: cache.wallClock(),
             shouldCache: Self.shouldCacheServeResponse(outcome.response))
     }
 

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -534,8 +534,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache prunes expired config token entries`() async {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage::old-config",
@@ -655,8 +654,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache serves last good payload when refresh fails`() async {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
         let counter = ServeTestCounter()
 
         let first = await CodexBarCLI.cachedServeResponse(
@@ -763,8 +761,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `cost refresh keeps fresh providers while replacing timed out rows`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "cost:",
@@ -816,8 +813,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache replaces only failed provider account rows`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -860,8 +856,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache retains newer per-row success across all-error refresh`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -914,8 +909,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache fails closed on timeout after merged rows`() async {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -963,8 +957,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache fails closed on timeout after a partial refresh`() async {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1051,8 +1044,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache preserves newer row when another failed row has no fallback`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1100,8 +1092,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache keeps fresh rows when a failed row has no stale match`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1135,8 +1126,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache does not merge duplicate provider account labels`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1182,8 +1172,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache follows stable account identity across label changes`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1215,8 +1204,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache does not reuse a label for a different account identity`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1253,8 +1241,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache does not use whole fallback after an account switch`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1301,8 +1288,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache prunes accounts absent from a successful snapshot`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1345,8 +1331,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache fails closed when all-error rows have ambiguous identities`() async throws {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1401,8 +1386,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache does not whole-fallback ambiguous usage after timeout`() async {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1435,8 +1419,7 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache mixed identities do not enable timeout fallback`() async {
-        let wallClock = ServeTestWallClock()
-        let cache = CLIServeResponseCache(wallClock: wallClock.now)
+        let (wallClock, cache) = makeServeTestCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1659,21 +1642,6 @@ private actor ServeTestCounter {
 
     func current() -> Int {
         self.value
-    }
-}
-
-private final class ServeTestWallClock: @unchecked Sendable {
-    private let lock = NSLock()
-    private var date = Date(timeIntervalSince1970: 1000)
-
-    func now() -> Date {
-        self.lock.withLock { self.date }
-    }
-
-    func advance(by interval: TimeInterval) {
-        self.lock.withLock {
-            self.date = self.date.addingTimeInterval(interval)
-        }
     }
 }
 

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -533,8 +533,9 @@ struct CLIServeRouterTests {
     }
 
     @Test
-    func `serve cache prunes expired config token entries`() async throws {
-        let cache = CLIServeResponseCache()
+    func `serve cache prunes expired config token entries`() async {
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage::old-config",
@@ -545,7 +546,7 @@ struct CLIServeRouterTests {
         }
         #expect(await cache.cachedEntryCount() == 1)
 
-        try await Task.sleep(nanoseconds: 20_000_000)
+        wallClock.advance(by: 0.001)
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage::new-config",
             cache: cache,
@@ -654,7 +655,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache serves last good payload when refresh fails`() async {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
         let counter = ServeTestCounter()
 
         let first = await CodexBarCLI.cachedServeResponse(
@@ -668,8 +670,7 @@ struct CLIServeRouterTests {
         }
         #expect(first.status == .ok)
 
-        // Let the fresh cache entry expire so the next request re-fetches.
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let failed = await CodexBarCLI.cachedServeResponse(
             key: "usage:antigravity",
@@ -688,7 +689,7 @@ struct CLIServeRouterTests {
         #expect(failedRows?.first?["call"] as? Int == 1)
         #expect(await counter.current() == 2)
 
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let recovered = await CodexBarCLI.cachedServeResponse(
             key: "usage:antigravity",
@@ -706,12 +707,13 @@ struct CLIServeRouterTests {
 
     @Test
     func `cost refresh timeout serves the last good payload`() async throws {
+        let wallClock = ServeTestWallClock()
         let deadline = ServeListeningSignal()
         let releaseSource = ServeListeningSignal()
         defer { releaseSource.signal() }
         let operations = CLIServeOperationCoordinator<CLIServeCoordinatedResponse>(
             sleepUntil: { _ in await deadline.wait() })
-        let cache = CLIServeResponseCache(operations: operations)
+        let cache = CLIServeResponseCache(operations: operations, wallClock: wallClock.now)
         let counter = ServeTestCounter()
 
         let first = await CodexBarCLI.cachedServeResponse(
@@ -723,10 +725,7 @@ struct CLIServeRouterTests {
             let call = await counter.increment()
             return Self.response("[{\"provider\":\"codex\",\"call\":\(call)}]")
         }
-        // Expire the fresh entry without relying on the scheduler to wake a TTL sleep promptly.
-        let cacheKey = CodexBarCLI.serveCacheKey(operationKey: "cost:", configToken: "")
-        _ = await cache.cachedResponse(for: cacheKey, now: Date().addingTimeInterval(1))
-        #expect(await cache.cachedEntryCount() == 0)
+        wallClock.advance(by: 0.01)
 
         let sourceEntered = ServeListeningSignal()
         let request = Task {
@@ -764,7 +763,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `cost refresh keeps fresh providers while replacing timed out rows`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "cost:",
@@ -779,7 +779,7 @@ struct CLIServeRouterTests {
             ]
             """)
         }
-        try? await Task.sleep(nanoseconds: 30_000_000)
+        wallClock.advance(by: 0.01)
 
         let partial = await CodexBarCLI.cachedServeResponse(
             key: "cost:",
@@ -799,7 +799,7 @@ struct CLIServeRouterTests {
         #expect(Self.row(partialRows, provider: "claude")?["call"] as? Int == 1)
         #expect(partialRows.allSatisfy { $0["error"] == nil })
 
-        try? await Task.sleep(nanoseconds: 30_000_000)
+        wallClock.advance(by: 0.01)
         let timedOut = await CodexBarCLI.cachedServeResponse(
             key: "cost:",
             cache: cache,
@@ -816,7 +816,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache replaces only failed provider account rows`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -833,7 +834,7 @@ struct CLIServeRouterTests {
             """)
         }
 
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let refreshed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -859,7 +860,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache retains newer per-row success across all-error refresh`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -874,7 +876,7 @@ struct CLIServeRouterTests {
             ]
             """)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -889,7 +891,7 @@ struct CLIServeRouterTests {
             ]
             """)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let failed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -912,7 +914,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache fails closed on timeout after merged rows`() async {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -927,7 +930,7 @@ struct CLIServeRouterTests {
             ]
             """)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -942,7 +945,7 @@ struct CLIServeRouterTests {
             ]
             """)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let timedOut = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -960,7 +963,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache fails closed on timeout after a partial refresh`() async {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -970,7 +974,7 @@ struct CLIServeRouterTests {
         {
             Self.response(#"[{"provider":"codex","call":1}]"#)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -985,7 +989,7 @@ struct CLIServeRouterTests {
             ]
             """)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let timedOut = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1047,7 +1051,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache preserves newer row when another failed row has no fallback`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1057,7 +1062,7 @@ struct CLIServeRouterTests {
         {
             Self.response(#"[{"provider":"codex","call":1}]"#)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1072,7 +1077,7 @@ struct CLIServeRouterTests {
             ]
             """)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let failed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1095,7 +1100,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache keeps fresh rows when a failed row has no stale match`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1106,7 +1112,7 @@ struct CLIServeRouterTests {
             Self.response(#"[{"provider":"codex","account":"personal","call":1}]"#)
         }
 
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let refreshed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1129,7 +1135,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache does not merge duplicate provider account labels`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1145,7 +1152,7 @@ struct CLIServeRouterTests {
             """)
         }
 
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let refreshed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1175,7 +1182,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache follows stable account identity across label changes`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1187,7 +1195,7 @@ struct CLIServeRouterTests {
                 #"[{"provider":"codex","account":"old label","call":1}]"#,
                 usageCacheKeys: ["account-1"])
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let failed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1207,7 +1215,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache does not reuse a label for a different account identity`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1219,7 +1228,7 @@ struct CLIServeRouterTests {
                 #"[{"provider":"codex","account":"shared","call":1}]"#,
                 usageCacheKeys: ["account-1"])
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let refreshed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1244,7 +1253,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache does not use whole fallback after an account switch`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1256,7 +1266,7 @@ struct CLIServeRouterTests {
                 #"[{"provider":"codex","account":"shared","call":1}]"#,
                 usageCacheKeys: ["account-1"])
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let failed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1291,7 +1301,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache prunes accounts absent from a successful snapshot`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1301,7 +1312,7 @@ struct CLIServeRouterTests {
         {
             Self.response(#"[{"provider":"codex","account":"shared","call":1}]"#)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1311,7 +1322,7 @@ struct CLIServeRouterTests {
         {
             Self.response(#"[{"provider":"antigravity","account":"work","call":2}]"#)
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let refreshed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1334,7 +1345,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache fails closed when all-error rows have ambiguous identities`() async throws {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1352,7 +1364,7 @@ struct CLIServeRouterTests {
                 """,
                 usageCacheKeys: [nil, nil, nil])
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let failed = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1389,7 +1401,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache does not whole-fallback ambiguous usage after timeout`() async {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1401,7 +1414,7 @@ struct CLIServeRouterTests {
                 #"[{"provider":"antigravity","account":"first@example.com","call":1}]"#,
                 usageCacheKeys: [nil])
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let timedOut = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1422,7 +1435,8 @@ struct CLIServeRouterTests {
 
     @Test
     func `serve cache mixed identities do not enable timeout fallback`() async {
-        let cache = CLIServeResponseCache()
+        let wallClock = ServeTestWallClock()
+        let cache = CLIServeResponseCache(wallClock: wallClock.now)
 
         _ = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1439,7 +1453,7 @@ struct CLIServeRouterTests {
                 """,
                 usageCacheKeys: ["account-1", nil])
         }
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        wallClock.advance(by: 0.05)
 
         let timedOut = await CodexBarCLI.cachedServeResponse(
             key: "usage:",
@@ -1645,6 +1659,21 @@ private actor ServeTestCounter {
 
     func current() -> Int {
         self.value
+    }
+}
+
+private final class ServeTestWallClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var date = Date(timeIntervalSince1970: 1000)
+
+    func now() -> Date {
+        self.lock.withLock { self.date }
+    }
+
+    func advance(by interval: TimeInterval) {
+        self.lock.withLock {
+            self.date = self.date.addingTimeInterval(interval)
+        }
     }
 }
 

--- a/Tests/CodexBarTests/CLIServeTestSupport.swift
+++ b/Tests/CodexBarTests/CLIServeTestSupport.swift
@@ -1,0 +1,22 @@
+import Foundation
+@testable import CodexBarCLI
+
+func makeServeTestCache() -> (ServeTestWallClock, CLIServeResponseCache) {
+    let wallClock = ServeTestWallClock()
+    return (wallClock, CLIServeResponseCache(wallClock: wallClock.now))
+}
+
+final class ServeTestWallClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var date = Date(timeIntervalSince1970: 1000)
+
+    func now() -> Date {
+        self.lock.withLock { self.date }
+    }
+
+    func advance(by interval: TimeInterval) {
+        self.lock.withLock {
+            self.date = self.date.addingTimeInterval(interval)
+        }
+    }
+}

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -154,13 +154,19 @@ struct ProviderPluginRuntimeTests {
 
     @Test
     func `HTTP request deadline cancels a transport that exceeds it`() async throws {
+        let cancellation = TransportCancellationProbe()
         let runtime = try ProviderPluginRuntime(
             source: Self.plugin(fetchBody: """
             await ctx.http.getJSON("https://api.example.test/slow", { timeoutSeconds: 1 });
             return { primary: { usedPercent: 1 } };
             """),
             transport: ProviderHTTPTransportHandler { request in
-                try await Task.sleep(for: .seconds(5))
+                do {
+                    try await Task.sleep(for: .seconds(5))
+                } catch is CancellationError {
+                    await cancellation.markCancelled()
+                    throw CancellationError()
+                }
                 let response = try #require(HTTPURLResponse(
                     url: request.url!,
                     statusCode: 200,
@@ -168,13 +174,19 @@ struct ProviderPluginRuntimeTests {
                     headerFields: ["Content-Type": "application/json"]))
                 return (Data(#"{"used":1}"#.utf8), response)
             })
-        let startedAt = ContinuousClock.now
 
-        await #expect(throws: ProviderPluginError.self) {
+        do {
             _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret-value"])
+            Issue.record("Expected the request deadline to reject the plugin fetch")
+        } catch let error as ProviderPluginError {
+            guard case .script = error else {
+                Issue.record("Expected a request deadline failure, received \(error)")
+                return
+            }
+            await cancellation.waitUntilCancelled()
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
-
-        #expect(ContinuousClock.now - startedAt < .seconds(2))
     }
 
     @Test
@@ -672,6 +684,26 @@ struct ProviderPluginRuntimeTests {
                 httpVersion: nil,
                 headerFields: ["Content-Type": "application/json"]))
             return (Data(body.utf8), response)
+        }
+    }
+}
+
+private actor TransportCancellationProbe {
+    private var cancelled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func markCancelled() {
+        self.cancelled = true
+        for waiter in self.waiters {
+            waiter.resume()
+        }
+        self.waiters.removeAll()
+    }
+
+    func waitUntilCancelled() async {
+        if self.cancelled { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
         }
     }
 }


### PR DESCRIPTION
## Summary

- inject a cache-owned wall clock so TTL transitions are deterministic in tests while production still defaults to Date()
- replace fixed TTL-settling sleeps across the CLIServe cache test class with explicit clock advancement
- replace the provider HTTP deadline test's wall-clock ceiling with an explicit transport-cancellation acknowledgment after repeated Linux x64 CI misses

## Tests

- provider HTTP deadline regression 20x
- `swift test --filter ProviderPluginRuntimeTests`
- named cost-refresh regression 10x
- `swift test --filter CLIServeRouterTests`
- `swift test --filter CLIServeTimeoutTests`
- `make check`
