### PR TITLE
Fix sub2api usage summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## 0.49.2 — Unreleased
 
+### Fixed
+- Sub2API: localize and group menu-card quota labels and request, token, and cost totals into a compact usage summary (#2835). Thanks @weirdo-adam!
+- Codex: avoid repeatedly converting historical token snapshots during cost-cache refreshes, preventing sustained CPU usage on large session histories.
+
 ## 0.49.1 — 2026-08-09
 
 ### Fixed
-- Codex: avoid repeatedly converting historical token snapshots during cost-cache refreshes, preventing sustained CPU usage on large session histories.
 - DeepInfra: show billing-cycle spend against a positive spending limit in the automatic menu-bar icon (#2822). Thanks @selfagency for the report!
 - z.ai: restore pace for verified 5-hour, weekly, and MCP-monthly usage windows without treating rolling 30-day limits as calendar months (#2431). Thanks @kiranmagic7!
 - Codex: publish refreshed core quota immediately while optional Credits and OpenAI Web enrichment continues, without unfreezing cards whose layout still needs reconciliation (#2799). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -471,14 +471,62 @@ extension UsageMenuCardView.Model {
             AmpProviderDescriptor.secondaryLabel(snapshot: snapshot) ?? input.metadata.weeklyLabel
         } else if input.provider == .alibabatokenplan {
             AlibabaTokenPlanProviderDescriptor.secondaryLabel(window: snapshot.secondary) ?? input.metadata.weeklyLabel
+        } else if input.provider == .sub2api {
+            "Weekly"
         } else {
             input.metadata.weeklyLabel
         }
+        let tertiaryLabel = input.provider == .sub2api
+            ? L("Monthly")
+            : input.metadata.opusLabel.map(L) ?? L("Sonnet")
         return (
             L(primaryLabel),
             L(secondaryLabel),
-            input.metadata.opusLabel.map(L) ?? L("Sonnet"),
+            tertiaryLabel,
             input.metadata.supportsOpus)
+    }
+
+    static func sub2APILocalizedDetails(_ details: [ProviderDetailSection]) -> [ProviderDetailSection] {
+        details.map { section in
+            guard section.title == "Usage summary" else { return section }
+
+            do {
+                var rows: [ProviderDetailSection.Row] = []
+                var consumedLabels: Set<String> = []
+
+                if let balance = section.rows.first(where: { $0.label == "Balance" }) {
+                    try rows.append(ProviderDetailSection.Row(
+                        label: L("Balance"),
+                        value: balance.value,
+                        secondaryValue: balance.secondaryValue))
+                    consumedLabels.insert(balance.label)
+                }
+
+                for period in [
+                    (label: "Today", requests: "Today requests", tokens: "Today tokens"),
+                    (label: "Total", requests: "All time requests", tokens: "All time tokens"),
+                ] {
+                    guard let requests = section.rows.first(where: { $0.label == period.requests }),
+                          let tokens = section.rows.first(where: { $0.label == period.tokens })
+                    else { continue }
+
+                    var secondaryParts = ["\(tokens.value) \(L("tokens"))"]
+                    if let cost = tokens.secondaryValue {
+                        secondaryParts.append("\(L("Cost")): \(cost)")
+                    }
+                    try rows.append(ProviderDetailSection.Row(
+                        label: L(period.label),
+                        value: "\(requests.value) \(L("requests"))",
+                        secondaryValue: secondaryParts.joined(separator: " · ")))
+                    consumedLabels.formUnion([period.requests, period.tokens])
+                }
+
+                rows.append(contentsOf: section.rows.filter { !consumedLabels.contains($0.label) })
+                return try ProviderDetailSection(title: L("Usage"), rows: rows, chart: section.chart)
+            } catch {
+                return section
+            }
+        }
     }
 
     static func resetText(

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1005,6 +1005,9 @@ extension UsageMenuCardView.Model {
                 }
             }
         }
+        if input.provider == .sub2api {
+            details = Self.sub2APILocalizedDetails(details)
+        }
         guard input.hidePersonalInfo else { return details }
         return details.compactMap { section in
             let rows = section.rows.compactMap { row in

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1838,7 +1838,7 @@ struct ProviderArchitectureGatekeeperTests {
             line: 449,
             anchor: "if input.provider == .factory, snapshot.tertiary != nil {",
             expectedProviderIDs: ["alibabatokenplan", "amp", "crof", "cursor", "doubao", "factory", "grok", "sub2api"],
-            expectedReferenceCount: 10,
+            expectedReferenceCount: 12,
             expectedReferenceFingerprint: [
                 "factory@0",
                 "cursor@4",
@@ -1850,11 +1850,13 @@ struct ProviderArchitectureGatekeeperTests {
                 "alibabatokenplan@16",
                 "amp@21",
                 "alibabatokenplan@23",
+                "sub2api@25",
+                "sub2api@30",
             ],
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 562,
+            line: 610,
             anchor: "case .minimax:",
             expectedProviderIDs: ["codex", "minimax", "poe"],
             expectedReferenceCount: 3,
@@ -1862,7 +1864,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 763,
+            line: 811,
             anchor: "if input.provider == .codex, !input.showOptionalCreditsAndExtraUsage {",
             expectedProviderIDs: ["claude", "codex", "copilot"],
             expectedReferenceCount: 4,
@@ -1870,7 +1872,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 788,
+            line: 836,
             anchor: "let resetText = input.provider == .sub2api && namedWindow.window.resetsAt == nil",
             expectedProviderIDs: ["doubao", "sub2api"],
             expectedReferenceCount: 3,
@@ -1878,7 +1880,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 859,
+            line: 907,
             anchor: "if input.provider == .antigravity,",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,
@@ -1886,7 +1888,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 893,
+            line: 941,
             anchor: "if provider == .claude, window.windowMinutes != 10080 {",
             expectedProviderIDs: ["antigravity", "claude", "codex"],
             expectedReferenceCount: 4,
@@ -1894,7 +1896,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 925,
+            line: 973,
             anchor: "guard input.provider == .antigravity else { return nil }",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,
@@ -1926,7 +1928,15 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1065,
+            line: 1008,
+            anchor: "if input.provider == .sub2api {",
+            expectedProviderIDs: ["sub2api"],
+            expectedReferenceCount: 1,
+            expectedReferenceFingerprint: ["sub2api@0"],
+            reason: "The sub2api menu card localizes and groups provider-owned usage detail rows for display."),
+        AllowedProviderConstruct(
+            path: "Sources/CodexBar/MenuCardView.swift",
+            line: 1068,
             anchor: "if provider == .kiro,",
             expectedProviderIDs: ["kilo", "kiro"],
             expectedReferenceCount: 2,
@@ -1934,7 +1944,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1088,
+            line: 1091,
             anchor: "if provider == .minimax {",
             expectedProviderIDs: ["codex", "minimax"],
             expectedReferenceCount: 2,
@@ -1942,7 +1952,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1123,
+            line: 1126,
             anchor: "guard let loginMethod = snapshot?.loginMethod(for: .kilo) else {",
             expectedProviderIDs: ["kilo"],
             expectedReferenceCount: 1,
@@ -1950,7 +1960,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1207,
+            line: 1210,
             anchor: "if input.provider == .antigravity {",
             expectedProviderIDs: ["antigravity", "mistral"],
             expectedReferenceCount: 2,
@@ -1958,7 +1968,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1227,
+            line: 1230,
             anchor: "if input.provider == .codex, let codexProjection = input.codexProjection {",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "codex", "perplexity", "sub2api"],
             expectedReferenceCount: 6,
@@ -1973,7 +1983,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1278,
+            line: 1281,
             anchor: "if input.provider == .kilo || input.provider == .kimi,",
             expectedProviderIDs: ["kilo", "kimi"],
             expectedReferenceCount: 2,
@@ -1981,7 +1991,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1360,
+            line: 1363,
             anchor: "var paceDetail = if input.provider == .kimi {",
             expectedProviderIDs: ["kimi"],
             expectedReferenceCount: 1,
@@ -1989,7 +1999,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1376,
+            line: 1379,
             anchor: "if input.provider == .warp,",
             expectedProviderIDs: ["chutes", "kilo", "kiro", "litellm", "sub2api", "warp"],
             expectedReferenceCount: 6,
@@ -1997,7 +2007,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1409,
+            line: 1412,
             anchor: "if input.provider == .alibaba || input.provider == .alibabatokenplan,",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "copilot", "crof", "manus", "perplexity", "zenmux"],
             expectedReferenceCount: 8,
@@ -2014,7 +2024,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1450,
+            line: 1453,
             anchor: "if input.provider == .synthetic,",
             expectedProviderIDs: ["synthetic"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/Sub2APIMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/Sub2APIMenuCardModelTests.swift
@@ -154,9 +154,9 @@ struct Sub2APIMenuCardModelTests {
         #expect(model.metrics.map(\.title) == ["每日配额", "每周", "每月"])
         let usage = try #require(model.providerDetails.first)
         #expect(usage.title == "用量")
-        #expect(usage.rows.map(\.label) == ["余额", "今天", "总计"])
-        #expect(usage.rows[1].value == "4 请求")
-        #expect(usage.rows[1].secondaryValue == "1,200 token · 费用: $1.25")
+        #expect(usage.rows.map(\.label) == ["今日", "总计"])
+        #expect(usage.rows[0].value == "4 请求")
+        #expect(usage.rows[0].secondaryValue == "1,200 token · 费用: $1.25")
     }
 
     @Test

--- a/Tests/CodexBarTests/Sub2APIMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/Sub2APIMenuCardModelTests.swift
@@ -97,9 +97,66 @@ struct Sub2APIMenuCardModelTests {
 
         #expect(model.planText == "Enterprise")
         #expect(model.usageNotes.isEmpty)
-        #expect(model.providerDetails.first?.rows.map(\.label) == [
-            "Balance", "Today requests", "Today tokens", "All time requests", "All time tokens",
-        ])
+        let usage = try #require(model.providerDetails.first)
+        #expect(usage.title == "Usage")
+        #expect(usage.rows.map(\.label) == ["Balance", "Today", "Total"])
+        #expect(usage.rows[1].value == "4 requests")
+        #expect(usage.rows[1].secondaryValue == "1,200 tokens · Cost: $1.25")
+        #expect(usage.rows[2].value == "40 requests")
+        #expect(usage.rows[2].secondaryValue == "12,000 tokens · Cost: $25.00")
+    }
+
+    @Test
+    func `usage summary and quota labels follow the selected language`() async throws {
+        let now = Date(timeIntervalSince1970: 1_720_440_000)
+        let json = """
+        {
+          "mode": "unrestricted",
+          "subscription": {
+            "daily_usage_usd": 12,
+            "weekly_usage_usd": 70,
+            "monthly_usage_usd": 280,
+            "daily_limit_usd": 120,
+            "weekly_limit_usd": 700,
+            "monthly_limit_usd": 2800
+          },
+          "usage": {
+            "today": { "requests": 4, "total_tokens": 1200, "actual_cost": 1.25 },
+            "total": { "requests": 40, "total_tokens": 12000, "actual_cost": 25 }
+          }
+        }
+        """
+        let snapshot = try await Self.snapshot(json, now: now)
+        let metadata = try #require(ProviderDefaults.metadata[.sub2api])
+
+        let model = CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hans") {
+            UsageMenuCardView.Model.make(.init(
+                provider: .sub2api,
+                metadata: metadata,
+                snapshot: snapshot,
+                credits: nil,
+                creditsError: nil,
+                dashboard: nil,
+                dashboardError: nil,
+                tokenSnapshot: nil,
+                tokenError: nil,
+                account: AccountInfo(email: nil, plan: nil),
+                isRefreshing: false,
+                lastError: nil,
+                usageBarsShowUsed: false,
+                resetTimeDisplayStyle: .countdown,
+                tokenCostUsageEnabled: false,
+                showOptionalCreditsAndExtraUsage: true,
+                hidePersonalInfo: false,
+                now: now))
+        }
+
+        #expect(model.metrics.map(\.title) == ["每日配额", "每周", "每月"])
+        let usage = try #require(model.providerDetails.first)
+        #expect(usage.title == "用量")
+        #expect(usage.rows.map(\.label) == ["余额", "今天", "总计"])
+        #expect(usage.rows[1].value == "4 请求")
+        #expect(usage.rows[1].secondaryValue == "1,200 token · 费用: $1.25")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- localize the sub2api usage summary and quota labels in the menu card
- group request and token totals into Today and Total rows with an explicit Cost label
- preserve canonical provider detail labels for CLI and plugin output

## Validation
- exact-head CI: all 9 checks passed, including both macOS Swift test shards, Linux builds/tests, lint, architecture gates, and security checks
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter Sub2APIMenuCardModelTests` — 4 tests passed
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter ProviderArchitectureGatekeeperTests` — 38 tests passed
- `git diff --check origin/main...HEAD` — passed
- Developer-ID-signed debug bundles built successfully for both pinned revisions
- structured autoreview — secret scan clean; no accepted/actionable findings

## Native before/after proof

Both captures use Developer-ID-signed debug bundles, the same loopback-only synthetic Sub2API response, a synthetic API key, and hidden personal info. The production path exercised is bundled `sub2api.js` → `UsageStore` → `UsageMenuCardView.Model` → the real composited native menu window.

| Before (`main`) | After (this PR) |
| --- | --- |
| ![Sub2API menu before grouping](https://github.com/user-attachments/assets/80bdc014-1603-4923-bac7-871e14ead449) | ![Sub2API menu after grouping](https://github.com/user-attachments/assets/9a4da73c-b596-444b-985b-d8a24b0dade3) |

The after image confirms that `Today` and `Total` combine requests, tokens, and cost without clipping, while weekly/monthly labels remain readable. The unchanged lower test-plugin card is synthetic and was held at the same values in both captures.
