### PR TITLE
fix: stop the CLI version lookup walking past the filesystem root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.49.3 — Unreleased
 
+### Fixed
+- CLI: stop the version lookup from walking past the filesystem root — `deleteLastPathComponent()` appends `..` at `/` rather than staying put, so the loop's path-equality guard never tripped and a binary outside a `.app` spun a core while allocating without bound. `codexbar --help` from a plain build reached 1.2 GB in 11 seconds and never printed; the CLI test suites were timing out on it.
+
 ## 0.49.2 — 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## 0.49.3 — Unreleased
 
-### Fixed
-- CLI: stop the version lookup from walking past the filesystem root — `deleteLastPathComponent()` appends `..` at `/` rather than staying put, so the loop's path-equality guard never tripped and a binary outside a `.app` spun a core while allocating without bound. `codexbar --help` from a plain build reached 1.2 GB in 11 seconds and never printed; the CLI test suites were timing out on it.
-
 ## 0.49.2 — 2026-08-10
 
 ### Fixed

--- a/Sources/CodexBarCLI/CLIIO.swift
+++ b/Sources/CodexBarCLI/CLIIO.swift
@@ -109,8 +109,6 @@ extension CodexBarCLI {
         var currentURL = executableURL.deletingLastPathComponent()
         let fileManager = FileManager.default
 
-        // `deleteLastPathComponent()` appends ".." at the filesystem root instead of staying
-        // put, so a path-equality guard never trips. Component counts strictly decrease.
         while currentURL.pathComponents.count > 1 {
             if currentURL.pathExtension == "app" {
                 let infoURL = currentURL

--- a/Sources/CodexBarCLI/CLIIO.swift
+++ b/Sources/CodexBarCLI/CLIIO.swift
@@ -109,7 +109,9 @@ extension CodexBarCLI {
         var currentURL = executableURL.deletingLastPathComponent()
         let fileManager = FileManager.default
 
-        while currentURL.path != currentURL.deletingLastPathComponent().path {
+        // `deleteLastPathComponent()` appends ".." at the filesystem root instead of staying
+        // put, so a path-equality guard never trips. Component counts strictly decrease.
+        while currentURL.pathComponents.count > 1 {
             if currentURL.pathExtension == "app" {
                 let infoURL = currentURL
                     .appendingPathComponent("Contents")
@@ -119,7 +121,9 @@ extension CodexBarCLI {
                 else { return nil }
                 return Self.normalizedBundleVersion(plist["CFBundleShortVersionString"] as? String)
             }
-            currentURL.deleteLastPathComponent()
+            let parent = currentURL.deletingLastPathComponent()
+            guard parent.pathComponents.count < currentURL.pathComponents.count else { break }
+            currentURL = parent
         }
 
         return nil

--- a/Sources/CodexBarCLI/CLIIO.swift
+++ b/Sources/CodexBarCLI/CLIIO.swift
@@ -106,10 +106,11 @@ extension CodexBarCLI {
     }
 
     static func containingAppVersion(for executableURL: URL) -> String? {
-        var currentURL = executableURL.deletingLastPathComponent()
+        var currentURL = executableURL
         let fileManager = FileManager.default
 
-        while currentURL.pathComponents.count > 1 {
+        while let ancestorURL = Self.nextAncestor(from: currentURL) {
+            currentURL = ancestorURL
             if currentURL.pathExtension == "app" {
                 let infoURL = currentURL
                     .appendingPathComponent("Contents")
@@ -119,12 +120,17 @@ extension CodexBarCLI {
                 else { return nil }
                 return Self.normalizedBundleVersion(plist["CFBundleShortVersionString"] as? String)
             }
-            let parent = currentURL.deletingLastPathComponent()
-            guard parent.pathComponents.count < currentURL.pathComponents.count else { break }
-            currentURL = parent
         }
 
         return nil
+    }
+
+    static func nextAncestor(
+        from url: URL,
+        parentProvider: (URL) -> URL = { $0.deletingLastPathComponent() }) -> URL?
+    {
+        let parent = parentProvider(url)
+        return parent.pathComponents.count < url.pathComponents.count ? parent : nil
     }
 
     static func adjacentVersionFileVersion(for executableURL: URL) -> String? {

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -224,6 +224,25 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertNil(CodexBarCLI.containingAppVersion(for: URL(fileURLWithPath: "/")))
     }
 
+    func test_nextAncestorRejectsNonDecreasingParents() {
+        let current = URL(fileURLWithPath: "/synthetic/current")
+        let candidates = [
+            URL(fileURLWithPath: "/distinct/sibling"),
+            URL(fileURLWithPath: "/synthetic/current/child"),
+        ]
+
+        for candidate in candidates {
+            var calls = 0
+            let ancestor = CodexBarCLI.nextAncestor(from: current) { _ in
+                calls += 1
+                return candidate
+            }
+
+            XCTAssertNil(ancestor)
+            XCTAssertEqual(calls, 1)
+        }
+    }
+
     func test_cliVersionFollowsSymlinkedHelper() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-cli-version-symlink-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -210,8 +210,6 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertEqual(CodexBarCLI.containingAppVersion(for: helperURL), "9.8.7")
     }
 
-    /// A binary outside any .app must stop at the filesystem root. Returning at all is the
-    /// assertion — a regression loops forever and hangs the suite rather than failing it.
     func test_containingAppVersionTerminatesOutsideAppBundle() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-cli-version-noapp-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -210,6 +210,22 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertEqual(CodexBarCLI.containingAppVersion(for: helperURL), "9.8.7")
     }
 
+    /// A binary outside any .app must stop at the filesystem root. Returning at all is the
+    /// assertion — a regression loops forever and hangs the suite rather than failing it.
+    func test_containingAppVersionTerminatesOutsideAppBundle() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-cli-version-noapp-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let binURL = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
+        let executableURL = binURL.appendingPathComponent("CodexBarCLI")
+        try Data().write(to: executableURL)
+
+        XCTAssertNil(CodexBarCLI.containingAppVersion(for: executableURL))
+        XCTAssertNil(CodexBarCLI.containingAppVersion(for: URL(fileURLWithPath: "/")))
+    }
+
     func test_cliVersionFollowsSymlinkedHelper() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-cli-version-symlink-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

`codexbar --help` never returns when run from a plain SwiftPM build output on affected macOS 15 Foundation versions. `containingAppVersion` walks ancestors looking for a containing `.app`, but `deletingLastPathComponent()` can produce a distinct, growing `/..`-style URL at the filesystem root. The old path-equality termination therefore never fires, so the standalone CLI spins and allocates indefinitely.

The final repair extracts one monotonic ancestor step: the candidate parent is accepted only when it has strictly fewer path components. `containingAppVersion` loops through that helper and returns `nil` as soon as no decreasing ancestor exists. Version-source precedence is unchanged: adjacent `VERSION`, enclosing `.app` `Info.plist`, then the existing bundle-version fallback.

## Regression coverage

The deterministic regression injects synthetic parent providers that return a distinct URL with the same component count and a URL with a greater component count. The helper rejects each candidate after one provider call, so removing the monotonic guard produces an immediate assertion failure without relying on host Foundation root behavior, memory growth, or an outer suite timeout.

The integration coverage still asserts that a standalone executable outside an app and a root input return `nil`. Existing coverage continues to verify enclosing-app resolution, adjacent `VERSION` precedence, and symlinked invocation behavior.

## Red / green proof

- Red: temporarily returning the injected candidate without the component-count guard made `test_nextAncestorRejectsNonDecreasingParents` fail with two `XCTAssertNil` failures in 0.060s.
- Green: after restoring the guard, the same deterministic test passed in 0.001s. The red state was not committed.

## Validation

- `swift test --filter CLIEntryTests` — 37 tests, 0 failures; repeated after the final rebase.
- Raw `CodexBarCLI` built with SwiftPM and exercised under a 10s watchdog: `--help` exited 0 in 0.014s with 2,612 bytes of output; `--version` exited 0 in 0.010s with 9 bytes of output.
- `make check` — passed; SwiftFormat required no changes and SwiftLint reported 0 violations across 1,842 files.
- `make test` — 839 selections across 70 groups, exit 0. 69 groups passed first attempt; the existing heavy cost/performance shard hit its 180s aggregate timeout, then all 12 isolated selections passed and the group recovered. Total: 0 unrecovered failures, 1 recovered group, 1 timed-out aggregate group, 12 isolated retries, 1,238.2s.
- `git diff --check` — passed.
- `autoreview --mode branch --base origin/main --max-priority P2` — clean; no accepted/actionable findings.

## Original macOS 15 evidence

Contributor reproduction host: macOS 15.7.4 (24G517), arm64, Xcode 26.2 / Swift 6.2.3.

- Before the repair, `CodexBarCLI --help` under an RSS watchdog grew from 166 MB to 1,181 MB in 11 seconds, was killed at the ceiling, and produced no output. After the repair it peaked at 1 MB and exited immediately with help output.
- A pre-fix `sample` attributed 4,176 of 4,176 samples to `containingAppVersion` at `CLIIO.swift:112-122`.
- A `JetsamEvent` from a pre-fix suite run recorded `CodexBarCLI` as the largest process, with three concurrent instances at 65.21 GB, 46.51 GB, and 11.48 GB.
- Test discovery dropped from 153.8s to 9.8s because discovery itself invokes the CLI.

## Linked issue

None open that matches this failure.
