### PR TITLE
perf: avoid reprocessing stable Codex cost cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.1 — Unreleased
 
 ### Fixed
+- Codex: avoid repeatedly converting historical token snapshots during cost-cache refreshes, preventing sustained CPU usage on large session histories.
 - DeepInfra: show billing-cycle spend against a positive spending limit in the automatic menu-bar icon (#2822). Thanks @selfagency for the report!
 - z.ai: restore pace for verified 5-hour, weekly, and MCP-monthly usage windows without treating rolling 30-day limits as calendar months (#2431). Thanks @kiranmagic7!
 - Codex: publish refreshed core quota immediately while optional Credits and OpenAI Web enrichment continues, without unfreezing cards whose layout still needs reconciliation (#2799). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
@@ -1,5 +1,47 @@
 import Foundation
 
+enum CostUsagePersistenceAction: Equatable {
+    case reuse
+    case append(startingAt: Int)
+    case replace
+
+    func materialize<Source, Persisted>(
+        _ source: [Source],
+        transform: (Int, Source) -> Persisted?) -> [Persisted]
+    {
+        switch self {
+        case .reuse:
+            []
+        case let .append(startingAt):
+            source.enumerated().dropFirst(startingAt).compactMap { index, value in
+                transform(index, value)
+            }
+        case .replace:
+            source.enumerated().compactMap { index, value in
+                transform(index, value)
+            }
+        }
+    }
+}
+
+enum CostUsagePersistencePlanner {
+    static func action(
+        canReuse: Bool,
+        stableCursor: Bool,
+        appendSafe: Bool,
+        persistedCount: Int,
+        sourceCount: Int) -> CostUsagePersistenceAction
+    {
+        if canReuse, stableCursor, persistedCount == sourceCount {
+            return .reuse
+        }
+        if appendSafe, persistedCount <= sourceCount {
+            return .append(startingAt: persistedCount)
+        }
+        return .replace
+    }
+}
+
 extension CostUsageStore {
     static let defaultRowBudget = 25000
     static let defaultFileBudgetBytes: Int64 = 256 * 1024 * 1024
@@ -216,13 +258,10 @@ extension CostUsageStore {
         baseline: PersistedFileBaseline,
         calendar: Calendar)
     {
-        let snapshots = (usage.codexTokenSnapshots ?? []).enumerated().map {
-            Self.tokenSnapshot(path: path, eventIndex: $0.offset, snapshot: $0.element, calendar: calendar)
-        }
-        let rows = (usage.codexRows ?? []).enumerated().compactMap { index, row -> CostUsageStoreUsageRow? in
-            guard let payload = try? JSONEncoder().encode(row) else { return nil }
-            return CostUsageStoreUsageRow(path: path, rowIndex: index, payload: payload)
-        }
+        let sourceSnapshots = usage.codexTokenSnapshots ?? []
+        let sourceRows = usage.codexRows ?? []
+        let snapshotCount = sourceSnapshots.count
+        let rowCount = sourceRows.count
         let details = StoredFileDetails(
             lastTotals: usage.lastTotals,
             projectPath: usage.projectPath,
@@ -269,18 +308,41 @@ extension CostUsageStore {
         let appendSafe = baseline.canReuseRows
             && baseline.file?.scanState.fileIdentity == file.scanState.fileIdentity
             && oldParsedBytes < newParsedBytes
-        if baseline.canReuseRows, oldParsedBytes == newParsedBytes, baseline.snapshotCount == snapshots.count {
-            // Stable cursor: the persisted prefix is already authoritative.
-        } else if appendSafe, baseline.snapshotCount <= snapshots.count {
-            _ = self.appendTokenSnapshots(Array(snapshots.dropFirst(baseline.snapshotCount)))
-        } else {
+        let stableCursor = oldParsedBytes == newParsedBytes
+        let snapshotAction = CostUsagePersistencePlanner.action(
+            canReuse: baseline.canReuseRows,
+            stableCursor: stableCursor,
+            appendSafe: appendSafe,
+            persistedCount: baseline.snapshotCount,
+            sourceCount: snapshotCount)
+        let snapshots = snapshotAction.materialize(sourceSnapshots) { index, snapshot in
+            Self.tokenSnapshot(path: path, eventIndex: index, snapshot: snapshot, calendar: calendar)
+        }
+        switch snapshotAction {
+        case .reuse:
+            break
+        case .append:
+            _ = self.appendTokenSnapshots(snapshots)
+        case .replace:
             _ = self.replaceTokenSnapshots(path: path, snapshots: snapshots)
         }
-        if baseline.canReuseRows, oldParsedBytes == newParsedBytes, baseline.rowCount == rows.count {
-            // Stable cursor: metadata/aggregate updates do not rewrite historical rows.
-        } else if appendSafe, baseline.rowCount <= rows.count {
-            _ = self.appendUsageRows(Array(rows.dropFirst(baseline.rowCount)))
-        } else {
+
+        let rowAction = CostUsagePersistencePlanner.action(
+            canReuse: baseline.canReuseRows,
+            stableCursor: stableCursor,
+            appendSafe: appendSafe,
+            persistedCount: baseline.rowCount,
+            sourceCount: rowCount)
+        let rows: [CostUsageStoreUsageRow] = rowAction.materialize(sourceRows) { index, row in
+            guard let payload = try? JSONEncoder().encode(row) else { return nil }
+            return CostUsageStoreUsageRow(path: path, rowIndex: index, payload: payload)
+        }
+        switch rowAction {
+        case .reuse:
+            break
+        case .append:
+            _ = self.appendUsageRows(rows)
+        case .replace:
             _ = self.replaceUsageRows(path: path, rows: rows)
         }
         _ = self.replaceFileDayAggregates(path: path, aggregates: Self.fileAggregates(usage))
@@ -295,7 +357,7 @@ extension CostUsageStore {
         self.persistBuffers(path: path, usage: usage)
         _ = self.upsertAccumulator(CostUsageStoreAccumulator(
             path: path,
-            eventCount: snapshots.count,
+            eventCount: snapshotCount,
             nextUsageRowIndex: CostUsageScanner.nextCodexUsageRowIndex(usage.codexRows),
             countedTotals: Self.totals(usage.lastCountedTotals),
             rawTotalsBaseline: Self.totals(usage.lastRawTotalsBaseline),

--- a/Tests/CodexBarTests/CostUsageStoreTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreTests.swift
@@ -218,6 +218,147 @@ extension CostUsageStoreTests {
     }
 
     @Test
+    func `persistence planner materializes only the delta and store preserves absolute indexes`() async throws {
+        var transformedIndexes: [Int] = []
+
+        func materialize(
+            _ action: CostUsagePersistenceAction,
+            source: [Int]) -> [Int]
+        {
+            transformedIndexes = []
+            return action.materialize(source) { index, value in
+                transformedIndexes.append(index)
+                return value
+            }
+        }
+
+        let initialAction = CostUsagePersistencePlanner.action(
+            canReuse: false,
+            stableCursor: false,
+            appendSafe: false,
+            persistedCount: 0,
+            sourceCount: 2)
+        #expect(initialAction == .replace)
+        #expect(materialize(initialAction, source: [10, 20]) == [10, 20])
+        #expect(transformedIndexes == [0, 1])
+
+        let stableAction = CostUsagePersistencePlanner.action(
+            canReuse: true,
+            stableCursor: true,
+            appendSafe: false,
+            persistedCount: 2,
+            sourceCount: 2)
+        #expect(stableAction == .reuse)
+        #expect(materialize(stableAction, source: [10, 20]).isEmpty)
+        #expect(transformedIndexes.isEmpty)
+
+        let appendAction = CostUsagePersistencePlanner.action(
+            canReuse: true,
+            stableCursor: false,
+            appendSafe: true,
+            persistedCount: 2,
+            sourceCount: 3)
+        #expect(appendAction == .append(startingAt: 2))
+        #expect(materialize(appendAction, source: [10, 20, 30]) == [30])
+        #expect(transformedIndexes == [2])
+
+        let replacementAction = CostUsagePersistencePlanner.action(
+            canReuse: true,
+            stableCursor: false,
+            appendSafe: false,
+            persistedCount: 3,
+            sourceCount: 2)
+        #expect(replacementAction == .replace)
+        #expect(materialize(replacementAction, source: [40, 50]) == [40, 50])
+        #expect(transformedIndexes == [0, 1])
+
+        let fixture = try StoreFixture()
+        defer { fixture.remove() }
+        let store = CostUsageStore(cacheRoot: fixture.root)
+        let path = "/rollouts/delta.jsonl"
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+
+        func token(_ index: Int) -> CostUsageCodexTokenSnapshot {
+            CostUsageCodexTokenSnapshot(
+                timestamp: "2026-08-01T12:00:0\(index)Z",
+                last: CostUsageCodexTotals(input: index + 1, cached: 0, output: 1),
+                total: CostUsageCodexTotals(input: (index + 1) * 10, cached: 0, output: index + 1),
+                endOffset: Int64(100 + index))
+        }
+
+        func row(_ index: Int) -> CostUsageScanner.CodexUsageRow {
+            CostUsageScanner.CodexUsageRow(
+                day: "2026-08-01",
+                model: "model-\(index)",
+                turnID: "turn-\(index)",
+                eventIndex: index,
+                timestampUnixMs: Int64(1_754_046_000_000 + index),
+                input: index + 1,
+                cached: 0,
+                output: 1)
+        }
+
+        var usage = CostUsageFileUsage(
+            mtimeUnixMs: 1000,
+            size: 200,
+            days: ["2026-08-01": ["model-0": [1, 0, 1]]])
+        usage.parsedBytes = 200
+        usage.codexScanFileId = "1:42"
+        usage.codexScanComplete = true
+        usage.codexTokenTimestampsMonotonic = true
+        usage.codexTokenSnapshots = [token(0), token(1)]
+        usage.codexRows = [row(0), row(1)]
+
+        var cache = CostUsageCache()
+        cache.scanSinceKey = "2026-08-01"
+        cache.scanUntilKey = "2026-08-01"
+        cache.files = [path: usage]
+        cache.days = usage.days
+
+        func save() {
+            _ = store.syncSaveCodexCache(
+                cache,
+                calendar: calendar,
+                requestedScanWindow: (sinceKey: "2026-08-01", untilKey: "2026-08-01"))
+        }
+
+        save()
+        save()
+
+        usage.parsedBytes = 300
+        usage.size = 300
+        usage.codexTokenSnapshots = [token(0), token(1), token(2)]
+        usage.codexRows = [row(0), row(1), row(2)]
+        cache.files[path] = usage
+        save()
+
+        #expect(await store.fetchTokenSnapshots(path: path).map(\.eventIndex) == [0, 1, 2])
+        let appendedRows = await store.fetchUsageRows(path: path)
+        #expect(appendedRows.map(\.rowIndex) == [0, 1, 2])
+        #expect(try appendedRows.map {
+            try JSONDecoder().decode(CostUsageScanner.CodexUsageRow.self, from: $0.payload)
+        } == usage.codexRows)
+
+        usage.parsedBytes = 400
+        usage.size = 400
+        usage.codexScanFileId = "2:99"
+        usage.codexTokenSnapshots = [token(3), token(4)]
+        usage.codexRows = [row(3), row(4)]
+        cache.files[path] = usage
+        save()
+
+        let replacedSnapshots = await store.fetchTokenSnapshots(path: path)
+        #expect(replacedSnapshots.map(\.eventIndex) == [0, 1])
+        #expect(replacedSnapshots.map(\.timestamp) == usage.codexTokenSnapshots?.map(\.timestamp))
+        let replacedRows = await store.fetchUsageRows(path: path)
+        #expect(replacedRows.map(\.rowIndex) == [0, 1])
+        #expect(try replacedRows.map {
+            try JSONDecoder().decode(CostUsageScanner.CodexUsageRow.self, from: $0.payload)
+        } == usage.codexRows)
+    }
+
+    @Test
     func `day aggregate inserts and reads by model`() async throws {
         let fixture = try StoreFixture()
         defer { fixture.remove() }


### PR DESCRIPTION
## Summary

Stable Codex cost-cache saves were converting every unchanged historical token snapshot and encoding every row before deciding whether persistence could reuse, append, or replace the existing data.

This change plans persistence first: stable collections are reused without materialization, safe appends materialize only the suffix using absolute indexes, and the cache is fully replaced whenever append safety is lost.

## Performance

- The installed 0.49.0 production trace recorded 8,993 ms of sampled CPU in 45 seconds. The `saveCodexCache` branch accounted for 4,085 ms and `CostUsageTimestampParser.parseISO` for 3,307 ms.
- The copied real-world cache contained 168,047 token snapshots and 126,227 rows.
- Patched stable saves averaged 0.98 seconds over 35 runs, compared with 4.09 seconds for the traced pre-fix save branch.
- A corrected 30-second post-fix Time Profiler trace contained zero samples in `CostUsageTimestampParser` or `parseISO`.

## Validation

- Focused regression suite: 87 tests across `CostUsageStoreTests`, `CodexForkAppendResumeTests`, and `CostUsagePerformanceGateTests` passed.
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer make check` passed.
- `git diff --check` passed.
- Pre-commit autoreview found no accepted or actionable findings.
- The local full `make test` ran 834 selections and failed only the pre-existing unrelated `MenuSwitchFlickerProbeTests` expectation that its synthetic 400 ms probe log contains `handled=true`. The same expectation fails unchanged in isolation under the machine's extreme load.
