### PR TITLE
docs: link originating issues in fix PRs

### DIFF
--- a/docs/FORK_SETUP.md
+++ b/docs/FORK_SETUP.md
@@ -272,8 +272,13 @@ git push origin upstream-pr/fix-cursor-bonus
 
 Every fix PR should reference its originating issue (if there is one) in the PR body:
 
-- `Closes #N` — the PR fully resolves the issue (GitHub will close it on merge)
-- `Refs #N` — the PR only relates to the issue (partial fix, tracking, or precedent)
+- For issues in `steipete/CodexBar`, use `Closes #N` when the PR fully resolves the issue or `Refs #N`
+  when it only relates to the issue.
+- For issues in a contributor fork or another repository, use `Closes owner/repository#N` or
+  `Refs owner/repository#N`.
+
+An upstream PR resolves bare `#N` references in `steipete/CodexBar`. Qualify cross-repository references to avoid
+linking—or with `Closes`, closing—an unrelated upstream issue with the same number.
 
 Verify the cross-reference renders on the PR page before requesting review, so
 contributors can see which issue each fix belongs to.

--- a/docs/FORK_SETUP.md
+++ b/docs/FORK_SETUP.md
@@ -264,7 +264,19 @@ git push origin upstream-pr/fix-cursor-bonus
 # Go to: https://github.com/steipete/CodexBar
 # Click "New Pull Request"
 # Select: base: steipete:main <- compare: topoffunnel:upstream-pr/fix-cursor-bonus
+
+# 7. Link the originating issue in the PR body (see below)
 ```
+
+### Linking Issues
+
+Every fix PR should reference its originating issue (if there is one) in the PR body:
+
+- `Closes #N` — the PR fully resolves the issue (GitHub will close it on merge)
+- `Refs #N` — the PR only relates to the issue (partial fix, tracking, or precedent)
+
+Verify the cross-reference renders on the PR page before requesting review, so
+contributors can see which issue each fix belongs to.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a Linking Issues section to docs/FORK_SETUP.md in the upstream contribution workflow
- fix PRs must reference their originating issue: Closes #N when the PR fully resolves it, Refs #N when it only relates (partial fix, tracking, or precedent)
- verify the cross-reference renders on the PR page before requesting review, so contributors can see which issue each fix belongs to

## Validation
- docs-only change: 1 file changed, 12 insertions
- git diff --check clean
- based on latest upstream main (b20dc237)

## Linked issue
None: this is a documentation convention change; maintainer sign-off requested.