### PR TITLE
Fix PTY overflow abort latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fireworks: track 30-day rated billing spend with an API key and account slug (#2687). Thanks @x0mh0x!
 
 ### Fixed
+- PTY probes: abort output-overflow children through a bounded process-group kill path, avoiding minute-long cleanup stalls under load (refs #2792).
 - Codex: reject Standard/Fast pricing rows that exceed canonical fork-deduplicated usage, preventing copied fork rows and their Fast surcharge from inflating cost estimates (#2754). Thanks @1328189205 for the report and @Yuxin-Qiao for the initial fix and regression-test approach!
 - Claude: stop rotating Claude Code's own refresh-token chain on keychain-only installs — ownership evidence is now tri-state with indeterminate treated as CLI-owned, so delegated refreshes can never invalidate credentials CodexBar cannot read (#2745, refs #2634). Thanks @avenoxai!
 - Plugins: run the QuickJS worker and TypeScript transpiler on Thread subclasses instead of Thread(block:) closures — binaries built with the Xcode 26.3 SDK inferred @MainActor on those blocks, and macOS runtimes that enforce dynamic isolation crashed (SIGTRAP) on the first plugin fetch; this was the deterministic macOS CI shard crash since #2775 and could crash shipped builds at runtime.

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -661,13 +661,14 @@ public struct TTYCommandRunner {
 
         var cleanedUp = false
         var launchedProcess: SpawnedProcessGroup?
+        var didExceedOutputLimit = false
         /// Always tear down the PTY child (and its process group) even if we throw early
         /// while bootstrapping the CLI (e.g. when it prompts for login/telemetry).
         func cleanup() {
             guard !cleanedUp else { return }
             cleanedUp = true
 
-            if let launchedProcess, launchedProcess.isRunning {
+            if !didExceedOutputLimit, let launchedProcess, launchedProcess.isRunning {
                 Self.log.debug("PTY stopping", metadata: ["binary": binaryName])
                 let exitData = Data("/exit\n".utf8)
                 try? writeAllToPrimary(exitData)
@@ -679,8 +680,16 @@ public struct TTYCommandRunner {
                 try? primaryHandle.close()
                 return
             }
-            launchedProcess.terminateSynchronously()
-            try? primaryHandle.close()
+            if didExceedOutputLimit {
+                // Once the bounded buffer overflows, do not spend seconds sweeping every process's
+                // descriptors before signaling. Closing the master unblocks a child stuck writing,
+                // and the scoped abort escalates within its fixed grace window.
+                try? primaryHandle.close()
+                launchedProcess.abortSynchronously()
+            } else {
+                launchedProcess.terminateSynchronously()
+                try? primaryHandle.close()
+            }
             TTYCommandRunnerActiveProcessRegistry.unregister(pid: launchedProcess.pid)
         }
 
@@ -741,7 +750,6 @@ public struct TTYCommandRunner {
         let isCodexStatus = isCodex && trimmed == (ttyStatusCommand ?? "/status")
 
         var buffer = BoundedOutputBuffer()
-        var didExceedOutputLimit = false
 
         func checkOutputLimit() throws {
             if didExceedOutputLimit {

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -590,6 +590,35 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         return self.finishSynchronously()
     }
 
+    /// Abort a process whose output channel is no longer safe to inspect.
+    ///
+    /// Unlike normal cleanup, this deliberately avoids the system-wide output-holder scan. The caller closes
+    /// the output descriptor first, then this method targets only the launch process tree and dedicated process
+    /// group so TERM-to-KILL escalation remains bounded even when process enumeration is slow under load.
+    @discardableResult
+    package func abortSynchronously(grace: TimeInterval = 0.4) -> Int32? {
+        let grace = max(0, grace)
+        let termDeadline = Date().addingTimeInterval(grace)
+        var processIdentities = self.currentAbortProcessIdentities()
+
+        self.signalOwnedProcessGroup(SIGTERM)
+        Self.signal(processIdentities: processIdentities, signal: SIGTERM)
+
+        while self.abortTargetsRemain(processIdentities), Date() < termDeadline {
+            usleep(20000)
+        }
+
+        processIdentities.formUnion(self.currentAbortProcessIdentities())
+        self.signalOwnedProcessGroup(SIGKILL)
+        Self.signal(processIdentities: processIdentities, signal: SIGKILL)
+
+        let killDeadline = Date().addingTimeInterval(grace)
+        while self.abortTargetsRemain(processIdentities), Date() < killDeadline {
+            usleep(20000)
+        }
+        return self.finishSynchronously()
+    }
+
     @discardableResult
     package func finishSynchronously(timeout: TimeInterval = 1) -> Int32? {
         self.termination.requestReap()
@@ -751,6 +780,35 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
                     .compactMap(TTYProcessTreeTerminator.processIdentity(for:)))
         }
         return identities
+    }
+
+    private func currentAbortProcessIdentities() -> Set<TTYProcessTreeTerminator.ProcessIdentity> {
+        var identities = self.observedProcessGroupMembers.snapshot
+        identities.formUnion(self.currentProcessGroupMemberIdentities())
+        guard let rootIdentity = self.rootIdentity,
+              TTYProcessTreeTerminator.isCurrent(rootIdentity)
+        else {
+            return identities
+        }
+
+        identities.insert(rootIdentity)
+        identities.formUnion(
+            TTYProcessTreeTerminator.descendantPIDs(of: self.pid)
+                .compactMap(TTYProcessTreeTerminator.processIdentity(for:)))
+        return identities
+    }
+
+    private func signalOwnedProcessGroup(_ signal: Int32) {
+        guard let rootIdentity = self.rootIdentity,
+              TTYProcessTreeTerminator.isCurrent(rootIdentity)
+        else { return }
+        _ = kill(-self.processGroup, signal)
+    }
+
+    private func abortTargetsRemain(
+        _ processIdentities: Set<TTYProcessTreeTerminator.ProcessIdentity>) -> Bool
+    {
+        processIdentities.contains(where: TTYProcessTreeTerminator.isCurrent(_:)) || self.hasResidualProcessGroup
     }
 
     private func currentOutputHolderIdentities() -> Set<TTYProcessTreeTerminator.ProcessIdentity> {


### PR DESCRIPTION
## Summary

- close the PTY master immediately when bounded output overflows, unblocking writers before process cleanup
- abort through a scoped process-tree/process-group path with 400 ms TERM-to-KILL escalation instead of the system-wide descriptor sweep
- preserve the exhaustive escaped-output-holder cleanup for normal PTY completion and document the release fix

## Root cause

The overflow error was detected promptly, but deferred cleanup reused the normal termination path. That path scans every process and file descriptor for PTY holders before SIGTERM and repeats the scan before SIGKILL. Under load, those two scans delayed signaling and return by tens of seconds; instrumentation measured 6.64 seconds before SIGTERM plus another 4.98 seconds after the child had already exited on this machine.

## Proof

- five consecutive overflow proof runs: 3.198s, 2.945s, 4.116s, 3.401s, 4.472s
- `swift test --filter 'BoundedChildProcess|ProcessPipeCapture|CLICardsClaudeSwap'`: 29 tests green
- `make test`: all 70 sharded groups completed without a timeout
- `make check`: green, including SwiftFormat and SwiftLint with zero violations
- autoreview: clean, no accepted/actionable findings

Release-blocking; refs #2792.
