### PR TITLE
fix: show DeepInfra spending-limit usage in menu icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.1 — Unreleased
 
 ### Fixed
+- DeepInfra: show billing-cycle spend against a positive spending limit in the automatic menu-bar icon (#2822). Thanks @selfagency for the report!
 - z.ai: restore pace for verified 5-hour, weekly, and MCP-monthly usage windows without treating rolling 30-day limits as calendar months (#2431). Thanks @kiranmagic7!
 - Codex: publish refreshed core quota immediately while optional Credits and OpenAI Web enrichment continues, without unfreezing cards whose layout still needs reconciliation (#2799). Thanks @Yuxin-Qiao!
 - Menu bar: keep DeepSeek balances compact and consistent between saved custom layouts and their live editor preview (#2638). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCore/Providers/DeepInfra/DeepInfraProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/DeepInfra/DeepInfraProviderDescriptor.swift
@@ -53,6 +53,19 @@ public enum DeepInfraProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "DeepInfra per-request cost history is not available in CodexBar." }),
             presentation: ProviderUsagePresentation(
+                menuBarWindowResolver: { context in
+                    guard context.metric == .automatic,
+                          let cost = context.snapshot.providerCost,
+                          cost.used.isFinite,
+                          cost.limit.isFinite,
+                          cost.limit > 0
+                    else { return .unhandled }
+                    return .resolved(RateWindow(
+                        usedPercent: min(100, max(0, cost.used / cost.limit * 100)),
+                        windowMinutes: nil,
+                        resetsAt: cost.resetsAt,
+                        resetDescription: nil))
+                },
                 menuCard: ProviderMenuCardPresentation(
                     showsPrimaryBalanceDescription: true,
                     hidesPrimaryResetWithoutDate: true,

--- a/Tests/CodexBarTests/DeepInfraMenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/DeepInfraMenuBarMetricWindowResolverTests.swift
@@ -1,0 +1,102 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct DeepInfraMenuBarMetricWindowResolverTests {
+    @Test
+    func `automatic metric uses billing cycle spend against a positive limit`() {
+        let reset = Date(timeIntervalSince1970: 2000)
+        let snapshot = Self.snapshot(used: 25, limit: 100, resetsAt: reset)
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .deepinfra,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 25)
+        #expect(window?.resetsAt == reset)
+    }
+
+    @Test
+    func `automatic metric reports zero when billing cycle spend is zero`() {
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .deepinfra,
+            snapshot: Self.snapshot(used: 0, limit: 100),
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 0)
+    }
+
+    @Test
+    func `automatic metric clamps over limit spend`() {
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .deepinfra,
+            snapshot: Self.snapshot(used: 125, limit: 100),
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 100)
+    }
+
+    @Test
+    func `automatic metric keeps balance health without a positive finite limit`() {
+        for limit in [nil, 0, -1, .infinity, .nan] as [Double?] {
+            let snapshot = Self.snapshot(used: 25, limit: limit, primaryUsedPercent: 73)
+            let window = MenuBarMetricWindowResolver.rateWindow(
+                preference: .automatic,
+                provider: .deepinfra,
+                snapshot: snapshot,
+                supportsAverage: false)
+
+            #expect(window?.usedPercent == 73)
+            #expect(window?.resetDescription == "Balance health")
+        }
+    }
+
+    @Test
+    func `spending limit projection does not affect explicit metrics or other providers`() {
+        let snapshot = Self.snapshot(used: 25, limit: 100, primaryUsedPercent: 73)
+
+        let explicit = MenuBarMetricWindowResolver.rateWindow(
+            preference: .primary,
+            provider: .deepinfra,
+            snapshot: snapshot,
+            supportsAverage: false)
+        let otherProvider = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .deepseek,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(explicit?.usedPercent == 73)
+        #expect(otherProvider?.usedPercent == 73)
+    }
+
+    private static func snapshot(
+        used: Double,
+        limit: Double?,
+        primaryUsedPercent: Double = 0,
+        resetsAt: Date? = nil) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: primaryUsedPercent,
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: "Balance health"),
+            secondary: nil,
+            providerCost: limit.map {
+                ProviderCostSnapshot(
+                    used: used,
+                    limit: $0,
+                    currencyCode: "USD",
+                    period: "Billing cycle",
+                    resetsAt: resetsAt,
+                    updatedAt: Date())
+            },
+            updatedAt: Date())
+    }
+}

--- a/docs/deepinfra.md
+++ b/docs/deepinfra.md
@@ -28,7 +28,8 @@ DeepInfra represents prepaid funds as a negative `stripe_balance`; CodexBar conv
 
 ## Display
 
-- The automatic menu-bar metric shows available prepaid balance.
+- When DeepInfra provides a positive spending limit, the automatic menu-bar metric shows billing-cycle spend against
+  that limit. Without one, it keeps the existing available-balance health indicator.
 - The provider card shows available balance and current-month spend without inventing a percentage quota.
 - If the account has a positive spending limit, CodexBar shows billing-cycle spend against that limit.
 - A suspended account is shown as exhausted with DeepInfra's suspension reason when one is provided.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -443,7 +443,7 @@ provider-specific cookie validation, endpoints, login detection, and error trans
 - API key via `DEEPINFRA_API_KEY` / `DEEPINFRA_TOKEN` env var or DeepInfra token accounts.
 - Reads prepaid balance, current billing-cycle spend, spending limit, and account suspension state from the billing checklist endpoint.
 - Reads current-month spend from the billing usage endpoint.
-- The automatic menu-bar metric shows the available balance; the provider card shows balance text rather than an inferred percentage, plus real spending-limit progress when configured.
+- The automatic menu-bar metric shows billing-cycle spend against a positive spending limit when available, otherwise it keeps the balance-health indicator; the provider card continues to show balance text plus real spending-limit progress when configured.
 - Status: `https://status.deepinfra.com` (link only, no auto-polling).
 - Details: `docs/deepinfra.md`.
 


### PR DESCRIPTION
## Summary

- Project DeepInfra billing-cycle spend against a positive spending limit into the automatic menu-bar metric.
- Preserve the existing balance-health fallback for missing, zero, or non-finite limits.
- Keep detailed card text, CLI provider cost data, explicit metrics, Mistral, and other providers unchanged.
- Document the behavior and add a 0.49.1 Unreleased changelog entry thanking the reporter.

Fixes #2822

## Proof

- `swift test --filter 'DeepInfraUsageFetcherTests|MenuBarMetricWindowResolverTests|StatusItemIconObservationSignatureTests|IconRendererHideCrittersTests|ProviderIconResourcesTests'` — 78 tests passed.
- `swift test --filter 'DeepInfraMenuBarMetricWindowResolverTests|DeepInfraUsageFetcherTests'` — 11 tests passed after moving the focused tests into their own lint-safe file.
- `make check` — passed with zero SwiftLint violations.
- `make test` — all 834 selections passed across 70/70 groups with no retries or timeouts.
- `swift build -c release --product CodexBar` — passed.
- `swift build -c release --product CodexBarCLI` — passed.
- Codex autoreview — clean, with no accepted/actionable findings.

## Real provider proof

A maintainer-owned DeepInfra QA credential was injected through the approved 1Password service-account path. The key, account identity, billing values, and exact live percentage were never printed or added to the PR.

- Current-main input: source `api`; usage succeeds; primary icon input is exactly zero; provider cost contains positive billing-cycle spend and a positive spending limit.
- PR resolver: the same live snapshot produces a nonzero automatic DeepInfra menu-bar percentage; authentication, cost data, balance/card data, and explicit metrics remain unchanged.

The credentialed proof ran through the exact production `MenuBarMetricWindowResolver` and emitted only boolean assertions: `baselineZero=true`, `spendPositive=true`, `limitPositive=true`, `resolvedNonZero=true`.

## Screenshots

Synthetic before/after proof rendered through the production automatic metric resolver and icon renderer (25 used / 100 limit; no account identity or live billing data):

![DeepInfra automatic icon before and after](https://github.com/user-attachments/assets/82fbb7e5-85dd-43b6-988a-890ff6f17705)

