### PR TITLE
fix: stop the cost store's executor assumption trapping on macOS 26+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fireworks: track 30-day rated billing spend with an API key and account slug (#2687). Thanks @x0mh0x!
 
 ### Fixed
+- Cost store: give the store actor's custom serial executor an `isIsolatingCurrentContext()` implementation — macOS 26+ runtimes consult it before `checkIsolated()`, and its default cannot see through `DispatchQueue.sync`, so every synchronous store bridge tripped "Incorrect actor executor assumption" and the app died on launch.
 - Codex: reject Standard/Fast pricing rows that exceed canonical fork-deduplicated usage, preventing copied fork rows and their Fast surcharge from inflating cost estimates (#2754). Thanks @1328189205 for the report and @Yuxin-Qiao for the initial fix and regression-test approach!
 - Claude: stop rotating Claude Code's own refresh-token chain on keychain-only installs — ownership evidence is now tri-state with indeterminate treated as CLI-owned, so delegated refreshes can never invalidate credentials CodexBar cannot read (#2745, refs #2634). Thanks @avenoxai!
 - Plugins: run the QuickJS worker and TypeScript transpiler on Thread subclasses instead of Thread(block:) closures — binaries built with the Xcode 26.3 SDK inferred @MainActor on those blocks, and macOS runtimes that enforce dynamic isolation crashed (SIGTRAP) on the first plugin fetch; this was the deterministic macOS CI shard crash since #2775 and could crash shipped builds at runtime.

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore.swift
@@ -13,9 +13,11 @@ import CSQLite3
 actor CostUsageStore {
     private final class StoreSerialExecutor: SerialExecutor, @unchecked Sendable {
         private let queue: DispatchQueue
+        private static let queueKey = DispatchSpecificKey<ObjectIdentifier>()
 
         init(label: String) {
             self.queue = DispatchQueue(label: label, qos: .utility)
+            self.queue.setSpecific(key: Self.queueKey, value: ObjectIdentifier(self))
         }
 
         func enqueue(_ job: consuming ExecutorJob) {
@@ -28,6 +30,15 @@ actor CostUsageStore {
 
         func checkIsolated() {
             dispatchPrecondition(condition: .onQueue(self.queue))
+        }
+
+        /// macOS 26+ runtimes ask this before falling back to `checkIsolated()`, and the
+        /// default implementation cannot see through `DispatchQueue.sync` — so every
+        /// `assumeIsolated` in the sync bridges below trapped on launch even though the
+        /// work really was on this queue. A queue-specific token answers accurately.
+        @available(macOS 26.0, *)
+        func isIsolatingCurrentContext() -> Bool? {
+            DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self)
         }
 
         func sync<T>(_ operation: () throws -> T) rethrows -> T {

--- a/Tests/CodexBarTests/CostUsageStoreTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreTests.swift
@@ -9,6 +9,48 @@ import CSQLite3
 #endif
 
 struct CostUsageStoreTests {
+    /// The store actor runs on a custom DispatchQueue-backed `SerialExecutor`, and its
+    /// `sync*` bridges call `assumeIsolated` from inside `queue.sync`. macOS 26+ runtimes
+    /// verify that through `SerialExecutor.isIsolatingCurrentContext()`, whose default
+    /// implementation cannot see through `DispatchQueue.sync` — without an explicit
+    /// implementation the bridge traps ("Incorrect actor executor assumption") and the app
+    /// dies on launch.
+    ///
+    /// This covers the bridges from a non-actor thread. Note it does not by itself
+    /// reproduce the trap: whether `assumeIsolated` traps depends on the calling context's
+    /// current executor, and no test-harness context reproduced it (plain thread, Task, and
+    /// MainActor were all tried). The regression was verified against the app itself —
+    /// it died on launch with "Incorrect actor executor assumption" and starts cleanly now.
+    @Test
+    func `sync bridges are callable from a plain thread`() throws {
+        let fixture = try StoreFixture()
+        defer { fixture.remove() }
+        let store = CostUsageStore(cacheRoot: fixture.root)
+
+        final class Outcome: @unchecked Sendable {
+            var loadedScanStamp: Int64?
+            var savedRowCount: Int?
+        }
+        let outcome = Outcome()
+        let finished = DispatchSemaphore(value: 0)
+
+        let thread = Thread {
+            let loaded = store.syncLoadCodexCache(calendar: .current)
+            outcome.loadedScanStamp = loaded.lastScanUnixMs
+            let saved = store.syncSaveCodexCache(
+                loaded,
+                calendar: .current,
+                requestedScanWindow: (sinceKey: "2026-08-01", untilKey: "2026-08-03"))
+            outcome.savedRowCount = saved.rowCount
+            finished.signal()
+        }
+        thread.start()
+
+        #expect(finished.wait(timeout: .now() + 10) == .success)
+        #expect(outcome.loadedScanStamp == 0)
+        #expect((outcome.savedRowCount ?? -1) >= 0)
+    }
+
     @Test
     func `database lives beside the legacy artifact directory`() throws {
         let fixture = try StoreFixture()


### PR DESCRIPTION
## Summary

CodexBar died on launch on macOS 26 and 27 with:

```
CostUsageStore.swift:117: Fatal error: Incorrect actor executor assumption;
Expected same executor as CodexBarCore.CostUsageStore.
```

`CostUsageStore` is an actor running on a custom `DispatchQueue`-backed `SerialExecutor`, and its `sync*` bridges call `assumeIsolated` from inside `queue.sync`. The executor implemented `checkIsolated()`, which satisfied older runtimes. Swift 6.2+ runtimes consult the newer `SerialExecutor.isIsolatingCurrentContext()` **first**, and the stdlib's default implementation cannot see through `DispatchQueue.sync` — so the assumption failed even though the work genuinely was on the store's queue.

The fix tags the queue with a `DispatchSpecificKey` and answers from it, gated `@available(macOS 26.0, *)`. The macOS 14 deployment target is unaffected; older runtimes keep using `checkIsolated()`.

## Why this matters

`assumeIsolated` traps in **release** builds too, so this was not debug-only — it would take down shipped builds on macOS 26, which is already GA. CI did not catch it because the *runtime*, not the compiler, decides which verification path is taken.

This is the same class of macOS-26+ platform change as the QuickJS/`@MainActor` crash fixed earlier in this release.

## Testing

- `swift test --filter CostUsageStore` — 78 tests across 5 suites pass.
- Crash report before the fix confirms the path: `OS_dispatch_queue.sync` → `closure #1 in CostUsageStore.syncLoadCodexCache` → `Actor.assumeIsolated` → `_assertionFailure`.
- App verified by launch: it died immediately before the change and now starts and stays up with zero fatal errors.

## A caveat on the added test, stated plainly

The new test exercises both sync bridges from a non-actor thread, which is real coverage of that path, but **it does not by itself reproduce the trap**. Whether `assumeIsolated` traps depends on the calling context's current executor, and no test-harness context reproduced it — a plain `Thread`, a normal `@Test` (which runs inside a Task), and `@MainActor` all passed with the fix reverted. It is committed as a contract/documentation test, not as proof. The regression proof is the app launch plus the crash report above.
