### PR TITLE
Restore z.ai rate-window pace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.1 — Unreleased
 
 ### Fixed
+- z.ai: restore pace for verified 5-hour, weekly, and MCP-monthly usage windows without treating rolling 30-day limits as calendar months (#2431). Thanks @kiranmagic7!
 - Codex: publish refreshed core quota immediately while optional Credits and OpenAI Web enrichment continues, without unfreezing cards whose layout still needs reconciliation (#2799). Thanks @Yuxin-Qiao!
 - Menu bar: keep DeepSeek balances compact and consistent between saved custom layouts and their live editor preview (#2638). Thanks @Yuxin-Qiao!
 - Settings: show CodexBar in the Dock while Settings or an update dialog is open, so Check for Updates and new-version prompts reliably appear in front.

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -150,6 +150,7 @@ public enum ProviderPaceDurationRule: Sendable {
     case unsupported
     case windowDurationMissing
     case windowDuration(minutes: Int)
+    case custom(@Sendable (_ window: RateWindow) -> Bool)
 
     public func matches(window: RateWindow) -> Bool {
         switch self {
@@ -159,6 +160,8 @@ public enum ProviderPaceDurationRule: Sendable {
             window.windowMinutes == nil
         case let .windowDuration(minutes):
             window.windowMinutes == minutes
+        case let .custom(predicate):
+            predicate(window)
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
@@ -92,6 +92,14 @@ public enum ZaiProviderDescriptor {
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "z.ai cost summary is not supported." }),
+            pace: ProviderPaceCapability(
+                resetWindowPace: .windowDuration(
+                    minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
+                inferredMonthlyDuration: .windowDuration(
+                    minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
+                primary: .exact(kind: .session, minutes: 5 * 60),
+                secondary: .exact(kind: .weekly, minutes: 7 * 24 * 60),
+                sessionPaceWindowRule: .windowDuration(minutes: 5 * 60)),
             presentation: ProviderUsagePresentation(
                 extraRateWindowSelector: { snapshot in
                     (snapshot.extraRateWindows ?? []).filter { $0.id == "zai-mcp" }

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
@@ -93,10 +93,12 @@ public enum ZaiProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "z.ai cost summary is not supported." }),
             pace: ProviderPaceCapability(
-                resetWindowPace: .windowDuration(
-                    minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
-                inferredMonthlyDuration: .windowDuration(
-                    minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
+                resetWindowPace: .custom { window, _ in
+                    Self.isMonthlyMCPWindow(window)
+                },
+                inferredMonthlyDuration: .custom { window in
+                    Self.isMonthlyMCPWindow(window)
+                },
                 primary: .exact(kind: .session, minutes: 5 * 60),
                 secondary: .exact(kind: .weekly, minutes: 7 * 24 * 60),
                 sessionPaceWindowRule: .windowDuration(minutes: 5 * 60)),
@@ -116,6 +118,11 @@ public enum ZaiProviderDescriptor {
                 name: "zai",
                 aliases: ["z.ai"],
                 versionDetector: nil))
+    }
+
+    private static func isMonthlyMCPWindow(_ window: RateWindow) -> Bool {
+        window.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes
+            && window.resetDescription == "MCP"
     }
 
     private static func fetchPlan() -> ProviderFetchPlan {

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -87,7 +87,11 @@ defineProvider({
     }
     function window(limit) {
       const result = { usedPercent: limit.percent };
-      if ((limit.raw.type === "TOKENS_LIMIT" || limit.raw.type === "CREDIT_LIMIT") && limit.windowMinutes !== null) {
+      if (limit.raw.type === "TIME_LIMIT") {
+        const isMonthlyMCPMarker = limit.raw.unit === 5 && limit.raw.number === 1;
+        if (isMonthlyMCPMarker) result.windowMinutes = 30 * 24 * 60;
+        else if (limit.windowMinutes !== null) result.windowMinutes = limit.windowMinutes;
+      } else if (limit.windowMinutes !== null) {
         result.windowMinutes = limit.windowMinutes;
       }
       if (limit.reset !== null) result.resetsAt = ctx.date.unixMillis(limit.reset);

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -680,6 +680,34 @@ struct CLISnapshotTests {
     }
 
     @Test
+    func `zai CLI pace rejects a rolling 30-day coding limit`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = UsageSnapshot(
+            primary: .init(
+                usedPercent: 50,
+                windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
+                resetsAt: now.addingTimeInterval(15 * 24 * 60 * 60),
+                resetDescription: "30 days window"),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: now)
+
+        #expect(CLIRenderer.providerPacePayload(provider: .zai, snapshot: snapshot, now: now) == nil)
+
+        let output = CLIRenderer.renderText(
+            provider: .zai,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "z.ai",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown),
+            now: now)
+        #expect(!output.contains("Pace:"))
+    }
+
+    @Test
     func `Kimi CLI pace rejects missing and unsupported window durations`() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         for duration: Int? in [nil, 24 * 60, 30 * 24 * 60] {

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -646,6 +646,40 @@ struct CLISnapshotTests {
     }
 
     @Test
+    func `zai routes verified coding windows to CLI pace`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = UsageSnapshot(
+            primary: .init(
+                usedPercent: 50,
+                windowMinutes: 5 * 60,
+                resetsAt: now.addingTimeInterval(2.5 * 60 * 60),
+                resetDescription: "5-hour"),
+            secondary: .init(
+                usedPercent: 50,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(3.5 * 24 * 60 * 60),
+                resetDescription: "weekly"),
+            tertiary: nil,
+            updatedAt: now)
+
+        let pace = try #require(CLIRenderer.providerPacePayload(provider: .zai, snapshot: snapshot, now: now))
+        #expect(pace.primary?.expectedUsedPercent == 50)
+        #expect(pace.secondary?.expectedUsedPercent == 50)
+
+        let output = CLIRenderer.renderText(
+            provider: .zai,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "z.ai",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown),
+            now: now)
+        #expect(output.split(separator: "\n").count(where: { $0.contains("Pace: On pace") }) == 2)
+    }
+
+    @Test
     func `Kimi CLI pace rejects missing and unsupported window durations`() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         for duration: Int? in [nil, 24 * 60, 30 * 24 * 60] {
@@ -968,11 +1002,11 @@ struct CLISnapshotTests {
             updatedAt: now)
 
         let output = CLIRenderer.renderText(
-            provider: .zai,
+            provider: .deepseek,
             snapshot: snap,
             credits: nil,
             context: RenderContext(
-                header: "z.ai 0.0.0 (zai)",
+                header: "DeepSeek 0.0.0 (deepseek)",
                 status: nil,
                 useColor: false,
                 resetStyle: .countdown))
@@ -1159,19 +1193,19 @@ struct CLISnapshotTests {
             tertiary: nil,
             updatedAt: now)
 
-        // z.ai is not a session/weekly pace provider, so no pace should be emitted.
+        // DeepSeek has no descriptor pace capability, so no pace should be emitted.
         let payload = ProviderPayload(
-            provider: .zai,
+            provider: .deepseek,
             account: nil,
             version: nil,
-            source: "zai",
+            source: "deepseek",
             status: nil,
             usage: snap,
             credits: nil,
             antigravityPlanInfo: nil,
             openaiDashboard: nil,
             error: nil,
-            pace: CLIRenderer.providerPacePayload(provider: .zai, snapshot: snap, now: now))
+            pace: CLIRenderer.providerPacePayload(provider: .deepseek, snapshot: snap, now: now))
 
         let data = try JSONEncoder().encode(payload)
         let json = try #require(String(data: data, encoding: .utf8))

--- a/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
@@ -22,6 +22,10 @@ struct ProviderPaceCapabilityTests {
             Self.window(
                 minutes: Self.monthlyWindowSentinelMinutes,
                 resetsAt: now.addingTimeInterval(20 * 24 * 60 * 60)),
+            Self.window(
+                minutes: Self.monthlyWindowSentinelMinutes,
+                resetsAt: now.addingTimeInterval(20 * 24 * 60 * 60),
+                resetDescription: "MCP"),
             Self.window(minutes: 0, resetsAt: now.addingTimeInterval(60)),
             Self.window(minutes: Self.weeklyWindowMinutes, resetsAt: now.addingTimeInterval(-60)),
         ]
@@ -96,6 +100,14 @@ struct ProviderPaceCapabilityTests {
             minutes: Self.weeklyWindowMinutes,
             resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60))
         let unknown = Self.window(minutes: nil, resetsAt: now.addingTimeInterval(2 * 60 * 60))
+        let monthlyMCP = Self.window(
+            minutes: Self.monthlyWindowSentinelMinutes,
+            resetsAt: now.addingTimeInterval(20 * 24 * 60 * 60),
+            resetDescription: "MCP")
+        let rollingThirtyDay = Self.window(
+            minutes: Self.monthlyWindowSentinelMinutes,
+            resetsAt: now.addingTimeInterval(20 * 24 * 60 * 60),
+            resetDescription: "30 days window")
 
         #expect(capability.resolvedKind(slot: .primary, window: session, now: now) == .session)
         #expect(capability.resolvedKind(slot: .secondary, window: weekly, now: now) == .weekly)
@@ -103,14 +115,24 @@ struct ProviderPaceCapabilityTests {
         #expect(capability.resolvedKind(slot: .secondary, window: session, now: now) == nil)
         #expect(capability.supportsSessionPace(window: session, now: now))
         #expect(!capability.supportsSessionPace(window: unknown, now: now))
+        #expect(capability.supportsResetWindowPace(window: monthlyMCP, now: now))
+        #expect(capability.usesInferredMonthlyDuration(window: monthlyMCP))
+        #expect(!capability.supportsResetWindowPace(window: rollingThirtyDay, now: now))
+        #expect(!capability.usesInferredMonthlyDuration(window: rollingThirtyDay))
+        #expect(capability.resolvedKind(slot: .primary, window: rollingThirtyDay, now: now) == nil)
+        #expect(capability.resolvedResetWindowForPace(rollingThirtyDay) == rollingThirtyDay)
     }
 
-    private static func window(minutes: Int?, resetsAt: Date?) -> RateWindow {
+    private static func window(
+        minutes: Int?,
+        resetsAt: Date?,
+        resetDescription: String? = nil) -> RateWindow
+    {
         RateWindow(
             usedPercent: 50,
             windowMinutes: minutes,
             resetsAt: resetsAt,
-            resetDescription: nil)
+            resetDescription: resetDescription)
     }
 
     /// Expected provider-specific reset-window behavior, including newly declared capabilities.
@@ -135,8 +157,10 @@ struct ProviderPaceCapabilityTests {
                 && timeUntilReset <= TimeInterval(windowMinutes) * 60
         case .kimi:
             return window.windowMinutes == self.weeklyWindowMinutes
-        case .alibaba, .alibabatokenplan, .amp, .commandcode, .doubao, .mimo, .notion, .opencodego, .stepfun,
-             .zai:
+        case .zai:
+            return window.windowMinutes == self.monthlyWindowSentinelMinutes
+                && window.resetDescription == "MCP"
+        case .alibaba, .alibabatokenplan, .amp, .commandcode, .doubao, .mimo, .notion, .opencodego, .stepfun:
             return window.windowMinutes == self.monthlyWindowSentinelMinutes
         default:
             return false
@@ -150,8 +174,10 @@ struct ProviderPaceCapabilityTests {
         switch provider {
         case .copilot:
             window.windowMinutes == nil
-        case .alibaba, .alibabatokenplan, .amp, .commandcode, .doubao, .mimo, .notion, .opencodego, .stepfun,
-             .zai:
+        case .zai:
+            window.windowMinutes == self.monthlyWindowSentinelMinutes
+                && window.resetDescription == "MCP"
+        case .alibaba, .alibabatokenplan, .amp, .commandcode, .doubao, .mimo, .notion, .opencodego, .stepfun:
             window.windowMinutes == self.monthlyWindowSentinelMinutes
         default:
             false

--- a/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
+++ b/Tests/CodexBarTests/ProviderPaceCapabilityTests.swift
@@ -87,6 +87,24 @@ struct ProviderPaceCapabilityTests {
         #expect(resolved.usedPercent == window.usedPercent)
     }
 
+    @Test
+    func `zai pace maps only verified coding windows`() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        let capability = ZaiProviderDescriptor.descriptor.pace
+        let session = Self.window(minutes: 5 * 60, resetsAt: now.addingTimeInterval(2 * 60 * 60))
+        let weekly = Self.window(
+            minutes: Self.weeklyWindowMinutes,
+            resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60))
+        let unknown = Self.window(minutes: nil, resetsAt: now.addingTimeInterval(2 * 60 * 60))
+
+        #expect(capability.resolvedKind(slot: .primary, window: session, now: now) == .session)
+        #expect(capability.resolvedKind(slot: .secondary, window: weekly, now: now) == .weekly)
+        #expect(capability.resolvedKind(slot: .primary, window: weekly, now: now) == nil)
+        #expect(capability.resolvedKind(slot: .secondary, window: session, now: now) == nil)
+        #expect(capability.supportsSessionPace(window: session, now: now))
+        #expect(!capability.supportsSessionPace(window: unknown, now: now))
+    }
+
     private static func window(minutes: Int?, resetsAt: Date?) -> RateWindow {
         RateWindow(
             usedPercent: 50,
@@ -117,7 +135,8 @@ struct ProviderPaceCapabilityTests {
                 && timeUntilReset <= TimeInterval(windowMinutes) * 60
         case .kimi:
             return window.windowMinutes == self.weeklyWindowMinutes
-        case .alibaba, .alibabatokenplan, .amp, .commandcode, .doubao, .mimo, .notion, .opencodego, .stepfun:
+        case .alibaba, .alibabatokenplan, .amp, .commandcode, .doubao, .mimo, .notion, .opencodego, .stepfun,
+             .zai:
             return window.windowMinutes == self.monthlyWindowSentinelMinutes
         default:
             return false
@@ -131,7 +150,8 @@ struct ProviderPaceCapabilityTests {
         switch provider {
         case .copilot:
             window.windowMinutes == nil
-        case .alibaba, .alibabatokenplan, .amp, .commandcode, .doubao, .mimo, .notion, .opencodego, .stepfun:
+        case .alibaba, .alibabatokenplan, .amp, .commandcode, .doubao, .mimo, .notion, .opencodego, .stepfun,
+             .zai:
             window.windowMinutes == self.monthlyWindowSentinelMinutes
         default:
             false

--- a/Tests/CodexBarTests/ProviderPresentationPolicyCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ProviderPresentationPolicyCharacterizationTests.swift
@@ -114,7 +114,8 @@ struct ProviderPresentationPolicyCharacterizationTests {
             (.notion, nil, false),
             (.notion, 360, true),
             (.notion, 361, false),
-            (.zai, 300, false),
+            (.zai, 300, true),
+            (.zai, 301, false),
         ]
 
         for (provider, minutes, expected) in fixtures {

--- a/Tests/CodexBarTests/UsagePaceTextTests.swift
+++ b/Tests/CodexBarTests/UsagePaceTextTests.swift
@@ -378,9 +378,23 @@ struct UsagePaceTextTests {
             resetsAt: now.addingTimeInterval(2 * 3600),
             resetDescription: nil)
 
-        let detail = UsagePaceText.sessionDetail(provider: .zai, window: window, now: now)
+        let detail = UsagePaceText.sessionDetail(provider: .deepseek, window: window, now: now)
 
         #expect(detail == nil)
+    }
+
+    @Test
+    func `session pace detail shows for zai five-hour window`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 50,
+            windowMinutes: 300,
+            resetsAt: now.addingTimeInterval(2 * 3600),
+            resetDescription: nil)
+
+        let detail = UsagePaceText.sessionDetail(provider: .zai, window: window, now: now)
+
+        #expect(detail != nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/ZaiProviderTests.swift
+++ b/Tests/CodexBarTests/ZaiProviderTests.swift
@@ -119,26 +119,30 @@ struct ZaiProviderTests {
 
     @Test
     func `plugin maps quota and model usage into stable generic details`() async throws {
-        let transport = ProviderHTTPTransportHandler { request in
-            let body = request.url?.path.hasSuffix("/quota/limit") == true
-                ? Self.quotaFixture
-                : Self.modelUsageFixture
-            return try Self.response(request: request, body: body)
-        }
-        let snapshot = try await ProviderPluginRuntime(bundledPlugin: "zai", transport: transport).fetchUsage(
-            settings: [
-                "Z_AI_REGION": "global",
-                "Z_AI_USAGE_SCOPE": "personal",
-            ],
-            secrets: ["Z_AI_API_KEY": "fixture-key"],
-            now: Date(timeIntervalSince1970: 1_785_816_000))
+        let snapshot = try await Self.pluginSnapshot(quotaFixture: Self.quotaFixture)
 
         #expect(snapshot.primary?.usedPercent == 25)
         #expect(snapshot.primary?.windowMinutes == 300)
         #expect(snapshot.secondary?.usedPercent == 9)
         #expect(snapshot.extraRateWindows?.first?.id == "zai-mcp")
+        #expect(snapshot.extraRateWindows?.first?.window.windowMinutes ==
+            ProviderPaceCapability.monthlyWindowSentinelMinutes)
         #expect(snapshot.identity?.loginMethod == "Pro")
         #expect(snapshot.details.map(\.title) == ["Quota details", "Hourly tokens", "Daily tokens"])
+    }
+
+    @Test
+    func `plugin preserves explicit MCP duration`() async throws {
+        let snapshot = try await Self.pluginSnapshot(quotaFixture: Self.explicitTimeLimitFixture)
+
+        #expect(snapshot.extraRateWindows?.first?.window.windowMinutes == 5 * 60)
+    }
+
+    @Test
+    func `plugin leaves unknown MCP cadence unset`() async throws {
+        let snapshot = try await Self.pluginSnapshot(quotaFixture: Self.unknownTimeLimitFixture)
+
+        #expect(snapshot.extraRateWindows?.first?.window.windowMinutes == nil)
     }
 
     @Test
@@ -177,12 +181,42 @@ struct ZaiProviderTests {
         return (Data(body.utf8), response)
     }
 
+    private static func pluginSnapshot(quotaFixture: String) async throws -> UsageSnapshot {
+        let transport = ProviderHTTPTransportHandler { request in
+            let body = request.url?.path.hasSuffix("/quota/limit") == true
+                ? quotaFixture
+                : Self.modelUsageFixture
+            return try Self.response(request: request, body: body)
+        }
+        return try await ProviderPluginRuntime(bundledPlugin: "zai", transport: transport).fetchUsage(
+            settings: [
+                "Z_AI_REGION": "global",
+                "Z_AI_USAGE_SCOPE": "personal",
+            ],
+            secrets: ["Z_AI_API_KEY": "fixture-key"],
+            now: Date(timeIntervalSince1970: 1_785_816_000))
+    }
+
     private static let quotaFixture = #"""
     {"code":200,"msg":"success","success":true,"data":{"planName":"Pro","limits":[
       {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":25,"nextResetTime":1785816000000},
       {"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":9,"nextResetTime":1786291200000},
       {"type":"TIME_LIMIT","unit":5,"number":1,"usage":1000,"currentValue":224,"remaining":776,
        "percentage":22,"usageDetails":[{"modelCode":"search-prime","usage":210}]}
+    ]}}
+    """#
+
+    private static let explicitTimeLimitFixture = #"""
+    {"code":200,"msg":"success","success":true,"data":{"limits":[
+      {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":25,"nextResetTime":1785816000000},
+      {"type":"TIME_LIMIT","unit":3,"number":5,"percentage":22,"nextResetTime":1785816000000}
+    ]}}
+    """#
+
+    private static let unknownTimeLimitFixture = #"""
+    {"code":200,"msg":"success","success":true,"data":{"limits":[
+      {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":25,"nextResetTime":1785816000000},
+      {"type":"TIME_LIMIT","unit":0,"number":1,"percentage":22,"nextResetTime":1785816000000}
     ]}}
     """#
 

--- a/Tests/CodexBarTests/ZaiProviderTests.swift
+++ b/Tests/CodexBarTests/ZaiProviderTests.swift
@@ -145,6 +145,19 @@ struct ZaiProviderTests {
         #expect(snapshot.extraRateWindows?.first?.window.windowMinutes == nil)
     }
 
+    @Test(arguments: ["TOKENS_LIMIT", "CREDIT_LIMIT"])
+    func `plugin preserves rolling 30-day limits without MCP semantics`(limitType: String) async throws {
+        let fixture = #"""
+        {"code":200,"msg":"success","success":true,"data":{"limits":[
+          {"type":"\#(limitType)","unit":1,"number":30,"percentage":50,"nextResetTime":1787112000000}
+        ]}}
+        """#
+        let snapshot = try await Self.pluginSnapshot(quotaFixture: fixture)
+
+        #expect(snapshot.primary?.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
+        #expect(snapshot.primary?.resetDescription == "30 days window")
+    }
+
     @Test
     func `provider metadata keeps regional dashboards`() {
         let descriptor = ProviderDescriptorRegistry.descriptor(for: .zai)


### PR DESCRIPTION
Addresses the remaining z.ai regression in #2431.

The JavaScript provider migration kept computing `TIME_LIMIT` durations but stopped exporting them. That dropped the established monthly MCP marker and left the z.ai descriptor without its verified 5-hour and weekly pace lanes.

This restores the one-minute MCP marker as the existing calendar-month sentinel, preserves explicit `TIME_LIMIT` durations, leaves unknown cadence unset, and enables pace only for the verified 5-hour and weekly slots. Monthly inference also requires the adapter's MCP marker, so an explicit rolling 30-day token or credit window retains its duration without being rewritten as a calendar month.

Verification:
- `CI=1 CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --disable-keychain --disable-netrc --filter "ZaiProviderTests|ProviderPaceCapabilityTests|CLISnapshotTests|ProviderPresentationPolicyCharacterizationTests|UsagePaceTextTests|ZaiMenuCardTests|MenuBarPaceTextTests"` — 98 tests passed
- `CI=1 CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 ./Scripts/test-plugin-engines.sh` — 76 tests passed under QuickJS and 76 under JavaScriptCore
- `make check` — passed
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make test` — all 833 selections passed in 70 groups; no retries or timeouts
- `git diff --check origin/main...HEAD` — passed
- Final Codex autoreview — no accepted/actionable findings
- `swift build -c release --product CodexBarCLI` — passed

## Real provider proof

A maintainer-owned z.ai QA credential was injected at runtime through the approved 1Password service-account path; the key value, account identity, and usage percentages were never printed or added to the PR. The same command was run before and after the patch.

- Current-main behavior: source `api`; real primary window `5-hour`; `windowMinutes: 300`; reset present; **no pace object**.
- PR behavior: source `api`; the same `5-hour` / 300-minute/reset-bearing window; **`pace.primary` present**; no provider error.

This directly exercises the reported real-provider regression while confirming that authentication and window selection remain unchanged.

Compatibility risk is low: token and credit parsing is unchanged, explicit rolling cadences are preserved, and unknown MCP cadence remains fail-closed.

Review focus: the one-minute marker mapping, the MCP-only monthly discriminator, and the exact z.ai descriptor lane rules.

