### PR TITLE
Skip unchanged cost snapshot conversions

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
@@ -216,13 +216,8 @@ extension CostUsageStore {
         baseline: PersistedFileBaseline,
         calendar: Calendar)
     {
-        let snapshots = (usage.codexTokenSnapshots ?? []).enumerated().map {
-            Self.tokenSnapshot(path: path, eventIndex: $0.offset, snapshot: $0.element, calendar: calendar)
-        }
-        let rows = (usage.codexRows ?? []).enumerated().compactMap { index, row -> CostUsageStoreUsageRow? in
-            guard let payload = try? JSONEncoder().encode(row) else { return nil }
-            return CostUsageStoreUsageRow(path: path, rowIndex: index, payload: payload)
-        }
+        let tokenSnapshots = usage.codexTokenSnapshots ?? []
+        let usageRows = usage.codexRows ?? []
         let details = StoredFileDetails(
             lastTotals: usage.lastTotals,
             projectPath: usage.projectPath,
@@ -269,19 +264,34 @@ extension CostUsageStore {
         let appendSafe = baseline.canReuseRows
             && baseline.file?.scanState.fileIdentity == file.scanState.fileIdentity
             && oldParsedBytes < newParsedBytes
-        if baseline.canReuseRows, oldParsedBytes == newParsedBytes, baseline.snapshotCount == snapshots.count {
+        if baseline.canReuseRows, oldParsedBytes == newParsedBytes, baseline.snapshotCount == tokenSnapshots.count {
             // Stable cursor: the persisted prefix is already authoritative.
-        } else if appendSafe, baseline.snapshotCount <= snapshots.count {
-            _ = self.appendTokenSnapshots(Array(snapshots.dropFirst(baseline.snapshotCount)))
+        } else if appendSafe, baseline.snapshotCount <= tokenSnapshots.count {
+            _ = self.appendTokenSnapshots(Self.storeTokenSnapshots(
+                path: path,
+                snapshots: tokenSnapshots,
+                startingAt: baseline.snapshotCount,
+                calendar: calendar))
         } else {
-            _ = self.replaceTokenSnapshots(path: path, snapshots: snapshots)
+            _ = self.replaceTokenSnapshots(
+                path: path,
+                snapshots: Self.storeTokenSnapshots(
+                    path: path,
+                    snapshots: tokenSnapshots,
+                    startingAt: 0,
+                    calendar: calendar))
         }
-        if baseline.canReuseRows, oldParsedBytes == newParsedBytes, baseline.rowCount == rows.count {
+        if baseline.canReuseRows, oldParsedBytes == newParsedBytes, baseline.rowCount == usageRows.count {
             // Stable cursor: metadata/aggregate updates do not rewrite historical rows.
-        } else if appendSafe, baseline.rowCount <= rows.count {
-            _ = self.appendUsageRows(Array(rows.dropFirst(baseline.rowCount)))
+        } else if appendSafe, baseline.rowCount <= usageRows.count {
+            _ = self.appendUsageRows(Self.storeUsageRows(
+                path: path,
+                rows: usageRows,
+                startingAt: baseline.rowCount))
         } else {
-            _ = self.replaceUsageRows(path: path, rows: rows)
+            _ = self.replaceUsageRows(
+                path: path,
+                rows: Self.storeUsageRows(path: path, rows: usageRows, startingAt: 0))
         }
         _ = self.replaceFileDayAggregates(path: path, aggregates: Self.fileAggregates(usage))
         _ = self.upsertForkLineage(CostUsageStoreForkLineage(
@@ -295,7 +305,7 @@ extension CostUsageStore {
         self.persistBuffers(path: path, usage: usage)
         _ = self.upsertAccumulator(CostUsageStoreAccumulator(
             path: path,
-            eventCount: snapshots.count,
+            eventCount: tokenSnapshots.count,
             nextUsageRowIndex: CostUsageScanner.nextCodexUsageRowIndex(usage.codexRows),
             countedTotals: Self.totals(usage.lastCountedTotals),
             rawTotalsBaseline: Self.totals(usage.lastRawTotalsBaseline),
@@ -579,6 +589,7 @@ extension CostUsageStore {
         snapshot: CostUsageCodexTokenSnapshot,
         calendar: Calendar) -> CostUsageStoreTokenSnapshot
     {
+        tokenSnapshotConversionForTesting?(path, eventIndex)
         let date = CostUsageScanner.dateFromTimestamp(snapshot.timestamp)
         return CostUsageStoreTokenSnapshot(
             path: path,
@@ -589,6 +600,28 @@ extension CostUsageStore {
             last: Self.totals(snapshot.last),
             total: Self.totals(snapshot.total),
             endOffset: snapshot.endOffset)
+    }
+
+    private static func storeTokenSnapshots(
+        path: String,
+        snapshots: [CostUsageCodexTokenSnapshot],
+        startingAt startIndex: Int,
+        calendar: Calendar) -> [CostUsageStoreTokenSnapshot]
+    {
+        snapshots.indices.dropFirst(startIndex).map { index in
+            Self.tokenSnapshot(path: path, eventIndex: index, snapshot: snapshots[index], calendar: calendar)
+        }
+    }
+
+    private static func storeUsageRows(
+        path: String,
+        rows: [CostUsageScanner.CodexUsageRow],
+        startingAt startIndex: Int) -> [CostUsageStoreUsageRow]
+    {
+        rows.indices.dropFirst(startIndex).compactMap { index in
+            guard let payload = try? JSONEncoder().encode(rows[index]) else { return nil }
+            return CostUsageStoreUsageRow(path: path, rowIndex: index, payload: payload)
+        }
     }
 
     private static func tokenSnapshot(from value: CostUsageStoreTokenSnapshot) -> CostUsageCodexTokenSnapshot {

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore.swift
@@ -77,6 +77,10 @@ actor CostUsageStore {
     /// process at a deterministic mid-save point. Never set in production.
     nonisolated(unsafe) static var saveCycleCheckpointForTesting: ((Int) -> Void)?
 
+    /// Test-only observer for snapshot rows converted during a save. Stable rows should
+    /// remain in SQLite without repeating timestamp parsing on every bounded catch-up pass.
+    nonisolated(unsafe) static var tokenSnapshotConversionForTesting: ((String, Int) -> Void)?
+
     /// Process-wide serialization keeps every writable store connection on the same queue.
     /// This matches the scan pipeline's single-writer contract without multiplying executor
     /// threads when tests or short-lived readers create several store actors.

--- a/Tests/CodexBarTests/CostUsageStoreCutoverTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreCutoverTests.swift
@@ -105,6 +105,16 @@ struct CostUsageStoreCutoverTests {
             now: day,
             options: options)
 
+        let storedPath = try #require(CostUsageStoreAccess.read(cacheRoot: env.cacheRoot).files.keys.first {
+            $0.hasSuffix("linear.jsonl")
+        })
+        let conversionCounter = StoreSnapshotConversionCounter()
+        CostUsageStore.tokenSnapshotConversionForTesting = { path, _ in
+            guard path == storedPath else { return }
+            conversionCounter.increment()
+        }
+        defer { CostUsageStore.tokenSnapshotConversionForTesting = nil }
+
         try Self.append(Self.tokenLine(timestamp: timestamp, input: 2) + "\n", to: fileURL)
         let appendRecorder = CostUsageScanner.CodexScanWorkRecorder()
         options.codexScanWorkRecorderForTesting = appendRecorder
@@ -116,15 +126,15 @@ struct CostUsageStoreCutoverTests {
             options: options)
         #expect(appendRecorder.snapshot().usageRowsProcessed == 1)
         #expect(appendRecorder.snapshot().usageRowsRepriced == 1)
+        #expect(conversionCounter.value == 1)
 
-        let cache = CostUsageStoreAccess.read(cacheRoot: env.cacheRoot)
-        let path = try #require(cache.files.keys.first { $0.hasSuffix("linear.jsonl") })
         let store = CostUsageStore(cacheRoot: env.cacheRoot)
-        #expect(await store.fetchUsageRows(path: path).count == 2)
-        #expect(await store.fetchAccumulator(path: path)?.eventCount == 2)
+        #expect(await store.fetchUsageRows(path: storedPath).count == 2)
+        #expect(await store.fetchAccumulator(path: storedPath)?.eventCount == 2)
 
         let stableRecorder = CostUsageScanner.CodexScanWorkRecorder()
         options.codexScanWorkRecorderForTesting = stableRecorder
+        conversionCounter.reset()
         let stable = CostUsageScanner.loadDailyReport(
             provider: .codex,
             since: day,
@@ -133,6 +143,7 @@ struct CostUsageStoreCutoverTests {
             options: options)
         #expect(stableRecorder.snapshot().usageRowsProcessed == 0)
         #expect(stableRecorder.snapshot().usageRowsRepriced == 0)
+        #expect(conversionCounter.value == 0)
         #expect(stable.data == appended.data)
         #expect(stable.summary == appended.summary)
     }
@@ -181,5 +192,22 @@ struct CostUsageStoreCutoverTests {
         defer { try? handle.close() }
         try handle.seekToEnd()
         try handle.write(contentsOf: Data(contents.utf8))
+    }
+}
+
+private final class StoreSnapshotConversionCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        self.lock.withLock { self.count }
+    }
+
+    func increment() {
+        self.lock.withLock { self.count += 1 }
+    }
+
+    func reset() {
+        self.lock.withLock { self.count = 0 }
     }
 }


### PR DESCRIPTION
Refs #2824.

`persistFile` converted every retained Codex token timestamp and JSON-encoded every usage row before deciding whether the SQLite cursor was unchanged. During bounded catch-up, that repeated the hottest ISO-8601 work across the full historical prefix even when the stable-cursor branch wrote no rows.

This moves conversion and encoding behind the persistence decision. Stable files do none of that work, append-safe files convert only the new suffix, and replacement behavior stays the same. The database schema, metadata, aggregates, event indexes, and row indexes are unchanged.

Tests:

- `CI=1 CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --disable-keychain --disable-netrc --filter 'CostUsageStore|CostUsagePerformanceGateTests'` (103 tests passed)
- `CI=1 CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make check` (passed)
- `CI=1 CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make test` does not complete locally because two unrelated `AdaptiveRefreshTimerTests` time out with `CancellationError()`. The exact clean base, `1ba79680364dddbc611d710fbf59dddf76062627`, reproduces both failures at lines 39 and 78.

Real-corpus proof (redacted):

I ran the exact pre-fix base and this head against the same completed 125.8 MB local Codex session-day subset, using a fresh isolated cache for each run. The base carried only the same counter hook around token-snapshot conversion; it did not change persistence decisions.

```text
pre-fix base  files=62 snapshots=1866 cold_conversions=1866 stable_conversions=1866 cold_seconds=4.801 stable_seconds=0.234
patched head  files=62 snapshots=1866 cold_conversions=1866 stable_conversions=0    cold_seconds=4.802 stable_seconds=0.118
```

The patched run asserted that stable conversions were zero and passed. The near-identical cold times are a useful comparability check; the conversion counts are the deterministic signal. No filenames, paths, session contents, report output, project names, or account/model/cost data were captured.

This is a narrow reduction in the repeated store work reported in #2824, not the broader delta-persistence redesign. Compatibility risk should be low because the write branches and schema are unchanged. Review focus: the append-only suffix indexes and the stable-cursor no-conversion invariant.
