### PR TITLE
fix: drain overdue flicker probe switches

### DIFF
--- a/Sources/CodexBar/MenuSwitchFlickerProbe.swift
+++ b/Sources/CodexBar/MenuSwitchFlickerProbe.swift
@@ -243,6 +243,28 @@ enum MenuSwitchFlickerProbe {
         private func tick() {
             guard let startedAt = self.startedAtOrLocateMenu() else { return }
             let now = Int((DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds) / 1_000_000)
+            if !self.holdMode,
+               self.switchScheduleIndex < self.configuration.switchScheduleMs.count,
+               now >= self.configuration.switchScheduleMs[self.switchScheduleIndex]
+            {
+                let switchIndex = self.switchScheduleIndex
+                self.switchScheduleIndex += 1
+                // Cycle through overview (segment 0) too so full-rebuild transitions
+                // are exercised alongside cached swaps.
+                let cycle: [Int?] = [
+                    self.targetSegment,
+                    0,
+                    self.originalSegment,
+                    0,
+                    self.targetSegment,
+                    self.originalSegment,
+                ]
+                let segment = cycle[switchIndex % cycle.count]
+                let handled = segment.map { self.switchSegment($0) } ?? false
+                self.log.append("switch#\(switchIndex) to segment \(String(describing: segment)) " +
+                    "at \(now)ms handled=\(handled)")
+                return
+            }
             let endMs = self.holdMode
                 ? self.configuration.holdSessionEndMs
                 : self.configuration.sessionEndMs
@@ -250,27 +272,7 @@ enum MenuSwitchFlickerProbe {
                 self.timer?.invalidate()
                 self.timer = nil
                 self.menu?.cancelTracking()
-                return
             }
-            guard !self.holdMode,
-                  self.switchScheduleIndex < self.configuration.switchScheduleMs.count,
-                  now >= self.configuration.switchScheduleMs[self.switchScheduleIndex] else { return }
-            let switchIndex = self.switchScheduleIndex
-            self.switchScheduleIndex += 1
-            // Cycle through overview (segment 0) too so full-rebuild transitions
-            // are exercised alongside cached swaps.
-            let cycle: [Int?] = [
-                self.targetSegment,
-                0,
-                self.originalSegment,
-                0,
-                self.targetSegment,
-                self.originalSegment,
-            ]
-            let segment = cycle[switchIndex % cycle.count]
-            let handled = segment.map { self.switchSegment($0) } ?? false
-            self.log.append("switch#\(switchIndex) to segment \(String(describing: segment)) " +
-                "at \(now)ms handled=\(handled)")
         }
 
         private func startedAtOrLocateMenu() -> DispatchTime? {

--- a/Tests/CodexBarTests/MenuSwitchFlickerProbeTests.swift
+++ b/Tests/CodexBarTests/MenuSwitchFlickerProbeTests.swift
@@ -87,14 +87,7 @@ struct MenuSwitchFlickerProbeTests {
         defer { try? FileManager.default.removeItem(at: directory) }
 
         var sessionWasRetainedWhileRunning = false
-        var configuration = MenuSwitchFlickerProbe.ProbeSession.Configuration()
-        configuration.switchScheduleMs = [40, 80, 120, 160, 200, 240]
-        configuration.sessionEndMs = 400
-        configuration.openMenu = {
-            // Stand-in for NSMenu's blocking tracking loop: expose the menu the
-            // way tracking would and pump the run loop until the session's
-            // timer schedule completes.
-            sessionWasRetainedWhileRunning = !MenuSwitchFlickerProbe.activeSessions.isEmpty
+        func pumpSession() {
             controller.openMenus[ObjectIdentifier(menu)] = menu
             let deadline = Date().addingTimeInterval(10)
             while let session = MenuSwitchFlickerProbe.activeSessions.last,
@@ -104,6 +97,17 @@ struct MenuSwitchFlickerProbeTests {
                 RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.01))
             }
             controller.openMenus.removeValue(forKey: ObjectIdentifier(menu))
+        }
+
+        var configuration = MenuSwitchFlickerProbe.ProbeSession.Configuration()
+        configuration.switchScheduleMs = [40, 80, 120, 160, 200, 240]
+        configuration.sessionEndMs = 400
+        configuration.openMenu = {
+            // Stand-in for NSMenu's blocking tracking loop: expose the menu the
+            // way tracking would and pump the run loop until the session's
+            // timer schedule completes.
+            sessionWasRetainedWhileRunning = !MenuSwitchFlickerProbe.activeSessions.isEmpty
+            pumpSession()
         }
 
         MenuSwitchFlickerProbe.beginRetainedSession(
@@ -124,5 +128,31 @@ struct MenuSwitchFlickerProbeTests {
             "probe log missing sample summary: \(log)")
         let sampleCount = try #require(Int(capturedLine.split(separator: " ")[1]))
         #expect(sampleCount > 0, "probe recorded no frame samples: \(log)")
+
+        let overdueDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("flicker-probe-overdue-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: overdueDirectory) }
+        var overdueConfiguration = MenuSwitchFlickerProbe.ProbeSession.Configuration()
+        overdueConfiguration.switchScheduleMs = [0, 0, 0, 0, 0, 0]
+        overdueConfiguration.sessionEndMs = 0
+        overdueConfiguration.openMenu = { pumpSession() }
+
+        MenuSwitchFlickerProbe.beginRetainedSession(
+            controller: controller,
+            directory: overdueDirectory,
+            holdMode: false,
+            configuration: overdueConfiguration)
+
+        let overdueLog = try String(
+            contentsOf: overdueDirectory.appendingPathComponent("probe-log.txt"),
+            encoding: .utf8)
+        let overdueSwitches = overdueLog.split(separator: "\n").filter { $0.hasPrefix("switch#") }
+        #expect(
+            overdueSwitches.count == 6,
+            "probe did not drain overdue switches one per tick: \(overdueLog)")
+        #expect(
+            overdueSwitches.allSatisfy { $0.contains("handled=true") },
+            "probe did not handle every overdue switch: \(overdueLog)")
+        #expect(MenuSwitchFlickerProbe.activeSessions.isEmpty, "overdue session must be released")
     }
 }


### PR DESCRIPTION
## Summary

The flicker probe checked its cutoff before processing scheduled switches. When several non-hold switches were already overdue, that ordering could end the probe before the finite schedule had drained.

This change processes one due switch per timer tick before evaluating the cutoff. The ordering stays deterministic, preserves the original segment after the finite schedule drains, and leaves hold mode and cleanup behavior unchanged.

## Regression coverage

The zero-cutoff regression schedules six overdue switches and verifies that they are handled one per tick before the session ends on the original segment.

## Proof

- Focused test passed 10 consecutive runs plus independent reruns.
- Full `make test` passed all 834 selections across 70 groups with no retries or timeouts.
- `make check` passed.
- `git diff --check` is clean.
- Final autoreview reported no accepted or actionable findings.
