### PR TITLE
Preserve Codex cost usage window under byte pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.
 - Cost history: honor the preferred display currency throughout the detail chart and refresh converted labels when exchange rates change (#2887). Thanks @vAhyThe!
+- Codex: preserve requested Spend Dashboard history when the local cost cache exceeds its byte budget, rather than deleting in-window sessions or repeatedly rebuilding protected data (#2823). Thanks @WillStark for the report and @Whiteknight07 for the initial fix!
 
 ## 0.49.3 — 2026-08-12
 

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+Retention.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+Retention.swift
@@ -283,10 +283,9 @@ extension CostUsageStore {
             }
 
             var catchUpRequired = false
-            // The row budget mirrors the former entry budget: it only ever removes files the
-            // requested window does not read. In-window and recently active files are never
-            // dropped just for a row overage; the byte budget below is the sole authority
-            // that may sacrifice in-window data.
+            // The row and byte budgets only remove files outside the requested window. Once
+            // only protected data remains, preserving report fidelity takes precedence over
+            // forcing the database under its best-effort byte cap.
             while try Self.rowCount(database) > Int64(rowLimit) {
                 guard try Self.deleteOldestRetainedFile(
                     database,
@@ -305,15 +304,8 @@ extension CostUsageStore {
                     sinceDay: sinceDay,
                     untilDay: untilDay,
                     calendar: calendar,
-                    protectRequestedWindow: false)
-                else {
-                    guard try Self.stripOldestRebuildableDetail(database) else { break }
-                    catchUpRequired = true
-                    try Self.markCatchUpRequired(database)
-                    try Self.reclaimFreePages(database)
-                    fileBytes = Self.fileSize(at: self.databaseURL)
-                    continue
-                }
+                    protectRequestedWindow: true)
+                else { break }
                 catchUpRequired = true
                 try Self.reclaimFreePages(database)
                 fileBytes = Self.fileSize(at: self.databaseURL)
@@ -391,43 +383,6 @@ extension CostUsageStore {
 
     private static func rowCount(_ database: OpaquePointer) throws -> Int64 {
         try self.scalarInt(database, "SELECT COUNT(*) FROM files")
-    }
-
-    private static func stripOldestRebuildableDetail(_ database: OpaquePointer) throws -> Bool {
-        let statement = try self.prepare(database, """
-        SELECT f.id, f.scan_state
-        FROM files f
-        WHERE NOT EXISTS (SELECT 1 FROM buffered_lines b WHERE b.file_id = f.id)
-          AND ((SELECT COUNT(*) FROM token_snapshots t WHERE t.file_id = f.id) > 0
-            OR (SELECT COUNT(*) FROM usage_rows r WHERE r.file_id = f.id) > 0)
-        ORDER BY f.updated_at_ms, f.id
-        LIMIT 1
-        """)
-        defer { sqlite3_finalize(statement) }
-        guard sqlite3_step(statement) == SQLITE_ROW,
-              let stateData = self.columnData(statement, at: 1),
-              var state = try? JSONDecoder().decode(CostUsageStoreScanState.self, from: stateData)
-        else { return false }
-        let fileID = sqlite3_column_int64(statement, 0)
-        state.isComplete = false
-        state.resumePayload = nil
-        state.tokenTimestampsMonotonic = nil
-        state.nextUsageRowIndex = nil
-        let updatedState = try JSONEncoder().encode(state)
-        let update = try self.prepare(database, """
-        UPDATE files
-        SET parsed_bytes = 0, anchor_indexed_bytes = NULL, anchor_window_start = NULL,
-            anchor_sha256 = NULL, scan_state = ?, scan_complete = 0
-        WHERE id = ?
-        """)
-        defer { sqlite3_finalize(update) }
-        self.bind(updatedState, to: update, at: 1)
-        sqlite3_bind_int64(update, 2, fileID)
-        try self.stepDone(update, database: database)
-        try self.execute(database, "DELETE FROM token_snapshots WHERE file_id = \(fileID)")
-        try self.execute(database, "DELETE FROM usage_rows WHERE file_id = \(fileID)")
-        try self.execute(database, "DELETE FROM accumulators WHERE file_id = \(fileID)")
-        return true
     }
 
     private static func rebuildDayAggregates(_ database: OpaquePointer) throws {

--- a/Tests/CodexBarTests/CostUsageStoreTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreTests.swift
@@ -543,15 +543,18 @@ extension CostUsageStoreTests {
         #expect(changedCountersAfter.rows - changedCountersBefore.rows > 1)
         #expect(await store.fetchTokenSnapshots(path: path).map(\.eventIndex) == [0, 1, 2])
 
-        // Tightening the budget must run retention before any identical-content return, so an
-        // already oversized store is compacted/deleted rather than declared unchanged.
+        // Tightening the byte budget still runs enforcement before any identical-content
+        // return, but requested-window content is protected, so the cap becomes best-effort
+        // and the unchanged save completes without requesting a rescan.
         let tightenedBudget = store.syncSaveCodexCache(
             CostUsageStoreAccess.read(cacheRoot: fixture.root, calendar: calendar),
             calendar: calendar,
             requestedScanWindow: (sinceKey: "2026-08-01", untilKey: "2026-08-01"),
             fileBudgetBytes: 1,
             skipIdenticalContent: true)
-        #expect(tightenedBudget.catchUpRequired)
+        #expect(tightenedBudget.catchUpRequired == false)
+        #expect(tightenedBudget.fileBytes > 1)
+        #expect(await store.fetchUsageRows(path: path).count == 3)
     }
 
     @Test
@@ -1502,7 +1505,7 @@ extension CostUsageStoreTests {
 
 extension CostUsageStoreTests {
     @Test
-    func `save preserves an existing complete previous report across repeated trims`() async throws {
+    func `save preserves an existing previous report when protected data exceeds the byte cap`() async throws {
         let fixture = try StoreFixture()
         defer { fixture.remove() }
         let store = CostUsageStore(cacheRoot: fixture.root)
@@ -1549,7 +1552,7 @@ extension CostUsageStoreTests {
             reportWindow: (sinceKey: "2026-06-01", untilKey: "2026-07-01"),
             fileBudgetBytes: 1)
 
-        #expect(result.catchUpRequired)
+        #expect(result.catchUpRequired == false)
         let metadata = await store.fetchMetadata()
         let payload = try #require(metadata.previousReportPayload)
         let preserved = try JSONDecoder().decode(CostUsageCodexPreviousReport.self, from: payload)
@@ -1559,7 +1562,7 @@ extension CostUsageStoreTests {
     }
 
     @Test
-    func `save catch up report honors a non-gregorian system calendar`() async throws {
+    func `save over byte cap keeps non-gregorian in window report intact`() async throws {
         let fixture = try StoreFixture()
         defer { fixture.remove() }
         let store = CostUsageStore(cacheRoot: fixture.root)
@@ -1582,13 +1585,12 @@ extension CostUsageStoreTests {
             requestedScanWindow: (sinceKey: "2026-06-01", untilKey: "2026-07-01"),
             reportWindow: (sinceKey: "2026-06-01", untilKey: "2026-07-01"),
             fileBudgetBytes: 1)
+        let report = await store.readReport(sinceDay: "2026-06-01", untilDay: "2026-07-01")
 
-        #expect(result.catchUpRequired)
-        let metadata = await store.fetchMetadata()
-        let payload = try #require(metadata.previousReportPayload)
-        let previous = try JSONDecoder().decode(CostUsageCodexPreviousReport.self, from: payload)
-        #expect(previous.data.contains { $0.date == "2026-06-05" })
-        #expect(previous.data.contains { $0.date == "1483-06-05" } == false)
+        #expect(result.catchUpRequired == false)
+        #expect(await store.fetchMetadata().previousReportPayload == nil)
+        #expect(report.aggregates.map(\.day) == ["2026-06-05"])
+        #expect(report.aggregates.contains { $0.day == "1483-06-05" } == false)
     }
 }
 
@@ -1693,35 +1695,49 @@ extension CostUsageStoreTests {
     }
 
     @Test
-    func `in window byte budget trim marks catch up and preserves previous report`() async throws {
+    func `byte budget preserves in window data across repeated enforcement`() async throws {
         let fixture = try StoreFixture()
         defer { fixture.remove() }
         let store = CostUsageStore(cacheRoot: fixture.root)
-        let previous = Data("previous-report".utf8)
-        var metadata = CostUsageStoreMetadata.empty
-        metadata.lastScanUnixMs = 1234
-        metadata.previousReportPayload = previous
-        #expect(await store.setMetadata(metadata))
+        let day = "2026-08-01"
+        let model = "gpt-5.5"
         for (index, path) in ["/rollouts/one.jsonl", "/rollouts/two.jsonl"].enumerated() {
-            #expect(await store.upsertFile(Self.file(path: path, day: "2026-08-01", updatedAt: Int64(index))))
-            let row = CostUsageStoreUsageRow(
+            let file = Self.file(path: path, day: day, updatedAt: Int64(index))
+            #expect(await store.upsertFile(file))
+            #expect(await store.replaceUsageRows(path: path, rows: [CostUsageStoreUsageRow(
                 path: path,
                 rowIndex: 0,
-                payload: Data(repeating: UInt8(index), count: 256 * 1024))
-            #expect(await store.replaceUsageRows(path: path, rows: [row]))
+                payload: Data(repeating: UInt8(index), count: 256 * 1024))]))
+            #expect(await store.replaceFileDayAggregates(
+                path: path,
+                aggregates: [Self.aggregate(day: day, model: model, scale: 1)]))
         }
+        #expect(await store.mergeDayAggregates([Self.aggregate(day: day, model: model, scale: 2)]))
 
-        let result = await store.enforceBudgets(
+        let first = await store.enforceBudgets(
             maxRows: .max,
             maxFileBytes: 1,
-            requestedSinceDay: "2026-08-01",
-            requestedUntilDay: "2026-08-02")
-        let retained = await store.fetchMetadata()
+            requestedSinceDay: day,
+            requestedUntilDay: day)
+        let second = await store.enforceBudgets(
+            maxRows: .max,
+            maxFileBytes: 1,
+            requestedSinceDay: day,
+            requestedUntilDay: day)
+        let report = await store.readReport(sinceDay: day, untilDay: day)
 
-        #expect(result.catchUpRequired)
-        #expect(retained.catchUpPending)
-        #expect(retained.lastScanUnixMs == 0)
-        #expect(retained.previousReportPayload == previous)
+        #expect(first.catchUpRequired == false)
+        #expect(second.catchUpRequired == false)
+        #expect(first.deletedRows == 0)
+        #expect(second.deletedRows == 0)
+        #expect(first.rowCount == 2)
+        #expect(second.rowCount == 2)
+        #expect(first.fileBytes > 1)
+        #expect(second.fileBytes > 1)
+        #expect(await store.fetchUsageRows(path: "/rollouts/one.jsonl").count == 1)
+        #expect(await store.fetchUsageRows(path: "/rollouts/two.jsonl").count == 1)
+        #expect(report.aggregates == [Self.aggregate(day: day, model: model, scale: 2)])
+        #expect(await store.fetchMetadata().catchUpPending == false)
     }
 
     @Test
@@ -1749,19 +1765,19 @@ extension CostUsageStoreTests {
     }
 
     @Test
-    func `byte budget strips detail from a protected file instead of stalling`() async throws {
+    func `byte budget removes only data outside the requested window`() async throws {
         let fixture = try StoreFixture()
         defer { fixture.remove() }
         let store = CostUsageStore(cacheRoot: fixture.root)
-        var file = Self.file(path: "/rollouts/resuming.jsonl", day: "2026-08-01")
-        file.scanState.isComplete = false
-        #expect(await store.upsertFile(file))
-        #expect(await store.appendTokenSnapshots([Self.snapshot(path: file.path, eventIndex: 0)]))
-        #expect(await store.replaceUsageRows(path: file.path, rows: [CostUsageStoreUsageRow(
-            path: file.path,
-            rowIndex: 0,
-            payload: Data(repeating: 7, count: 256 * 1024))]))
-        #expect(await store.upsertAccumulator(Self.accumulator(path: file.path)))
+        let stale = Self.file(path: "/rollouts/stale.jsonl", day: "2026-06-01", updatedAt: 0)
+        let current = Self.file(path: "/rollouts/current.jsonl", day: "2026-08-01", updatedAt: 1)
+        for file in [stale, current] {
+            #expect(await store.upsertFile(file))
+            #expect(await store.replaceUsageRows(path: file.path, rows: [CostUsageStoreUsageRow(
+                path: file.path,
+                rowIndex: 0,
+                payload: Data(repeating: 7, count: 256 * 1024))]))
+        }
 
         let result = await store.enforceBudgets(
             maxRows: .max,
@@ -1769,23 +1785,21 @@ extension CostUsageStoreTests {
             requestedSinceDay: "2026-08-01",
             requestedUntilDay: "2026-08-02")
 
-        let stripped = try #require(await store.fetchFile(path: file.path))
-        #expect(result.catchUpRequired)
-        #expect(stripped.parsedBytes == 0)
-        #expect(stripped.scanState.isComplete == false)
-        #expect(stripped.scanState.resumePayload == nil)
-        #expect(await store.fetchTokenSnapshots(path: file.path).isEmpty)
-        #expect(await store.fetchUsageRows(path: file.path).isEmpty)
-        #expect(await store.fetchAccumulator(path: file.path) == nil)
-        #expect(await store.fetchMetadata().catchUpPending)
+        #expect(result.deletedRows == 1)
+        #expect(result.rowCount == 1)
+        #expect(result.fileBytes > 1)
+        #expect(await store.fetchFile(path: stale.path) == nil)
+        #expect(await store.fetchFile(path: current.path) != nil)
+        #expect(await store.fetchUsageRows(path: current.path).count == 1)
+        #expect(await store.fetchMetadata().catchUpPending == false)
     }
 
     @Test
-    func `byte budget compacts a fork parent required by a surviving child`() async throws {
+    func `byte budget preserves fork parent detail required by a surviving child`() async throws {
         let fixture = try StoreFixture()
         defer { fixture.remove() }
         let store = CostUsageStore(cacheRoot: fixture.root)
-        var parent = Self.file(path: "/rollouts/parent.jsonl", day: "2026-08-01", updatedAt: 1)
+        var parent = Self.file(path: "/rollouts/parent.jsonl", day: "2026-06-01", updatedAt: 1)
         parent.sessionID = "parent-session"
         #expect(await store.upsertFile(parent))
         #expect(await store.upsertForkLineage(CostUsageStoreForkLineage(
@@ -1814,14 +1828,13 @@ extension CostUsageStoreTests {
             requestedSinceDay: "2026-08-01",
             requestedUntilDay: "2026-08-02")
 
-        // The parent cannot be deleted while the incomplete child still needs its baseline,
-        // so byte pressure compacts its rebuildable detail instead.
-        let compacted = try #require(await store.fetchFile(path: parent.path))
-        #expect(result.catchUpRequired)
-        #expect(compacted.parsedBytes == 0)
-        #expect(compacted.scanState.isComplete == false)
-        #expect(await store.fetchUsageRows(path: parent.path).isEmpty)
+        let retained = try #require(await store.fetchFile(path: parent.path))
+        #expect(result.catchUpRequired == false)
+        #expect(retained.parsedBytes == parent.parsedBytes)
+        #expect(retained.scanState.isComplete)
+        #expect(await store.fetchUsageRows(path: parent.path).count == 1)
         #expect(await store.fetchFile(path: child.path) != nil)
+        #expect(await store.fetchMetadata().catchUpPending == false)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- protect completed files that touch the requested Codex cost-usage window from both row- and byte-budget deletion
- keep the 256 MiB database cap best-effort once only requested-window or recently active data remains
- remove the fallback that stripped protected scan detail and immediately scheduled it for reconstruction
- add repeated-enforcement, report-integrity, fork-parent, out-of-window pruning, and non-Gregorian calendar coverage
- move the post-0.49.1 cost-cache CPU fix into the correct 0.49.2 changelog section

## Root cause

The row-budget path protected the requested reporting window, but the byte-budget path explicitly disabled that protection. Deleting a file cascaded into `file_day_aggregates`, so rebuilding global aggregates permanently removed older requested days from Spend Dashboard.

The initial PR patch correctly enabled requested-window protection, but then fell back to `stripOldestRebuildableDetail`. That reset protected files to incomplete, deleted their token/row/accumulator state, and marked catch-up pending. The next refresh would reconstruct the same detail, exceed the same cap, strip it again, and potentially repeat indefinitely.

The maintainer revision uses a stable policy: delete only safe out-of-window completed files. Once every remaining file is protected, stop enforcement without mutating scan state. The current report and fork baselines remain authoritative, catch-up does not restart, and the database may remain above its best-effort byte cap.

## Storage-policy decision

`VISION.md` requires explicit sign-off for data-storage behavior changes. This PR deliberately prioritizes requested-window report fidelity and stable refresh behavior over an absolute 256 MiB SQLite cap.

**Recommendation:** approve the fidelity-first policy. A hard cap cannot be maintained for arbitrarily large requested windows without either deleting displayed history or introducing a larger durable aggregate-only storage design.

## Validation

- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter CostUsageStoreTests` — 60 tests passed
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter CostUsagePerformanceGateTests` — 25 tests passed
- `make check` — passed
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make test` — 834 selections in 70 groups passed; zero failures or retries
- structured autoreview — secret scan clean; no accepted/actionable findings
- regression coverage uses the real `CostUsageStore`/SQLite path and proves two consecutive over-cap enforcement passes retain in-window rows and report aggregates without setting catch-up pending

Fixes #2823
