### PR TITLE
Bound PTY hard-stop cleanup latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.4 — Unreleased
 
 ### Fixed
+- PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.
 - Cost history: honor the preferred display currency throughout the detail chart and refresh converted labels when exchange rates change (#2887). Thanks @vAhyThe!
 
 ## 0.49.3 — 2026-08-12

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -677,7 +677,11 @@ public struct TTYCommandRunner {
                 launchedProcess.abortSynchronously()
             } else {
                 if !didTerminateSynchronously {
-                    launchedProcess.terminateSynchronously()
+                    if launchedProcess.isRunning {
+                        launchedProcess.hardStopLivePTYRootSynchronously()
+                    } else {
+                        launchedProcess.terminateSynchronously()
+                    }
                 }
                 try? primaryHandle.close()
             }

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -678,11 +678,8 @@ public struct TTYCommandRunner {
                 launchedProcess.abortSynchronously()
             } else {
                 if !didTerminateSynchronously {
-                    if launchedProcess.isRunning {
-                        launchedProcess.hardStopLivePTYRootSynchronously()
-                    } else {
-                        launchedProcess.terminateSynchronously()
-                    }
+                    // An early-stopped root may exit during settle while detached PTY holders remain.
+                    launchedProcess.hardStopLivePTYRootSynchronously()
                 }
                 try? primaryHandle.close()
             }

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -673,12 +673,13 @@ public struct TTYCommandRunner {
                 // Once the bounded buffer overflows, do not spend seconds sweeping every process's
                 // descriptors before signaling. Closing the master unblocks a child stuck writing,
                 // and the scoped abort escalates within its fixed grace window.
+                launchedProcess.discardReservedPTYPrimaryDescriptor()
                 try? primaryHandle.close()
                 launchedProcess.abortSynchronously()
             } else {
                 if !didTerminateSynchronously {
                     if launchedProcess.isRunning {
-                        launchedProcess.hardStopLivePTYRootSynchronously(primaryFileDescriptor: primaryFD)
+                        launchedProcess.hardStopLivePTYRootSynchronously()
                     } else {
                         launchedProcess.terminateSynchronously()
                     }

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -678,7 +678,7 @@ public struct TTYCommandRunner {
             } else {
                 if !didTerminateSynchronously {
                     if launchedProcess.isRunning {
-                        launchedProcess.hardStopLivePTYRootSynchronously()
+                        launchedProcess.hardStopLivePTYRootSynchronously(primaryFileDescriptor: primaryFD)
                     } else {
                         launchedProcess.terminateSynchronously()
                     }

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -10,6 +10,7 @@ import Foundation
 #if DEBUG
 private enum SpawnedProcessGroupTestingOverrides {
     @TaskLocal static var outputHolderDiscoveryDelay: TimeInterval?
+    @TaskLocal static var outputHolderPreKillDelay: TimeInterval?
 }
 #endif
 
@@ -912,6 +913,7 @@ extension SpawnedProcessGroup {
         let outputTTYs: Set<OutputTTYIdentity>
         let excludedPIDs: Set<pid_t>
         let grace: TimeInterval
+        let preKillDelay: TimeInterval
 
         private let deadline: DispatchTime
         private let completion = DispatchGroup()
@@ -925,6 +927,7 @@ extension SpawnedProcessGroup {
             outputTTYs: Set<OutputTTYIdentity>,
             excludedPIDs: Set<pid_t>,
             grace: TimeInterval,
+            preKillDelay: TimeInterval,
             maxLifetime: TimeInterval)
         {
             self.duplicatedPrimaryFileDescriptor = duplicatedPrimaryFileDescriptor
@@ -932,6 +935,7 @@ extension SpawnedProcessGroup {
             self.outputTTYs = outputTTYs
             self.excludedPIDs = excludedPIDs
             self.grace = max(0, grace)
+            self.preKillDelay = max(0, preKillDelay)
             self.deadline = .now() + max(0, maxLifetime)
             self.completion.enter()
         }
@@ -995,8 +999,10 @@ extension SpawnedProcessGroup {
         #if DEBUG
         // Task-local values do not cross a GCD boundary, so capture the test delay before dispatching.
         let discoveryDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderDiscoveryDelay ?? 0)
+        let preKillDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderPreKillDelay ?? 0)
         #else
         let discoveryDelay: TimeInterval = 0
+        let preKillDelay: TimeInterval = 0
         #endif
         guard let duplicatedPrimaryFileDescriptor = Self.duplicateCloseOnExec(primaryFileDescriptor) else {
             return self.terminateSynchronously(grace: grace)
@@ -1008,6 +1014,7 @@ extension SpawnedProcessGroup {
             outputTTYs: self.outputTTYs,
             excludedPIDs: [getpid(), self.pid],
             grace: grace,
+            preKillDelay: preKillDelay,
             maxLifetime: 15)
         lease.scheduleExpiry()
         DispatchQueue.global(qos: .utility).async {
@@ -1024,7 +1031,7 @@ extension SpawnedProcessGroup {
     }
 
     private static func duplicateCloseOnExec(_ fileDescriptor: Int32) -> Int32? {
-        let duplicate = fcntl(fileDescriptor, F_DUPFD_CLOEXEC, 0)
+        let duplicate = fcntl(fileDescriptor, F_DUPFD_CLOEXEC, STDERR_FILENO + 1)
         return duplicate >= 0 ? duplicate : nil
     }
 
@@ -1040,7 +1047,7 @@ extension SpawnedProcessGroup {
 
     private static func terminateOutputHoldersSynchronously(lease: OutputHolderCleanupLease) {
         guard lease.isActive else { return }
-        var processIdentities = Self.outputHolderIdentities(
+        let processIdentities = Self.outputHolderIdentities(
             outputPipes: lease.outputPipes,
             outputTTYs: lease.outputTTYs,
             excludedPIDs: lease.excludedPIDs)
@@ -1050,16 +1057,21 @@ extension SpawnedProcessGroup {
 
         Self.waitWhileCurrent(processIdentities, until: Date().addingTimeInterval(lease.grace), lease: lease)
 
-        // A TERM handler can fork a new holder, so refresh only this launch's recorded output identities.
-        guard lease.isActive else { return }
-        let rescannedIdentities = Self.outputHolderIdentities(
-            outputPipes: lease.outputPipes,
-            outputTTYs: lease.outputTTYs,
-            excludedPIDs: lease.excludedPIDs)
-        guard lease.isActive else { return }
-        processIdentities.formUnion(rescannedIdentities)
-        guard Self.signal(processIdentities: processIdentities, signal: SIGKILL, lease: lease) else { return }
-        Self.waitWhileCurrent(processIdentities, until: Date().addingTimeInterval(lease.grace), lease: lease)
+        while lease.isActive {
+            let currentIdentities = Self.outputHolderIdentities(
+                outputPipes: lease.outputPipes,
+                outputTTYs: lease.outputTTYs,
+                excludedPIDs: lease.excludedPIDs)
+            guard lease.isActive else { return }
+            guard !currentIdentities.isEmpty else { return }
+            if lease.preKillDelay > 0 {
+                Thread.sleep(forTimeInterval: lease.preKillDelay)
+            }
+            guard lease.isActive,
+                  Self.signal(processIdentities: currentIdentities, signal: SIGKILL, lease: lease)
+            else { return }
+            Self.waitWhileCurrent(currentIdentities, until: Date().addingTimeInterval(lease.grace), lease: lease)
+        }
     }
 
     private static func signal(
@@ -1099,6 +1111,13 @@ extension SpawnedProcessGroup {
         try SpawnedProcessGroupTestingOverrides.$outputHolderDiscoveryDelay.withValue(delay, operation: operation)
     }
 
+    package static func withOutputHolderPreKillDelayForTesting<T>(
+        _ delay: TimeInterval,
+        operation: () throws -> T) rethrows -> T
+    {
+        try SpawnedProcessGroupTestingOverrides.$outputHolderPreKillDelay.withValue(delay, operation: operation)
+    }
+
     package static func _test_outputHolderCleanupLeaseExpiry(
         ownedFileDescriptor: Int32,
         maxLifetime: TimeInterval,
@@ -1110,6 +1129,7 @@ extension SpawnedProcessGroup {
             outputTTYs: [],
             excludedPIDs: [],
             grace: 0,
+            preKillDelay: 0,
             maxLifetime: maxLifetime)
         lease.scheduleExpiry()
         let completed = lease.waitForCompletion(timeout: waitTimeout)

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -12,6 +12,7 @@ private enum SpawnedProcessGroupTestingOverrides {
     @TaskLocal static var outputHolderDiscoveryDelay: TimeInterval?
     @TaskLocal static var outputHolderPreKillDelay: TimeInterval?
     @TaskLocal static var outputHolderCleanupMaxLifetime: TimeInterval?
+    @TaskLocal static var forcePTYPrimaryDescriptorReservationFailure = false
 }
 #endif
 
@@ -322,16 +323,19 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
     private let outputPipes: Set<OutputPipeIdentity>
     private let outputTTYs: Set<OutputTTYIdentity>
     private let rootIdentity: TTYProcessTreeTerminator.ProcessIdentity?
+    private let reservedPTYPrimaryDescriptor: OwnedFileDescriptorState?
 
     private init(
         pid: pid_t,
         outputPipes: Set<OutputPipeIdentity>,
-        outputTTYs: Set<OutputTTYIdentity> = [])
+        outputTTYs: Set<OutputTTYIdentity> = [],
+        reservedPTYPrimaryDescriptor: OwnedFileDescriptorState? = nil)
     {
         self.pid = pid
         self.processGroup = pid
         self.outputPipes = outputPipes
         self.outputTTYs = outputTTYs
+        self.reservedPTYPrimaryDescriptor = reservedPTYPrimaryDescriptor
         self.rootIdentity = TTYProcessTreeTerminator.processIdentity(for: pid)
         self.startWaiter()
     }
@@ -457,6 +461,9 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         guard let outputTTY = OutputTTYIdentity.resolve(fileDescriptor: secondaryFD) else {
             throw LaunchError.setupFailed("resolve PTY identity")
         }
+        guard let reservedPTYPrimaryDescriptor = Self.reservePTYPrimaryDescriptor(primaryFD) else {
+            throw LaunchError.setupFailed("reserve PTY primary descriptor")
+        }
         #if canImport(Darwin)
         var fileActions: posix_spawn_file_actions_t?
         #else
@@ -545,7 +552,11 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         guard spawnResult == 0 else {
             throw LaunchError.spawnFailed(String(cString: strerror(spawnResult)))
         }
-        return SpawnedProcessGroup(pid: pid, outputPipes: [], outputTTYs: [outputTTY])
+        return SpawnedProcessGroup(
+            pid: pid,
+            outputPipes: [],
+            outputTTYs: [outputTTY],
+            reservedPTYPrimaryDescriptor: reservedPTYPrimaryDescriptor)
     }
 
     package var isRunning: Bool {
@@ -819,14 +830,6 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         processIdentities.contains(where: TTYProcessTreeTerminator.isCurrent(_:)) || self.hasResidualProcessGroup
     }
 
-    private func currentOutputHolderIdentities() -> Set<TTYProcessTreeTerminator.ProcessIdentity> {
-        let excludedPIDs: Set<pid_t> = [getpid(), self.pid]
-        return Self.outputHolderIdentities(
-            outputPipes: self.outputPipes,
-            outputTTYs: self.outputTTYs,
-            excludedPIDs: excludedPIDs)
-    }
-
     private func currentProcessGroupMemberIdentities() -> Set<TTYProcessTreeTerminator.ProcessIdentity> {
         if self.termination.hasObservedExit, self.termination.value == nil {
             let identities = Self.processGroupMemberIdentities(
@@ -908,6 +911,42 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
 }
 
 extension SpawnedProcessGroup {
+    private func currentOutputHolderIdentities() -> Set<TTYProcessTreeTerminator.ProcessIdentity> {
+        let excludedPIDs: Set<pid_t> = [getpid(), self.pid]
+        return Self.outputHolderIdentities(
+            outputPipes: self.outputPipes,
+            outputTTYs: self.outputTTYs,
+            excludedPIDs: excludedPIDs)
+    }
+
+    /// Serializes transfer and closure of a descriptor owned by the process group.
+    private final class OwnedFileDescriptorState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var fileDescriptor: Int32?
+
+        init(fileDescriptor: Int32) {
+            self.fileDescriptor = fileDescriptor
+        }
+
+        deinit {
+            self.discard()
+        }
+
+        func take() -> Int32? {
+            self.lock.withLock {
+                defer { self.fileDescriptor = nil }
+                return self.fileDescriptor
+            }
+        }
+
+        @discardableResult
+        func discard() -> Bool {
+            guard let fileDescriptor = self.take() else { return false }
+            _ = close(fileDescriptor)
+            return true
+        }
+    }
+
     /// The lock makes the descriptor/completion transition one-shot across worker and expiry queues.
     private final class OutputHolderCleanupLease: @unchecked Sendable {
         let outputPipes: Set<OutputPipeIdentity>
@@ -993,10 +1032,7 @@ extension SpawnedProcessGroup {
 
     /// Hard-stop a live PTY root without making the caller wait on system-wide holder discovery.
     @discardableResult
-    package func hardStopLivePTYRootSynchronously(
-        primaryFileDescriptor: Int32,
-        grace: TimeInterval = 0.4) -> Int32?
-    {
+    package func hardStopLivePTYRootSynchronously(grace: TimeInterval = 0.4) -> Int32? {
         #if DEBUG
         // Task-local values do not cross a GCD boundary, so capture the test delay before dispatching.
         let discoveryDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderDiscoveryDelay ?? 0)
@@ -1007,12 +1043,12 @@ extension SpawnedProcessGroup {
         let preKillDelay: TimeInterval = 0
         let cleanupMaxLifetime: TimeInterval = 15
         #endif
-        guard let duplicatedPrimaryFileDescriptor = Self.duplicateCloseOnExec(primaryFileDescriptor) else {
-            return self.terminateSynchronously(grace: grace)
+        guard let reservedPrimaryFileDescriptor = self.reservedPTYPrimaryDescriptor?.take() else {
+            return self.abortSynchronously(grace: grace)
         }
         // Production caps the lease at 15 seconds; DEBUG fixtures may add their artificial delay separately.
         let lease = OutputHolderCleanupLease(
-            duplicatedPrimaryFileDescriptor: duplicatedPrimaryFileDescriptor,
+            duplicatedPrimaryFileDescriptor: reservedPrimaryFileDescriptor,
             outputPipes: self.outputPipes,
             outputTTYs: self.outputTTYs,
             excludedPIDs: [getpid(), self.pid],
@@ -1033,9 +1069,17 @@ extension SpawnedProcessGroup {
         return status
     }
 
-    private static func duplicateCloseOnExec(_ fileDescriptor: Int32) -> Int32? {
+    private static func reservePTYPrimaryDescriptor(_ fileDescriptor: Int32) -> OwnedFileDescriptorState? {
+        #if DEBUG
+        guard !SpawnedProcessGroupTestingOverrides.forcePTYPrimaryDescriptorReservationFailure else { return nil }
+        #endif
         let duplicate = fcntl(fileDescriptor, F_DUPFD_CLOEXEC, STDERR_FILENO + 1)
-        return duplicate >= 0 ? duplicate : nil
+        guard duplicate >= 0 else { return nil }
+        return OwnedFileDescriptorState(fileDescriptor: duplicate)
+    }
+
+    package func discardReservedPTYPrimaryDescriptor() {
+        self.reservedPTYPrimaryDescriptor?.discard()
     }
 
     private static func outputHolderIdentities(
@@ -1128,6 +1172,33 @@ extension SpawnedProcessGroup {
         try SpawnedProcessGroupTestingOverrides.$outputHolderCleanupMaxLifetime.withValue(
             maxLifetime,
             operation: operation)
+    }
+
+    package static func withPTYPrimaryDescriptorReservationFailureForTesting<T>(
+        _ operation: () throws -> T) rethrows -> T
+    {
+        try SpawnedProcessGroupTestingOverrides.$forcePTYPrimaryDescriptorReservationFailure.withValue(
+            true,
+            operation: operation)
+    }
+
+    package static func _test_ownedDescriptorTakeOnce(
+        ownedFileDescriptor: Int32) -> (first: Int32?, second: Int32?, discardAfterTake: Bool)
+    {
+        let state = OwnedFileDescriptorState(fileDescriptor: ownedFileDescriptor)
+        let first = state.take()
+        return (first, state.take(), state.discard())
+    }
+
+    package static func _test_ownedDescriptorDiscardTwice(
+        ownedFileDescriptor: Int32) -> (first: Bool, second: Bool)
+    {
+        let state = OwnedFileDescriptorState(fileDescriptor: ownedFileDescriptor)
+        return (state.discard(), state.discard())
+    }
+
+    package static func _test_ownedDescriptorDeinit(ownedFileDescriptor: Int32) {
+        _ = OwnedFileDescriptorState(fileDescriptor: ownedFileDescriptor)
     }
 
     package static func _test_outputHolderCleanupLeaseExpiry(

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -7,9 +7,11 @@ import Musl
 #endif
 import Foundation
 
+#if DEBUG
 private enum SpawnedProcessGroupTestingOverrides {
     @TaskLocal static var outputHolderDiscoveryDelay: TimeInterval?
 }
+#endif
 
 package final class SpawnedProcessGroup: @unchecked Sendable {
     package enum LaunchError: LocalizedError {
@@ -906,8 +908,12 @@ extension SpawnedProcessGroup {
     /// Hard-stop a live PTY root without making the caller wait on system-wide holder discovery.
     @discardableResult
     package func hardStopLivePTYRootSynchronously(grace: TimeInterval = 0.4) -> Int32? {
+        #if DEBUG
         // Task-local values do not cross a GCD boundary, so capture the test delay before dispatching.
         let discoveryDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderDiscoveryDelay ?? 0)
+        #else
+        let discoveryDelay: TimeInterval = 0
+        #endif
         let holderSweep = DispatchGroup()
         holderSweep.enter()
         DispatchQueue.global(qos: .utility).async { [self] in
@@ -925,7 +931,7 @@ extension SpawnedProcessGroup {
 
     private func terminateOutputHoldersSynchronously(grace: TimeInterval) {
         let grace = max(0, grace)
-        let processIdentities = self.currentOutputHolderIdentities()
+        var processIdentities = self.currentOutputHolderIdentities()
         Self.signal(processIdentities: processIdentities, signal: SIGTERM)
 
         let termDeadline = Date().addingTimeInterval(grace)
@@ -935,6 +941,8 @@ extension SpawnedProcessGroup {
             usleep(20000)
         }
 
+        // A TERM handler can fork a new holder, so refresh only this launch's recorded output identities.
+        processIdentities.formUnion(self.currentOutputHolderIdentities())
         Self.signal(processIdentities: processIdentities, signal: SIGKILL)
         let killDeadline = Date().addingTimeInterval(grace)
         while processIdentities.contains(where: TTYProcessTreeTerminator.isCurrent(_:)),
@@ -944,10 +952,12 @@ extension SpawnedProcessGroup {
         }
     }
 
+    #if DEBUG
     package static func withOutputHolderDiscoveryDelayForTesting<T>(
         _ delay: TimeInterval,
         operation: () throws -> T) rethrows -> T
     {
         try SpawnedProcessGroupTestingOverrides.$outputHolderDiscoveryDelay.withValue(delay, operation: operation)
     }
+    #endif
 }

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -1056,6 +1056,7 @@ extension SpawnedProcessGroup {
             preKillDelay: preKillDelay,
             maxLifetime: cleanupMaxLifetime)
         lease.scheduleExpiry()
+        let status = self.abortSynchronously(grace: grace)
         DispatchQueue.global(qos: .utility).async {
             defer { lease.finish() }
             if discoveryDelay > 0 {
@@ -1063,8 +1064,6 @@ extension SpawnedProcessGroup {
             }
             SpawnedProcessGroup.terminateOutputHoldersSynchronously(lease: lease)
         }
-
-        let status = self.abortSynchronously(grace: grace)
         _ = lease.waitForCompletion(timeout: 0.2)
         return status
     }

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -7,6 +7,10 @@ import Musl
 #endif
 import Foundation
 
+private enum SpawnedProcessGroupTestingOverrides {
+    @TaskLocal static var outputHolderDiscoveryDelay: TimeInterval?
+}
+
 package final class SpawnedProcessGroup: @unchecked Sendable {
     package enum LaunchError: LocalizedError {
         case setupFailed(String)
@@ -895,5 +899,55 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
     private static func exitStatus(from rawStatus: Int32) -> Int32 {
         let signal = rawStatus & 0x7F
         return signal == 0 ? (rawStatus >> 8) & 0xFF : signal
+    }
+}
+
+extension SpawnedProcessGroup {
+    /// Hard-stop a live PTY root without making the caller wait on system-wide holder discovery.
+    @discardableResult
+    package func hardStopLivePTYRootSynchronously(grace: TimeInterval = 0.4) -> Int32? {
+        // Task-local values do not cross a GCD boundary, so capture the test delay before dispatching.
+        let discoveryDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderDiscoveryDelay ?? 0)
+        let holderSweep = DispatchGroup()
+        holderSweep.enter()
+        DispatchQueue.global(qos: .utility).async { [self] in
+            defer { holderSweep.leave() }
+            if discoveryDelay > 0 {
+                Thread.sleep(forTimeInterval: discoveryDelay)
+            }
+            self.terminateOutputHoldersSynchronously(grace: grace)
+        }
+
+        let status = self.abortSynchronously(grace: grace)
+        _ = holderSweep.wait(timeout: .now() + 0.2)
+        return status
+    }
+
+    private func terminateOutputHoldersSynchronously(grace: TimeInterval) {
+        let grace = max(0, grace)
+        let processIdentities = self.currentOutputHolderIdentities()
+        Self.signal(processIdentities: processIdentities, signal: SIGTERM)
+
+        let termDeadline = Date().addingTimeInterval(grace)
+        while processIdentities.contains(where: TTYProcessTreeTerminator.isCurrent(_:)),
+              Date() < termDeadline
+        {
+            usleep(20000)
+        }
+
+        Self.signal(processIdentities: processIdentities, signal: SIGKILL)
+        let killDeadline = Date().addingTimeInterval(grace)
+        while processIdentities.contains(where: TTYProcessTreeTerminator.isCurrent(_:)),
+              Date() < killDeadline
+        {
+            usleep(20000)
+        }
+    }
+
+    package static func withOutputHolderDiscoveryDelayForTesting<T>(
+        _ delay: TimeInterval,
+        operation: () throws -> T) rethrows -> T
+    {
+        try SpawnedProcessGroupTestingOverrides.$outputHolderDiscoveryDelay.withValue(delay, operation: operation)
     }
 }

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -11,6 +11,7 @@ import Foundation
 private enum SpawnedProcessGroupTestingOverrides {
     @TaskLocal static var outputHolderDiscoveryDelay: TimeInterval?
     @TaskLocal static var outputHolderPreKillDelay: TimeInterval?
+    @TaskLocal static var outputHolderCleanupMaxLifetime: TimeInterval?
 }
 #endif
 
@@ -1000,14 +1001,16 @@ extension SpawnedProcessGroup {
         // Task-local values do not cross a GCD boundary, so capture the test delay before dispatching.
         let discoveryDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderDiscoveryDelay ?? 0)
         let preKillDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderPreKillDelay ?? 0)
+        let cleanupMaxLifetime = max(0, SpawnedProcessGroupTestingOverrides.outputHolderCleanupMaxLifetime ?? 15)
         #else
         let discoveryDelay: TimeInterval = 0
         let preKillDelay: TimeInterval = 0
+        let cleanupMaxLifetime: TimeInterval = 15
         #endif
         guard let duplicatedPrimaryFileDescriptor = Self.duplicateCloseOnExec(primaryFileDescriptor) else {
             return self.terminateSynchronously(grace: grace)
         }
-        // Allow two loaded system-wide scans plus the 2.5-second regression delay, but cap the PTY lease at 15 seconds.
+        // Production caps the lease at 15 seconds; DEBUG fixtures may add their artificial delay separately.
         let lease = OutputHolderCleanupLease(
             duplicatedPrimaryFileDescriptor: duplicatedPrimaryFileDescriptor,
             outputPipes: self.outputPipes,
@@ -1015,7 +1018,7 @@ extension SpawnedProcessGroup {
             excludedPIDs: [getpid(), self.pid],
             grace: grace,
             preKillDelay: preKillDelay,
-            maxLifetime: 15)
+            maxLifetime: cleanupMaxLifetime)
         lease.scheduleExpiry()
         DispatchQueue.global(qos: .utility).async {
             defer { lease.finish() }
@@ -1116,6 +1119,15 @@ extension SpawnedProcessGroup {
         operation: () throws -> T) rethrows -> T
     {
         try SpawnedProcessGroupTestingOverrides.$outputHolderPreKillDelay.withValue(delay, operation: operation)
+    }
+
+    package static func withOutputHolderCleanupMaxLifetimeForTesting<T>(
+        _ maxLifetime: TimeInterval,
+        operation: () throws -> T) rethrows -> T
+    {
+        try SpawnedProcessGroupTestingOverrides.$outputHolderCleanupMaxLifetime.withValue(
+            maxLifetime,
+            operation: operation)
     }
 
     package static func _test_outputHolderCleanupLeaseExpiry(

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -93,7 +93,7 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         }
     }
 
-    private struct OutputPipeIdentity: Hashable {
+    private struct OutputPipeIdentity: Hashable, Sendable {
         #if canImport(Darwin)
         let firstHandle: UInt64
         let secondHandle: UInt64
@@ -183,7 +183,7 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
         #endif
     }
 
-    private struct OutputTTYIdentity: Hashable {
+    private struct OutputTTYIdentity: Hashable, Sendable {
         let device: UInt64
         let inode: UInt64
         let rawDevice: UInt64
@@ -819,9 +819,10 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
 
     private func currentOutputHolderIdentities() -> Set<TTYProcessTreeTerminator.ProcessIdentity> {
         let excludedPIDs: Set<pid_t> = [getpid(), self.pid]
-        var holderPIDs = OutputPipeIdentity.holderPIDs(for: self.outputPipes)
-        holderPIDs.formUnion(OutputTTYIdentity.holderPIDs(for: self.outputTTYs))
-        return Set(holderPIDs.subtracting(excludedPIDs).compactMap(TTYProcessTreeTerminator.processIdentity(for:)))
+        return Self.outputHolderIdentities(
+            outputPipes: self.outputPipes,
+            outputTTYs: self.outputTTYs,
+            excludedPIDs: excludedPIDs)
     }
 
     private func currentProcessGroupMemberIdentities() -> Set<TTYProcessTreeTerminator.ProcessIdentity> {
@@ -905,49 +906,187 @@ package final class SpawnedProcessGroup: @unchecked Sendable {
 }
 
 extension SpawnedProcessGroup {
+    /// The lock makes the descriptor/completion transition one-shot across worker and expiry queues.
+    private final class OutputHolderCleanupLease: @unchecked Sendable {
+        let outputPipes: Set<OutputPipeIdentity>
+        let outputTTYs: Set<OutputTTYIdentity>
+        let excludedPIDs: Set<pid_t>
+        let grace: TimeInterval
+
+        private let deadline: DispatchTime
+        private let completion = DispatchGroup()
+        private let lock = NSLock()
+        private var duplicatedPrimaryFileDescriptor: Int32?
+        private var finished = false
+
+        init(
+            duplicatedPrimaryFileDescriptor: Int32,
+            outputPipes: Set<OutputPipeIdentity>,
+            outputTTYs: Set<OutputTTYIdentity>,
+            excludedPIDs: Set<pid_t>,
+            grace: TimeInterval,
+            maxLifetime: TimeInterval)
+        {
+            self.duplicatedPrimaryFileDescriptor = duplicatedPrimaryFileDescriptor
+            self.outputPipes = outputPipes
+            self.outputTTYs = outputTTYs
+            self.excludedPIDs = excludedPIDs
+            self.grace = max(0, grace)
+            self.deadline = .now() + max(0, maxLifetime)
+            self.completion.enter()
+        }
+
+        var isActive: Bool {
+            self.withActiveState { true } == true
+        }
+
+        func scheduleExpiry() {
+            let deadline = self.deadline
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: deadline) { [self] in
+                self.finish()
+            }
+        }
+
+        func withActiveState<T>(_ operation: () -> T) -> T? {
+            var descriptorToClose: Int32?
+            self.lock.lock()
+            if !self.finished, DispatchTime.now().uptimeNanoseconds >= self.deadline.uptimeNanoseconds {
+                self.finished = true
+                descriptorToClose = self.duplicatedPrimaryFileDescriptor
+                self.duplicatedPrimaryFileDescriptor = nil
+            }
+            guard !self.finished else {
+                self.lock.unlock()
+                self.closeAndComplete(descriptorToClose)
+                return nil
+            }
+            let result = operation()
+            self.lock.unlock()
+            return result
+        }
+
+        func finish() {
+            let descriptorToClose = self.lock.withLock { () -> Int32? in
+                guard !self.finished else { return nil }
+                self.finished = true
+                defer { self.duplicatedPrimaryFileDescriptor = nil }
+                return self.duplicatedPrimaryFileDescriptor
+            }
+            self.closeAndComplete(descriptorToClose)
+        }
+
+        func waitForCompletion(timeout: TimeInterval) -> Bool {
+            self.completion.wait(timeout: .now() + max(0, timeout)) == .success
+        }
+
+        private func closeAndComplete(_ descriptor: Int32?) {
+            guard let descriptor else { return }
+            _ = close(descriptor)
+            self.completion.leave()
+        }
+    }
+
     /// Hard-stop a live PTY root without making the caller wait on system-wide holder discovery.
     @discardableResult
-    package func hardStopLivePTYRootSynchronously(grace: TimeInterval = 0.4) -> Int32? {
+    package func hardStopLivePTYRootSynchronously(
+        primaryFileDescriptor: Int32,
+        grace: TimeInterval = 0.4) -> Int32?
+    {
         #if DEBUG
         // Task-local values do not cross a GCD boundary, so capture the test delay before dispatching.
         let discoveryDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderDiscoveryDelay ?? 0)
         #else
         let discoveryDelay: TimeInterval = 0
         #endif
-        let holderSweep = DispatchGroup()
-        holderSweep.enter()
-        DispatchQueue.global(qos: .utility).async { [self] in
-            defer { holderSweep.leave() }
+        guard let duplicatedPrimaryFileDescriptor = Self.duplicateCloseOnExec(primaryFileDescriptor) else {
+            return self.terminateSynchronously(grace: grace)
+        }
+        // Allow two loaded system-wide scans plus the 2.5-second regression delay, but cap the PTY lease at 15 seconds.
+        let lease = OutputHolderCleanupLease(
+            duplicatedPrimaryFileDescriptor: duplicatedPrimaryFileDescriptor,
+            outputPipes: self.outputPipes,
+            outputTTYs: self.outputTTYs,
+            excludedPIDs: [getpid(), self.pid],
+            grace: grace,
+            maxLifetime: 15)
+        lease.scheduleExpiry()
+        DispatchQueue.global(qos: .utility).async {
+            defer { lease.finish() }
             if discoveryDelay > 0 {
                 Thread.sleep(forTimeInterval: discoveryDelay)
             }
-            self.terminateOutputHoldersSynchronously(grace: grace)
+            SpawnedProcessGroup.terminateOutputHoldersSynchronously(lease: lease)
         }
 
         let status = self.abortSynchronously(grace: grace)
-        _ = holderSweep.wait(timeout: .now() + 0.2)
+        _ = lease.waitForCompletion(timeout: 0.2)
         return status
     }
 
-    private func terminateOutputHoldersSynchronously(grace: TimeInterval) {
-        let grace = max(0, grace)
-        var processIdentities = self.currentOutputHolderIdentities()
-        Self.signal(processIdentities: processIdentities, signal: SIGTERM)
+    private static func duplicateCloseOnExec(_ fileDescriptor: Int32) -> Int32? {
+        let duplicate = fcntl(fileDescriptor, F_DUPFD_CLOEXEC, 0)
+        return duplicate >= 0 ? duplicate : nil
+    }
 
-        let termDeadline = Date().addingTimeInterval(grace)
-        while processIdentities.contains(where: TTYProcessTreeTerminator.isCurrent(_:)),
-              Date() < termDeadline
-        {
-            usleep(20000)
-        }
+    private static func outputHolderIdentities(
+        outputPipes: Set<OutputPipeIdentity>,
+        outputTTYs: Set<OutputTTYIdentity>,
+        excludedPIDs: Set<pid_t>) -> Set<TTYProcessTreeTerminator.ProcessIdentity>
+    {
+        var holderPIDs = OutputPipeIdentity.holderPIDs(for: outputPipes)
+        holderPIDs.formUnion(OutputTTYIdentity.holderPIDs(for: outputTTYs))
+        return Set(holderPIDs.subtracting(excludedPIDs).compactMap(TTYProcessTreeTerminator.processIdentity(for:)))
+    }
+
+    private static func terminateOutputHoldersSynchronously(lease: OutputHolderCleanupLease) {
+        guard lease.isActive else { return }
+        var processIdentities = Self.outputHolderIdentities(
+            outputPipes: lease.outputPipes,
+            outputTTYs: lease.outputTTYs,
+            excludedPIDs: lease.excludedPIDs)
+        guard lease.isActive,
+              Self.signal(processIdentities: processIdentities, signal: SIGTERM, lease: lease)
+        else { return }
+
+        Self.waitWhileCurrent(processIdentities, until: Date().addingTimeInterval(lease.grace), lease: lease)
 
         // A TERM handler can fork a new holder, so refresh only this launch's recorded output identities.
-        processIdentities.formUnion(self.currentOutputHolderIdentities())
-        Self.signal(processIdentities: processIdentities, signal: SIGKILL)
-        let killDeadline = Date().addingTimeInterval(grace)
-        while processIdentities.contains(where: TTYProcessTreeTerminator.isCurrent(_:)),
-              Date() < killDeadline
-        {
+        guard lease.isActive else { return }
+        let rescannedIdentities = Self.outputHolderIdentities(
+            outputPipes: lease.outputPipes,
+            outputTTYs: lease.outputTTYs,
+            excludedPIDs: lease.excludedPIDs)
+        guard lease.isActive else { return }
+        processIdentities.formUnion(rescannedIdentities)
+        guard Self.signal(processIdentities: processIdentities, signal: SIGKILL, lease: lease) else { return }
+        Self.waitWhileCurrent(processIdentities, until: Date().addingTimeInterval(lease.grace), lease: lease)
+    }
+
+    private static func signal(
+        processIdentities: Set<TTYProcessTreeTerminator.ProcessIdentity>,
+        signal: Int32,
+        lease: OutputHolderCleanupLease) -> Bool
+    {
+        for identity in processIdentities {
+            guard lease.withActiveState({
+                guard TTYProcessTreeTerminator.isCurrent(identity) else { return }
+                _ = kill(identity.pid, signal)
+            }) != nil else {
+                return false
+            }
+        }
+        return lease.isActive
+    }
+
+    private static func waitWhileCurrent(
+        _ processIdentities: Set<TTYProcessTreeTerminator.ProcessIdentity>,
+        until deadline: Date,
+        lease: OutputHolderCleanupLease)
+    {
+        while Date() < deadline {
+            guard let targetsRemain = lease.withActiveState({
+                processIdentities.contains(where: TTYProcessTreeTerminator.isCurrent(_:))
+            }), targetsRemain else { return }
             usleep(20000)
         }
     }
@@ -958,6 +1097,23 @@ extension SpawnedProcessGroup {
         operation: () throws -> T) rethrows -> T
     {
         try SpawnedProcessGroupTestingOverrides.$outputHolderDiscoveryDelay.withValue(delay, operation: operation)
+    }
+
+    package static func _test_outputHolderCleanupLeaseExpiry(
+        ownedFileDescriptor: Int32,
+        maxLifetime: TimeInterval,
+        waitTimeout: TimeInterval) -> (completed: Bool, active: Bool)
+    {
+        let lease = OutputHolderCleanupLease(
+            duplicatedPrimaryFileDescriptor: ownedFileDescriptor,
+            outputPipes: [],
+            outputTTYs: [],
+            excludedPIDs: [],
+            grace: 0,
+            maxLifetime: maxLifetime)
+        lease.scheduleExpiry()
+        let completed = lease.waitForCompletion(timeout: waitTimeout)
+        return (completed, lease.isActive)
     }
     #endif
 }

--- a/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
+++ b/Sources/CodexBarCore/Host/Process/SpawnedProcessGroup.swift
@@ -10,6 +10,7 @@ import Foundation
 #if DEBUG
 private enum SpawnedProcessGroupTestingOverrides {
     @TaskLocal static var outputHolderDiscoveryDelay: TimeInterval?
+    @TaskLocal static var outputHolderPreKillSnapshotHook: (@Sendable () -> Void)?
     @TaskLocal static var outputHolderPreKillDelay: TimeInterval?
     @TaskLocal static var outputHolderCleanupMaxLifetime: TimeInterval?
     @TaskLocal static var forcePTYPrimaryDescriptorReservationFailure = false
@@ -953,6 +954,7 @@ extension SpawnedProcessGroup {
         let outputTTYs: Set<OutputTTYIdentity>
         let excludedPIDs: Set<pid_t>
         let grace: TimeInterval
+        let preKillSnapshotHook: (@Sendable () -> Void)?
         let preKillDelay: TimeInterval
 
         private let deadline: DispatchTime
@@ -967,6 +969,7 @@ extension SpawnedProcessGroup {
             outputTTYs: Set<OutputTTYIdentity>,
             excludedPIDs: Set<pid_t>,
             grace: TimeInterval,
+            preKillSnapshotHook: (@Sendable () -> Void)?,
             preKillDelay: TimeInterval,
             maxLifetime: TimeInterval)
         {
@@ -975,6 +978,7 @@ extension SpawnedProcessGroup {
             self.outputTTYs = outputTTYs
             self.excludedPIDs = excludedPIDs
             self.grace = max(0, grace)
+            self.preKillSnapshotHook = preKillSnapshotHook
             self.preKillDelay = max(0, preKillDelay)
             self.deadline = .now() + max(0, maxLifetime)
             self.completion.enter()
@@ -1036,10 +1040,12 @@ extension SpawnedProcessGroup {
         #if DEBUG
         // Task-local values do not cross a GCD boundary, so capture the test delay before dispatching.
         let discoveryDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderDiscoveryDelay ?? 0)
+        let preKillSnapshotHook = SpawnedProcessGroupTestingOverrides.outputHolderPreKillSnapshotHook
         let preKillDelay = max(0, SpawnedProcessGroupTestingOverrides.outputHolderPreKillDelay ?? 0)
         let cleanupMaxLifetime = max(0, SpawnedProcessGroupTestingOverrides.outputHolderCleanupMaxLifetime ?? 15)
         #else
         let discoveryDelay: TimeInterval = 0
+        let preKillSnapshotHook: (@Sendable () -> Void)? = nil
         let preKillDelay: TimeInterval = 0
         let cleanupMaxLifetime: TimeInterval = 15
         #endif
@@ -1053,6 +1059,7 @@ extension SpawnedProcessGroup {
             outputTTYs: self.outputTTYs,
             excludedPIDs: [getpid(), self.pid],
             grace: grace,
+            preKillSnapshotHook: preKillSnapshotHook,
             preKillDelay: preKillDelay,
             maxLifetime: cleanupMaxLifetime)
         lease.scheduleExpiry()
@@ -1110,6 +1117,7 @@ extension SpawnedProcessGroup {
                 excludedPIDs: lease.excludedPIDs)
             guard lease.isActive else { return }
             guard !currentIdentities.isEmpty else { return }
+            lease.preKillSnapshotHook?()
             if lease.preKillDelay > 0 {
                 Thread.sleep(forTimeInterval: lease.preKillDelay)
             }
@@ -1164,6 +1172,15 @@ extension SpawnedProcessGroup {
         try SpawnedProcessGroupTestingOverrides.$outputHolderPreKillDelay.withValue(delay, operation: operation)
     }
 
+    package static func withOutputHolderPreKillSnapshotHookForTesting<T>(
+        _ hook: @escaping @Sendable () -> Void,
+        operation: () throws -> T) rethrows -> T
+    {
+        try SpawnedProcessGroupTestingOverrides.$outputHolderPreKillSnapshotHook.withValue(
+            hook,
+            operation: operation)
+    }
+
     package static func withOutputHolderCleanupMaxLifetimeForTesting<T>(
         _ maxLifetime: TimeInterval,
         operation: () throws -> T) rethrows -> T
@@ -1211,6 +1228,7 @@ extension SpawnedProcessGroup {
             outputTTYs: [],
             excludedPIDs: [],
             grace: 0,
+            preKillSnapshotHook: nil,
             preKillDelay: 0,
             maxLifetime: maxLifetime)
         lease.scheduleExpiry()

--- a/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
@@ -16,6 +16,7 @@ extension KiroStatusProbeTests {
         let termChildPIDFile = childPIDFile.appendingPathExtension("term-child")
         let lateChildPIDFile = childPIDFile.appendingPathExtension("late-child")
         let rootTermChildPIDFile = childPIDFile.appendingPathExtension("root-term-child")
+        let preKillSnapshotTriggerFile = childPIDFile.appendingPathExtension("pre-kill-snapshot")
         let cliURL = try self.makeHardStopCLI()
         defer {
             for pidFile in [childPIDFile, termChildPIDFile, lateChildPIDFile, rootTermChildPIDFile] {
@@ -26,6 +27,7 @@ extension KiroStatusProbeTests {
                 }
                 try? FileManager.default.removeItem(at: pidFile)
             }
+            try? FileManager.default.removeItem(at: preKillSnapshotTriggerFile)
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
         }
 
@@ -34,24 +36,31 @@ extension KiroStatusProbeTests {
         // sequential discovery beyond that assertion in both environments without consuming the cleanup window.
         let discoveryDelay = hardStopBudget + 1
         let cleanupMaxLifetime = discoveryDelay + 15
+        let preKillSnapshotTriggerPath = preKillSnapshotTriggerFile.path
+        #expect(!FileManager.default.fileExists(atPath: preKillSnapshotTriggerPath))
         let start = Date()
         let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(discoveryDelay) {
             try SpawnedProcessGroup.withOutputHolderCleanupMaxLifetimeForTesting(cleanupMaxLifetime) {
-                try SpawnedProcessGroup.withOutputHolderPreKillDelayForTesting(0.5) {
-                    try TTYCommandRunner().run(
-                        binary: cliURL.path,
-                        send: "",
-                        options: .init(
-                            timeout: 4,
-                            idleTimeout: 0.1,
-                            extraArgs: [
-                                childPIDFile.path,
-                                termChildPIDFile.path,
-                                lateChildPIDFile.path,
-                                rootTermChildPIDFile.path,
-                            ],
-                            initialDelay: 0,
-                            settleAfterStop: 0))
+                try SpawnedProcessGroup.withOutputHolderPreKillSnapshotHookForTesting {
+                    Self.touchFile(atPath: preKillSnapshotTriggerPath)
+                } operation: {
+                    try SpawnedProcessGroup.withOutputHolderPreKillDelayForTesting(0.5) {
+                        try TTYCommandRunner().run(
+                            binary: cliURL.path,
+                            send: "",
+                            options: .init(
+                                timeout: 4,
+                                idleTimeout: 0.1,
+                                extraArgs: [
+                                    childPIDFile.path,
+                                    termChildPIDFile.path,
+                                    lateChildPIDFile.path,
+                                    rootTermChildPIDFile.path,
+                                    preKillSnapshotTriggerPath,
+                                ],
+                                initialDelay: 0,
+                                settleAfterStop: 0))
+                    }
                 }
             }
         }
@@ -78,6 +87,7 @@ extension KiroStatusProbeTests {
         }
         let lateChildPIDText = try String(contentsOf: lateChildPIDFile, encoding: .utf8)
         let lateChildPID = try #require(pid_t(lateChildPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        #expect(FileManager.default.fileExists(atPath: preKillSnapshotTriggerPath))
         for _ in 0..<1000 where !FileManager.default.fileExists(atPath: rootTermChildPIDFile.path) {
             try await Task.sleep(for: .milliseconds(20))
         }
@@ -96,6 +106,70 @@ extension KiroStatusProbeTests {
         #expect(kill(termChildPID, 0) == -1)
         #expect(kill(lateChildPID, 0) == -1)
         #expect(kill(rootTermChildPID, 0) == -1)
+    }
+
+    @Test
+    func `tty runner bounds hard stop when root exits during early stop settle`() async throws {
+        let holderPIDFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-settle-holder-\(UUID().uuidString).pid")
+        let allowRootExitFile = holderPIDFile.appendingPathExtension("allow-root-exit")
+        let rootExitedFile = holderPIDFile.appendingPathExtension("root-exited")
+        let cliURL = try self.makeSettleExitHardStopCLI()
+        defer {
+            if let text = try? String(contentsOf: holderPIDFile, encoding: .utf8),
+               let holderPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                _ = kill(holderPID, SIGKILL)
+            }
+            for file in [holderPIDFile, allowRootExitFile, rootExitedFile] {
+                try? FileManager.default.removeItem(at: file)
+            }
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+        }
+
+        let hardStopBudget = 3 * TestTimingBudget.slowdownFactor
+        let discoveryDelay = hardStopBudget + 1
+        let cleanupMaxLifetime = discoveryDelay + 15
+        let allowRootExitPath = allowRootExitFile.path
+        #expect(!FileManager.default.fileExists(atPath: allowRootExitPath))
+        #expect(!FileManager.default.fileExists(atPath: rootExitedFile.path))
+
+        let start = Date()
+        let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(discoveryDelay) {
+            try SpawnedProcessGroup.withOutputHolderCleanupMaxLifetimeForTesting(cleanupMaxLifetime) {
+                try TTYCommandRunner().run(
+                    binary: cliURL.path,
+                    send: "",
+                    options: .init(
+                        timeout: 4 * TestTimingBudget.slowdownFactor,
+                        idleTimeout: 0,
+                        extraArgs: [holderPIDFile.path, allowRootExitPath, rootExitedFile.path],
+                        initialDelay: 0,
+                        settleAfterStop: 0.6 * TestTimingBudget.slowdownFactor),
+                    onURLDetected: {
+                        Self.touchFile(atPath: allowRootExitPath)
+                    })
+            }
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        print("PTY settle-exit hard-stop latency: \(String(format: "%.3f", elapsed))s")
+
+        #expect(result.completion == .processExited(status: 0))
+        #expect(FileManager.default.fileExists(atPath: rootExitedFile.path))
+        let snapshot = try KiroStatusProbe().parse(output: result.text)
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.creditsUsed == 12.50)
+        #expect(
+            elapsed < hardStopBudget,
+            "Delayed holder discovery should not extend cleanup after a settle exit, took \(elapsed)s")
+
+        let holderPIDText = try String(contentsOf: holderPIDFile, encoding: .utf8)
+        let holderPID = try #require(pid_t(holderPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        let cleanupDeadline = Date().addingTimeInterval(20)
+        while kill(holderPID, 0) == 0, Date() < cleanupDeadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(kill(holderPID, 0) == -1)
     }
 
     private func makeHardStopCLI() throws -> URL {
@@ -141,7 +215,8 @@ extension KiroStatusProbeTests {
                     signal.signal(signal.SIGTERM, signal.SIG_IGN)
                     with open(sys.argv[2], "w") as handle:
                         handle.write(str(os.getpid()))
-                    time.sleep(0.35)
+                    while not os.path.exists(sys.argv[5]):
+                        time.sleep(0.01)
                     late_child = os.fork()
                     if late_child == 0:
                         with open(sys.argv[3], "w") as handle:
@@ -163,6 +238,8 @@ extension KiroStatusProbeTests {
             time.sleep(0.01)
         if os.path.exists(sys.argv[4]):
             raise RuntimeError("root TERM child started before TERM")
+        if os.path.exists(sys.argv[5]):
+            raise RuntimeError("pre-kill snapshot trigger existed before cleanup")
         print("Estimated Usage | resets on 2026-06-01 | KIRO FREE", flush=True)
         print("Credits (12.50 of 50 covered in plan)", flush=True)
         print("████████████████████ 25%", flush=True)
@@ -172,6 +249,55 @@ extension KiroStatusProbeTests {
         try script.write(to: cliURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cliURL.path)
         return cliURL
+    }
+
+    private func makeSettleExitHardStopCLI() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-settle-cli-\(UUID().uuidString)", isDirectory: true)
+        let cliURL = root.appendingPathComponent("kiro-cli")
+        let script = """
+        #!/usr/bin/python3
+        import os
+        import signal
+        import sys
+        import time
+
+        intermediate = os.fork()
+        if intermediate == 0:
+            holder = os.fork()
+            if holder > 0:
+                os._exit(0)
+            os.setsid()
+            signal.signal(signal.SIGHUP, signal.SIG_IGN)
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            with open(sys.argv[1], "w") as handle:
+                handle.write(str(os.getpid()))
+            time.sleep(30)
+            os._exit(0)
+
+        os.waitpid(intermediate, 0)
+        while not os.path.exists(sys.argv[1]):
+            time.sleep(0.01)
+        print("Estimated Usage | resets on 2026-06-01 | KIRO FREE", flush=True)
+        print("Credits (12.50 of 50 covered in plan)", flush=True)
+        print("https://example.com/idle-stop-ready", flush=True)
+        while not os.path.exists(sys.argv[2]):
+            time.sleep(0.01)
+        time.sleep(0.1)
+        with open(sys.argv[3], "w") as handle:
+            handle.write(str(os.getpid()))
+        os._exit(0)
+        """
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try script.write(to: cliURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cliURL.path)
+        return cliURL
+    }
+
+    private static func touchFile(atPath path: String) {
+        let fileDescriptor = open(path, O_WRONLY | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        guard fileDescriptor >= 0 else { return }
+        _ = close(fileDescriptor)
     }
 }
 #endif

--- a/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
@@ -28,18 +28,25 @@ extension KiroStatusProbeTests {
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
         }
 
+        let hardStopBudget = 3 * TestTimingBudget.slowdownFactor
+        // Repository wall-clock tests use 3 seconds locally and scale to 9 seconds on loaded CI runners. Keep
+        // sequential discovery beyond that assertion in both environments without consuming the cleanup window.
+        let discoveryDelay = hardStopBudget + 1
+        let cleanupMaxLifetime = discoveryDelay + 15
         let start = Date()
-        let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(4) {
-            try SpawnedProcessGroup.withOutputHolderPreKillDelayForTesting(0.5) {
-                try TTYCommandRunner().run(
-                    binary: cliURL.path,
-                    send: "",
-                    options: .init(
-                        timeout: 4,
-                        idleTimeout: 0.1,
-                        extraArgs: [childPIDFile.path, termChildPIDFile.path, lateChildPIDFile.path],
-                        initialDelay: 0,
-                        settleAfterStop: 0))
+        let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(discoveryDelay) {
+            try SpawnedProcessGroup.withOutputHolderCleanupMaxLifetimeForTesting(cleanupMaxLifetime) {
+                try SpawnedProcessGroup.withOutputHolderPreKillDelayForTesting(0.5) {
+                    try TTYCommandRunner().run(
+                        binary: cliURL.path,
+                        send: "",
+                        options: .init(
+                            timeout: 4,
+                            idleTimeout: 0.1,
+                            extraArgs: [childPIDFile.path, termChildPIDFile.path, lateChildPIDFile.path],
+                            initialDelay: 0,
+                            settleAfterStop: 0))
+                }
             }
         }
         let elapsed = Date().timeIntervalSince(start)
@@ -49,7 +56,9 @@ extension KiroStatusProbeTests {
         let snapshot = try KiroStatusProbe().parse(output: result.text)
         #expect(snapshot.planName == "KIRO FREE")
         #expect(snapshot.creditsUsed == 12.50)
-        #expect(elapsed < 3, "Delayed holder discovery should not extend the PTY hard stop, took \(elapsed)s")
+        #expect(
+            elapsed < hardStopBudget,
+            "Delayed holder discovery should not extend the PTY hard stop, took \(elapsed)s")
 
         let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
         let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))

--- a/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
@@ -29,7 +29,7 @@ extension KiroStatusProbeTests {
         }
 
         let start = Date()
-        let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(2.5) {
+        let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(4) {
             try SpawnedProcessGroup.withOutputHolderPreKillDelayForTesting(0.5) {
                 try TTYCommandRunner().run(
                     binary: cliURL.path,

--- a/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
@@ -10,14 +10,15 @@ import Glibc
 #if DEBUG
 extension KiroStatusProbeTests {
     @Test
-    func `tty runner bounds hard stop while cleaning a double forked PTY holder`() async throws {
+    func `tty runner bounds hard stop while cleaning root TERM and third generation PTY holders`() async throws {
         let childPIDFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-kiro-double-fork-\(UUID().uuidString).pid")
         let termChildPIDFile = childPIDFile.appendingPathExtension("term-child")
         let lateChildPIDFile = childPIDFile.appendingPathExtension("late-child")
+        let rootTermChildPIDFile = childPIDFile.appendingPathExtension("root-term-child")
         let cliURL = try self.makeHardStopCLI()
         defer {
-            for pidFile in [childPIDFile, termChildPIDFile, lateChildPIDFile] {
+            for pidFile in [childPIDFile, termChildPIDFile, lateChildPIDFile, rootTermChildPIDFile] {
                 if let text = try? String(contentsOf: pidFile, encoding: .utf8),
                    let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
                 {
@@ -43,7 +44,12 @@ extension KiroStatusProbeTests {
                         options: .init(
                             timeout: 4,
                             idleTimeout: 0.1,
-                            extraArgs: [childPIDFile.path, termChildPIDFile.path, lateChildPIDFile.path],
+                            extraArgs: [
+                                childPIDFile.path,
+                                termChildPIDFile.path,
+                                lateChildPIDFile.path,
+                                rootTermChildPIDFile.path,
+                            ],
                             initialDelay: 0,
                             settleAfterStop: 0))
                 }
@@ -72,16 +78,24 @@ extension KiroStatusProbeTests {
         }
         let lateChildPIDText = try String(contentsOf: lateChildPIDFile, encoding: .utf8)
         let lateChildPID = try #require(pid_t(lateChildPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        for _ in 0..<1000 where !FileManager.default.fileExists(atPath: rootTermChildPIDFile.path) {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let rootTermChildPIDText = try String(contentsOf: rootTermChildPIDFile, encoding: .utf8)
+        let rootTermChildPID = try #require(
+            pid_t(rootTermChildPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
 
         let cleanupDeadline = Date().addingTimeInterval(20)
-        while kill(childPID, 0) == 0 || kill(termChildPID, 0) == 0 || kill(lateChildPID, 0) == 0,
-              Date() < cleanupDeadline
+        while kill(childPID, 0) == 0 || kill(termChildPID, 0) == 0 || kill(lateChildPID, 0) == 0
+            || kill(rootTermChildPID, 0) == 0,
+            Date() < cleanupDeadline
         {
             try await Task.sleep(for: .milliseconds(20))
         }
         #expect(kill(childPID, 0) == -1)
         #expect(kill(termChildPID, 0) == -1)
         #expect(kill(lateChildPID, 0) == -1)
+        #expect(kill(rootTermChildPID, 0) == -1)
     }
 
     private func makeHardStopCLI() throws -> URL {
@@ -95,7 +109,25 @@ extension KiroStatusProbeTests {
         import sys
         import time
 
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        root_term_handled = False
+        def handle_root_term(_signal, _frame):
+            global root_term_handled
+            if root_term_handled:
+                return
+            root_term_handled = True
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            root_term_child = os.fork()
+            if root_term_child == 0:
+                os.setsid()
+                signal.signal(signal.SIGHUP, signal.SIG_IGN)
+                signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                with open(sys.argv[4], "w") as handle:
+                    handle.write(str(os.getpid()))
+                time.sleep(30)
+                os._exit(0)
+            time.sleep(0.2)
+            os._exit(0)
+        signal.signal(signal.SIGTERM, handle_root_term)
         intermediate = os.fork()
         if intermediate == 0:
             child = os.fork()
@@ -129,6 +161,8 @@ extension KiroStatusProbeTests {
         os.waitpid(intermediate, 0)
         while not os.path.exists(sys.argv[1]):
             time.sleep(0.01)
+        if os.path.exists(sys.argv[4]):
+            raise RuntimeError("root TERM child started before TERM")
         print("Estimated Usage | resets on 2026-06-01 | KIRO FREE", flush=True)
         print("Credits (12.50 of 50 covered in plan)", flush=True)
         print("████████████████████ 25%", flush=True)

--- a/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
@@ -14,9 +14,10 @@ extension KiroStatusProbeTests {
         let childPIDFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-kiro-double-fork-\(UUID().uuidString).pid")
         let termChildPIDFile = childPIDFile.appendingPathExtension("term-child")
+        let lateChildPIDFile = childPIDFile.appendingPathExtension("late-child")
         let cliURL = try self.makeHardStopCLI()
         defer {
-            for pidFile in [childPIDFile, termChildPIDFile] {
+            for pidFile in [childPIDFile, termChildPIDFile, lateChildPIDFile] {
                 if let text = try? String(contentsOf: pidFile, encoding: .utf8),
                    let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
                 {
@@ -29,15 +30,17 @@ extension KiroStatusProbeTests {
 
         let start = Date()
         let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(2.5) {
-            try TTYCommandRunner().run(
-                binary: cliURL.path,
-                send: "",
-                options: .init(
-                    timeout: 4,
-                    idleTimeout: 0.1,
-                    extraArgs: [childPIDFile.path, termChildPIDFile.path],
-                    initialDelay: 0,
-                    settleAfterStop: 0))
+            try SpawnedProcessGroup.withOutputHolderPreKillDelayForTesting(0.5) {
+                try TTYCommandRunner().run(
+                    binary: cliURL.path,
+                    send: "",
+                    options: .init(
+                        timeout: 4,
+                        idleTimeout: 0.1,
+                        extraArgs: [childPIDFile.path, termChildPIDFile.path, lateChildPIDFile.path],
+                        initialDelay: 0,
+                        settleAfterStop: 0))
+            }
         }
         let elapsed = Date().timeIntervalSince(start)
         print("PTY hard-stop latency: \(String(format: "%.3f", elapsed))s")
@@ -55,13 +58,21 @@ extension KiroStatusProbeTests {
         }
         let termChildPIDText = try String(contentsOf: termChildPIDFile, encoding: .utf8)
         let termChildPID = try #require(pid_t(termChildPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        for _ in 0..<1000 where !FileManager.default.fileExists(atPath: lateChildPIDFile.path) {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let lateChildPIDText = try String(contentsOf: lateChildPIDFile, encoding: .utf8)
+        let lateChildPID = try #require(pid_t(lateChildPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
 
-        let cleanupDeadline = Date().addingTimeInterval(10)
-        while kill(childPID, 0) == 0 || kill(termChildPID, 0) == 0, Date() < cleanupDeadline {
+        let cleanupDeadline = Date().addingTimeInterval(20)
+        while kill(childPID, 0) == 0 || kill(termChildPID, 0) == 0 || kill(lateChildPID, 0) == 0,
+              Date() < cleanupDeadline
+        {
             try await Task.sleep(for: .milliseconds(20))
         }
         #expect(kill(childPID, 0) == -1)
         #expect(kill(termChildPID, 0) == -1)
+        #expect(kill(lateChildPID, 0) == -1)
     }
 
     private func makeHardStopCLI() throws -> URL {
@@ -89,6 +100,13 @@ extension KiroStatusProbeTests {
                     signal.signal(signal.SIGTERM, signal.SIG_IGN)
                     with open(sys.argv[2], "w") as handle:
                         handle.write(str(os.getpid()))
+                    time.sleep(0.35)
+                    late_child = os.fork()
+                    if late_child == 0:
+                        with open(sys.argv[3], "w") as handle:
+                            handle.write(str(os.getpid()))
+                        time.sleep(30)
+                        os._exit(0)
                     time.sleep(30)
                     os._exit(0)
                 time.sleep(0.2)

--- a/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
@@ -50,7 +50,7 @@ extension KiroStatusProbeTests {
 
         let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
         let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        for _ in 0..<500 where !FileManager.default.fileExists(atPath: termChildPIDFile.path) {
+        for _ in 0..<1000 where !FileManager.default.fileExists(atPath: termChildPIDFile.path) {
             try await Task.sleep(for: .milliseconds(20))
         }
         let termChildPIDText = try String(contentsOf: termChildPIDFile, encoding: .utf8)

--- a/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
@@ -7,20 +7,24 @@ import Darwin
 import Glibc
 #endif
 
+#if DEBUG
 extension KiroStatusProbeTests {
     @Test
     func `tty runner bounds hard stop while cleaning a double forked PTY holder`() async throws {
         let childPIDFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-kiro-double-fork-\(UUID().uuidString).pid")
+        let termChildPIDFile = childPIDFile.appendingPathExtension("term-child")
         let cliURL = try self.makeHardStopCLI()
         defer {
-            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8),
-               let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
-            {
-                _ = kill(childPID, SIGKILL)
+            for pidFile in [childPIDFile, termChildPIDFile] {
+                if let text = try? String(contentsOf: pidFile, encoding: .utf8),
+                   let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+                {
+                    _ = kill(childPID, SIGKILL)
+                }
+                try? FileManager.default.removeItem(at: pidFile)
             }
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
-            try? FileManager.default.removeItem(at: childPIDFile)
         }
 
         let start = Date()
@@ -31,7 +35,7 @@ extension KiroStatusProbeTests {
                 options: .init(
                     timeout: 4,
                     idleTimeout: 0.1,
-                    extraArgs: [childPIDFile.path],
+                    extraArgs: [childPIDFile.path, termChildPIDFile.path],
                     initialDelay: 0,
                     settleAfterStop: 0))
         }
@@ -46,11 +50,18 @@ extension KiroStatusProbeTests {
 
         let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
         let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        let cleanupDeadline = Date().addingTimeInterval(6)
-        while kill(childPID, 0) == 0, Date() < cleanupDeadline {
+        for _ in 0..<500 where !FileManager.default.fileExists(atPath: termChildPIDFile.path) {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let termChildPIDText = try String(contentsOf: termChildPIDFile, encoding: .utf8)
+        let termChildPID = try #require(pid_t(termChildPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+
+        let cleanupDeadline = Date().addingTimeInterval(10)
+        while kill(childPID, 0) == 0 || kill(termChildPID, 0) == 0, Date() < cleanupDeadline {
             try await Task.sleep(for: .milliseconds(20))
         }
         #expect(kill(childPID, 0) == -1)
+        #expect(kill(termChildPID, 0) == -1)
     }
 
     private func makeHardStopCLI() throws -> URL {
@@ -72,7 +83,17 @@ extension KiroStatusProbeTests {
                 os._exit(0)
             os.setsid()
             signal.signal(signal.SIGHUP, signal.SIG_IGN)
-            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            def handle_term(_signal, _frame):
+                term_child = os.fork()
+                if term_child == 0:
+                    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                    with open(sys.argv[2], "w") as handle:
+                        handle.write(str(os.getpid()))
+                    time.sleep(30)
+                    os._exit(0)
+                time.sleep(0.2)
+                os._exit(0)
+            signal.signal(signal.SIGTERM, handle_term)
             with open(sys.argv[1], "w") as handle:
                 handle.write(str(os.getpid()))
             time.sleep(30)
@@ -92,3 +113,4 @@ extension KiroStatusProbeTests {
         return cliURL
     }
 }
+#endif

--- a/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+extension KiroStatusProbeTests {
+    @Test
+    func `tty runner bounds hard stop while cleaning a double forked PTY holder`() async throws {
+        let childPIDFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-double-fork-\(UUID().uuidString).pid")
+        let cliURL = try self.makeHardStopCLI()
+        defer {
+            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8),
+               let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                _ = kill(childPID, SIGKILL)
+            }
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: childPIDFile)
+        }
+
+        let start = Date()
+        let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(2.5) {
+            try TTYCommandRunner().run(
+                binary: cliURL.path,
+                send: "",
+                options: .init(
+                    timeout: 4,
+                    idleTimeout: 0.1,
+                    extraArgs: [childPIDFile.path],
+                    initialDelay: 0,
+                    settleAfterStop: 0))
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        print("PTY hard-stop latency: \(String(format: "%.3f", elapsed))s")
+
+        #expect(result.completion == .idleTimeout)
+        let snapshot = try KiroStatusProbe().parse(output: result.text)
+        #expect(snapshot.planName == "KIRO FREE")
+        #expect(snapshot.creditsUsed == 12.50)
+        #expect(elapsed < 3, "Delayed holder discovery should not extend the PTY hard stop, took \(elapsed)s")
+
+        let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
+        let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        let cleanupDeadline = Date().addingTimeInterval(6)
+        while kill(childPID, 0) == 0, Date() < cleanupDeadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(kill(childPID, 0) == -1)
+    }
+
+    private func makeHardStopCLI() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-cli-\(UUID().uuidString)", isDirectory: true)
+        let cliURL = root.appendingPathComponent("kiro-cli")
+        let script = """
+        #!/usr/bin/python3
+        import os
+        import signal
+        import sys
+        import time
+
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        intermediate = os.fork()
+        if intermediate == 0:
+            child = os.fork()
+            if child > 0:
+                os._exit(0)
+            os.setsid()
+            signal.signal(signal.SIGHUP, signal.SIG_IGN)
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            with open(sys.argv[1], "w") as handle:
+                handle.write(str(os.getpid()))
+            time.sleep(30)
+            os._exit(0)
+
+        os.waitpid(intermediate, 0)
+        while not os.path.exists(sys.argv[1]):
+            time.sleep(0.01)
+        print("Estimated Usage | resets on 2026-06-01 | KIRO FREE", flush=True)
+        print("Credits (12.50 of 50 covered in plan)", flush=True)
+        print("████████████████████ 25%", flush=True)
+        time.sleep(30)
+        """
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try script.write(to: cliURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cliURL.path)
+        return cliURL
+    }
+}

--- a/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
+++ b/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
@@ -8,6 +8,33 @@ import Glibc
 #endif
 
 struct SpawnedProcessGroupTests {
+    #if DEBUG
+    @Test
+    func `output holder cleanup lease expires closes descriptor and disarms cleanup`() throws {
+        var descriptors = [Int32](repeating: -1, count: 2)
+        try #require(pipe(&descriptors) == 0)
+        let readDescriptor = descriptors[0]
+        let leasedWriteDescriptor = descriptors[1]
+        defer { _ = close(readDescriptor) }
+
+        let start = Date()
+        let result = SpawnedProcessGroup._test_outputHolderCleanupLeaseExpiry(
+            ownedFileDescriptor: leasedWriteDescriptor,
+            maxLifetime: 0.05,
+            waitTimeout: 0.5)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(result.completed)
+        #expect(!result.active)
+        #expect(elapsed < 0.5)
+        let flags = fcntl(readDescriptor, F_GETFL)
+        #expect(flags >= 0)
+        #expect(fcntl(readDescriptor, F_SETFL, flags | O_NONBLOCK) == 0)
+        var byte: UInt8 = 0
+        #expect(read(readDescriptor, &byte, 1) == 0)
+    }
+    #endif
+
     @Test
     func `pipe cleanup preserves standard descriptors`() {
         let descriptors = SpawnedProcessGroup.pipeDescriptorsToClose([0, 1, 2, 3, 4, 3])

--- a/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
+++ b/Tests/CodexBarTests/SpawnedProcessGroupTests.swift
@@ -10,6 +10,78 @@ import Glibc
 struct SpawnedProcessGroupTests {
     #if DEBUG
     @Test
+    func `owned descriptor take discard and deinit are one shot`() throws {
+        func makePipe() throws -> (read: Int32, write: Int32) {
+            var descriptors = [Int32](repeating: -1, count: 2)
+            try #require(pipe(&descriptors) == 0)
+            return (descriptors[0], descriptors[1])
+        }
+
+        func expectEOF(_ readDescriptor: Int32) {
+            let flags = fcntl(readDescriptor, F_GETFL)
+            #expect(flags >= 0)
+            #expect(fcntl(readDescriptor, F_SETFL, flags | O_NONBLOCK) == 0)
+            var byte: UInt8 = 0
+            #expect(read(readDescriptor, &byte, 1) == 0)
+        }
+
+        let transferredPipe = try makePipe()
+        defer { _ = close(transferredPipe.read) }
+        let transferred = SpawnedProcessGroup._test_ownedDescriptorTakeOnce(
+            ownedFileDescriptor: transferredPipe.write)
+        let transferredDescriptor = try #require(transferred.first)
+        #expect(transferred.second == nil)
+        #expect(!transferred.discardAfterTake)
+        _ = close(transferredDescriptor)
+        expectEOF(transferredPipe.read)
+
+        let discardedPipe = try makePipe()
+        defer { _ = close(discardedPipe.read) }
+        let discarded = SpawnedProcessGroup._test_ownedDescriptorDiscardTwice(
+            ownedFileDescriptor: discardedPipe.write)
+        #expect(discarded.first)
+        #expect(!discarded.second)
+        expectEOF(discardedPipe.read)
+
+        let deinitPipe = try makePipe()
+        defer { _ = close(deinitPipe.read) }
+        SpawnedProcessGroup._test_ownedDescriptorDeinit(ownedFileDescriptor: deinitPipe.write)
+        expectEOF(deinitPipe.read)
+    }
+
+    @Test
+    func `PTY descriptor reservation failure prevents child launch`() throws {
+        let marker = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-pty-reservation-\(UUID().uuidString).marker")
+        defer { try? FileManager.default.removeItem(at: marker) }
+
+        var primaryFD: Int32 = -1
+        var secondaryFD: Int32 = -1
+        try #require(openpty(&primaryFD, &secondaryFD, nil, nil, nil) == 0)
+        defer {
+            _ = close(primaryFD)
+            _ = close(secondaryFD)
+        }
+
+        do {
+            _ = try SpawnedProcessGroup.withPTYPrimaryDescriptorReservationFailureForTesting {
+                try SpawnedProcessGroup.launchPTY(
+                    binary: "/usr/bin/python3",
+                    arguments: ["-c", "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()", marker.path],
+                    environment: ProcessInfo.processInfo.environment,
+                    workingDirectory: nil,
+                    fileDescriptors: (primary: primaryFD, secondary: secondaryFD))
+            }
+            Issue.record("Expected PTY descriptor reservation to fail")
+        } catch let SpawnedProcessGroup.LaunchError.setupFailed(details) {
+            #expect(details == "reserve PTY primary descriptor")
+        } catch {
+            Issue.record("Unexpected launch error: \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: marker.path))
+    }
+
+    @Test
     func `output holder cleanup lease expires closes descriptor and disarms cleanup`() throws {
         var descriptors = [Int32](repeating: -1, count: 2)
         try #require(pipe(&descriptors) == 0)


### PR DESCRIPTION
## Summary

Bound PTY idle/deadline hard-stop latency without abandoning detached processes that still retain the PTY.

The original PR routed a live root through the scoped abort path, but that could miss true double-forked/session-escaped holders. This reconstruction keeps the immediate bounded abort while moving holder discovery and cleanup into a small, deadline-bounded lease.

## Design

- `launchPTY` reserves one CLOEXEC duplicate of the PTY master before `posix_spawn`. Reservation failure prevents child creation, so cleanup never needs to allocate under `EMFILE`/`ENFILE` pressure.
- A lock-protected one-shot owner transfers that descriptor to cleanup, discards it before output-overflow close-master-first aborts, or closes it during ordinary teardown.
- Early-stop cleanup always uses the bounded path, even if the root exits during the settle window. Normal exited-before-deadline #2807 pre-drain cleanup remains unchanged.
- The owned root/process group is synchronously aborted first. Holder discovery starts afterward, so processes created by root TERM handlers are visible.
- The deferred worker captures no `SpawnedProcessGroup`: only immutable output identities, exclusions, grace values, and the reserved master descriptor.
- The reserved descriptor prevents PTY identity reuse. A production 15-second lease closes/disarms it exactly once; expired scan results cannot signal.
- Holder cleanup sends TERM, then repeatedly discovers current PID-safe holders, sends SIGKILL, waits, and rescans until the PTY is clear or the lease expires.

Deliberately unchanged:

- the `/exit` write for ordinary non-overflow cleanup;
- output-overflow ordering: discard reserve, close master, scoped abort;
- normal exited-before-deadline synchronous cleanup and #2807 EOF/EIO drain bookkeeping;
- non-PTY subprocess behavior.

## Regression proof

The composite deterministic fixture covers four escaped generations:

1. a double-forked holder whose intermediate parent exits and whose grandchild calls `setsid()`;
2. a holder forked by that process's TERM handler;
3. a third-generation holder created only after cleanup records its first kill snapshot;
4. a separate session-escaped holder created by the root's TERM handler during the synchronous abort.

A second fixture proves an early-stopped root can exit during settle while a detached holder remains, without returning to synchronous system-wide discovery.

Wall-clock assertions use the repository standard: 3 seconds locally and 9 seconds on loaded CI. Synthetic discovery begins one second beyond that budget in either environment, so an implementation that waits for discovery still fails. A DEBUG-only lease allowance keeps the artificial delay separate from production's fixed 15-second cleanup window.

## Validation

- Composite four-generation regression repeatedly returned in 1.36–1.52 seconds locally and removed every PID.
- Settle-exit regression repeatedly returned in 1.04–1.05 seconds locally and removed the detached holder.
- `KiroStatusProbeTests`: 57/57 passed.
- `SpawnedProcessGroupTests`: 18/18 passed, including descriptor ownership, reservation failure, and lease expiry.
- `TTYCommandRunnerTests`: 29/29 passed.
- `BoundedChildProcessProofTests`: 3/3 across repeated runs.
- Release `CodexBarCore` build passed with DEBUG test APIs excluded.
- `make check` passed.
- Full local matrix: 841 selections across 71 groups passed with zero retries or timeouts.
- Structured Codex autoreview through P2 and TruffleHog passed with no accepted/actionable finding.
