### PR TITLE
fix: show dock icon while Settings is open so update dialogs can front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.49.1 — Unreleased
 
+### Fixed
+- Settings: show CodexBar in the Dock while Settings or an update dialog is open, so Check for Updates and new-version prompts reliably appear in front.
+
 ## 0.49.0 — 2026-08-09
 
 ### Added

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -132,6 +132,7 @@ struct CodexBarApp: App {
 
     private func openSettings(pane: SettingsPane) {
         self.preferencesSelection.pane = pane
+        DockIconController.shared.promote()
         NSApp.activate(ignoringOtherApps: true)
         let outcome = SettingsWindowOpener.live().open(preferred: .appKit)
         let logger = CodexBarLog.logger(LogCategories.app)
@@ -239,12 +240,13 @@ final class SparkleUpdaterController: NSObject, UpdaterProviding, SPUUpdaterDele
     }
 
     func checkForUpdates(_ sender: Any?) {
+        DockIconController.shared.promote()
         self.controller.checkForUpdates(sender)
     }
 
     func installUpdate() {
         guard let immediateInstallHandler else {
-            self.controller.checkForUpdates(nil)
+            self.checkForUpdates(nil)
             return
         }
 
@@ -386,6 +388,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let cloudSyncState = CloudSyncState()
     private let confettiOverlayController = ScreenConfettiOverlayController()
     private let confettiLogger = CodexBarLog.logger(LogCategories.confetti)
+    private let dockIconController = DockIconController.shared
     private lazy var memoryPressureMonitor = MemoryPressureMonitor(trimAppCaches: { [weak self] in
         self?.trimRebuildableCachesForMemoryPressure() ?? MemoryPressureCacheTrimSummary()
     })
@@ -421,6 +424,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        self.dockIconController.start()
         self.memoryPressureMonitor.start()
         #if DEBUG
         self.installDebugMemoryPressureObserverIfNeeded()

--- a/Sources/CodexBar/DockIconController.swift
+++ b/Sources/CodexBar/DockIconController.swift
@@ -1,0 +1,181 @@
+import AppKit
+
+struct DockIconWindowDescriptor: Equatable, Sendable {
+    let identifier: String?
+    let title: String
+    let classNames: [String]
+    let width: Double
+    let height: Double
+    let isVisible: Bool
+    let isMiniaturized: Bool
+    let canBecomeKey: Bool
+    let isKnownSettingsWindow: Bool
+
+    var isSettingsWindow: Bool {
+        if self.isKnownSettingsWindow {
+            return true
+        }
+        guard let identifier else { return false }
+        return identifier.contains("com_apple_SwiftUI_Settings")
+    }
+
+    var isSparkleWindow: Bool {
+        !self.title.isEmpty && self.classNames.contains { className in
+            className.contains("SPU") || className.contains("SUUpdate") || className.contains("Sparkle")
+        }
+    }
+
+    var isRealWindow: Bool {
+        guard self.isVisible, !self.isMiniaturized, self.canBecomeKey else { return false }
+        guard !self.isKeepaliveWindow, !self.isStatusBarWindow else { return false }
+        return true
+    }
+
+    private var isKeepaliveWindow: Bool {
+        if self.identifier == "CodexBarLifecycleKeepalive" || self.title == "CodexBarLifecycleKeepalive" {
+            return true
+        }
+        return self.width <= 20 && self.height <= 20
+    }
+
+    private var isStatusBarWindow: Bool {
+        self.classNames.contains { $0.contains("NSStatusBarWindow") }
+    }
+}
+
+enum DockIconPolicyDecision {
+    static func shouldUseRegularActivationPolicy(windows: [DockIconWindowDescriptor]) -> Bool {
+        windows.contains(where: \.isRealWindow)
+    }
+
+    static func shouldPromoteForPresentedWindow(_ window: DockIconWindowDescriptor) -> Bool {
+        window.isVisible && (window.isSettingsWindow || window.isSparkleWindow)
+    }
+}
+
+@MainActor
+final class DockIconController: NSObject {
+    static let shared = DockIconController()
+
+    private var isStarted = false
+    private var isManagingRegularPolicy = false
+    private var isAwaitingPresentedWindow = false
+    private var presentedWindowIDs: Set<ObjectIdentifier> = []
+    private weak var settingsWindow: NSWindow?
+
+    func start() {
+        guard !self.isStarted else { return }
+        self.isStarted = true
+
+        let center = NotificationCenter.default
+        center.addObserver(
+            self,
+            selector: #selector(self.windowStateDidChange(_:)),
+            name: NSApplication.didUpdateNotification,
+            object: nil)
+        for name in [
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didBecomeMainNotification,
+            NSWindow.didUpdateNotification,
+            NSWindow.didMiniaturizeNotification,
+        ] {
+            center.addObserver(
+                self,
+                selector: #selector(self.windowStateDidChange(_:)),
+                name: name,
+                object: nil)
+        }
+        center.addObserver(
+            self,
+            selector: #selector(self.windowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: nil)
+    }
+
+    func promote() {
+        self.isAwaitingPresentedWindow = true
+        self.ensureRegularPolicy(activate: true)
+    }
+
+    func registerSettingsWindow(_ window: NSWindow) {
+        guard self.settingsWindow !== window else { return }
+        self.settingsWindow = window
+        self.reevaluatePolicy()
+    }
+
+    @objc private func windowStateDidChange(_ notification: Notification) {
+        _ = notification
+        self.reevaluatePolicy()
+    }
+
+    @objc private func windowWillClose(_ notification: Notification) {
+        _ = notification
+        Task { @MainActor [weak self] in
+            await Task.yield()
+            self?.reevaluatePolicy()
+        }
+    }
+
+    private func reevaluatePolicy() {
+        let describedWindows = NSApp.windows.map { window in
+            (window: window, descriptor: Self.describe(window, isKnownSettingsWindow: window === self.settingsWindow))
+        }
+        let presentedWindowIDs = Set(describedWindows.compactMap { item in
+            DockIconPolicyDecision.shouldPromoteForPresentedWindow(item.descriptor)
+                ? ObjectIdentifier(item.window)
+                : nil
+        })
+        let hasNewPresentedWindow = !presentedWindowIDs.subtracting(self.presentedWindowIDs).isEmpty
+        self.presentedWindowIDs = presentedWindowIDs
+
+        if !presentedWindowIDs.isEmpty {
+            self.isAwaitingPresentedWindow = false
+            self.ensureRegularPolicy(activate: hasNewPresentedWindow)
+        }
+
+        guard self.isManagingRegularPolicy, !self.isAwaitingPresentedWindow else { return }
+        let windows = describedWindows.map(\.descriptor)
+        guard !DockIconPolicyDecision.shouldUseRegularActivationPolicy(windows: windows) else { return }
+
+        if NSApp.setActivationPolicy(.accessory) {
+            self.isManagingRegularPolicy = false
+        }
+    }
+
+    private func ensureRegularPolicy(activate: Bool) {
+        if NSApp.activationPolicy() != .regular, NSApp.setActivationPolicy(.regular) {
+            self.isManagingRegularPolicy = true
+        }
+        if activate {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    private static func describe(_ window: NSWindow, isKnownSettingsWindow: Bool) -> DockIconWindowDescriptor {
+        var classNames = [NSStringFromClass(type(of: window))]
+        if let windowController = window.windowController {
+            classNames.append(NSStringFromClass(type(of: windowController)))
+        }
+        if let contentViewController = window.contentViewController {
+            classNames.append(NSStringFromClass(type(of: contentViewController)))
+        }
+        if let delegate = window.delegate {
+            classNames.append(NSStringFromClass(type(of: delegate)))
+        }
+
+        return DockIconWindowDescriptor(
+            identifier: window.identifier?.rawValue,
+            title: window.title,
+            classNames: classNames,
+            width: window.frame.width,
+            height: window.frame.height,
+            isVisible: window.isVisible,
+            isMiniaturized: window.isMiniaturized,
+            canBecomeKey: window.canBecomeKey,
+            isKnownSettingsWindow: isKnownSettingsWindow)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}

--- a/Sources/CodexBar/HiddenWindowView.swift
+++ b/Sources/CodexBar/HiddenWindowView.swift
@@ -31,12 +31,14 @@ struct SettingsWindowOpener {
     static func live() -> Self {
         Self(
             notification: {
+                DockIconController.shared.promote()
                 let request = SettingsOpenRequest()
                 NotificationCenter.default.post(name: .codexbarOpenSettings, object: request)
                 return request.wasHandled
             },
             appKit: {
-                NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+                DockIconController.shared.promote()
+                return NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
             })
     }
 

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -340,6 +340,7 @@ final class SettingsWindowAppearanceView: NSView {
 
     private func configureWindowStyle() {
         guard let window else { return }
+        DockIconController.shared.registerSettingsWindow(window)
         if !window.styleMask.contains(.resizable) {
             window.styleMask.insert(.resizable)
         }

--- a/Tests/CodexBarTests/DockIconPolicyDecisionTests.swift
+++ b/Tests/CodexBarTests/DockIconPolicyDecisionTests.swift
@@ -1,0 +1,91 @@
+import Testing
+@testable import CodexBar
+
+struct DockIconPolicyDecisionTests {
+    @Test
+    func `settings window requires regular activation policy`() {
+        let settings = self.window(identifier: "com_apple_SwiftUI_Settings_window")
+        let hostedSettings = self.window(identifier: "future-settings-identifier", isKnownSettingsWindow: true)
+
+        #expect(DockIconPolicyDecision.shouldUseRegularActivationPolicy(windows: [settings]))
+        #expect(DockIconPolicyDecision.shouldPromoteForPresentedWindow(settings))
+        #expect(DockIconPolicyDecision.shouldPromoteForPresentedWindow(hostedSettings))
+    }
+
+    @Test
+    func `Sparkle window requires regular activation policy`() {
+        let sparkle = self.window(
+            title: "A new version is available",
+            classNames: ["Sparkle.SPUStandardUserDriverWindowController"])
+
+        #expect(DockIconPolicyDecision.shouldUseRegularActivationPolicy(windows: [sparkle]))
+        #expect(DockIconPolicyDecision.shouldPromoteForPresentedWindow(sparkle))
+    }
+
+    @Test
+    func `another real window keeps regular activation policy after settings closes`() {
+        let closedSettings = self.window(
+            isVisible: false,
+            isKnownSettingsWindow: true)
+        let updateWindow = self.window(
+            title: "Update Ready",
+            classNames: ["SPUUpdateAlert"])
+        let otherWindow = self.window(title: "Share Usage")
+
+        #expect(DockIconPolicyDecision.shouldUseRegularActivationPolicy(windows: [closedSettings, updateWindow]))
+        #expect(DockIconPolicyDecision.shouldUseRegularActivationPolicy(windows: [closedSettings, otherWindow]))
+    }
+
+    @Test
+    func `ignored windows allow accessory activation policy`() {
+        let keepalive = self.window(
+            identifier: "CodexBarLifecycleKeepalive",
+            title: "CodexBarLifecycleKeepalive",
+            width: 1,
+            height: 1,
+            canBecomeKey: false)
+        let statusBar = self.window(
+            classNames: ["NSStatusBarWindow"],
+            width: 300,
+            height: 30)
+        let borderlessPanel = self.window(
+            classNames: ["NSPanel"],
+            canBecomeKey: false)
+
+        #expect(!DockIconPolicyDecision.shouldUseRegularActivationPolicy(
+            windows: [keepalive, statusBar, borderlessPanel]))
+    }
+
+    @Test
+    func `hidden miniaturized and tiny windows allow accessory activation policy`() {
+        let hidden = self.window(isVisible: false)
+        let miniaturized = self.window(isMiniaturized: true)
+        let tiny = self.window(width: 20, height: 20)
+
+        #expect(!DockIconPolicyDecision.shouldUseRegularActivationPolicy(windows: [hidden, miniaturized, tiny]))
+    }
+
+    private func window(
+        identifier: String? = nil,
+        title: String = "Window",
+        classNames: [String] = ["NSWindow"],
+        width: Double = 600,
+        height: Double = 400,
+        isVisible: Bool = true,
+        isMiniaturized: Bool = false,
+        canBecomeKey: Bool = true,
+        isKnownSettingsWindow: Bool = false)
+        -> DockIconWindowDescriptor
+    {
+        DockIconWindowDescriptor(
+            identifier: identifier,
+            title: title,
+            classNames: classNames,
+            width: width,
+            height: height,
+            isVisible: isVisible,
+            isMiniaturized: isMiniaturized,
+            canBecomeKey: canBecomeKey,
+            isKnownSettingsWindow: isKnownSettingsWindow)
+    }
+}


### PR DESCRIPTION
## Problem

CodexBar is packaged as an LSUIElement accessory app. Opening Settings did not change the activation policy, so Sparkle's Check for Updates and automatic new-version windows could appear behind other apps or fail to become key.

## Root cause

The app remained on the accessory activation policy while presenting real windows. Calling activate alone is insufficient for reliable Dock presence and frontmost window behavior, and reverting too early can pull an update dialog away when Settings closes first.

## Behavior

- Promote CodexBar to the regular activation policy and activate it before opening Settings or invoking Sparkle.
- Recognize the actual PreferencesView hosting window as well as SwiftUI's settings identifier.
- Promote for automatically presented titled Sparkle windows.
- Stay regular while any real visible keyable window remains.
- Ignore the lifecycle keepalive window, status-bar windows, tiny keepalive windows, and utility windows that cannot become key.
- Re-evaluate after close on the next main-actor turn, then return to accessory mode only after the last real window closes.

## Test evidence

- `swift test --filter '(DockIconPolicyDecisionTests|SettingsWindowOpeningTests)'` — 6 tests passed.
- `make check` — formatting, SwiftLint, manifests, package checks, docs, and repository gates passed.
- `CODEXBAR_TEST_SUITE_TIMEOUT=600 make test` through the structured review helper — all 833 selections in 70 groups passed; no retries or timeouts.
- Structured autoreview — clean, no accepted/actionable findings.

Live source-blind UI validation was not run because app startup can exercise real Keychain migration/read paths, which repository safety rules prohibit without an explicit live-test request.
