### PR TITLE
fix: honor usage direction in plugin cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.2 — Unreleased
 
 ### Fixed
+- Plugins: honor the “Usage bars fill” remaining/used setting in user-installed provider cards, keeping percentage labels and bar direction aligned (#2749). Thanks @RyloRiz!
 - Sub2API: localize and group menu-card quota labels and request, token, and cost totals into a compact usage summary (#2835). Thanks @weirdo-adam!
 - Codex: avoid repeatedly converting historical token snapshots during cost-cache refreshes, preventing sustained CPU usage on large session histories.
 

--- a/Sources/CodexBar/StatusItemController+UserPlugins.swift
+++ b/Sources/CodexBar/StatusItemController+UserPlugins.swift
@@ -18,6 +18,7 @@ extension StatusItemController {
                 snapshot: snapshot,
                 error: error,
                 isRefreshing: self.store.refreshingProviders.contains(plugin.manifest.id),
+                showUsed: self.settings.usageBarsShowUsed,
                 width: width,
                 onRefresh: { [weak store = self.store] in
                     Task { @MainActor in await store?.refreshUserPlugin(plugin.manifest.id) }
@@ -37,11 +38,25 @@ extension StatusItemController {
     }
 }
 
+struct UserPluginQuotaPresentation: Equatable {
+    let percent: Double
+    let text: String
+
+    static func make(usedPercent: Double, showUsed: Bool) -> Self {
+        let used = min(100, max(0, usedPercent))
+        let remaining = 100 - used
+        return Self(
+            percent: showUsed ? used : remaining,
+            text: UsageFormatter.usageLine(remaining: remaining, used: used, showUsed: showUsed))
+    }
+}
+
 private struct UserPluginMenuCardView: View {
     let plugin: UserProviderPlugin
     let snapshot: UsageSnapshot?
     let error: String?
     let isRefreshing: Bool
+    let showUsed: Bool
     let width: CGFloat
     let onRefresh: () -> Void
 
@@ -129,15 +144,18 @@ private struct UserPluginMenuCardView: View {
     @ViewBuilder
     private func window(_ title: String, _ window: RateWindow?) -> some View {
         if let window {
+            let presentation = UserPluginQuotaPresentation.make(
+                usedPercent: window.usedPercent,
+                showUsed: self.showUsed)
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
                     Text(title).foregroundStyle(.secondary)
                     Spacer()
-                    Text("\(Int(window.usedPercent.rounded()))% used").monospacedDigit()
+                    Text(presentation.text).monospacedDigit()
                 }
                 .font(.caption)
                 UsageProgressBar(
-                    percent: window.usedPercent,
+                    percent: presentation.percent,
                     tint: self.tint,
                     accessibilityLabel: "\(title) usage")
             }

--- a/Tests/CodexBarTests/UserPluginQuotaPresentationTests.swift
+++ b/Tests/CodexBarTests/UserPluginQuotaPresentationTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import CodexBar
+
+#if canImport(JavaScriptCore)
+struct UserPluginQuotaPresentationTests {
+    @Test
+    func `remaining mode aligns plugin label and bar`() {
+        let presentation = UserPluginQuotaPresentation.make(usedPercent: 4, showUsed: false)
+
+        #expect(presentation.percent == 96)
+        #expect(presentation.text == "96% left")
+    }
+
+    @Test
+    func `used mode aligns plugin label and bar`() {
+        let presentation = UserPluginQuotaPresentation.make(usedPercent: 4, showUsed: true)
+
+        #expect(presentation.percent == 4)
+        #expect(presentation.text == "4% used")
+    }
+
+    @Test
+    func `plugin percentage is clamped before presentation`() {
+        #expect(UserPluginQuotaPresentation.make(usedPercent: -5, showUsed: true).percent == 0)
+        #expect(UserPluginQuotaPresentation.make(usedPercent: 105, showUsed: false).percent == 0)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- pass the existing `Usage bars fill` preference into user-installed provider menu cards
- derive one clamped used/remaining presentation and use it for both percentage text and progress-bar fill
- add focused remaining, used, and out-of-range regression coverage
- document the user-visible fix for 0.49.2

## Root cause

Built-in rich cards already normalize each metric to the selected used/remaining direction before rendering. The bespoke user-plugin card bypassed that model and hard-coded `window.usedPercent`, `"% used"`, and a used-oriented bar. As a result, `As remaining` affected built-in cards but not user-installed providers.

The fix keeps this local to the user-plugin presentation boundary. CLI output, provider snapshots, and semantically fixed spend/headroom displays are unchanged.

## Validation

- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter UserPluginQuotaPresentationTests` — 3 tests passed
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter 'StatusMenuUsageDisplayTests|UsageMenuCardLayoutTests'` — 11 tests passed
- `make check` — passed
- structured autoreview — secret scan clean; no accepted/actionable findings
- Developer-ID-signed before/after debug bundles exercised the real user-plugin card in the composited native menu

## Native before/after proof

Both captures set `Usage bars fill` to **As remaining** and use the same deterministic local plugin snapshot: 4% used, 96% remaining. The manifest retains its existing approved identity; the temporary fetch body makes no network request. The surrounding Sub2API data is synthetic, and personal information is hidden.

| Before (`main`) | After (this PR) |
| --- | --- |
| ![User plugin card before: 4% used with remaining mode selected](https://github.com/user-attachments/assets/833a6e61-fee0-467e-a856-ad14be6b96e7) | ![User plugin card after: 96% left with matching bar](https://github.com/user-attachments/assets/a2d3ee05-12ef-4805-8f63-29f736be0562) |

Fixes #2749
