### PR TITLE
fix: drain PTY output after process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - PTY probes: abort output-overflow children through a bounded process-group kill path, avoiding minute-long cleanup stalls under load (refs #2792).
+- PTY runner: drain short-lived commands to terminal closure after exit, preventing false empty probe results when output is still buffered.
 - Cost store: give the store actor's custom serial executor an `isIsolatingCurrentContext()` implementation — macOS 26+ runtimes consult it before `checkIsolated()`, and its default cannot see through `DispatchQueue.sync`, so every synchronous store bridge tripped "Incorrect actor executor assumption" and the app died on launch.
 - Codex: reject Standard/Fast pricing rows that exceed canonical fork-deduplicated usage, preventing copied fork rows and their Fast surcharge from inflating cost estimates (#2754). Thanks @1328189205 for the report and @Yuxin-Qiao for the initial fix and regression-test approach!
 - Claude: stop rotating Claude Code's own refresh-token chain on keychain-only installs — ownership evidence is now tri-state with indeterminate treated as CLI-owned, so delegated refreshes can never invalidate credentials CodexBar cannot read (#2745, refs #2634). Thanks @avenoxai!

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -273,6 +273,7 @@ private enum TTYCommandRunnerTestingOverrides {
 /// Keeps it minimal so we can reuse for Codex and Claude without tmux.
 public struct TTYCommandRunner {
     private static let log = CodexBarLog.logger(LogCategories.ttyRunner)
+    private static let postExitDrainTimeout: TimeInterval = 1
 
     public struct Result: Sendable {
         public enum Completion: Sendable, Equatable {
@@ -472,20 +473,25 @@ public struct TTYCommandRunner {
         return out
     }
 
+    @discardableResult
     static func drainRemainingOutput(
         until drainDeadline: Date,
         readChunk: () -> DrainReadResult,
         processChunk: (Data) -> Void,
+        shouldContinue: () -> Bool = { true },
         sleep: (UInt32) -> Void = { usleep($0) })
+        -> Bool
     {
-        while Date() < drainDeadline {
+        while true {
+            guard shouldContinue() else { return false }
             switch readChunk() {
             case let .data(newData):
                 processChunk(newData)
             case .wouldBlock:
+                guard Date() < drainDeadline else { return false }
                 sleep(20000)
             case .closed:
-                return
+                return true
             }
         }
     }
@@ -942,22 +948,20 @@ public struct TTYCommandRunner {
                 usleep(60000)
             }
 
-            let exitStatusBeforeDrain: Int32? = if !stoppedEarly,
-                                                   let exitObservedAt = process.exitObservationDate,
-                                                   exitObservedAt <= deadline
-            {
-                process.finishSynchronously()
-            } else {
-                nil
-            }
+            let exitedBeforeDeadline = !stoppedEarly
+                && process.exitObservationDate.map { $0 <= deadline } == true
+            let exitStatusBeforeDrain = exitedBeforeDeadline ? process.finishSynchronously() : nil
 
-            func drainNonCodexOutput(for duration: TimeInterval) {
+            func drainNonCodexOutput(for duration: TimeInterval) throws -> Bool {
                 let drainFor = max(0, duration)
-                guard drainFor > 0 else { return }
-                Self.drainRemainingOutput(
+                guard drainFor > 0 else { return false }
+                let closed = Self.drainRemainingOutput(
                     until: Date().addingTimeInterval(drainFor),
                     readChunk: readDrainChunk,
-                    processChunk: { _ = processNonCodexChunk($0, allowSends: false, allowStop: false) })
+                    processChunk: { _ = processNonCodexChunk($0, allowSends: false, allowStop: false) },
+                    shouldContinue: { !options.cancellationCheck() })
+                try checkCancellation()
+                return closed
             }
 
             if stoppedEarly {
@@ -979,12 +983,19 @@ public struct TTYCommandRunner {
                         usleep(50000)
                     }
                 }
+            } else if exitedBeforeDeadline {
+                // Exit observation, reaping, and PTY delivery are separate kernel events. Reaping alone is not
+                // enough: do not classify an empty result until the master has also drained through EOF/EIO.
+                guard try drainNonCodexOutput(for: Self.postExitDrainTimeout) else {
+                    Self.log.warning("PTY did not close after process exit", metadata: ["binary": binaryName])
+                    throw Error.timedOut
+                }
             } else {
                 // PTY-backed scripts can exit before their final echo becomes readable on the parent side.
                 // Give the kernel a brief non-blocking drain window so we don't lose the last line of output.
                 let defaultDrainDuration = min(0.5, max(0.2, options.settleAfterStop))
                 let drainDuration = TTYCommandRunnerTestingOverrides.postDeadlineDrainDuration ?? defaultDrainDuration
-                drainNonCodexOutput(for: drainDuration)
+                _ = try drainNonCodexOutput(for: drainDuration)
             }
 
             try checkOutputLimit()

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -269,6 +269,12 @@ private enum TTYCommandRunnerTestingOverrides {
     @TaskLocal static var outputLimitBytes: Int?
 }
 
+enum TTYCommandRunnerDrainReadResult {
+    case data(Data)
+    case wouldBlock
+    case closed
+}
+
 /// Executes an interactive CLI inside a pseudo-terminal and returns all captured text.
 /// Keeps it minimal so we can reuse for Codex and Claude without tmux.
 public struct TTYCommandRunner {
@@ -448,11 +454,7 @@ public struct TTYCommandRunner {
         }
     }
 
-    enum DrainReadResult {
-        case data(Data)
-        case wouldBlock
-        case closed
-    }
+    typealias DrainReadResult = TTYCommandRunnerDrainReadResult
 
     static func lowercasedASCII(_ data: Data) -> Data {
         guard !data.isEmpty else { return data }

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -498,27 +498,6 @@ public struct TTYCommandRunner {
         }
     }
 
-    static func drainReadResult(for data: Data, terminalRead: Int, errno err: Int32) -> DrainReadResult {
-        if !data.isEmpty {
-            return .data(data)
-        }
-
-        if terminalRead == 0 {
-            return .closed
-        }
-
-        if terminalRead < 0 {
-            if err == EAGAIN || err == EWOULDBLOCK || err == EINTR {
-                return .wouldBlock
-            }
-            if err == EIO {
-                return .closed
-            }
-        }
-
-        return .closed
-    }
-
     static func locateBundledHelper(_ name: String) -> String? {
         let fm = FileManager.default
 
@@ -671,6 +650,7 @@ public struct TTYCommandRunner {
         var cleanedUp = false
         var launchedProcess: SpawnedProcessGroup?
         var didExceedOutputLimit = false
+        var didTerminateSynchronously = false
         /// Always tear down the PTY child (and its process group) even if we throw early
         /// while bootstrapping the CLI (e.g. when it prompts for login/telemetry).
         func cleanup() {
@@ -696,7 +676,9 @@ public struct TTYCommandRunner {
                 try? primaryHandle.close()
                 launchedProcess.abortSynchronously()
             } else {
-                launchedProcess.terminateSynchronously()
+                if !didTerminateSynchronously {
+                    launchedProcess.terminateSynchronously()
+                }
                 try? primaryHandle.close()
             }
             TTYCommandRunnerActiveProcessRegistry.unregister(pid: launchedProcess.pid)
@@ -952,7 +934,13 @@ public struct TTYCommandRunner {
 
             let exitedBeforeDeadline = !stoppedEarly
                 && process.exitObservationDate.map { $0 <= deadline } == true
-            let exitStatusBeforeDrain = exitedBeforeDeadline ? process.finishSynchronously() : nil
+            let exitStatusBeforeDrain: Int32?
+            if exitedBeforeDeadline {
+                exitStatusBeforeDrain = process.terminateSynchronously()
+                didTerminateSynchronously = true
+            } else {
+                exitStatusBeforeDrain = nil
+            }
 
             func drainNonCodexOutput(for duration: TimeInterval) throws -> Bool {
                 let drainFor = max(0, duration)
@@ -1189,6 +1177,27 @@ public struct TTYCommandRunner {
 }
 
 extension TTYCommandRunner {
+    static func drainReadResult(for data: Data, terminalRead: Int, errno err: Int32) -> DrainReadResult {
+        if !data.isEmpty {
+            return .data(data)
+        }
+
+        if terminalRead == 0 {
+            return .closed
+        }
+
+        if terminalRead < 0 {
+            if err == EAGAIN || err == EWOULDBLOCK || err == EINTR {
+                return .wouldBlock
+            }
+            if err == EIO {
+                return .closed
+            }
+        }
+
+        return .closed
+    }
+
     static func withIsolatedActiveProcessRegistryForTesting<T>(_ operation: () throws -> T) rethrows -> T {
         try TTYCommandRunnerActiveProcessRegistry.withIsolatedStateForTesting(operation)
     }

--- a/Tests/CodexBarTests/TTYCommandRunnerTests.swift
+++ b/Tests/CodexBarTests/TTYCommandRunnerTests.swift
@@ -250,6 +250,29 @@ struct TTYCommandRunnerEnvTests {
     }
 
     @Test
+    func `fast process exit drains buffered PTY output`() throws {
+        let expected = "pty-drain-race"
+        let runner = TTYCommandRunner()
+
+        for iteration in 0..<50 {
+            let result = try runner.run(
+                binary: "/bin/echo",
+                send: "",
+                options: .init(
+                    timeout: Self.harnessPTYTimeout,
+                    extraArgs: [expected],
+                    initialDelay: 0.05,
+                    stopOnSubstrings: [expected],
+                    settleAfterStop: 0,
+                    returnOnEmptyProcessExit: true))
+            let clean = result.text.replacingOccurrences(of: "\r", with: "")
+            #expect(
+                clean.contains(expected),
+                "PTY output was missing on iteration \(iteration); completion: \(result.completion)")
+        }
+    }
+
+    @Test
     func `claude runner keeps normal working directory by default`() throws {
         let runner = TTYCommandRunner()
         let fakeClaude = try Self.makeFakeClaudeCLI()


### PR DESCRIPTION
## Summary

Root exit and reaping can precede PTY delivery. The shared runner now terminates and reaps residual same-group or output-holder helpers before draining, so they cannot keep the PTY slave open. The PTY master then drains through EOF/EIO before output is classified as empty, while genuinely empty exits remain supported.

The shared Kiro and Claude login/provider version paths are covered. Regressions include a 50-iteration fast-process-exit test and a same-group-helper cleanup test.

## Testing

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --build-tests` (passed)
- `make check` (passed with zero violations)
- `tty runner cleans a same group helper after normal exit` (passed)
- `fast process exit drains buffered PTY output` (passed for 50 iterations)
- `post-exit drain processes trailing chunk through callback path` (passed)
- Autoreview clean; no accepted/actionable findings
