### PR TITLE
Fix Claude CLI fallback availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Settings: show CodexBar in the Dock while Settings or an update dialog is open, so Check for Updates and new-version prompts reliably appear in front.
+- Claude CLI: let explicit CLI usage and Auto fallback delegate authentication to the installed Claude executable, so an unavailable browser session no longer masks usable reduced-fidelity CLI usage.
 
 ## 0.49.0 — 2026-08-09
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLIAuthStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLIAuthStatusProbe.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 enum ClaudeCLIAuthStatusProbe {
+    enum AuthenticationStatus: Equatable {
+        case loggedIn
+        case loggedOut
+        case unavailable
+    }
+
     private struct Response: Decodable {
         let loggedIn: Bool
     }
@@ -32,8 +38,21 @@ enum ClaudeCLIAuthStatusProbe {
         workingDirectory: URL? = nil,
         timeout: TimeInterval = 5) async -> Bool
     {
+        await self.authenticationStatus(
+            binary: binary,
+            environment: environment,
+            workingDirectory: workingDirectory,
+            timeout: timeout) == .loggedIn
+    }
+
+    static func authenticationStatus(
+        binary: String,
+        environment: [String: String],
+        workingDirectory: URL? = nil,
+        timeout: TimeInterval = 5) async -> AuthenticationStatus
+    {
         if let resultOverrideForTesting = self.resultOverrideForTesting {
-            return resultOverrideForTesting
+            return resultOverrideForTesting ? .loggedIn : .loggedOut
         }
         do {
             let workingDirectory = workingDirectory ?? ClaudeStatusProbe.preparedProbeWorkingDirectoryURL()
@@ -46,19 +65,24 @@ enum ClaudeCLIAuthStatusProbe {
                 timeout: self.timeoutOverrideForTesting ?? timeout,
                 standardInput: FileHandle.nullDevice,
                 currentDirectoryURL: workingDirectory,
+                acceptsNonZeroExit: true,
                 label: "claude-auth-status")
-            return self.parseLoggedIn(result.stdout)
+            return self.parseStatus(result.stdout) ?? .unavailable
         } catch {
-            return false
+            return .unavailable
         }
     }
 
     static func parseLoggedIn(_ output: String) -> Bool {
+        self.parseStatus(output) == .loggedIn
+    }
+
+    static func parseStatus(_ output: String) -> AuthenticationStatus? {
         guard let data = output.data(using: .utf8),
               let response = try? JSONDecoder().decode(Response.self, from: data)
         else {
-            return false
+            return nil
         }
-        return response.loggedIn
+        return response.loggedIn ? .loggedIn : .loggedOut
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -966,11 +966,18 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
     let hasWebFallback: Bool
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        // Claude's "auth status" command is an opaque child process that may invoke /usr/bin/security itself.
-        // CodexBar cannot impose its no-UI policy on that child, so background Auto refresh must not launch it
-        // unless the user explicitly opted into Keychain access for background work.
-        let isBackgroundAppRefresh = context.runtime == .app
-            && ProviderInteractionContext.current == .background
+        guard let binary = ClaudeCLIResolver.resolvedBinaryPath(environment: context.env) else { return false }
+
+        if context.runtime == .cli {
+            // A CodexBarCLI invocation is already an explicit user action. Preserve the definitive logged-out guard,
+            // but do not let an unavailable credential-reading `auth status` child override the owner CLI's ability
+            // to provide usage. The app keeps the stricter marker policy below for prompt-free scheduled refreshes.
+            return await ClaudeCLIAuthStatusProbe.authenticationStatus(
+                binary: binary,
+                environment: context.env) != .loggedOut
+        }
+
+        let isBackgroundAppRefresh = ProviderInteractionContext.current == .background
         // Explicit OAuth may recover through the interactive owner CLI only from a user action. A scheduled
         // refresh with missing credentials must remain on the selected OAuth authority and fail without UI.
         if isBackgroundAppRefresh, context.sourceMode == .oauth {
@@ -983,18 +990,13 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
             // `claude auth status`. Background Auto therefore reuses only availability established by a
             // successful user-initiated CLI fetch in this process. The narrow exception is the owner usage
             // fetch when Keychain access is explicitly disabled; version/auth children retain the global gate.
-            guard let binary = ClaudeCLIResolver.resolvedBinaryPath(environment: context.env) else { return false }
             return ClaudeCLIBackgroundAvailability.allowsBackgroundAutoUsageFetch(
                 binary: binary,
                 environment: context.env)
         }
 
-        // The interactive Claude REPL can open browser OAuth when it starts logged out. CLI-runtime paths
-        // establish authentication through the noninteractive status command first. App user
-        // actions intentionally launch the interactive path directly so the user can complete authentication.
-        guard let binary = ClaudeCLIResolver.resolvedBinaryPath(environment: context.env) else { return false }
-        guard context.runtime == .cli else { return true }
-        return await ClaudeCLIAuthStatusProbe.isLoggedIn(binary: binary, environment: context.env)
+        // App user actions intentionally launch the interactive path directly so the user can complete authentication.
+        return true
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {

--- a/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/ClaudeBaselineCharacterizationTests.swift
@@ -210,6 +210,137 @@ struct ClaudeBaselineCharacterizationTests {
     }
 
     @Test
+    func `CLI explicit source delegates authentication to the configured Claude executable`() async throws {
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
+        let stubCLIPath = try self.makeStubClaudeCLI(
+            authStatusScript: "printf '%s\\n' 'not-json'",
+            invocationLog: invocationLog)
+        defer {
+            try? FileManager.default.removeItem(atPath: stubCLIPath)
+            try? FileManager.default.removeItem(at: invocationLog)
+        }
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .cli,
+            webExtrasEnabled: false,
+            cookieSource: .off,
+            manualCookieHeader: nil))
+        let env = ["CLAUDE_CLI_PATH": stubCLIPath]
+        let fetchOverride: ClaudeStatusProbe.FetchOverride = { binary, _, _ in
+            #expect(binary == stubCLIPath)
+            return Self.makeUsageStatusSnapshot()
+        }
+
+        let outcome = await ClaudeStatusProbe.$fetchOverride.withValue(fetchOverride) {
+            await self.fetchOutcome(runtime: .cli, sourceMode: .cli, env: env, settings: settings)
+        }
+        let result = try outcome.result.get()
+
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [true])
+        #expect(result.strategyID == "claude.cli")
+        #expect(result.usage.dataConfidence == .percentOnly)
+        #expect(try String(contentsOf: invocationLog, encoding: .utf8) == "auth status --json\n")
+    }
+
+    @Test
+    func `CLI auto reaches Claude executable after web credentials are unavailable`() async throws {
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
+        let stubCLIPath = try self.makeStubClaudeCLI(
+            authStatusScript: "printf '%s\\n' 'not-json'",
+            invocationLog: invocationLog)
+        defer {
+            try? FileManager.default.removeItem(atPath: stubCLIPath)
+            try? FileManager.default.removeItem(at: invocationLog)
+        }
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .auto,
+            webExtrasEnabled: false,
+            cookieSource: .auto,
+            manualCookieHeader: nil))
+        let env = ["CLAUDE_CLI_PATH": stubCLIPath]
+        let webLoader: ClaudeWebFetchStrategy.UsageLoader = { _ in
+            throw ClaudeWebAPIFetcher.FetchError.noSessionKeyFound
+        }
+        let fetchOverride: ClaudeStatusProbe.FetchOverride = { binary, _, _ in
+            #expect(binary == stubCLIPath)
+            return Self.makeUsageStatusSnapshot()
+        }
+
+        let outcome = await ClaudeWebFetchStrategy.$usageLoaderOverrideForTesting.withValue(webLoader) {
+            await ClaudeStatusProbe.$fetchOverride.withValue(fetchOverride) {
+                await self.fetchOutcome(runtime: .cli, sourceMode: .auto, env: env, settings: settings)
+            }
+        }
+        let result = try outcome.result.get()
+
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.web", "claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [true, true])
+        #expect(result.strategyID == "claude.cli")
+        #expect(result.usage.dataConfidence == .percentOnly)
+        #expect(try String(contentsOf: invocationLog, encoding: .utf8) == "auth status --json\n")
+    }
+
+    @Test(arguments: [
+        "/definitely/missing/claude",
+        "/etc/hosts",
+    ])
+    func `CLI source rejects missing and non executable Claude paths`(path: String) async {
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .cli,
+            webExtrasEnabled: false,
+            cookieSource: .off,
+            manualCookieHeader: nil))
+        let outcome = await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(path) {
+            await self.fetchOutcome(
+                runtime: .cli,
+                sourceMode: .cli,
+                env: ["CLAUDE_CLI_PATH": path],
+                settings: settings)
+        }
+
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [false])
+        switch outcome.result {
+        case let .failure(error as ProviderFetchError):
+            guard case .noAvailableStrategy(.claude) = error else {
+                Issue.record("Unexpected provider fetch error: \(error)")
+                return
+            }
+        case let .failure(error):
+            Issue.record("Unexpected error: \(error)")
+        case let .success(result):
+            Issue.record("Unavailable Claude executable unexpectedly produced \(result.strategyID)")
+        }
+    }
+
+    @Test
+    func `CLI source keeps definitive logged out guard`() async throws {
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-invocations-\(UUID().uuidString).log")
+        let stubCLIPath = try self.makeStubClaudeCLI(loggedIn: false, invocationLog: invocationLog)
+        defer {
+            try? FileManager.default.removeItem(atPath: stubCLIPath)
+            try? FileManager.default.removeItem(at: invocationLog)
+        }
+        let settings = ProviderSettingsSnapshot.make(claude: .init(
+            usageDataSource: .cli,
+            webExtrasEnabled: false,
+            cookieSource: .off,
+            manualCookieHeader: nil))
+        let outcome = await self.fetchOutcome(
+            runtime: .cli,
+            sourceMode: .cli,
+            env: ["CLAUDE_CLI_PATH": stubCLIPath],
+            settings: settings)
+
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [false])
+        #expect(try String(contentsOf: invocationLog, encoding: .utf8) == "auth status --json\n")
+    }
+
+    @Test
     func `app explicit CLI remains available for interactive authentication without preflight`() async {
         let settings = ProviderSettingsSnapshot.make(claude: .init(
             usageDataSource: .cli,
@@ -698,5 +829,19 @@ struct ClaudeBaselineCharacterizationTests {
     func `Claude OAuth token heuristics reject cookie shaped inputs`() {
         #expect(!TokenAccountSupportCatalog.isClaudeOAuthToken("sessionKey=sk-ant-session"))
         #expect(!TokenAccountSupportCatalog.isClaudeOAuthToken("Cookie: sessionKey=sk-ant-session; foo=bar"))
+    }
+
+    private static func makeUsageStatusSnapshot() -> ClaudeStatusSnapshot {
+        ClaudeStatusSnapshot(
+            sessionPercentLeft: 88,
+            weeklyPercentLeft: 60,
+            opusPercentLeft: 95,
+            accountEmail: "user@example.com",
+            accountOrganization: "Example Org",
+            loginMethod: nil,
+            primaryResetDescription: "Resets 11am",
+            secondaryResetDescription: "Resets Nov 21",
+            opusResetDescription: "Resets Nov 21",
+            rawText: "stub")
     }
 }

--- a/Tests/CodexBarTests/ClaudeCLIAuthStatusProbeTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIAuthStatusProbeTests.swift
@@ -13,6 +13,8 @@ struct ClaudeCLIAuthStatusProbeTests {
         #expect(!ClaudeCLIAuthStatusProbe.parseLoggedIn(#"{"loggedIn":false,"authMethod":"none"}"#))
         #expect(!ClaudeCLIAuthStatusProbe.parseLoggedIn("not-json"))
         #expect(!ClaudeCLIAuthStatusProbe.parseLoggedIn(#"{"authMethod":"none"}"#))
+        #expect(ClaudeCLIAuthStatusProbe.parseStatus(#"{"loggedIn":false}"#) == .loggedOut)
+        #expect(ClaudeCLIAuthStatusProbe.parseStatus("not-json") == nil)
     }
 
     @Test
@@ -47,5 +49,23 @@ struct ClaudeCLIAuthStatusProbeTests {
 
         #expect(loggedIn)
         #expect(try String(contentsOf: invocationLog, encoding: .utf8) == "\(workingDirectory.path)|yes\n")
+    }
+
+    @Test
+    func `nonzero logged out status remains definitive`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeCLIAuthStatusProbe-\(UUID().uuidString)", isDirectory: true)
+        let binary = root.appendingPathComponent("claude")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data("#!/bin/sh\nprintf '%s\\n' '{\"loggedIn\":false}'\nexit 1\n".utf8).write(to: binary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+
+        let status = await ClaudeCLIAuthStatusProbe.authenticationStatus(
+            binary: binary.path,
+            environment: [:],
+            workingDirectory: root)
+
+        #expect(status == .loggedOut)
     }
 }

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -135,6 +135,35 @@ struct PlatformGatingTests {
     }
 
     @Test
+    func `Claude CLI runtime delegates unavailable auth status to owner executable`() async throws {
+        let invocationLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-cli-runtime-invocations-\(UUID().uuidString).log")
+        let binaryURL = try Self.makeClaudeCLI(loggedIn: nil, invocationLog: invocationLog)
+        defer {
+            try? FileManager.default.removeItem(at: binaryURL)
+            try? FileManager.default.removeItem(at: invocationLog)
+        }
+        let context = self.makeClaudeContext(
+            sourceMode: .cli,
+            env: ["CLAUDE_CLI_PATH": binaryURL.path])
+        let cliFetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in
+            Self.makeClaudeStatus()
+        }
+
+        let outcome = await ClaudeStatusProbe.withFetchOverrideForTesting(cliFetchOverride) {
+            await ClaudeProviderDescriptor.makeDescriptor().fetchPlan.fetchOutcome(
+                context: context,
+                provider: .claude)
+        }
+        let result = try outcome.result.get()
+
+        #expect(result.strategyID == "claude.cli")
+        #expect(outcome.attempts.map(\.strategyID) == ["claude.cli"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [true])
+        #expect(try String(contentsOf: invocationLog, encoding: .utf8) == "auth status --json\n")
+    }
+
+    @Test
     func claudeOAuthUsageDoesNotDetectCLIVersion() {
         #expect(!CodexBarCLI.shouldDetectVersion(
             provider: .claude,
@@ -215,19 +244,19 @@ struct PlatformGatingTests {
             browserDetection: browserDetection)
     }
 
-    private static func makeClaudeCLI(loggedIn: Bool, invocationLog: URL? = nil) throws -> URL {
+    private static func makeClaudeCLI(loggedIn: Bool?, invocationLog: URL? = nil) throws -> URL {
         if let invocationLog {
             try Data().write(to: invocationLog)
         }
         let binaryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("claude-cli-runtime-\(UUID().uuidString)")
         let recordInvocation = invocationLog.map { "printf '%s\\n' \"$*\" >> '\($0.path)'" } ?? ""
-        let loggedInJSON = loggedIn ? "true" : "false"
+        let authStatusJSON = loggedIn.map { #"{"loggedIn":\#($0)}"# } ?? "not-json"
         let script = """
         #!/bin/sh
         \(recordInvocation)
         if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-          printf '%s\\n' '{"loggedIn":\(loggedInJSON)}'
+          printf '%s\\n' '\(authStatusJSON)'
         fi
         """
         try FakeExecutable.install(script, at: binaryURL)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -139,6 +139,9 @@ See `docs/configuration.md` for the schema.
         - `--web-debug-dump-html` (writes HTML snapshots to `/tmp` when data is missing)
     - Claude web: claude.ai API (session + weekly usage, account metadata, and prepaid Usage credits balance when
       available).
+      CLI Auto falls back to the installed Claude executable when web credentials are unavailable. This foreground
+      command delegates authentication to Claude Code; the app keeps its stricter prompt-free background availability
+      gate for scheduled refreshes.
     - Command Code web: commandcode.ai browser session cookies on macOS, or a configured manual cookie on Linux, for monthly credit usage.
     - OpenCode Go auto: local SQLite usage on macOS and Linux, with optional manual-cookie web enrichment.
     - Kilo auto: app.kilo.ai API first, then CLI auth fallback (`~/.local/share/kilo/auth.json`) on missing/unauthorized API credentials.


### PR DESCRIPTION
## Summary

- distinguish definitive Claude CLI logout from unavailable or malformed `auth status --json`
- keep logged-out CLI usage blocked, while allowing foreground CodexBarCLI invocations to delegate uncertain authentication to the installed Claude executable
- preserve the stricter prompt-free app background and credential-ownership gates

## Why

The CLI availability probe previously collapsed command failures and unparseable output into logged out. That removed the CLI strategy before explicit CLI usage or Auto fallback could invoke the user-selected Claude executable.

A definitive `{ "loggedIn": false }` result still blocks the strategy. This Mac currently exercises that guard correctly; the newly fixed unavailable/malformed path is covered with source-blind fake executables.

## Proof

- 39 focused Claude tests
- 62 ownership, consent, and Claude Code 2.1.x safety tests
- 11 platform-gating tests
- `make check`
- `make test` — 833 selections across 70 groups
- Developer-ID-signed package and checkout-inaccessible launch smoke
- real logged-out CLI remains blocked; Auto web usage succeeds
- autoreview clean

No release, tag, appcast, or package publication is part of this PR.
