### PR TITLE
Plugin host contract: sparse snapshots, delayed retries, private origins

### DIFF
--- a/Sources/CodexBar/StatusItemController+UserPlugins.swift
+++ b/Sources/CodexBar/StatusItemController+UserPlugins.swift
@@ -87,6 +87,9 @@ private struct UserPluginMenuCardView: View {
                     Divider()
                     ProviderDetailSectionsContent(sections: snapshot.details, chartColor: self.tint)
                 }
+                if let identity = snapshot.identity(for: self.plugin.manifest.id) {
+                    self.identity(identity)
+                }
             } else if let error {
                 Text(error).font(.caption).foregroundStyle(.red).textSelection(.enabled)
             } else {
@@ -96,6 +99,31 @@ private struct UserPluginMenuCardView: View {
         .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
         .padding(.vertical, 8)
         .frame(width: self.width, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func identity(_ identity: ProviderIdentitySnapshot) -> some View {
+        if identity.accountEmail != nil || identity.accountOrganization != nil || identity.loginMethod != nil
+            || identity.accountID != nil
+        {
+            Divider()
+            self.identityRow("Account", identity.accountEmail)
+            self.identityRow("Organization", identity.accountOrganization)
+            self.identityRow("Plan", identity.loginMethod)
+            self.identityRow("Account ID", identity.accountID)
+        }
+    }
+
+    @ViewBuilder
+    private func identityRow(_ label: String, _ value: String?) -> some View {
+        if let value {
+            HStack {
+                Text(label).foregroundStyle(.secondary)
+                Spacer()
+                Text(value).fontWeight(.medium).textSelection(.enabled)
+            }
+            .font(.caption)
+        }
     }
 
     @ViewBuilder

--- a/Sources/CodexBarCLI/CLIPluginsCommand.swift
+++ b/Sources/CodexBarCLI/CLIPluginsCommand.swift
@@ -86,7 +86,9 @@ extension CodexBarCLI {
                 }
                 print(json)
             } else {
-                self.printPluginSnapshot(plugin: plugin, snapshot: snapshot)
+                for line in self.pluginSnapshotLines(plugin: plugin, snapshot: snapshot) {
+                    print(line)
+                }
             }
         } catch {
             Self.exit(code: .failure, message: error.localizedDescription, kind: .provider)
@@ -116,24 +118,43 @@ extension CodexBarCLI {
         return readLine()?.lowercased() == "y"
     }
 
-    private static func printPluginSnapshot(plugin: UserProviderPlugin, snapshot: UsageSnapshot) {
-        print(plugin.manifest.name)
+    static func pluginSnapshotLines(plugin: UserProviderPlugin, snapshot: UsageSnapshot) -> [String] {
+        var lines = [plugin.manifest.name]
         if let primary = snapshot.primary {
-            print("Primary: \(Int(primary.usedPercent.rounded()))% used")
+            lines.append("Primary: \(Int(primary.usedPercent.rounded()))% used")
         }
         if let secondary = snapshot.secondary {
-            print("Secondary: \(Int(secondary.usedPercent.rounded()))% used")
+            lines.append("Secondary: \(Int(secondary.usedPercent.rounded()))% used")
         }
         if let cost = snapshot.providerCost {
-            print("Cost: \(cost.used) \(cost.currencyCode)")
+            lines.append("Cost: \(cost.used) \(cost.currencyCode)")
         }
         for section in snapshot.details {
             if let title = section.title {
-                print(title)
+                lines.append(title)
             }
             for row in section.rows {
-                print("\(row.label): \(row.value)")
+                lines.append("\(row.label): \(row.value)")
             }
+        }
+        if let identity = snapshot.identity(for: plugin.manifest.id) {
+            Self.appendPluginIdentity(identity, lines: &lines)
+        }
+        return lines
+    }
+
+    private static func appendPluginIdentity(_ identity: ProviderIdentitySnapshot, lines: inout [String]) {
+        if let email = identity.accountEmail {
+            lines.append("Account: \(email)")
+        }
+        if let organization = identity.accountOrganization {
+            lines.append("Organization: \(organization)")
+        }
+        if let loginMethod = identity.loginMethod {
+            lines.append("Plan: \(loginMethod)")
+        }
+        if let accountID = identity.accountID {
+            lines.append("Account ID: \(accountID)")
         }
     }
 }

--- a/Sources/CodexBarCore/Plugins/ProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginEngine.swift
@@ -30,7 +30,7 @@ enum ProviderPluginEngineFactory {
         transport: any ProviderHTTPTransport,
         timeout: TimeInterval,
         responseSizeLimit: Int,
-        rejectsNonSuccessResponses: Bool,
+        enforcesUserResponsePolicy: Bool,
         allowsDynamicID: Bool) throws -> any ProviderPluginEngine
     {
         switch kind {
@@ -43,7 +43,7 @@ enum ProviderPluginEngineFactory {
                 preludeSource: preludeSource,
                 transport: transport,
                 responseSizeLimit: responseSizeLimit,
-                rejectsNonSuccessResponses: rejectsNonSuccessResponses,
+                enforcesUserResponsePolicy: enforcesUserResponsePolicy,
                 allowsDynamicID: allowsDynamicID)
             #else
             throw ProviderPluginError.load("JavaScriptCore is unavailable on this platform")
@@ -55,7 +55,7 @@ enum ProviderPluginEngineFactory {
                 transport: transport,
                 timeout: timeout,
                 responseSizeLimit: responseSizeLimit,
-                rejectsNonSuccessResponses: rejectsNonSuccessResponses,
+                enforcesUserResponsePolicy: enforcesUserResponsePolicy,
                 allowsDynamicID: allowsDynamicID)
         }
     }

--- a/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
@@ -63,6 +63,7 @@ public enum ProviderPluginEndpoint: Equatable, Hashable, Sendable {
 
 public enum ProviderPluginCapability: String, Hashable, Sendable {
     case browserCookies = "browser-cookies"
+    case httpStatus = "http-status"
 }
 
 public struct ProviderPluginManifest: Sendable {
@@ -440,7 +441,7 @@ public enum ProviderPluginError: LocalizedError, Sendable, Equatable {
 
 enum ProviderPluginClassifiedFailureParser {
     private static let markerV1 = "__CODEXBAR_FAILURE__:"
-    private static let markerV2 = "__CODEXBAR_FAILURE_V2__:"
+    fileprivate static let markerV2 = "__CODEXBAR_FAILURE_V2__:"
 
     static func error(from message: String) -> ProviderFetchClassifiedError? {
         if message.hasPrefix(self.markerV2) {
@@ -467,5 +468,34 @@ enum ProviderPluginClassifiedFailureParser {
             kind: kind,
             message: String(retryAndMessage[retryAndMessage.index(after: retrySeparator)...]),
             retryAfterSeconds: retryAfterSeconds)
+    }
+}
+
+struct ProviderPluginTransientHTTPFailure: LocalizedError, Sendable {
+    private static let retryPolicy = ProviderHTTPRetryPolicy.transientIdempotent
+
+    let errorDescription: String?
+
+    init?(statusCode: Int, retryAfterHeader: String?) {
+        guard let markerMessage = Self.markerMessage(
+            statusCode: statusCode,
+            retryAfterHeader: retryAfterHeader)
+        else { return nil }
+        self.errorDescription = markerMessage
+    }
+
+    static func markerMessage(statusCode: Int, retryAfterHeader: String?) -> String? {
+        guard self.retryPolicy.retryableStatusCodes.contains(statusCode) else { return nil }
+        let kind: ProviderFetchClassifiedError.Kind = statusCode == 429 ? .rateLimited : .providerUnavailable
+        let parsedRetryAfter = retryAfterHeader
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .flatMap(TimeInterval.init)
+        let retryAfterSeconds = if let parsedRetryAfter, parsedRetryAfter.isFinite, parsedRetryAfter >= 0 {
+            parsedRetryAfter
+        } else {
+            self.retryPolicy.baseDelaySeconds
+        }
+        let message = "request returned HTTP \(statusCode)"
+        return "\(ProviderPluginClassifiedFailureParser.markerV2)\(kind.rawValue):\(retryAfterSeconds):\(message)"
     }
 }

--- a/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
@@ -362,7 +362,7 @@ public struct ProviderPluginManifest: Sendable {
         return value
     }
 
-    // Provider-specific by design: only LLM Proxy and LiteLLM already grant private-network HTTP authority in Swift.
+    /// Provider-specific by design: only LLM Proxy and LiteLLM already grant private-network HTTP authority in Swift.
     private static let bundledPrivateNetworkHTTPProviders: Set<UsageProvider> = [.llmproxy, .litellm]
 }
 

--- a/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
@@ -54,6 +54,7 @@ public enum ProviderPluginEndpoint: Equatable, Hashable, Sendable {
     public enum Policy: String, Sendable {
         case https
         case httpsOrLoopbackHTTP = "https-or-loopback-http"
+        case httpsOrPrivateNetworkHTTP = "https-or-private-network-http"
     }
 
     case fixed(String)
@@ -119,6 +120,13 @@ public struct ProviderPluginManifest: Sendable {
             let rawPolicy = try Self.requiredString(rawEndpoint, property: "policy")
             guard let policy = ProviderPluginEndpoint.Policy(rawValue: rawPolicy) else {
                 throw ProviderPluginError.invalidManifest("unsupported endpoint policy '\(rawPolicy)'")
+            }
+            if policy == .httpsOrPrivateNetworkHTTP,
+               !allowsDynamicID,
+               id.firstPartyProvider.map(Self.bundledPrivateNetworkHTTPProviders.contains) != true
+            {
+                throw ProviderPluginError.invalidManifest(
+                    "private-network HTTP is not allowed for bundled provider '\(id.rawValue)'")
             }
             endpoints.insert(.setting(key: key, policy: policy))
         }
@@ -353,6 +361,8 @@ public struct ProviderPluginManifest: Sendable {
         }
         return value
     }
+
+    private static let bundledPrivateNetworkHTTPProviders: Set<UsageProvider> = [.llmproxy, .litellm]
 }
 
 enum ProviderPluginOrigin {
@@ -384,6 +394,8 @@ enum ProviderPluginOrigin {
             validator.validatedURL(url.absoluteString)
         case .httpsOrLoopbackHTTP:
             validator.validatedURLAllowingLoopbackHTTP(url.absoluteString)
+        case .httpsOrPrivateNetworkHTTP:
+            validator.validatedURLAllowingPrivateNetworkHTTP(url.absoluteString)
         }
         guard let validated, validated.fragment == nil, validated.user == nil, validated.password == nil else {
             throw ProviderPluginError.networkPolicy("URL does not satisfy the declared endpoint policy")

--- a/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
@@ -362,6 +362,7 @@ public struct ProviderPluginManifest: Sendable {
         return value
     }
 
+    // Provider-specific by design: only LLM Proxy and LiteLLM already grant private-network HTTP authority in Swift.
     private static let bundledPrivateNetworkHTTPProviders: Set<UsageProvider> = [.llmproxy, .litellm]
 }
 

--- a/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
@@ -424,3 +424,35 @@ public enum ProviderPluginError: LocalizedError, Sendable, Equatable {
         }
     }
 }
+
+enum ProviderPluginClassifiedFailureParser {
+    private static let markerV1 = "__CODEXBAR_FAILURE__:"
+    private static let markerV2 = "__CODEXBAR_FAILURE_V2__:"
+
+    static func error(from message: String) -> ProviderFetchClassifiedError? {
+        if message.hasPrefix(self.markerV2) {
+            return self.parseV2(String(message.dropFirst(self.markerV2.count)))
+        }
+        guard message.hasPrefix(self.markerV1) else { return nil }
+        let payload = message.dropFirst(self.markerV1.count)
+        guard let separator = payload.firstIndex(of: ":"),
+              let kind = ProviderFetchClassifiedError.Kind(rawValue: String(payload[..<separator]))
+        else { return nil }
+        return ProviderFetchClassifiedError(kind: kind, message: String(payload[payload.index(after: separator)...]))
+    }
+
+    private static func parseV2(_ payload: String) -> ProviderFetchClassifiedError? {
+        guard let kindSeparator = payload.firstIndex(of: ":"),
+              let kind = ProviderFetchClassifiedError.Kind(rawValue: String(payload[..<kindSeparator]))
+        else { return nil }
+        let retryAndMessage = payload[payload.index(after: kindSeparator)...]
+        guard let retrySeparator = retryAndMessage.firstIndex(of: ":") else { return nil }
+        let retryText = String(retryAndMessage[..<retrySeparator])
+        let retryAfterSeconds = retryText.isEmpty ? nil : TimeInterval(retryText)
+        guard retryText.isEmpty || retryAfterSeconds != nil else { return nil }
+        return ProviderFetchClassifiedError(
+            kind: kind,
+            message: String(retryAndMessage[retryAndMessage.index(after: retrySeparator)...]),
+            retryAfterSeconds: retryAfterSeconds)
+    }
+}

--- a/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
@@ -275,7 +275,10 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
             }
         }
         if let classifiedError = error as? ProviderFetchClassifiedError {
-            return ProviderFetchClassifiedError(kind: classifiedError.kind, message: message)
+            return ProviderFetchClassifiedError(
+                kind: classifiedError.kind,
+                message: message,
+                retryAfterSeconds: classifiedError.retryAfterSeconds)
         }
         return ProviderPluginError.script(message)
     }
@@ -974,14 +977,8 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
         redactionValues: ProviderPluginRedactionValues) -> Error
     {
         let message = redactionValues.redact(self.message(from: value))
-        let marker = "__CODEXBAR_FAILURE__:"
-        if message.hasPrefix(marker),
-           let separator = message[message.index(message.startIndex, offsetBy: marker.count)...].firstIndex(of: ":"),
-           let kind = ProviderFetchClassifiedError.Kind(
-               rawValue: String(message[message.index(message.startIndex, offsetBy: marker.count)..<separator]))
-        {
-            let body = String(message[message.index(after: separator)...])
-            return ProviderFetchClassifiedError(kind: kind, message: body)
+        if let classified = ProviderPluginClassifiedFailureParser.error(from: message) {
+            return classified
         }
         return ProviderPluginError.script(message)
     }

--- a/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginRuntime.swift
@@ -22,7 +22,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
     private let transport: any ProviderHTTPTransport
     private let timeout: TimeInterval
     private let responseSizeLimit: Int
-    private let rejectsNonSuccessResponses: Bool
+    private let enforcesUserResponsePolicy: Bool
     private let allowsDynamicID: Bool
     private let contextOptions: ProviderPluginContextOptions
     private let engineKind: ProviderPluginEngineKind
@@ -83,7 +83,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
         responseSizeLimit: Int = ProviderPluginRuntime.maximumResponseBytes,
-        rejectsNonSuccessResponses: Bool = false,
+        enforcesUserResponsePolicy: Bool = false,
         allowsDynamicID: Bool = false,
         engine: ProviderPluginEngineKind = .automatic) throws
     {
@@ -93,7 +93,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
             transport: transport,
             timeout: timeout,
             responseSizeLimit: responseSizeLimit,
-            rejectsNonSuccessResponses: rejectsNonSuccessResponses,
+            enforcesUserResponsePolicy: enforcesUserResponsePolicy,
             allowsDynamicID: allowsDynamicID,
             contextOptions: .production,
             engine: engine)
@@ -105,7 +105,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         timeout: TimeInterval = ProviderPluginRuntime.defaultTimeout,
         responseSizeLimit: Int = ProviderPluginRuntime.maximumResponseBytes,
-        rejectsNonSuccessResponses: Bool = false,
+        enforcesUserResponsePolicy: Bool = false,
         allowsDynamicID: Bool = false,
         contextOptions: ProviderPluginContextOptions = .production,
         engine: ProviderPluginEngineKind = .automatic) throws
@@ -132,7 +132,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
         self.transport = transport
         self.timeout = timeout
         self.responseSizeLimit = responseSizeLimit
-        self.rejectsNonSuccessResponses = rejectsNonSuccessResponses
+        self.enforcesUserResponsePolicy = enforcesUserResponsePolicy
         self.allowsDynamicID = allowsDynamicID
         self.contextOptions = contextOptions
         self.engineKind = Self.resolveEngineKind(engine)
@@ -144,7 +144,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
             transport: transport,
             timeout: timeout,
             responseSizeLimit: responseSizeLimit,
-            rejectsNonSuccessResponses: rejectsNonSuccessResponses,
+            enforcesUserResponsePolicy: enforcesUserResponsePolicy,
             allowsDynamicID: allowsDynamicID)
         self.worker = worker
         self.manifest = worker.manifest
@@ -214,7 +214,7 @@ public final class ProviderPluginRuntime: @unchecked Sendable {
             transport: self.transport,
             timeout: self.timeout,
             responseSizeLimit: self.responseSizeLimit,
-            rejectsNonSuccessResponses: self.rejectsNonSuccessResponses,
+            enforcesUserResponsePolicy: self.enforcesUserResponsePolicy,
             allowsDynamicID: self.allowsDynamicID)
         guard worker.manifest.id == self.manifest.id else {
             throw ProviderPluginError.load("reloaded plugin changed provider id")
@@ -386,9 +386,14 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
     private let fetchUsage: JSValue
     private let transport: any ProviderHTTPTransport
     private let responseSizeLimit: Int
-    private let rejectsNonSuccessResponses: Bool
+    private let enforcesUserResponsePolicy: Bool
     private var cache: [String: (value: JSValue, expiresAt: Date)] = [:]
     private var retainedCallbacks: [UUID: [Any]] = [:]
+
+    /// Opt-in relaxes only the status gate, never the representation gate.
+    private var rejectsNonSuccessResponses: Bool {
+        self.enforcesUserResponsePolicy && !self.manifest.capabilities.contains(.httpStatus)
+    }
 
     // swiftlint:disable:next function_parameter_count
     static func make(
@@ -396,7 +401,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
         preludeSource: String,
         transport: any ProviderHTTPTransport,
         responseSizeLimit: Int,
-        rejectsNonSuccessResponses: Bool,
+        enforcesUserResponsePolicy: Bool,
         allowsDynamicID: Bool) throws -> JavaScriptCoreProviderPluginEngine
     {
         let queue = DispatchQueue(label: "com.steipete.codexbar.provider-plugin.\(UUID().uuidString)")
@@ -407,7 +412,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
                 preludeSource: preludeSource,
                 transport: transport,
                 responseSizeLimit: responseSizeLimit,
-                rejectsNonSuccessResponses: rejectsNonSuccessResponses,
+                enforcesUserResponsePolicy: enforcesUserResponsePolicy,
                 allowsDynamicID: allowsDynamicID)
         }
     }
@@ -418,7 +423,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
         preludeSource: String,
         transport: any ProviderHTTPTransport,
         responseSizeLimit: Int,
-        rejectsNonSuccessResponses: Bool,
+        enforcesUserResponsePolicy: Bool,
         allowsDynamicID: Bool) throws
     {
         guard let context = JSContext() else {
@@ -428,7 +433,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
         self.context = context
         self.transport = transport
         self.responseSizeLimit = responseSizeLimit
-        self.rejectsNonSuccessResponses = rejectsNonSuccessResponses
+        self.enforcesUserResponsePolicy = enforcesUserResponsePolicy
 
         var definition: JSValue?
         let defineProvider: @convention(block) (JSValue) -> Void = { value in
@@ -747,9 +752,15 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
                     throw ProviderPluginError.http("response exceeded the \(responseSizeLimit)-byte limit")
                 }
                 if worker.rejectsNonSuccessResponses, !(200..<300).contains(response.statusCode) {
+                    if let failure = ProviderPluginTransientHTTPFailure(
+                        statusCode: response.statusCode,
+                        retryAfterHeader: response.response.value(forHTTPHeaderField: "Retry-After"))
+                    {
+                        throw failure
+                    }
                     throw ProviderPluginError.http("request returned HTTP \(response.statusCode)")
                 }
-                if worker.rejectsNonSuccessResponses,
+                if worker.enforcesUserResponsePolicy,
                    let encoding = response.response.value(forHTTPHeaderField: "Content-Encoding"),
                    !encoding.isEmpty,
                    encoding.caseInsensitiveCompare("identity") != .orderedSame
@@ -764,6 +775,12 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
                     _ = callbacks.resolve.value.call(withArguments: [value as Any])
                 }
             } catch {
+                if let failure = error as? ProviderPluginTransientHTTPFailure {
+                    worker.queue.async {
+                        worker.reject(callbacks.reject, error: failure)
+                    }
+                    return
+                }
                 let failure = ProviderPluginError.http(redactionValues.redact(error.localizedDescription))
                 worker.queue.async {
                     worker.reject(callbacks.reject, error: failure)
@@ -871,7 +888,7 @@ final class JavaScriptCoreProviderPluginEngine: ProviderPluginEngine, @unchecked
 
         // The broker owns representation headers so plugins cannot relax the user-plugin response boundary.
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        if self.rejectsNonSuccessResponses {
+        if self.enforcesUserResponsePolicy {
             request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
         }
         if method == "POST" {

--- a/Sources/CodexBarCore/Plugins/ProviderPluginSnapshotMapper.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginSnapshotMapper.swift
@@ -26,8 +26,10 @@ enum ProviderPluginSnapshotMapper {
         guard primary != nil || secondary != nil || tertiary != nil || !(extraRateWindows?.isEmpty ?? true)
             || providerCost != nil
             || !details.isEmpty
+            || self.hasMeaningfulIdentity(identity)
         else {
-            throw ProviderPluginError.invalidSnapshot("snapshot must contain at least one rate window, cost, or detail")
+            throw ProviderPluginError.invalidSnapshot(
+                "snapshot must contain at least one rate window, cost, detail section, or identity field")
         }
 
         return UsageSnapshot(
@@ -42,6 +44,12 @@ enum ProviderPluginSnapshotMapper {
             updatedAt: now,
             identity: identity,
             dataConfidence: dataConfidence)
+    }
+
+    private static func hasMeaningfulIdentity(_ identity: ProviderIdentitySnapshot?) -> Bool {
+        guard let identity else { return false }
+        return identity.accountEmail != nil || identity.accountOrganization != nil || identity.loginMethod != nil
+            || identity.accountID != nil
     }
 
     private static func dataConfidence(_ root: any ProviderPluginValue) throws -> UsageDataConfidence {

--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -180,7 +180,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
     private let transport: any ProviderHTTPTransport
     private let timeout: TimeInterval
     private let responseSizeLimit: Int
-    private let rejectsNonSuccessResponses: Bool
+    private let enforcesUserResponsePolicy: Bool
     private var watchdog: OpaquePointer?
     private var definition: JSValue?
     private var applyPrelude: JSValue?
@@ -196,6 +196,10 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
         return loadedManifest
     }
 
+    private var rejectsNonSuccessResponses: Bool {
+        self.enforcesUserResponsePolicy && !self.manifest.capabilities.contains(.httpStatus)
+    }
+
     // swiftlint:disable:next function_parameter_count
     static func make(
         source: String,
@@ -203,7 +207,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
         transport: any ProviderHTTPTransport,
         timeout: TimeInterval,
         responseSizeLimit: Int,
-        rejectsNonSuccessResponses: Bool,
+        enforcesUserResponsePolicy: Bool,
         allowsDynamicID: Bool,
         workerStackSizeBytes: Int = QuickJSRuntimeLimits.nativeStackSizeBytes) throws -> QuickJSProviderPluginEngine
     {
@@ -229,7 +233,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
                 transport: transport,
                 timeout: timeout,
                 responseSizeLimit: responseSizeLimit,
-                rejectsNonSuccessResponses: rejectsNonSuccessResponses)
+                enforcesUserResponsePolicy: enforcesUserResponsePolicy)
             try engine.load(source: source, preludeSource: preludeSource, allowsDynamicID: allowsDynamicID)
             return engine
         }
@@ -242,7 +246,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
         transport: any ProviderHTTPTransport,
         timeout: TimeInterval,
         responseSizeLimit: Int,
-        rejectsNonSuccessResponses: Bool)
+        enforcesUserResponsePolicy: Bool)
     {
         self.worker = worker
         self.runtime = runtime
@@ -250,7 +254,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
         self.transport = transport
         self.timeout = timeout
         self.responseSizeLimit = responseSizeLimit
-        self.rejectsNonSuccessResponses = rejectsNonSuccessResponses
+        self.enforcesUserResponsePolicy = enforcesUserResponsePolicy
     }
 
     deinit {
@@ -557,9 +561,15 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
                 throw ProviderPluginError.http("response exceeded the \(self.responseSizeLimit)-byte limit")
             }
             if self.rejectsNonSuccessResponses, !(200..<300).contains(response.statusCode) {
+                if let failure = ProviderPluginTransientHTTPFailure(
+                    statusCode: response.statusCode,
+                    retryAfterHeader: response.response.value(forHTTPHeaderField: "Retry-After"))
+                {
+                    throw failure
+                }
                 throw ProviderPluginError.http("request returned HTTP \(response.statusCode)")
             }
-            if self.rejectsNonSuccessResponses,
+            if self.enforcesUserResponsePolicy,
                let encoding = response.response.value(forHTTPHeaderField: "Content-Encoding"),
                !encoding.isEmpty,
                encoding.caseInsensitiveCompare("identity") != .orderedSame
@@ -713,7 +723,7 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
             }
         }
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        if self.rejectsNonSuccessResponses {
+        if self.enforcesUserResponsePolicy {
             request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
         }
         if method == "POST" {

--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -861,15 +861,8 @@ final class QuickJSProviderPluginEngine: ProviderPluginEngine, @unchecked Sendab
 
     private func failure(from value: JSValue, redactionValues: QuickJSRedactionValues) -> Error {
         let message = redactionValues.redact((try? self.message(from: value)) ?? "unknown plugin failure")
-        let marker = "__CODEXBAR_FAILURE__:"
-        if message.hasPrefix(marker),
-           let separator = message[message.index(message.startIndex, offsetBy: marker.count)...].firstIndex(of: ":"),
-           let kind = ProviderFetchClassifiedError.Kind(
-               rawValue: String(message[message.index(message.startIndex, offsetBy: marker.count)..<separator]))
-        {
-            return ProviderFetchClassifiedError(
-                kind: kind,
-                message: String(message[message.index(after: separator)...]))
+        if let classified = ProviderPluginClassifiedFailureParser.error(from: message) {
+            return classified
         }
         return ProviderPluginError.script(message)
     }

--- a/Sources/CodexBarCore/Plugins/UserProviderPlugins.swift
+++ b/Sources/CodexBarCore/Plugins/UserProviderPlugins.swift
@@ -324,7 +324,7 @@ public final class UserProviderPluginLoader: @unchecked Sendable {
             resourceBundle: self.resourceBundle,
             transport: self.transport,
             responseSizeLimit: UserProviderPlugin.maximumSourceBytes,
-            rejectsNonSuccessResponses: true,
+            enforcesUserResponsePolicy: true,
             allowsDynamicID: true)
         return UserProviderPlugin(
             fileURL: fileURL,

--- a/Sources/CodexBarCore/Plugins/UserProviderPlugins.swift
+++ b/Sources/CodexBarCore/Plugins/UserProviderPlugins.swift
@@ -18,6 +18,7 @@ public struct ProviderPluginApprovalBinding: Codable, Equatable, Sendable {
 
     public init(manifest: ProviderPluginManifest, settings: [String: String]) throws {
         var origins: Set<String> = []
+        var authenticatedHTTPOrigins: Set<String> = []
         for endpoint in manifest.endpoints {
             switch endpoint {
             case let .fixed(origin):
@@ -30,11 +31,18 @@ public struct ProviderPluginApprovalBinding: Codable, Equatable, Sendable {
                     throw ProviderPluginError.invalidManifest(
                         "endpoint setting '\(key)' must contain a valid URL before approval")
                 }
-                try origins.insert(ProviderPluginOrigin.normalizedOrigin(of: url, policy: policy))
+                let origin = try ProviderPluginOrigin.normalizedOrigin(of: url, policy: policy)
+                origins.insert(origin)
+                if policy == .httpsOrPrivateNetworkHTTP, origin.hasPrefix("http://") {
+                    authenticatedHTTPOrigins.insert(origin)
+                }
             }
         }
-        if manifest.auth != nil, origins.contains(where: { $0.hasPrefix("http://") }) {
-            throw ProviderPluginError.networkPolicy("authenticated plugin origins must use HTTPS")
+        if manifest.auth != nil,
+           origins.contains(where: { $0.hasPrefix("http://") && !authenticatedHTTPOrigins.contains($0) })
+        {
+            throw ProviderPluginError.networkPolicy(
+                "authenticated HTTP requires the private-network endpoint policy and typed approval")
         }
 
         self.instanceID = manifest.id
@@ -52,10 +60,11 @@ public struct ProviderPluginApprovalBinding: Codable, Equatable, Sendable {
 
     private static func requiresTypedConfirmation(_ origin: String) -> Bool {
         guard let host = URL(string: origin)?.host?.lowercased() else { return true }
-        if host == "localhost" || host.hasSuffix(".local") {
+        let normalizedHost = host.hasSuffix(".") ? String(host.dropLast()) : host
+        if normalizedHost == "localhost" || normalizedHost.hasSuffix(".local") {
             return true
         }
-        if self.isIPv4Literal(host) || host.contains(":") {
+        if self.isIPv4Literal(normalizedHost) || normalizedHost.contains(":") {
             return true
         }
         return false

--- a/Sources/CodexBarCore/Plugins/UserProviderPlugins.swift
+++ b/Sources/CodexBarCore/Plugins/UserProviderPlugins.swift
@@ -157,12 +157,14 @@ public struct UserProviderPlugin: @unchecked Sendable {
             secrets: secrets,
             manifest: self.manifest,
             environment: environment)
-        return try await self.runtime.fetchUsage(
-            settings: settings,
-            secrets: resolvedSecrets,
-            now: now,
-            cookieResolver: cookieResolver,
-            instanceCookieResolver: instanceCookieResolver)
+        return try await ProviderFetchDelayedRetry.run {
+            try await self.runtime.fetchUsage(
+                settings: settings,
+                secrets: resolvedSecrets,
+                now: now,
+                cookieResolver: cookieResolver,
+                instanceCookieResolver: instanceCookieResolver)
+        }
     }
 
     public static func environmentKey(instanceID: ProviderInstanceID, settingKey: String) -> String {

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -200,6 +200,8 @@ public enum ProviderFetchError: LocalizedError, Sendable {
 }
 
 public struct ProviderFetchClassifiedError: LocalizedError, Sendable, Equatable {
+    public static let maximumRetryAfterSeconds: TimeInterval = 10
+
     public enum Kind: String, Sendable, CaseIterable {
         case authenticationExpired = "authentication-expired"
         case missingCredential = "missing-credential"
@@ -213,10 +215,15 @@ public struct ProviderFetchClassifiedError: LocalizedError, Sendable, Equatable 
 
     public let kind: Kind
     public let message: String
+    public let retryAfterSeconds: TimeInterval?
 
-    public init(kind: Kind, message: String) {
+    public init(kind: Kind, message: String, retryAfterSeconds: TimeInterval? = nil) {
         self.kind = kind
         self.message = message
+        self.retryAfterSeconds = retryAfterSeconds.flatMap { seconds in
+            guard seconds.isFinite, seconds >= 0 else { return nil }
+            return min(seconds, Self.maximumRetryAfterSeconds)
+        }
     }
 
     public var errorDescription: String? {
@@ -261,10 +268,20 @@ extension ProviderFetchStrategy {
 }
 
 public struct ProviderFetchPipeline: Sendable {
-    public let resolveStrategies: @Sendable (ProviderFetchContext) async -> [any ProviderFetchStrategy]
+    public typealias RetrySleeper = @Sendable (TimeInterval) async throws -> Void
 
-    public init(resolveStrategies: @escaping @Sendable (ProviderFetchContext) async -> [any ProviderFetchStrategy]) {
+    public let resolveStrategies: @Sendable (ProviderFetchContext) async -> [any ProviderFetchStrategy]
+    private let retrySleeper: RetrySleeper
+
+    public init(
+        resolveStrategies: @escaping @Sendable (ProviderFetchContext) async -> [any ProviderFetchStrategy],
+        retrySleeper: @escaping RetrySleeper = { seconds in
+            guard seconds > 0 else { return }
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        })
+    {
         self.resolveStrategies = resolveStrategies
+        self.retrySleeper = retrySleeper
     }
 
     public func fetch(context: ProviderFetchContext, provider: UsageProvider) async -> ProviderFetchOutcome {
@@ -296,7 +313,9 @@ public struct ProviderFetchPipeline: Sendable {
             }
 
             do {
-                let result = try await strategy.fetch(context)
+                let result = try await ProviderFetchDelayedRetry.run(sleeper: self.retrySleeper) {
+                    try await strategy.fetch(context)
+                }
                 try Task.checkCancellation()
                 attempts.append(ProviderFetchAttempt(
                     strategyID: strategy.id,
@@ -323,6 +342,28 @@ public struct ProviderFetchPipeline: Sendable {
 
         let error = lastAvailableError ?? ProviderFetchError.noAvailableStrategy(provider)
         return ProviderFetchOutcome(result: .failure(error), attempts: attempts)
+    }
+}
+
+enum ProviderFetchDelayedRetry {
+    static func run<Value: Sendable>(
+        sleeper: ProviderFetchPipeline.RetrySleeper = Self.sleep,
+        operation: @escaping @Sendable () async throws -> Value) async throws -> Value
+    {
+        do {
+            return try await operation()
+        } catch let error as ProviderFetchClassifiedError {
+            guard let retryAfterSeconds = error.retryAfterSeconds else { throw error }
+            try Task.checkCancellation()
+            try await sleeper(retryAfterSeconds)
+            try Task.checkCancellation()
+            return try await operation()
+        }
+    }
+
+    static func sleep(seconds: TimeInterval) async throws {
+        guard seconds > 0 else { return }
+        try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
     }
 }
 

--- a/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
+++ b/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
@@ -98,6 +98,22 @@ interface CodexBarHTTPTextResponse extends CodexBarHTTPResponse {
   bodyText: string;
 }
 
+interface CodexBarRetryOptions {
+  /** Requests one delayed retry. The host clamps this interval to 10 seconds. */
+  retryAfterSeconds: number;
+}
+
+interface CodexBarFailures {
+  authenticationExpired(message: unknown): Error;
+  missingCredential(message: unknown): Error;
+  permissionDenied(message: unknown): Error;
+  rateLimited(message: unknown, options?: CodexBarRetryOptions): Error;
+  providerUnavailable(message: unknown, options?: CodexBarRetryOptions): Error;
+  parseFailure(message: unknown): Error;
+  networkFailure(message: unknown, options?: CodexBarRetryOptions): Error;
+  apiFailure(message: unknown, options?: CodexBarRetryOptions): Error;
+}
+
 interface CodexBarPluginContext {
   readonly http: {
     getJSON<T = unknown>(url: string, options?: CodexBarHTTPRequestOptions): Promise<CodexBarHTTPJSONResponse<T>>;
@@ -130,19 +146,7 @@ interface CodexBarPluginContext {
     usd(value: number): string;
     monthDay(value: Date | number | string): string;
   };
-  readonly fail: Readonly<
-    Record<
-      | "authenticationExpired"
-      | "missingCredential"
-      | "permissionDenied"
-      | "rateLimited"
-      | "providerUnavailable"
-      | "parseFailure"
-      | "networkFailure"
-      | "apiFailure",
-      (message: unknown) => Error
-    >
-  >;
+  readonly fail: Readonly<CodexBarFailures>;
   readonly env: {
     readonly timeZone: string;
   };

--- a/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
+++ b/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
@@ -67,6 +67,7 @@ interface CodexBarDetailSection {
 }
 
 interface CodexBarUsageSnapshot {
+  /** At least one rate window, cost, non-empty detail section, or non-empty identity field is required. */
   primary?: CodexBarRateWindow | null;
   secondary?: CodexBarRateWindow | null;
   tertiary?: CodexBarRateWindow | null;

--- a/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
+++ b/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
@@ -86,6 +86,7 @@ interface CodexBarHTTPRequestOptions {
 }
 
 interface CodexBarHTTPResponse {
+  /** `http-status` exposes non-2xx responses so the plugin can take over classification from the host. */
   status: number;
   headers: Readonly<Record<string, string>>;
 }
@@ -99,7 +100,7 @@ interface CodexBarHTTPTextResponse extends CodexBarHTTPResponse {
 }
 
 interface CodexBarRetryOptions {
-  /** Requests one delayed retry. The host clamps this interval to 10 seconds. */
+  /** Requests the same one delayed retry used automatically for transient HTTP statuses; the host clamps it to 10 seconds. */
   retryAfterSeconds: number;
 }
 
@@ -169,7 +170,8 @@ interface CodexBarProviderDefinition {
   endpoints: CodexBarEndpoint[];
   auth?: CodexBarAuth;
   settings: CodexBarSetting[];
-  capabilities?: Array<"browser-cookies">;
+  /** Grants declared browser-cookie access or lets the plugin observe and classify non-2xx HTTP responses. */
+  capabilities?: Array<"browser-cookies" | "http-status">;
   cookieDomains?: string[];
   fetchUsage(ctx: CodexBarPluginContext): CodexBarUsageSnapshot | Promise<CodexBarUsageSnapshot>;
 }

--- a/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
+++ b/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
@@ -5,7 +5,7 @@ type CodexBarEndpoint =
   | string
   | {
       setting: string;
-      policy: "https" | "https-or-loopback-http";
+      policy: "https" | "https-or-loopback-http" | "https-or-private-network-http";
     };
 
 type CodexBarAuth =

--- a/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
+++ b/Sources/CodexBarCore/Resources/Plugins/provider-plugin-prelude.js
@@ -48,7 +48,29 @@
     networkFailure: "network-failure",
     apiFailure: "api-failure",
   });
-  const classifiedFailure = (kind) => (message) => new Error(`__CODEXBAR_FAILURE__:${kind}:${String(message)}`);
+  const retryableFailureKinds = new Set([
+    failureKinds.rateLimited,
+    failureKinds.providerUnavailable,
+    failureKinds.networkFailure,
+    failureKinds.apiFailure,
+  ]);
+  const classifiedFailure = (kind) => (message, options) => {
+    let retryAfter = "";
+    if (options !== undefined) {
+      if (!retryableFailureKinds.has(kind)) {
+        throw new TypeError("retry options are supported only for transient failures");
+      }
+      if (!options || typeof options !== "object" || !("retryAfterSeconds" in options)) {
+        throw new TypeError("retry options require retryAfterSeconds");
+      }
+      const seconds = Number(options.retryAfterSeconds);
+      if (!Number.isFinite(seconds) || seconds < 0) {
+        throw new RangeError("retryAfterSeconds must be a non-negative finite number");
+      }
+      retryAfter = String(seconds);
+    }
+    return new Error(`__CODEXBAR_FAILURE_V2__:${kind}:${retryAfter}:${String(message)}`);
+  };
   ctx.fail = Object.freeze(
     Object.fromEntries(Object.entries(failureKinds).map(([name, kind]) => [name, classifiedFailure(kind)])),
   );

--- a/Tests/CodexBarTests/ProviderFetchErrorTests.swift
+++ b/Tests/CodexBarTests/ProviderFetchErrorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import CodexBarCore
 
@@ -8,5 +9,82 @@ struct ProviderFetchErrorTests {
 
         #expect(message.contains("Kiro CLI"))
         #expect(message.contains("kiro-cli login"))
+    }
+
+    @Test
+    func `pipeline honors one exact classified retry delay`() async throws {
+        let state = DelayedRetryStrategyState()
+        let strategy = DelayedRetryStrategy(state: state)
+        let delays = RetryDelayRecorder()
+        let pipeline = ProviderFetchPipeline(
+            resolveStrategies: { _ in [strategy] },
+            retrySleeper: { seconds in await delays.record(seconds) })
+
+        let outcome = await pipeline.fetch(context: Self.context(), provider: .neuralwatt)
+
+        _ = try outcome.result.get()
+        #expect(await state.fetchCount == 2)
+        #expect(await delays.values == [3])
+        #expect(outcome.attempts.count == 1)
+        #expect(outcome.attempts.first?.errorDescription == nil)
+    }
+
+    private static func context() -> ProviderFetchContext {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: .api,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: nil,
+            fetcher: UsageFetcher(environment: [:]),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+}
+
+private actor DelayedRetryStrategyState {
+    private(set) var fetchCount = 0
+
+    func nextFetchShouldFail() -> Bool {
+        self.fetchCount += 1
+        return self.fetchCount == 1
+    }
+}
+
+private struct DelayedRetryStrategy: ProviderFetchStrategy {
+    let state: DelayedRetryStrategyState
+    let id = "delayed-retry-test"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        if await self.state.nextFetchShouldFail() {
+            throw ProviderFetchClassifiedError(
+                kind: .rateLimited,
+                message: "retry fixture",
+                retryAfterSeconds: 3)
+        }
+        return self.makeResult(
+            usage: UsageSnapshot(primary: nil, secondary: nil, updatedAt: Date()),
+            sourceLabel: "test")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}
+
+private actor RetryDelayRecorder {
+    private(set) var values: [TimeInterval] = []
+
+    func record(_ value: TimeInterval) {
+        self.values.append(value)
     }
 }

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -792,7 +792,7 @@ struct ProviderPluginRuntimeTests {
             transport: ProviderHTTPTransportHandler { _ in throw URLError(.unsupportedURL) },
             timeout: ProviderPluginRuntime.defaultTimeout,
             responseSizeLimit: ProviderPluginRuntime.maximumResponseBytes,
-            rejectsNonSuccessResponses: false,
+            enforcesUserResponsePolicy: false,
             allowsDynamicID: false,
             workerStackSizeBytes: workerStackSizeBytes)
     }

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -303,6 +303,82 @@ struct ProviderPluginRuntimeTests {
         #expect(await rejectedRequests.isEmpty)
     }
 
+    @Test(arguments: [
+        "http://localhost:4000",
+        "http://10.0.0.8:4000",
+        "http://172.16.0.8:4000",
+        "http://192.168.1.8:4000",
+        "http://169.254.1.8:4000",
+        "http://[fc00::8]:4000",
+        "http://[fe80::8]:4000",
+        "http://gateway.local:4000",
+        "https://gateway.example:4000",
+    ])
+    func `private network endpoint policy accepts the native gateway origin set`(origin: String) async throws {
+        let requests = RequestRecorder()
+        let runtime = try ProviderPluginRuntime(
+            source: Self.plugin(
+                id: "llmproxy",
+                endpoints: #"[{ setting: "BASE_URL", policy: "https-or-private-network-http" }]"#,
+                settings: """
+                { key: "TEST_KEY", title: "API key", type: "secure" },
+                { key: "BASE_URL", title: "Base URL", type: "plain" }
+                """,
+                fetchBody: """
+                const response = await ctx.http.getJSON(`${ctx.settings.get("BASE_URL")}/usage`);
+                return { primary: { usedPercent: response.json.used } };
+                """),
+            transport: Self.transport(recorder: requests, body: #"{"used":4}"#))
+
+        let snapshot = try await runtime.fetchUsage(
+            settings: ["BASE_URL": origin],
+            secrets: ["TEST_KEY": "fixture-key"])
+
+        #expect(snapshot.primary?.usedPercent == 4)
+        #expect(await requests.first?.url?.absoluteString == "\(origin)/usage")
+    }
+
+    @Test
+    func `private network endpoint policy rejects public HTTP before transport`() async throws {
+        let requests = RequestRecorder()
+        let runtime = try ProviderPluginRuntime(
+            source: Self.plugin(
+                id: "litellm",
+                endpoints: #"[{ setting: "BASE_URL", policy: "https-or-private-network-http" }]"#,
+                settings: """
+                { key: "TEST_KEY", title: "API key", type: "secure" },
+                { key: "BASE_URL", title: "Base URL", type: "plain" }
+                """,
+                fetchBody: """
+                await ctx.http.getJSON(`${ctx.settings.get("BASE_URL")}/usage`);
+                return { primary: { usedPercent: 1 } };
+                """),
+            transport: Self.transport(recorder: requests))
+
+        await #expect(throws: ProviderPluginError.self) {
+            _ = try await runtime.fetchUsage(
+                settings: ["BASE_URL": "http://gateway.example"],
+                secrets: ["TEST_KEY": "fixture-key"])
+        }
+        #expect(await requests.isEmpty)
+    }
+
+    @Test
+    func `bundled private network policy is limited to providers with native parity`() throws {
+        _ = try ProviderPluginRuntime(source: Self.plugin(
+            id: "llmproxy",
+            endpoints: #"[{ setting: "BASE_URL", policy: "https-or-private-network-http" }]"#,
+            auth: "null",
+            settings: #"{ key: "BASE_URL", title: "Base URL", type: "plain" }"#))
+
+        #expect(throws: ProviderPluginError.self) {
+            _ = try ProviderPluginRuntime(source: Self.plugin(
+                endpoints: #"[{ setting: "BASE_URL", policy: "https-or-private-network-http" }]"#,
+                auth: "null",
+                settings: #"{ key: "BASE_URL", title: "Base URL", type: "plain" }"#))
+        }
+    }
+
     @Test
     func `browser cookie access is declared domain only and cookie values are redacted`() async throws {
         let access = CookieAccessRecorder(header: "session=secret-cookie-value")
@@ -679,6 +755,7 @@ struct ProviderPluginRuntimeTests {
     }
 
     private static func plugin(
+        id: String = "synthetic",
         endpoints: String = #"["https://api.example.test"]"#,
         auth: String = #"{ type: "bearer", secret: "TEST_KEY" }"#,
         settings: String = #"{ key: "TEST_KEY", title: "API key", type: "secure" }"#,
@@ -687,7 +764,7 @@ struct ProviderPluginRuntimeTests {
     {
         """
         defineProvider({
-          id: "synthetic",
+          id: "\(id)",
           name: "Fixture",
           endpoints: \(endpoints),
           auth: \(auth),

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -545,6 +545,40 @@ struct ProviderPluginRuntimeTests {
     }
 
     @Test
+    func `transient classified failure preserves capped retry delay`() async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
+        throw ctx.fail.rateLimited("retry later", { retryAfterSeconds: 30 });
+        """))
+
+        do {
+            _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+            Issue.record("Expected classified failure")
+        } catch let error as ProviderFetchClassifiedError {
+            #expect(error.kind == .rateLimited)
+            #expect(error.message == "retry later")
+            #expect(error.retryAfterSeconds == 10)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func `non transient classified failure rejects retry options`() async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
+        throw ctx.fail.parseFailure("bad payload", { retryAfterSeconds: 1 });
+        """))
+
+        do {
+            _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+            Issue.record("Expected script failure")
+        } catch let error as ProviderPluginError {
+            #expect(error.localizedDescription.contains("retry options are supported only for transient failures"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
     func `unclassified failures retain generic script mapping`() async throws {
         let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
         throw new Error("ordinary fixture");

--- a/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginRuntimeTests.swift
@@ -422,6 +422,35 @@ struct ProviderPluginRuntimeTests {
     }
 
     @Test
+    func `identity only snapshot preserves a successful sparse provider state`() async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
+        return { identity: { organization: "Moonshot", loginMethod: "Balance: $0.00" } };
+        """))
+
+        let snapshot = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.providerCost == nil)
+        #expect(snapshot.identity?.accountOrganization == "Moonshot")
+        #expect(snapshot.identity?.loginMethod == "Balance: $0.00")
+    }
+
+    @Test(arguments: [
+        #"return {};"#,
+        #"return { identity: {} };"#,
+        #"return { identity: { email: "  " } };"#,
+        #"return { dataConfidence: "exact" };"#,
+        #"return { subscriptionRenewsAt: "2026-09-01T00:00:00Z" };"#,
+    ])
+    func `empty and metadata only snapshots remain invalid`(fetchBody: String) async throws {
+        let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: fetchBody))
+
+        await #expect(throws: ProviderPluginError.self) {
+            _ = try await runtime.fetchUsage(secrets: ["TEST_KEY": "secret"])
+        }
+    }
+
+    @Test
     func `details map strictly and trim display strings`() async throws {
         let runtime = try ProviderPluginRuntime(source: Self.plugin(fetchBody: """
         return {

--- a/Tests/CodexBarTests/UserProviderPluginTests.swift
+++ b/Tests/CodexBarTests/UserProviderPluginTests.swift
@@ -48,7 +48,7 @@ struct UserProviderPluginTests {
     }
 
     @Test
-    func `user plugin broker owns identity encoding and rejects compressed responses`() async throws {
+    func `http status capability keeps identity encoding and compressed response rejection`() async throws {
         let fixture = try Fixture()
         defer { fixture.remove() }
         let source = """
@@ -57,6 +57,7 @@ struct UserProviderPluginTests {
           name: "Encoded Meter",
           endpoints: ["https://encoded.example"],
           settings: [],
+          capabilities: ["http-status"],
           async fetchUsage(ctx) {
             const response = await ctx.http.getJSON("https://encoded.example/usage", {
               headers: { "Accept-Encoding": "gzip" },
@@ -347,38 +348,113 @@ struct UserProviderPluginTests {
 
     @Test
     func `NeuralWatt style Retry After failure delays once then succeeds`() async throws {
-        let source = """
-        defineProvider({
-          id: "neuralwatt-prototype",
-          name: "NeuralWatt Prototype",
-          endpoints: ["https://api.neuralwatt.test"],
-          settings: [],
-          async fetchUsage(ctx) {
-            const response = await ctx.http.getJSON("https://api.neuralwatt.test/v1/quota");
-            if (response.status === 429) {
-              throw ctx.fail.rateLimited("rate limited", {
-                retryAfterSeconds: Number(response.headers["retry-after"] || 1),
-              });
-            }
-            return { cost: { used: response.json.balance, currency: "USD" } };
-          },
-        });
-        """
+        let fixture = try Fixture()
+        defer { fixture.remove() }
         let transport = SequenceResponseTransport(responses: [
             (429, #"{"error":"slow down"}"#, ["Retry-After": "0"]),
             (200, #"{"balance":5}"#, [:]),
         ])
-        let runtime = try ProviderPluginRuntime(
-            source: source,
-            transport: transport,
-            allowsDynamicID: true)
+        let plugin = try fixture.loader(transport: transport).load(fileURL: fixture.write(
+            name: "neuralwatt.js",
+            source: Self.retryAfterPlugin(capabilities: #"capabilities: ["http-status"],"#)))
+        let binding = try plugin.approvalBinding(settings: [:])
+        try fixture.approvals.record(binding)
 
-        let snapshot = try await ProviderFetchDelayedRetry.run {
-            try await runtime.fetchUsage()
-        }
+        let snapshot = try await plugin.fetchUsage(
+            settings: [:],
+            secrets: [:],
+            approvalStore: fixture.approvals)
 
+        #expect(binding.capabilities == ["http-status"])
         #expect(snapshot.providerCost?.used == 5)
         #expect(await transport.requestCount == 2)
+    }
+
+    @Test
+    func `naive user plugin automatically retries host 429 once`() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let transport = SequenceResponseTransport(responses: [
+            (429, #"{"error":"slow down"}"#, ["Retry-After": "0"]),
+            (200, #"{"used":42}"#, [:]),
+        ])
+        let plugin = try fixture.loader(transport: transport).load(fileURL: fixture.write(
+            name: "naive.js",
+            source: Self.naiveUsagePlugin()))
+        try fixture.approvals.record(plugin.approvalBinding(settings: [:]))
+
+        let snapshot = try await plugin.fetchUsage(
+            settings: [:],
+            secrets: [:],
+            approvalStore: fixture.approvals)
+
+        #expect(snapshot.primary?.usedPercent == 42)
+        #expect(await transport.requestCount == 2)
+    }
+
+    @Test
+    func `host 503 without Retry After requests one second retry without sleeping`() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let transport = SequenceResponseTransport(responses: [
+            (503, #"{"error":"unavailable"}"#, [:]),
+            (200, #"{"used":17}"#, [:]),
+        ])
+        let plugin = try fixture.loader(transport: transport).load(fileURL: fixture.write(
+            name: "naive.js",
+            source: Self.naiveUsagePlugin()))
+        let delays = RetryDelayRecorder()
+
+        let snapshot = try await ProviderFetchDelayedRetry.run(sleeper: { seconds in
+            await delays.record(seconds)
+        }, operation: {
+            try await plugin.runtime.fetchUsage()
+        })
+
+        #expect(snapshot.primary?.usedPercent == 17)
+        #expect(await transport.requestCount == 2)
+        #expect(await delays.values == [1])
+    }
+
+    @Test
+    func `host 404 remains unclassified and fails without retry`() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let transport = SequenceResponseTransport(responses: [
+            (404, #"{"error":"not found"}"#, [:]),
+        ])
+        let plugin = try fixture.loader(transport: transport).load(fileURL: fixture.write(
+            name: "naive.js",
+            source: Self.naiveUsagePlugin()))
+        try fixture.approvals.record(plugin.approvalBinding(settings: [:]))
+
+        do {
+            _ = try await plugin.fetchUsage(
+                settings: [:],
+                secrets: [:],
+                approvalStore: fixture.approvals)
+            Issue.record("Expected host HTTP status rejection")
+        } catch {
+            #expect(error.localizedDescription.contains("request returned HTTP 404"))
+        }
+        #expect(await transport.requestCount == 1)
+    }
+
+    @Test
+    func `http status capability parses and unknown capability remains rejected`() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let loader = fixture.loader(transport: RecordingTransport(responseJSON: "{}"))
+        let plugin = try loader.load(fileURL: fixture.write(
+            name: "http-status.js",
+            source: Self.retryAfterPlugin(capabilities: #"capabilities: ["http-status"],"#)))
+
+        #expect(plugin.manifest.capabilities == [.httpStatus])
+        #expect(throws: ProviderPluginError.self) {
+            _ = try loader.load(fileURL: fixture.write(
+                name: "unknown.js",
+                source: Self.retryAfterPlugin(capabilities: #"capabilities: ["unknown"],"#)))
+        }
     }
 
     private static func javaScriptPlugin(
@@ -415,6 +491,42 @@ struct UserProviderPluginTests {
           endpoints: ["https://delete.example"],
           settings: [],
           fetchUsage() { return { primary: { usedPercent: used } }; },
+        });
+        """
+    }
+
+    private static func retryAfterPlugin(capabilities: String = "") -> String {
+        """
+        defineProvider({
+          id: "neuralwatt-prototype",
+          name: "NeuralWatt Prototype",
+          endpoints: ["https://api.neuralwatt.test"],
+          settings: [],
+          \(capabilities)
+          async fetchUsage(ctx) {
+            const response = await ctx.http.getJSON("https://api.neuralwatt.test/v1/quota");
+            if (response.status === 429) {
+              throw ctx.fail.rateLimited("rate limited", {
+                retryAfterSeconds: Number(response.headers["retry-after"] || 1),
+              });
+            }
+            return { cost: { used: response.json.balance, currency: "USD" } };
+          },
+        });
+        """
+    }
+
+    private static func naiveUsagePlugin() -> String {
+        """
+        defineProvider({
+          id: "naive-meter",
+          name: "Naive Meter",
+          endpoints: ["https://api.naive.test"],
+          settings: [],
+          async fetchUsage(ctx) {
+            const response = await ctx.http.getJSON("https://api.naive.test/usage");
+            return { primary: { usedPercent: response.json.used } };
+          },
         });
         """
     }
@@ -455,6 +567,14 @@ private actor ResolverAccess {
 
     func record(provider _: UsageProvider, domain _: String) {
         self.calls += 1
+    }
+}
+
+private actor RetryDelayRecorder {
+    private(set) var values: [TimeInterval] = []
+
+    func record(_ seconds: TimeInterval) {
+        self.values.append(seconds)
     }
 }
 

--- a/Tests/CodexBarTests/UserProviderPluginTests.swift
+++ b/Tests/CodexBarTests/UserProviderPluginTests.swift
@@ -292,6 +292,42 @@ struct UserProviderPluginTests {
         ])
     }
 
+    @Test
+    func `NeuralWatt style Retry After failure delays once then succeeds`() async throws {
+        let source = """
+        defineProvider({
+          id: "neuralwatt-prototype",
+          name: "NeuralWatt Prototype",
+          endpoints: ["https://api.neuralwatt.test"],
+          settings: [],
+          async fetchUsage(ctx) {
+            const response = await ctx.http.getJSON("https://api.neuralwatt.test/v1/quota");
+            if (response.status === 429) {
+              throw ctx.fail.rateLimited("rate limited", {
+                retryAfterSeconds: Number(response.headers["retry-after"] || 1),
+              });
+            }
+            return { cost: { used: response.json.balance, currency: "USD" } };
+          },
+        });
+        """
+        let transport = SequenceResponseTransport(responses: [
+            (429, #"{"error":"slow down"}"#, ["Retry-After": "0"]),
+            (200, #"{"balance":5}"#, [:]),
+        ])
+        let runtime = try ProviderPluginRuntime(
+            source: source,
+            transport: transport,
+            allowsDynamicID: true)
+
+        let snapshot = try await ProviderFetchDelayedRetry.run {
+            try await runtime.fetchUsage()
+        }
+
+        #expect(snapshot.providerCost?.used == 5)
+        #expect(await transport.requestCount == 2)
+    }
+
     private static func javaScriptPlugin(
         id: String = "acme-meter",
         origin: String = "https://api.acme.test") -> String
@@ -366,6 +402,28 @@ private actor ResolverAccess {
 
     func record(provider _: UsageProvider, domain _: String) {
         self.calls += 1
+    }
+}
+
+private actor SequenceResponseTransport: ProviderHTTPTransport {
+    private var responses: [(status: Int, body: String, headers: [String: String])]
+    private(set) var requestCount = 0
+
+    init(responses: [(Int, String, [String: String])]) {
+        self.responses = responses
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        self.requestCount += 1
+        let response = self.responses.removeFirst()
+        var headers = response.headers
+        headers["Content-Type"] = "application/json"
+        let httpResponse = try HTTPURLResponse(
+            url: #require(request.url),
+            statusCode: response.status,
+            httpVersion: nil,
+            headerFields: headers)!
+        return (Data(response.body.utf8), httpResponse)
     }
 }
 

--- a/Tests/CodexBarTests/UserProviderPluginTests.swift
+++ b/Tests/CodexBarTests/UserProviderPluginTests.swift
@@ -265,6 +265,33 @@ struct UserProviderPluginTests {
         #expect(binding.typedConfirmationOrigins == binding.origins)
     }
 
+    @Test
+    func `plugin CLI renders identity only snapshots`() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let plugin = try fixture.loader(transport: RecordingTransport(responseJSON: "{}"))
+            .load(fileURL: fixture.write(name: "identity.js", source: Self.javaScriptPlugin()))
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: plugin.manifest.id,
+                accountEmail: "user@example.com",
+                accountOrganization: "Acme",
+                loginMethod: "API key",
+                accountID: "acct-1"))
+
+        #expect(CodexBarCLI.pluginSnapshotLines(plugin: plugin, snapshot: snapshot) == [
+            "Acme Meter",
+            "Account: user@example.com",
+            "Organization: Acme",
+            "Plan: API key",
+            "Account ID: acct-1",
+        ])
+    }
+
     private static func javaScriptPlugin(
         id: String = "acme-meter",
         origin: String = "https://api.acme.test") -> String

--- a/Tests/CodexBarTests/UserProviderPluginTests.swift
+++ b/Tests/CodexBarTests/UserProviderPluginTests.swift
@@ -266,6 +266,59 @@ struct UserProviderPluginTests {
     }
 
     @Test
+    func `LLM Proxy private HTTP requires approval and keeps auth bound to the typed origin`() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let source = """
+        defineProvider({
+          id: "llmproxy-prototype",
+          name: "LLM Proxy Prototype",
+          endpoints: [{ setting: "BASE_URL", policy: "https-or-private-network-http" }],
+          auth: { type: "bearer", secret: "TOKEN" },
+          settings: [
+            { key: "BASE_URL", title: "Base URL", type: "plain" },
+            { key: "TOKEN", title: "API token", type: "secure" },
+          ],
+          async fetchUsage(ctx) {
+            const response = await ctx.http.getJSON(`${ctx.settings.get("BASE_URL")}/usage`);
+            return { identity: { organization: response.json.organization } };
+          },
+        });
+        """
+        let transport = RecordingTransport(responseJSON: #"{"organization":"Acme gateway"}"#)
+        let plugin = try fixture.loader(transport: transport)
+            .load(fileURL: fixture.write(name: "llmproxy.js", source: source))
+        let settings = ["BASE_URL": "http://192.168.1.20:4000"]
+        let binding = try plugin.approvalBinding(settings: settings)
+
+        #expect(binding.origins == ["http://192.168.1.20:4000"])
+        #expect(binding.typedConfirmationOrigins == binding.origins)
+        let localBinding = try plugin.approvalBinding(settings: ["BASE_URL": "http://gateway.local.:4000"])
+        #expect(localBinding.typedConfirmationOrigins == localBinding.origins)
+        await #expect(throws: UserProviderPluginError.self) {
+            _ = try await plugin.fetchUsage(
+                settings: settings,
+                secrets: ["TOKEN": "fixture-secret"],
+                approvalStore: fixture.approvals)
+        }
+        #expect(transport.requestCount == 0)
+
+        try fixture.approvals.record(binding)
+        let snapshot = try await plugin.fetchUsage(
+            settings: settings,
+            secrets: ["TOKEN": "fixture-secret"],
+            approvalStore: fixture.approvals)
+
+        #expect(snapshot.identity?.accountOrganization == "Acme gateway")
+        #expect(transport.lastRequest?.url?.absoluteString == "http://192.168.1.20:4000/usage")
+        #expect(transport.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-secret")
+
+        #expect(throws: ProviderPluginError.self) {
+            _ = try plugin.approvalBinding(settings: ["BASE_URL": "http://gateway.example"])
+        }
+    }
+
+    @Test
     func `plugin CLI renders identity only snapshots`() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }

--- a/docs/custom-provider-design.md
+++ b/docs/custom-provider-design.md
@@ -131,8 +131,10 @@ string-aware scanner before materializing JSON, so a hostile nested payload cann
 
 ### Network and secret boundary
 
-- Require HTTPS for authenticated requests. Allow HTTP only for an unauthenticated loopback URL (`localhost`,
-  `127.0.0.0/8`, or `::1`). Reject URL user info and fragments.
+- Require HTTPS for every public origin. A settings-configured origin may use HTTP only for loopback, RFC 1918 IPv4,
+  IPv4 link-local, IPv6 unique-local/link-local, or `.local` targets under the separate typed-approval gate. This local
+  exception may be authenticated because self-hosted LLM Proxy and LiteLLM deployments require the same bearer behavior
+  their existing Swift providers support. Reject URL user info and fragments.
 - Extend `ProviderEndpointOverrideValidator`; do not create a second URL parser. Use a dedicated
   `ProviderHTTPClient` configuration that rejects every redirect, even though the shared client safely permits same-origin
   HTTPS redirects.
@@ -247,8 +249,9 @@ change.
 ## Accepted owner decisions
 
 1. Declarative provider support is worth the runtime identity migration and long-term versioned schema support.
-2. MVP may use unauthenticated loopback HTTP only under the same separate approval gate, including typed confirmation of
-   the normalized URL. Every authenticated request requires HTTPS.
+2. MVP may use private-network HTTP only under the same separate approval gate, including typed confirmation of the
+   normalized origin. Public origins always require HTTPS. Bundled first-party code may bypass interactive approval only
+   for LLM Proxy and LiteLLM, whose existing Swift implementations already grant the identical target authority.
 3. A derived per-instance environment variable plus local URL/auth approval is the only MVP secret source. Keychain
    storage is deferred; the initial design must not imply or preserve a second secret path.
 4. MVP supports one primary rate window, with cost and identity optional. Multi-window and aggregation semantics remain

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -30,11 +30,11 @@ weakening the plugin network policy.
 |---|---:|
 | `cut-over` | 11 |
 | `converted` | 5 |
-| `convertible-now` | 3 |
+| `convertible-now` | 7 |
 | `needs-cookie-import` | 19 |
 | `needs-files/subprocess/oauth-broker` | 15 |
 | `needs-pty/webview/native` | 8 |
-| `needs-host-extension` | 7 |
+| `needs-host-extension` | 3 |
 | **Total** | **68** |
 
 ## Matrix
@@ -45,7 +45,7 @@ weakening the plugin network policy.
 | openai | `converted` | Yes | Converted: fixed-origin bearer GET pagination with daily spend, model, line-item, and token details. |
 | azureopenai | `needs-pty/webview/native` | No | The current quota probe is a POST chat completion against a user-configured deployment origin. |
 | claude | `needs-files/subprocess/oauth-broker` | No | Full parity needs credential files/Keychain, OAuth refresh, CLI/PTY, cookies, local logs, and admin details. |
-| fireworks | `needs-host-extension` | No | Stopped: a valid empty billing window must return a successful snapshot with no window, cost, or detail, which the plugin snapshot contract rejects. |
+| fireworks | `convertible-now` | No | Identity can now carry the successful empty-billing state without inventing a rate window or cost. |
 | clinepass | `cut-over` | Yes | Cut over on both engines: fixed-origin bearer GET, typed quota lanes, credential aliases, and classified failures match native behavior; the Swift fetcher and Linux fixtures are deleted. |
 | cursor | `needs-cookie-import` | No | Browser cookies/app database provide auth, and integer request history also has bespoke detail. |
 | opencode | `needs-cookie-import` | No | Skipped: React server-function response parsing needs a protocol-specific text decoder beyond `matchFirst`. |
@@ -67,7 +67,7 @@ weakening the plugin network policy.
 | vertexai | `needs-files/subprocess/oauth-broker` | No | ADC/gcloud files, OAuth refresh, optional subprocess fallback, and local cost logs are required. |
 | augment | `needs-files/subprocess/oauth-broker` | No | The preferred strategy spawns `auggie`; the alternative imports browser cookies and maintains sessions. |
 | jetbrains | `needs-pty/webview/native` | No | There is no HTTP strategy; native IDE discovery and local XML parsing are the provider. |
-| moonshot | `needs-host-extension` | No | Stopped: balance is intentionally carried only in snapshot identity, but the plugin contract rejects identity-only snapshots. |
+| moonshot | `convertible-now` | No | Balance can remain intentionally identity-only, matching the native sparse snapshot. |
 | amp | `needs-files/subprocess/oauth-broker` | No | CLI subprocess and browser-cookie strategies plus workspace credit details are outside this host. |
 | t3chat | `converted` | Yes | Converted: declared-domain cookie import, JSONL text parsing, and generic base/overage windows. |
 | ollama | `needs-cookie-import` | No | Skipped: hosted parity requires HTML bootstrap/state extraction plus API-key fallback arbitration. |
@@ -98,14 +98,14 @@ weakening the plugin network policy.
 | litellm | `needs-host-extension` | No | Stopped: native private-network HTTP origins exceed the plugin policy; zero-spend keys without budgets can also produce an identity-only snapshot. |
 | deepgram | `cut-over` | Yes | Cut over on JavaScriptCore: project discovery, aggregation, configured origins, numeric validation, and classified auth/permission/rate/network/API/parse failures match native behavior; the native fetch core is Linux-only. |
 | poe | `cut-over` | Yes | Cut over on both engines: fixed-origin bearer GET balance/history pagination with daily points and model/type summaries; the native fetch twins are deleted. |
-| chutes | `needs-host-extension` | No | Stopped: tolerant parsing explicitly accepts successful no-usage payloads, yielding an empty snapshot that the plugin contract rejects. |
+| chutes | `convertible-now` | No | Tolerant no-usage payloads can return an API identity without inventing quota data. |
 | neuralwatt | `needs-host-extension` | No | Stopped: the native request uses delayed transient/`Retry-After` retries, while the plugin HTTP API exposes neither retry policy nor sleep. |
 | clawrouter | `cut-over` | Yes | Cut over on JavaScriptCore: validated configured origins, classified failures, exact confidence, budget/ledger details, and provider charts match native behavior; the native fetch core is Linux-only. |
 | longcat | `needs-cookie-import` | No | Skipped: browser-cookie retry needs domain/path-aware cookie selection across multiple imported sessions; the generic broker currently returns one flattened header. |
 | sub2api | `cut-over` | Yes | Cut over on JavaScriptCore: configured HTTPS/loopback origins, a hard 15-second request deadline, strict parsing, exact confidence, and classified failures match native behavior; the native fetch core is Linux-only. |
 | wayfinder | `needs-pty/webview/native` | No | The local unauthenticated HTTP gateway, metrics text, and routing/savings model violate HTTPS-only generic scope. |
 | zenmux | `convertible-now` | No | Verified fixed-origin bearer GET pair; subscription and optional PAYG balance map generically. |
-| aiand | `needs-host-extension` | No | Stopped: an empty 30-day log window must omit cost because its currency is unknowable, yielding a valid empty snapshot that plugins reject. |
+| aiand | `convertible-now` | No | An empty 30-day log window can omit unknowable currency and return its API identity. |
 | zoommate | `needs-cookie-import` | No | Skipped: cookie-to-JWT exchange plus paginated history requires provider-specific retry state. |
 | xai | `cut-over` | Yes | Cut over on both engines: bearer GET balance plus best-effort JSON POST history and billing details; the native fetch twins are deleted. |
 | notion | `needs-cookie-import` | No | Workspace selection and AI allowance calls require imported Notion cookies and forwarded session headers. |

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -30,11 +30,11 @@ weakening the plugin network policy.
 |---|---:|
 | `cut-over` | 11 |
 | `converted` | 5 |
-| `convertible-now` | 7 |
+| `convertible-now` | 8 |
 | `needs-cookie-import` | 19 |
 | `needs-files/subprocess/oauth-broker` | 15 |
 | `needs-pty/webview/native` | 8 |
-| `needs-host-extension` | 3 |
+| `needs-host-extension` | 2 |
 | **Total** | **68** |
 
 ## Matrix
@@ -99,7 +99,7 @@ weakening the plugin network policy.
 | deepgram | `cut-over` | Yes | Cut over on JavaScriptCore: project discovery, aggregation, configured origins, numeric validation, and classified auth/permission/rate/network/API/parse failures match native behavior; the native fetch core is Linux-only. |
 | poe | `cut-over` | Yes | Cut over on both engines: fixed-origin bearer GET balance/history pagination with daily points and model/type summaries; the native fetch twins are deleted. |
 | chutes | `convertible-now` | No | Tolerant no-usage payloads can return an API identity without inventing quota data. |
-| neuralwatt | `needs-host-extension` | No | Stopped: the native request uses delayed transient/`Retry-After` retries, while the plugin HTTP API exposes neither retry policy nor sleep. |
+| neuralwatt | `convertible-now` | No | Classified transient failures can request the same single delayed retry and capped `Retry-After` behavior as native. |
 | clawrouter | `cut-over` | Yes | Cut over on JavaScriptCore: validated configured origins, classified failures, exact confidence, budget/ledger details, and provider charts match native behavior; the native fetch core is Linux-only. |
 | longcat | `needs-cookie-import` | No | Skipped: browser-cookie retry needs domain/path-aware cookie selection across multiple imported sessions; the generic broker currently returns one flattened header. |
 | sub2api | `cut-over` | Yes | Cut over on JavaScriptCore: configured HTTPS/loopback origins, a hard 15-second request deadline, strict parsing, exact confidence, and classified failures match native behavior; the native fetch core is Linux-only. |

--- a/docs/plugin-conversion-matrix.md
+++ b/docs/plugin-conversion-matrix.md
@@ -30,11 +30,11 @@ weakening the plugin network policy.
 |---|---:|
 | `cut-over` | 11 |
 | `converted` | 5 |
-| `convertible-now` | 8 |
+| `convertible-now` | 10 |
 | `needs-cookie-import` | 19 |
 | `needs-files/subprocess/oauth-broker` | 15 |
 | `needs-pty/webview/native` | 8 |
-| `needs-host-extension` | 2 |
+| `needs-host-extension` | 0 |
 | **Total** | **68** |
 
 ## Matrix
@@ -94,8 +94,8 @@ weakening the plugin network policy.
 | bedrock | `needs-files/subprocess/oauth-broker` | No | AWS profiles/CLI credentials, SigV4 signing, pagination, and two services need host-owned credential/signing APIs. |
 | grok | `needs-pty/webview/native` | No | Persistent stdio JSON-RPC, auth/session files, cookies, logs, and binary gRPC-web are strongly native. |
 | groq | `needs-cookie-import` | No | Skipped: Stytch session exchange and console history remain a multi-step auth flow. |
-| llmproxy | `needs-host-extension` | No | Stopped: configured origins work for HTTPS/loopback, but native behavior also permits RFC 1918, link-local, unique-local IPv6, and `.local` HTTP, which the plugin policy rejects. |
-| litellm | `needs-host-extension` | No | Stopped: native private-network HTTP origins exceed the plugin policy; zero-spend keys without budgets can also produce an identity-only snapshot. |
+| llmproxy | `convertible-now` | No | Settings origins now preserve native HTTPS/public and approved private-network HTTP behavior. |
+| litellm | `convertible-now` | No | Settings origins now preserve native private-network HTTP behavior, and zero-spend identity-only snapshots are valid. |
 | deepgram | `cut-over` | Yes | Cut over on JavaScriptCore: project discovery, aggregation, configured origins, numeric validation, and classified auth/permission/rate/network/API/parse failures match native behavior; the native fetch core is Linux-only. |
 | poe | `cut-over` | Yes | Cut over on both engines: fixed-origin bearer GET balance/history pagination with daily points and model/type summaries; the native fetch twins are deleted. |
 | chutes | `convertible-now` | No | Tolerant no-usage payloads can return an API identity without inventing quota data. |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -98,6 +98,10 @@ so portable third-party plugins must use the host helpers below instead of ECMA-
 - `ctx.fail` creates classified errors for `authenticationExpired`, `missingCredential`, `permissionDenied`,
   `rateLimited`, `providerUnavailable`, `parseFailure`, `networkFailure`, and `apiFailure`. Throw the returned error,
   for example `throw ctx.fail.rateLimited("Provider rate limit reached")`; ordinary errors retain generic mapping.
+  Transient failures (`rateLimited`, `providerUnavailable`, `networkFailure`, and `apiFailure`) may request one delayed
+  retry with `{retryAfterSeconds}`. The host clamps the delay to 10 seconds, matching the built-in transient HTTP policy,
+  and never retries the retry. For a numeric `Retry-After` header, pass its value; use `1` for the built-in backoff when
+  the header is absent. Cancellation during the delay stops the retry.
 - `await ctx.browser.cookieHeader(domain)` returns a cookie header only with the `browser-cookies` capability and for a
   declared domain. The app imports from Chrome only. Cookie values are secret-equivalent and redacted.
 - `ctx.html.metaContent(html, name)` returns the first matching quoted meta value or `null`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -56,8 +56,11 @@ defineProvider({
   letter of `name` with a neutral tint. File/SVG icons are not supported.
 - `endpoints`: 1–16 declared network origins. A fixed endpoint is a normalized HTTPS origin such as
   `https://api.example.com` (no path, query, fragment, or user info). A settings-derived endpoint is
-  `{setting: "BASE_URL", policy: "https"}` or `{setting: "BASE_URL", policy: "https-or-loopback-http"}`. Its setting
-  must be declared as `plain`. HTTP is allowed only for unauthenticated loopback targets.
+  `{setting: "BASE_URL", policy: "https"}`, `{setting: "BASE_URL", policy: "https-or-loopback-http"}`, or
+  `{setting: "BASE_URL", policy: "https-or-private-network-http"}`. Its setting must be declared as `plain`.
+  `https-or-loopback-http` preserves the unauthenticated loopback-only rule. `https-or-private-network-http` also permits
+  authenticated HTTP for loopback, RFC 1918 IPv4, IPv4 link-local, IPv6 unique-local/link-local, and `.local` targets,
+  but only through the separate typed approval described below. Public targets always require HTTPS.
 - `auth` (optional): one of the forms below. The named secret must be a declared `secure` setting.
 - `settings`: up to 32 setting definitions. Keys contain 1–64 ASCII letters, digits, or underscores and start with a
   letter. Each entry has `key`, `title`, optional `subtitle`, and `type: "plain" | "secure"` (default `secure`).
@@ -74,8 +77,9 @@ auth: { type: "header", header: "X-Custom-Key", secret: "API_KEY" }
 auth: { type: "authorization-scheme", scheme: "Token", secret: "API_KEY" }
 ```
 
-The host owns the authentication header; plugin request options cannot override it. Authenticated origins must be
-HTTPS. Secure settings can be overridden for CLI use with
+The host owns the authentication header; plugin request options cannot override it. Authenticated public origins must be
+HTTPS; authenticated private-network HTTP requires `https-or-private-network-http` plus typed approval. Secure settings
+can be overridden for CLI use with
 `CODEXBAR_PLUGIN_<PLUGIN_ID>_<SETTING_KEY>`, uppercased with non-alphanumeric characters replaced by underscores. For
 example, `acme-usage` and `API_KEY` use `CODEXBAR_PLUGIN_ACME_USAGE_API_KEY`.
 
@@ -198,6 +202,10 @@ Transpile failures appear as that plugin's Settings error.
 Approval records live outside plugin files under `~/Library/Application Support/CodexBar/plugin-approvals.json`. A
 change to instance ID, normalized origins, auth mode/header, secure setting names, capabilities, or cookie domains
 invalidates approval before the next request. There is no bulk approval or import path.
+
+Bundled first-party plugins do not use the interactive plugin-approval flow. The private-network HTTP policy is therefore
+accepted for bundled code only for LLM Proxy and LiteLLM, whose existing Swift providers already permit exactly those
+targets. Other bundled providers fail manifest validation if they request that policy.
 
 `codexbar plugins list` shows locally discovered plugins. `codexbar plugins fetch <id>` displays the same approval
 fields and can approve only from an interactive terminal; redirected/headless input fails closed. Browser-cookie plugins

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -64,7 +64,8 @@ defineProvider({
 - `auth` (optional): one of the forms below. The named secret must be a declared `secure` setting.
 - `settings`: up to 32 setting definitions. Keys contain 1–64 ASCII letters, digits, or underscores and start with a
   letter. Each entry has `key`, `title`, optional `subtitle`, and `type: "plain" | "secure"` (default `secure`).
-- `capabilities` (optional): currently only `"browser-cookies"`.
+- `capabilities` (optional): `"browser-cookies"` and `"http-status"`. With `"http-status"`, the plugin observes
+  non-2xx responses itself instead of the host failing the request.
 - `cookieDomains`: required with `browser-cookies`; a non-empty list of normalized DNS host names.
 - `fetchUsage(ctx)`: function returning a snapshot object or a promise for one.
 
@@ -102,10 +103,12 @@ so portable third-party plugins must use the host helpers below instead of ECMA-
 - `ctx.fail` creates classified errors for `authenticationExpired`, `missingCredential`, `permissionDenied`,
   `rateLimited`, `providerUnavailable`, `parseFailure`, `networkFailure`, and `apiFailure`. Throw the returned error,
   for example `throw ctx.fail.rateLimited("Provider rate limit reached")`; ordinary errors retain generic mapping.
-  Transient failures (`rateLimited`, `providerUnavailable`, `networkFailure`, and `apiFailure`) may request one delayed
-  retry with `{retryAfterSeconds}`. The host clamps the delay to 10 seconds, matching the built-in transient HTTP policy,
-  and never retries the retry. For a numeric `Retry-After` header, pass its value; use `1` for the built-in backoff when
-  the header is absent. Cancellation during the delay stops the retry.
+  Every plugin automatically gets one delayed retry when a request returns 408, 429, 500, 502, 503, or 504. A numeric
+  `Retry-After` header sets the delay; otherwise the delay is 1 second, and the host clamps it to 10 seconds. A plugin
+  that needs provider-specific handling—such as a non-numeric `Retry-After`, quota data in the error body, or a vendor
+  retry field—declares `http-status`, receives the response, and throws `ctx.fail.rateLimited(message,
+  {retryAfterSeconds})` or another transient classified failure. Both paths share one retry budget and never retry the
+  retry. Cancellation during the delay stops the retry.
 - `await ctx.browser.cookieHeader(domain)` returns a cookie header only with the `browser-cookies` capability and for a
   declared domain. The app imports from Chrome only. Cookie values are secret-equivalent and redacted.
 - `ctx.html.metaContent(html, name)` returns the first matching quoted meta value or `null`.
@@ -125,8 +128,24 @@ so portable third-party plugins must use the host helpers below instead of ECMA-
 - `ctx.pct(used, limit)` returns a finite percentage clamped to 0–100; non-positive limits map to 100.
 
 User-plugin requests run in an ephemeral session with no ambient cookies, credential store, or URL cache. Redirects are
-rejected, the timeout is 15 seconds, `Accept-Encoding: identity` is sent, compressed and non-2xx responses fail, and
-response bytes are capped at 1 MiB. Request URLs must match a declared, approved origin.
+rejected, the timeout is 15 seconds, `Accept-Encoding: identity` is sent, compressed responses always fail, and response
+bytes are capped at 1 MiB. By default, the host rejects non-2xx responses and automatically retries 408, 429, 500, 502,
+503, and 504 once, using a numeric `Retry-After` delay or 1 second when absent, clamped to 10 seconds. With `http-status`,
+the plugin instead receives `{status, headers, ...}` and owns classification, including any request for the same single
+delayed retry. Request URLs must match a declared, approved origin.
+
+```js
+capabilities: ["http-status"],
+async fetchUsage(ctx) {
+  const response = await ctx.http.getJSON("https://api.example.com/usage");
+  if (response.status === 429) {
+    const retryAfterSeconds = Number(response.headers["retry-after"] || 1);
+    throw ctx.fail.rateLimited("Rate limited", { retryAfterSeconds });
+  }
+}
+```
+
+Declaring `http-status` changes the approval binding, so an installed plugin requires re-approval after adding it.
 
 Bundled first-party providers that have cut over to JavaScript use the shared runtime's 20-second hung-script watchdog.
 A timeout fails that refresh and discards the poisoned worker so the next refresh starts with a fresh context; this is

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -132,7 +132,7 @@ abandoned evaluation thread can remain alive until process exit.
 
 ## Snapshot result
 
-Return at least one rate window, cost object, or detail section:
+Return at least one rate window, cost object, detail section, or non-empty identity field:
 
 ```js
 return {
@@ -161,6 +161,9 @@ Percentages must be finite and are clamped to 0–100. Window minutes are positi
 and a three-letter uppercase currency. Dates are JavaScript `Date` values or ISO-8601 strings. Snapshot identity is
 always scoped to the manifest's instance ID. Data confidence defaults to `unknown`. Details allow at most 8 sections, 24 rows per section, 120 chart points,
 and 120 characters per detail string. Wrong types and limit violations fail the whole fetch instead of truncating it.
+An identity-only snapshot is useful for balance-only or zero-usage provider states and renders its available account,
+organization, plan/login-method, and account-ID fields in the menu and CLI. An empty object, an empty `identity` object,
+or metadata such as confidence and subscription dates without displayable usage or identity remains invalid.
 
 ## TypeScript
 


### PR DESCRIPTION
Three additions to the local provider-plugin host contract, plus the fix that makes the middle one actually reachable.

## Sparse snapshots

A plugin may now return a snapshot carrying only identity or only a cost object. Balance-only and zero-usage providers previously had no valid shape to return: an identity-only object was rejected as an empty snapshot. The menu and CLI render whichever of account, organization, plan/login-method, and account ID are present. Metadata alone (confidence, subscription dates) without displayable usage or identity is still invalid.

## Delayed retries

Transient classified failures (`rateLimited`, `providerUnavailable`, `networkFailure`, `apiFailure`) accept `{retryAfterSeconds}`, and `ProviderFetchPipeline` performs exactly one delayed retry. The delay is clamped to 10 seconds, matching the built-in transient HTTP policy, and the retry is never itself retried. Cancellation during the delay stops it.

## Approved private origins

A settings-derived endpoint may declare `policy: "https-or-private-network-http"`, which permits authenticated HTTP to loopback, RFC 1918, link-local, IPv6 unique-local/link-local, and `.local` targets. It is gated behind the existing typed-confirmation approval, so a self-hosted gateway is reachable without weakening the rule that public origins are HTTPS-only.

## The fix: user plugins could not use any of the retry contract

Live testing found the delayed-retry contract unreachable from user-installed plugins. `UserProviderPluginLoader` built the runtime with `rejectsNonSuccessResponses`, so the host threw a bare `ProviderPluginError.http("request returned HTTP 429")` inside the HTTP bridge before `fetchUsage` ever observed the response. A plugin could not inspect a `Retry-After` header, and the unclassified error carried no `retryAfterSeconds` for `ProviderFetchDelayedRetry` to act on — so user plugins never retried at all, while bundled plugins did.

The root cause was one boolean covering two unrelated policies: the status gate (reject non-2xx) and the representation gate (`Accept-Encoding: identity`, reject compressed bodies). Those are now split. `enforcesUserResponsePolicy` keeps owning the representation gate unchanged; only the status gate is relaxable.

The fix has two halves:

- **Automatic, no manifest change.** The host's own non-2xx rejection is now a classified failure carrying `retryAfterSeconds`, so every user plugin gets one delayed retry on 408, 429, 500, 502, 503, and 504 — mirroring `ProviderHTTPRetryPolicy.transientIdempotent`. A numeric `Retry-After` sets the delay, otherwise one second, clamped to ten. Every other non-2xx status keeps its existing unclassified failure and its existing message.
- **Opt-in takeover.** A plugin that needs provider-specific handling — a non-numeric `Retry-After`, quota data carried in the error body, a vendor retry field — declares the new `http-status` capability, receives the non-2xx response itself, and throws `ctx.fail.rateLimited(message, {retryAfterSeconds})`. Both paths share one retry budget.

Classification travels as the existing `__CODEXBAR_FAILURE_V2__` marker so it survives the JavaScript boundary. The JavaScriptCore bridge was rewrapping that marker as `ProviderPluginError.http` and destroying it; it now forwards the carrier intact. QuickJS, the production default, already preserved it.

### Security posture

Unchanged. The representation gate, the 1 MiB response cap, redirect rejection, origin allowlisting, and host-owned auth headers all still apply, with or without the capability — a regression test covers a plugin declaring `http-status` still failing on a gzip-encoded response. `http-status` is part of `ProviderPluginApprovalBinding`, so adding it to an installed plugin invalidates the prior approval and forces re-approval, and it renders in the approval sheet with no UI change.

## Proof

- `make test` green.
- New coverage on both engines (QuickJS and the JavaScriptCore rollback): a naive plugin with no error handling retrying a 429 once through the real loader and `UserProviderPlugin.fetchUsage`; a 503 with no `Retry-After` using the 1-second default via an injected sleeper; a 404 still failing immediately with one request; the `http-status` path unchanged; gzip still rejected under the capability.
- The pre-existing `NeuralWatt style Retry After` test built its runtime directly with the permissive default, which is how this gap survived to live testing. It now goes through the loader.
- `make check` clean; autoreview clean.
