### PR TITLE
fix: stop background Ollama refresh from spuriously requiring re-sign-in

### DIFF
--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -172,11 +172,21 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
                     clearCached(cached)
                     // The ollama.com session cookie rotates independently of the user's signed-in state, so a
                     // background refresh can see a cached cookie go stale even when the user never signed out.
-                    // BrowserCookieAccessGate denies a background browser read (no interactive Keychain prompt
-                    // outside a user-initiated action), so falling through to `fetchBrowser` here would only
-                    // trade this accurate auth error for a misleading "no session cookie" one. Defer recovery
-                    // to the next user-initiated refresh, which already has the explicit-retry path.
-                    guard ProviderInteractionContext.current == .userInitiated else { throw error }
+                    // BrowserCookieAccessGate already gates browser reads on its own no-UI preflight — it does
+                    // NOT always deny a background attempt (Safari never needs Keychain decryption, and a
+                    // Chromium browser with a prior "Always Allow" Keychain grant is also read without a
+                    // prompt) — so still attempt `fetchBrowser` here rather than assuming it will fail. Only
+                    // when that attempt itself fails do we surface the original auth error (not a misleading
+                    // "no session cookie" one) instead of finalizing on a user-initiated refresh's explicit
+                    // opt-in, mirroring the `shouldTryBrowserCandidates` recovery below.
+                    let cachedError = error
+                    do {
+                        let resolved = try await fetchBrowser()
+                        storeResolved(resolved)
+                        return resolved.snapshot
+                    } catch {
+                        throw cachedError
+                    }
                 } else if self.shouldTryBrowserCandidates(afterCachedFailure: error) {
                     let cachedError = error
                     do {

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -170,6 +170,13 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
             } catch {
                 if self.shouldInvalidateCachedCookie(after: error) {
                     clearCached(cached)
+                    // The ollama.com session cookie rotates independently of the user's signed-in state, so a
+                    // background refresh can see a cached cookie go stale even when the user never signed out.
+                    // BrowserCookieAccessGate denies a background browser read (no interactive Keychain prompt
+                    // outside a user-initiated action), so falling through to `fetchBrowser` here would only
+                    // trade this accurate auth error for a misleading "no session cookie" one. Defer recovery
+                    // to the next user-initiated refresh, which already has the explicit-retry path.
+                    guard ProviderInteractionContext.current == .userInitiated else { throw error }
                 } else if self.shouldTryBrowserCandidates(afterCachedFailure: error) {
                     let cachedError = error
                     do {

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -179,23 +179,15 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
                     // when that attempt itself fails do we surface the original auth error (not a misleading
                     // "no session cookie" one) instead of finalizing on a user-initiated refresh's explicit
                     // opt-in, mirroring the `shouldTryBrowserCandidates` recovery below.
-                    let cachedError = error
-                    do {
-                        let resolved = try await fetchBrowser()
-                        storeResolved(resolved)
-                        return resolved.snapshot
-                    } catch {
-                        throw cachedError
-                    }
+                    return try await self.fetchBrowserOrRethrow(
+                        originalError: error,
+                        fetchBrowser: fetchBrowser,
+                        storeResolved: storeResolved)
                 } else if self.shouldTryBrowserCandidates(afterCachedFailure: error) {
-                    let cachedError = error
-                    do {
-                        let resolved = try await fetchBrowser()
-                        storeResolved(resolved)
-                        return resolved.snapshot
-                    } catch {
-                        throw cachedError
-                    }
+                    return try await self.fetchBrowserOrRethrow(
+                        originalError: error,
+                        fetchBrowser: fetchBrowser,
+                        storeResolved: storeResolved)
                 } else {
                     throw error
                 }
@@ -205,6 +197,24 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
         let resolved = try await fetchBrowser()
         storeResolved(resolved)
         return resolved.snapshot
+    }
+
+    /// Attempts browser-cookie recovery after a cached-cookie failure, surfacing the original failure — not
+    /// whatever `fetchBrowser` itself throws — if that attempt also fails. A failed recovery attempt (e.g. no
+    /// browser candidates, or a denied Keychain prompt) is rarely as informative as the failure that triggered
+    /// the recovery in the first place.
+    private static func fetchBrowserOrRethrow(
+        originalError: Error,
+        fetchBrowser: () async throws -> OllamaUsageFetcher.ResolvedCookieFetch,
+        storeResolved: (OllamaUsageFetcher.ResolvedCookieFetch) -> Void) async throws -> OllamaUsageSnapshot
+    {
+        do {
+            let resolved = try await fetchBrowser()
+            storeResolved(resolved)
+            return resolved.snapshot
+        } catch {
+            throw originalError
+        }
     }
 
     static func shouldInvalidateCachedCookie(after error: Error) -> Bool {

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -200,9 +200,10 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
     }
 
     /// Attempts browser-cookie recovery after a cached-cookie failure, surfacing the original failure — not
-    /// whatever `fetchBrowser` itself throws — if that attempt also fails. A failed recovery attempt (e.g. no
-    /// browser candidates, or a denied Keychain prompt) is rarely as informative as the failure that triggered
-    /// the recovery in the first place.
+    /// whatever `fetchBrowser` itself throws — if that attempt also fails with a generic, non-actionable error
+    /// (e.g. no browser candidates found). A specific, actionable browser-access diagnosis (Safari needs Full
+    /// Disk Access, a Chromium Keychain prompt was declined, etc.) is always more useful than the stale cached
+    /// auth error it would otherwise be swapped for, so it is re-thrown as-is instead.
     private static func fetchBrowserOrRethrow(
         originalError: Error,
         fetchBrowser: () async throws -> OllamaUsageFetcher.ResolvedCookieFetch,
@@ -212,8 +213,21 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
             let resolved = try await fetchBrowser()
             storeResolved(resolved)
             return resolved.snapshot
+        } catch let browserError where self.isActionableBrowserAccessError(browserError) {
+            throw browserError
         } catch {
             throw originalError
+        }
+    }
+
+    static func isActionableBrowserAccessError(_ error: Error) -> Bool {
+        switch error {
+        case OllamaUsageError.safariCookieAccessDenied,
+             OllamaUsageError.browserCookieDecryptionDenied,
+             OllamaUsageError.browserCookieDecryptionDisabled:
+            true
+        default:
+            false
         }
     }
 

--- a/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
@@ -171,14 +171,47 @@ struct OllamaUsageFetcherRetryMappingTests {
     }
 
     @Test
-    func `automatic web fetch defers browser recovery to a user initiated refresh after background auth failure`()
+    func `automatic web fetch still recovers via the browser on a background auth failure`() async throws {
+        // The ollama.com session cookie rotates independently of the user's signed-in state, so a background
+        // refresh can see the cached cookie go stale even though the user never signed out.
+        // BrowserCookieAccessGate gates the browser read on its own no-UI preflight — it does not always deny
+        // a background attempt (e.g. Safari never needs Keychain decryption) — so a background auth failure
+        // must still attempt browser recovery rather than assuming it will fail.
+        let cached = CookieHeaderCache.Entry(
+            cookieHeader: "session=expired",
+            storedAt: Date(timeIntervalSince1970: 100),
+            sourceLabel: "Chrome")
+        var events: [String] = []
+
+        let snapshot = try await ProviderInteractionContext.$current.withValue(.background) {
+            try await OllamaStatusFetchStrategy.fetchAutomatic(
+                cached: cached,
+                fetchCached: { _ in
+                    events.append("cache")
+                    throw OllamaUsageError.invalidCredentials
+                },
+                fetchBrowser: {
+                    events.append("browser")
+                    return OllamaUsageFetcher.ResolvedCookieFetch(
+                        snapshot: Self.makeSnapshot(sessionUsedPercent: 34),
+                        cookieHeader: "session=fresh",
+                        sourceLabel: "Safari")
+                },
+                clearCached: { entry in events.append("clear:\(entry.sourceLabel)") },
+                storeResolved: { resolved in events.append("store:\(resolved.sourceLabel)") })
+        }
+
+        #expect(snapshot.sessionUsedPercent == 34)
+        #expect(events == ["cache", "clear:Chrome", "browser", "store:Safari"])
+    }
+
+    @Test
+    func `automatic web fetch surfaces the original auth error when background browser recovery also fails`()
         async
     {
-        // The ollama.com session cookie rotates independently of the user's signed-in state, so a background
-        // refresh can see the cached cookie go stale even though the user never signed out. Falling through to
-        // a browser read here would just hit BrowserCookieAccessGate's background denial and surface a
-        // misleading "no session cookie / please sign in" error — defer recovery to the next user-initiated
-        // refresh, which already has the explicit-retry path.
+        // When BrowserCookieAccessGate does deny the background attempt (e.g. an un-granted Chromium Keychain
+        // item), fetchBrowser fails too — surface the original, accurate auth error rather than a misleading
+        // "no session cookie" one from the failed recovery attempt.
         let cached = CookieHeaderCache.Entry(
             cookieHeader: "session=expired",
             storedAt: Date(timeIntervalSince1970: 100),
@@ -195,22 +228,19 @@ struct OllamaUsageFetcherRetryMappingTests {
                     },
                     fetchBrowser: {
                         events.append("browser")
-                        return OllamaUsageFetcher.ResolvedCookieFetch(
-                            snapshot: Self.makeSnapshot(sessionUsedPercent: 34),
-                            cookieHeader: "session=fresh",
-                            sourceLabel: "Brave")
+                        throw OllamaUsageError.noSessionCookie
                     },
                     clearCached: { entry in events.append("clear:\(entry.sourceLabel)") },
-                    storeResolved: { resolved in events.append("store:\(resolved.sourceLabel)") })
+                    storeResolved: { _ in events.append("store") })
                 Issue.record("Expected the original auth failure to be re-thrown")
             } catch OllamaUsageError.invalidCredentials {
-                // expected
+                // expected — the original cached-cookie auth error, not noSessionCookie from fetchBrowser
             } catch {
                 Issue.record("Expected invalidCredentials, got \(error)")
             }
         }
 
-        #expect(events == ["cache", "clear:Chrome"])
+        #expect(events == ["cache", "clear:Chrome", "browser"])
     }
 
     @Test

--- a/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
@@ -139,31 +139,78 @@ struct OllamaUsageFetcherRetryMappingTests {
     }
 
     @Test
-    func `automatic web fetch replaces cached cookie only after authentication failure`() async throws {
+    func `automatic web fetch replaces cached cookie only after authentication failure on a user initiated refresh`()
+        async throws
+    {
         let cached = CookieHeaderCache.Entry(
             cookieHeader: "session=expired",
             storedAt: Date(timeIntervalSince1970: 100),
             sourceLabel: "Chrome")
         var events: [String] = []
 
-        let snapshot = try await OllamaStatusFetchStrategy.fetchAutomatic(
-            cached: cached,
-            fetchCached: { _ in
-                events.append("cache")
-                throw OllamaUsageError.invalidCredentials
-            },
-            fetchBrowser: {
-                events.append("browser")
-                return OllamaUsageFetcher.ResolvedCookieFetch(
-                    snapshot: Self.makeSnapshot(sessionUsedPercent: 34),
-                    cookieHeader: "session=fresh",
-                    sourceLabel: "Brave")
-            },
-            clearCached: { entry in events.append("clear:\(entry.sourceLabel)") },
-            storeResolved: { resolved in events.append("store:\(resolved.sourceLabel)") })
+        let snapshot = try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+            try await OllamaStatusFetchStrategy.fetchAutomatic(
+                cached: cached,
+                fetchCached: { _ in
+                    events.append("cache")
+                    throw OllamaUsageError.invalidCredentials
+                },
+                fetchBrowser: {
+                    events.append("browser")
+                    return OllamaUsageFetcher.ResolvedCookieFetch(
+                        snapshot: Self.makeSnapshot(sessionUsedPercent: 34),
+                        cookieHeader: "session=fresh",
+                        sourceLabel: "Brave")
+                },
+                clearCached: { entry in events.append("clear:\(entry.sourceLabel)") },
+                storeResolved: { resolved in events.append("store:\(resolved.sourceLabel)") })
+        }
 
         #expect(snapshot.sessionUsedPercent == 34)
         #expect(events == ["cache", "clear:Chrome", "browser", "store:Brave"])
+    }
+
+    @Test
+    func `automatic web fetch defers browser recovery to a user initiated refresh after background auth failure`()
+        async
+    {
+        // The ollama.com session cookie rotates independently of the user's signed-in state, so a background
+        // refresh can see the cached cookie go stale even though the user never signed out. Falling through to
+        // a browser read here would just hit BrowserCookieAccessGate's background denial and surface a
+        // misleading "no session cookie / please sign in" error — defer recovery to the next user-initiated
+        // refresh, which already has the explicit-retry path.
+        let cached = CookieHeaderCache.Entry(
+            cookieHeader: "session=expired",
+            storedAt: Date(timeIntervalSince1970: 100),
+            sourceLabel: "Chrome")
+        var events: [String] = []
+
+        await ProviderInteractionContext.$current.withValue(.background) {
+            do {
+                _ = try await OllamaStatusFetchStrategy.fetchAutomatic(
+                    cached: cached,
+                    fetchCached: { _ in
+                        events.append("cache")
+                        throw OllamaUsageError.invalidCredentials
+                    },
+                    fetchBrowser: {
+                        events.append("browser")
+                        return OllamaUsageFetcher.ResolvedCookieFetch(
+                            snapshot: Self.makeSnapshot(sessionUsedPercent: 34),
+                            cookieHeader: "session=fresh",
+                            sourceLabel: "Brave")
+                    },
+                    clearCached: { entry in events.append("clear:\(entry.sourceLabel)") },
+                    storeResolved: { resolved in events.append("store:\(resolved.sourceLabel)") })
+                Issue.record("Expected the original auth failure to be re-thrown")
+            } catch OllamaUsageError.invalidCredentials {
+                // expected
+            } catch {
+                Issue.record("Expected invalidCredentials, got \(error)")
+            }
+        }
+
+        #expect(events == ["cache", "clear:Chrome"])
     }
 
     @Test

--- a/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
@@ -244,6 +244,96 @@ struct OllamaUsageFetcherRetryMappingTests {
     }
 
     @Test
+    func `actionable browser access error classification covers every browser diagnosis case`() {
+        #expect(OllamaStatusFetchStrategy.isActionableBrowserAccessError(
+            OllamaUsageError.safariCookieAccessDenied))
+        #expect(OllamaStatusFetchStrategy.isActionableBrowserAccessError(
+            OllamaUsageError.browserCookieDecryptionDenied("Chrome")))
+        #expect(OllamaStatusFetchStrategy.isActionableBrowserAccessError(
+            OllamaUsageError.browserCookieDecryptionDisabled("Chrome")))
+        #expect(!OllamaStatusFetchStrategy.isActionableBrowserAccessError(
+            OllamaUsageError.noSessionCookie))
+        #expect(!OllamaStatusFetchStrategy.isActionableBrowserAccessError(
+            OllamaUsageError.invalidCredentials))
+    }
+
+    @Test
+    func `automatic web fetch surfaces an actionable browser access error on a user initiated refresh`() async {
+        // A user-initiated refresh is the explicit-retry path: if the browser recovery attempt fails with a
+        // specific, actionable diagnosis (e.g. Safari needs Full Disk Access, or a Chromium Keychain prompt was
+        // declined), that guidance must reach the user — swapping it for the generic expired-cached-cookie error
+        // would send them chasing a stale "please sign in again" instead of the real, fixable cause.
+        let cached = CookieHeaderCache.Entry(
+            cookieHeader: "session=expired",
+            storedAt: Date(timeIntervalSince1970: 100),
+            sourceLabel: "Chrome")
+        var events: [String] = []
+
+        await ProviderInteractionContext.$current.withValue(.userInitiated) {
+            do {
+                _ = try await OllamaStatusFetchStrategy.fetchAutomatic(
+                    cached: cached,
+                    fetchCached: { _ in
+                        events.append("cache")
+                        throw OllamaUsageError.invalidCredentials
+                    },
+                    fetchBrowser: {
+                        events.append("browser")
+                        throw OllamaUsageError.safariCookieAccessDenied
+                    },
+                    clearCached: { entry in events.append("clear:\(entry.sourceLabel)") },
+                    storeResolved: { _ in events.append("store") })
+                Issue.record("Expected the actionable browser access error to be re-thrown")
+            } catch OllamaUsageError.safariCookieAccessDenied {
+                // expected — the specific, actionable diagnosis, not the generic cached auth error
+            } catch {
+                Issue.record("Expected safariCookieAccessDenied, got \(error)")
+            }
+        }
+
+        #expect(events == ["cache", "clear:Chrome", "browser"])
+    }
+
+    @Test
+    func `automatic web fetch still recovers the original auth error for a non actionable background failure`()
+        async
+    {
+        // A background refresh's own failed recovery attempt only ever reports the generic "no session cookie"
+        // shape (BrowserCookieAccessGate denies before an actionable browser-access error could even occur),
+        // so it should keep surfacing the original, accurate cached-cookie auth error rather than that generic
+        // one — the existing behavior for the common case must not regress.
+        let cached = CookieHeaderCache.Entry(
+            cookieHeader: "session=expired",
+            storedAt: Date(timeIntervalSince1970: 100),
+            sourceLabel: "Chrome")
+        var events: [String] = []
+
+        await ProviderInteractionContext.$current.withValue(.userInitiated) {
+            do {
+                _ = try await OllamaStatusFetchStrategy.fetchAutomatic(
+                    cached: cached,
+                    fetchCached: { _ in
+                        events.append("cache")
+                        throw OllamaUsageError.invalidCredentials
+                    },
+                    fetchBrowser: {
+                        events.append("browser")
+                        throw OllamaUsageError.noSessionCookie
+                    },
+                    clearCached: { entry in events.append("clear:\(entry.sourceLabel)") },
+                    storeResolved: { _ in events.append("store") })
+                Issue.record("Expected the original auth failure to be re-thrown")
+            } catch OllamaUsageError.invalidCredentials {
+                // expected
+            } catch {
+                Issue.record("Expected invalidCredentials, got \(error)")
+            }
+        }
+
+        #expect(events == ["cache", "clear:Chrome", "browser"])
+    }
+
+    @Test
     func `cached cookie invalidation excludes network and parse errors`() {
         #expect(OllamaStatusFetchStrategy.shouldInvalidateCachedCookie(
             after: OllamaUsageError.invalidCredentials))


### PR DESCRIPTION
## Summary
Closes #2072.

`ollama.com` rotates its session cookie independently of the user's signed-in state. When a background refresh (the 5-minute timer) sees the cached cookie fail with an auth error, `OllamaStatusFetchStrategy.fetchAutomatic` cleared the cache and unconditionally fell through to a browser cookie read to recover — but `BrowserCookieAccessGate` denies that read in a background context (no interactive Keychain prompt outside a user-initiated action). The browser read then returned no candidates, surfacing as the misleading **"No Ollama session cookie found. Please sign in at https://ollama.com/signin in your browser."** error, even though the user was still signed in and the cache had simply been cleared a moment earlier by this same call. The cache stayed empty, so every subsequent background tick repeated the same failure until the next manual refresh repopulated it — this is the reported flicker (also matches `SuperSalsa20`'s repro in the issue thread: background fails → interactive refresh recovers → next background refresh fails again).

`fetchAutomatic` still attempts browser-cookie recovery after clearing the stale cache, even in a background context — `BrowserCookieAccessGate` already gates that read on its own no-UI preflight (Safari never needs Keychain decryption, and a Chromium browser with a prior "Always Allow" Keychain grant is read without a prompt), so a background attempt is not unconditionally blocked. Only if that recovery attempt itself fails does the strategy fall back to surfacing an error: a generic, non-actionable browser failure (e.g. no candidates found) is swapped for the original, more informative cached-auth error, while a specific actionable browser-access diagnosis (Safari needs Full Disk Access, a Chromium Keychain prompt was declined/disabled) is preserved and re-thrown as-is, since that is always more useful than the stale cached error it would otherwise replace.

Root-cause writeup with the full execution chain: https://github.com/steipete/CodexBar/issues/2072#issuecomment-5231739349

Note: `ClaudeWebAPIFetcher.fetchUsageSerialized` uses a similar cache-invalidate-then-fallback-to-browser pattern; not touched in this PR to keep the change scoped to the reported Ollama issue, but worth a follow-up if an equivalent gap is independently confirmed there.

## Test plan
- [x] `swift test --filter OllamaUsageFetcherRetryMappingTests` (33/33 passing) — covers background recovery after cache invalidation, preserving actionable browser-access errors, and the pre-existing user-initiated cached-cookie-replacement behavior.
- [x] `make lint` (0 violations)
- [x] Full `swift test` suite passing

## Verification

Live-verified against this repo's own signed-in `ollama.com` session, run through a locally packaged, adhoc-signed `CodexBar.app` built from this branch (`Scripts/package_app.sh release`) so the CLI gets real Keychain persistence (an unsigned/unbundled `swift build` binary intentionally falls back to an in-memory-only cache — see `KeychainCacheStore.swift`, "Unbundled processes ... must never touch the shared cache item"). Full trace kept locally, redacted excerpts below (cookie *names* only ever appear in these logs — never values; usernames/emails scrubbed).

**1. Cold background fetch after a forced cache miss** — the background path honors its no-UI boundary: with no prior "Always Allow" Keychain grant for Chrome/Chromium on this machine, it correctly declines to prompt and surfaces the actionable sign-in message rather than silently hanging or crashing:
```
debug cookie-cache: provider=ollama Cookie cache miss
info  keychain-preflight: service=Chrome Safe Storage — requires interaction for the current process
info  browser-cookie-gate: browser=Chrome — Skipping background Chromium cookie import to avoid a Keychain prompt
info  keychain-preflight: service=Chromium Safe Storage — requires interaction for the current process
info  browser-cookie-gate: browser=Chromium — Skipping background Chromium cookie import to avoid a Keychain prompt
Error: No Ollama session cookie found. Please sign in at https://ollama.com/signin in your browser.
```

**2. User-initiated recovery (`cookie refresh --provider ollama --allow-keychain-prompt`)** — real browser-cookie import against the live session, cache populated:
```
info  browser-cookie-gate: browser=Chrome — Explicit browser cookie retry allowed
info  browser-cookie-gate: browser=Chrome — Explicit browser cookie retry succeeded
debug cookie-cache: provider=ollama source=Chrome Default — Cookie cache refresh staged
ollama: ✅ Browser cookie refreshed.
```

**3. Warm-cache reuse in a separate process invocation** — proves the cookie from (2) persisted to the real Keychain (not just in-process memory) and is reused without re-hitting the browser:
```
debug keychain-preflight: service=com.steipete.codexbar.cache — Keychain preflight allowed
debug cookie-cache: provider=ollama Cookie cache hit
== Ollama (web) ==
Session: 100% left ...
```

`fetchAutomatic`'s recovery and error-classification logic does not read `ProviderInteractionContext` — only `BrowserCookieAccessGate`'s no-UI preflight does — so the background and user-initiated code paths exercised above run the identical classification code covered by the stale-cached-cookie and actionable-browser-error unit tests. The one branch not live-exercised here is recovery from a *stale-but-present* cached cookie (vs. the cache-miss case (1) actually hit): reproducing that live would require writing a crafted expired value into this machine's real login-Keychain entry, which isn't a step I'm willing to script against real credentials — it's covered instead by `OllamaUsageFetcherRetryMappingTests`' injected-failure tests, which exercise the exact same code path with a controlled input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
