### PR TITLE
Add Ghostty to the terminal app picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.49.4 — Unreleased
 
+### Added
+- Terminal picker: offer Ghostty 1.3+ as a default terminal for Open Terminal and provider login commands, falling back to Terminal.app when unavailable (#2830). Thanks @darwinz!
+
 ### Fixed
 - PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.
 - Cost history: honor the preferred display currency throughout the detail chart and refresh converted labels when exchange rates change (#2887). Thanks @vAhyThe!

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -653,9 +653,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     func openTerminal(command: String) {
         let terminal = self.settings.terminalApp
 
-        if terminal == .iTerm, !terminal.isInstalled {
+        if terminal != .terminal, !terminal.isInstalled {
             CodexBarLog.logger(LogCategories.terminal).warning(
-                "iTerm is not installed, falling back to Terminal.app",
+                "\(terminal.label) is not installed, falling back to Terminal.app",
                 metadata: ["terminal": terminal.rawValue])
             Self.openTerminalInDefaultTerminal(command: command)
             return

--- a/Sources/CodexBar/TerminalApp.swift
+++ b/Sources/CodexBar/TerminalApp.swift
@@ -5,6 +5,7 @@ enum TerminalApp: String, CaseIterable, Identifiable {
 
     case terminal
     case iTerm
+    case ghostty
 
     var id: String {
         self.rawValue
@@ -14,6 +15,7 @@ enum TerminalApp: String, CaseIterable, Identifiable {
         switch self {
         case .terminal: "Terminal"
         case .iTerm: "iTerm"
+        case .ghostty: "Ghostty"
         }
     }
 
@@ -21,6 +23,7 @@ enum TerminalApp: String, CaseIterable, Identifiable {
         switch self {
         case .terminal: "com.apple.Terminal"
         case .iTerm: "com.googlecode.iterm2"
+        case .ghostty: "com.mitchellh.ghostty"
         }
     }
 
@@ -110,6 +113,16 @@ enum TerminalApp: String, CaseIterable, Identifiable {
                 tell current session of newWindow
                     write text "\(escaped)"
                 end tell
+            end tell
+            """
+        case .ghostty:
+            // Requires Ghostty 1.3.0+ (first release with AppleScript support). `initial input`
+            // runs the command in the user's shell and keeps the window open afterward, matching
+            // the Terminal and iTerm behavior; older Ghostty fails here and falls back to Terminal.
+            """
+            tell application "Ghostty"
+                activate
+                new window with configuration {initial input:"\(escaped)" & linefeed}
             end tell
             """
         }

--- a/Tests/CodexBarTests/TerminalAppTests.swift
+++ b/Tests/CodexBarTests/TerminalAppTests.swift
@@ -50,8 +50,8 @@ struct TerminalAppTests {
     }
 
     @Test
-    func `only two cases exist`() {
-        #expect(TerminalApp.allCases.count == 2)
+    func `only three cases exist`() {
+        #expect(TerminalApp.allCases.count == 3)
     }
 
     @Test
@@ -63,12 +63,20 @@ struct TerminalAppTests {
 
         #expect(installed == [.terminal, .iTerm])
         #expect(TerminalApp.installed { _ in nil } == [.terminal])
+
+        let ghosttyURL = URL(fileURLWithPath: "/Applications/Ghostty.app")
+        let withGhostty = TerminalApp.installed { bundleIdentifier in
+            bundleIdentifier == TerminalApp.ghostty.bundleIdentifier ? ghosttyURL : nil
+        }
+
+        #expect(withGhostty == [.terminal, .ghostty])
     }
 
     @Test
     func `picker options preserve an unavailable persisted selection`() {
         #expect(TerminalApp.pickerOptions(selected: .terminal) { _ in nil } == [.terminal])
         #expect(TerminalApp.pickerOptions(selected: .iTerm) { _ in nil } == [.terminal, .iTerm])
+        #expect(TerminalApp.pickerOptions(selected: .ghostty) { _ in nil } == [.terminal, .ghostty])
     }
 
     @Test
@@ -121,10 +129,13 @@ struct TerminalAppTests {
         let command = #"echo "hello""#
         let terminalScript = TerminalApp.terminal.appleScript(command: command)
         let iTermScript = TerminalApp.iTerm.appleScript(command: command)
+        let ghosttyScript = TerminalApp.ghostty.appleScript(command: command)
 
         #expect(terminalScript.contains(#"tell application "Terminal""#))
         #expect(terminalScript.contains(#"do script "echo \"hello\"""#))
         #expect(iTermScript.contains(#"tell application "iTerm""#))
         #expect(iTermScript.contains(#"write text "echo \"hello\"""#))
+        #expect(ghosttyScript.contains(#"tell application "Ghostty""#))
+        #expect(ghosttyScript.contains(#"new window with configuration {initial input:"echo \"hello\"" & linefeed}"#))
     }
 }


### PR DESCRIPTION
## Summary

Add Ghostty 1.3+ as a third option in Settings → General → Default terminal so shared “Open Terminal” and provider login actions can launch commands in the user’s configured Ghostty shell.

- add `TerminalApp.ghostty` with bundle ID `com.mitchellh.ghostty`
- use Ghostty’s AppleScript `new window with configuration {initial input:… & linefeed}` path
- generalize the unavailable-app fallback from iTerm-only to every non-Terminal selection
- preserve Terminal.app fallback when Ghostty is absent, too old, has AppleScript disabled, or the script fails
- retain existing picker/persistence/icon behavior through the shared `CaseIterable` terminal abstraction

This branch is rebased onto current `main`; the public commit metadata is human-only and contains no model attribution.

## Compatibility decision

Ghostty documents AppleScript support starting in 1.3.0 and still describes the interface as preview. Merging this PR makes Ghostty 1.3+ an explicitly supported terminal choice while retaining Terminal.app as the compatibility fallback.

**Recommendation:** accept the bounded integration. It uses the existing launcher boundary, has direct signed-app proof, and degrades to established behavior on unsupported installations.

## Validation

- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter 'TerminalAppTests|PreferencesPaneSmokeTests'` — 38 tests passed
- `make check` — passed
- structured autoreview — secret scan clean; no accepted/actionable findings
- Developer-ID-signed debug bundle exercised the actual `StatusItemController.openTerminal` → `NSAppleScript` path against installed Ghostty 1.3.1 on macOS 26.6.1

## Signed-app proof

The signed CodexBar bundle selected Ghostty in-process, called its real `openTerminal` method, created a Ghostty window, and executed:

```text
printf ghostty-proof > /tmp/codexbar-ghostty-proof.txt
```

The marker file contained `ghostty-proof`, and the captured Ghostty accessibility tree showed the command in the terminal content followed by the returned shell prompt. No standalone `osascript` substitute was used for this proof.

The same signed bundle opened Settings with Ghostty detected and selected:

![Ghostty selected in CodexBar Settings](https://github.com/user-attachments/assets/09141588-81bd-495d-b493-eebb2a291ffc)

The original contributor transcript and redacted Ghostty screenshot remain useful independent corroboration.

Fixes #2830
