### PR TITLE
fix: stop the cost store's executor assumption trapping on macOS 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixed
 - CLI: stop standalone version lookup from walking past the filesystem root and hanging with unbounded memory on affected macOS versions (#2856). Thanks @Manwholikespie!
-- Cost store: stop the synchronous store bridges from trapping on macOS 15, where released builds died on every launch with “Incorrect actor executor assumption” — the macOS 26 fix in #2803 left earlier runtimes on the concurrency runtime's legacy executor check, which answers “not isolated” for a custom `SerialExecutor` without consulting `checkIsolated()`. Only shipped bundles reproduce it; a local `swift build` links against a newer SDK and takes the modern path.
 
 ## 0.49.2 — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - CLI: stop standalone version lookup from walking past the filesystem root and hanging with unbounded memory on affected macOS versions (#2856). Thanks @Manwholikespie!
+- Cost store: stop the synchronous store bridges from trapping on macOS 15, where released builds died on every launch with “Incorrect actor executor assumption” — the macOS 26 fix in #2803 left earlier runtimes on the concurrency runtime's legacy executor check, which answers “not isolated” for a custom `SerialExecutor` without consulting `checkIsolated()`. Only shipped bundles reproduce it; a local `swift build` links against a newer SDK and takes the modern path.
 
 ## 0.49.2 — 2026-08-10
 

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore.swift
@@ -7,6 +7,12 @@ import SQLite3
 import CSQLite3
 #endif
 
+package enum CostUsageStoreExecutorTestControl {
+    package static let suppressCurrentContextArgument = "--cost-store-suppress-current-context-for-testing"
+    package static let suppressCurrentContextAnswer = CommandLine.arguments.contains(
+        Self.suppressCurrentContextArgument)
+}
+
 /// Single-writer persistence for Codex cost scanning. The actor owns the only writable
 /// connection; Phase 2 can keep its existing scan-queue serialization while independent
 /// app and CLI readers use WAL snapshots through separate read-only connections.
@@ -32,14 +38,12 @@ actor CostUsageStore {
             dispatchPrecondition(condition: .onQueue(self.queue))
         }
 
-        /// macOS 26+ runtimes ask this before falling back to `checkIsolated()`, and the
-        /// default implementation cannot see through `DispatchQueue.sync`, so it reports a
-        /// false negative for work that really is on this queue. A queue-specific token
-        /// answers accurately. The requirement does not exist on earlier runtimes, which is
-        /// why the sync bridges below must not depend on any runtime isolation check.
+        /// macOS 26+ runtimes ask this before `checkIsolated()`; the queue-specific token
+        /// sees through `DispatchQueue.sync` accurately.
         @available(macOS 26.0, *)
         func isIsolatingCurrentContext() -> Bool? {
-            DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self)
+            guard !CostUsageStoreExecutorTestControl.suppressCurrentContextAnswer else { return nil }
+            return DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self)
         }
 
         func sync<T>(_ operation: () throws -> T) rethrows -> T {
@@ -124,38 +128,23 @@ actor CostUsageStore {
 }
 
 extension CostUsageStore {
-    /// Isolation bridge for the synchronous scanner entry points below.
-    ///
-    /// The `sharedExecutor.sync` hop is what actually establishes isolation; `assumeIsolated`
-    /// only re-derives that same fact through the concurrency runtime. That re-derivation is
-    /// what kept trapping. A binary linked against a pre-Swift-6 SDK selects the runtime's
-    /// legacy executor check, and that path answers "not isolated" for a custom
-    /// `SerialExecutor` without ever consulting `checkIsolated()`. Shipped bundles are exactly
-    /// that — released `CodexBar.app` carries `LC_BUILD_VERSION sdk 14.0`, while a plain
-    /// `swift build` carries the current SDK and takes the modern path, so the trap reaches
-    /// users and never dev machines. macOS 26 escaped it only because that runtime asks
-    /// `isIsolatingCurrentContext()` first (#2803), which is why the trap survived there and
-    /// still fired on macOS 15.
-    ///
-    /// Dispatch's own queue assertion is authoritative on every OS and SDK combination, so
-    /// assert with that and then hand the actor over without re-asking the runtime. This is
-    /// exactly what `assumeIsolated` does once its check passes.
-    private nonisolated func assumingStoreIsolation<T>(
+    /// The shared queue establishes isolation; runtime checks are unreliable for SDK-14 binaries on macOS 15.
+    private nonisolated func syncWithStoreIsolation<T: Sendable>(
         _ operation: (isolated CostUsageStore) throws -> T) rethrows -> T
     {
-        Self.sharedExecutor.checkIsolated()
-        typealias Isolated = (isolated CostUsageStore) throws -> T
-        typealias Unisolated = (CostUsageStore) throws -> T
-        return try withoutActuallyEscaping(operation) { (operation: @escaping Isolated) throws -> T in
-            try unsafeBitCast(operation, to: Unisolated.self)(self)
+        try Self.sharedExecutor.sync {
+            Self.sharedExecutor.checkIsolated()
+            typealias Isolated = (isolated CostUsageStore) throws -> T
+            typealias Unisolated = (CostUsageStore) throws -> T
+            return try withoutActuallyEscaping(operation) { (operation: @escaping Isolated) throws -> T in
+                try unsafeBitCast(operation, to: Unisolated.self)(self)
+            }
         }
     }
 
     nonisolated func syncLoadCodexCache(calendar: Calendar) -> CostUsageCache {
-        Self.sharedExecutor.sync {
-            self.assumingStoreIsolation { store in
-                store.loadCodexCache(calendar: calendar)
-            }
+        self.syncWithStoreIsolation { store in
+            store.loadCodexCache(calendar: calendar)
         }
     }
 
@@ -167,16 +156,14 @@ extension CostUsageStore {
         rowBudget: Int = CostUsageStore.defaultRowBudget,
         fileBudgetBytes: Int64 = CostUsageStore.defaultFileBudgetBytes) -> CostUsageStoreBudgetResult
     {
-        Self.sharedExecutor.sync {
-            self.assumingStoreIsolation { store in
-                store.saveCodexCache(
-                    cache,
-                    calendar: calendar,
-                    requestedScanWindow: requestedScanWindow,
-                    reportWindow: reportWindow,
-                    rowBudget: rowBudget,
-                    fileBudgetBytes: fileBudgetBytes)
-            }
+        self.syncWithStoreIsolation { store in
+            store.saveCodexCache(
+                cache,
+                calendar: calendar,
+                requestedScanWindow: requestedScanWindow,
+                reportWindow: reportWindow,
+                rowBudget: rowBudget,
+                fileBudgetBytes: fileBudgetBytes)
         }
     }
 }

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore.swift
@@ -33,9 +33,10 @@ actor CostUsageStore {
         }
 
         /// macOS 26+ runtimes ask this before falling back to `checkIsolated()`, and the
-        /// default implementation cannot see through `DispatchQueue.sync` — so every
-        /// `assumeIsolated` in the sync bridges below trapped on launch even though the
-        /// work really was on this queue. A queue-specific token answers accurately.
+        /// default implementation cannot see through `DispatchQueue.sync`, so it reports a
+        /// false negative for work that really is on this queue. A queue-specific token
+        /// answers accurately. The requirement does not exist on earlier runtimes, which is
+        /// why the sync bridges below must not depend on any runtime isolation check.
         @available(macOS 26.0, *)
         func isIsolatingCurrentContext() -> Bool? {
             DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self)
@@ -123,9 +124,36 @@ actor CostUsageStore {
 }
 
 extension CostUsageStore {
+    /// Isolation bridge for the synchronous scanner entry points below.
+    ///
+    /// The `sharedExecutor.sync` hop is what actually establishes isolation; `assumeIsolated`
+    /// only re-derives that same fact through the concurrency runtime. That re-derivation is
+    /// what kept trapping. A binary linked against a pre-Swift-6 SDK selects the runtime's
+    /// legacy executor check, and that path answers "not isolated" for a custom
+    /// `SerialExecutor` without ever consulting `checkIsolated()`. Shipped bundles are exactly
+    /// that — released `CodexBar.app` carries `LC_BUILD_VERSION sdk 14.0`, while a plain
+    /// `swift build` carries the current SDK and takes the modern path, so the trap reaches
+    /// users and never dev machines. macOS 26 escaped it only because that runtime asks
+    /// `isIsolatingCurrentContext()` first (#2803), which is why the trap survived there and
+    /// still fired on macOS 15.
+    ///
+    /// Dispatch's own queue assertion is authoritative on every OS and SDK combination, so
+    /// assert with that and then hand the actor over without re-asking the runtime. This is
+    /// exactly what `assumeIsolated` does once its check passes.
+    private nonisolated func assumingStoreIsolation<T>(
+        _ operation: (isolated CostUsageStore) throws -> T) rethrows -> T
+    {
+        Self.sharedExecutor.checkIsolated()
+        typealias Isolated = (isolated CostUsageStore) throws -> T
+        typealias Unisolated = (CostUsageStore) throws -> T
+        return try withoutActuallyEscaping(operation) { (operation: @escaping Isolated) throws -> T in
+            try unsafeBitCast(operation, to: Unisolated.self)(self)
+        }
+    }
+
     nonisolated func syncLoadCodexCache(calendar: Calendar) -> CostUsageCache {
         Self.sharedExecutor.sync {
-            self.assumeIsolated { store in
+            self.assumingStoreIsolation { store in
                 store.loadCodexCache(calendar: calendar)
             }
         }
@@ -140,7 +168,7 @@ extension CostUsageStore {
         fileBudgetBytes: Int64 = CostUsageStore.defaultFileBudgetBytes) -> CostUsageStoreBudgetResult
     {
         Self.sharedExecutor.sync {
-            self.assumeIsolated { store in
+            self.assumingStoreIsolation { store in
                 store.saveCodexCache(
                     cache,
                     calendar: calendar,

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStoreCrashHarness.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStoreCrashHarness.swift
@@ -59,6 +59,14 @@ package enum CostUsageStoreCrashHarness {
         self.save(self.updatedCache(), cacheRoot: cacheRoot, killAfterFiles: killAfterFiles)
     }
 
+    /// Drives the read bridge. The save entry points above only cross the store executor
+    /// through `syncSaveCodexCache`; `syncLoadCodexCache` is the bridge that runs on every
+    /// launch, so it needs its own probe. Returns the file count so a caller can tell a real
+    /// read from an empty one.
+    package static func load(cacheRoot: URL) -> Int {
+        CostUsageStoreAccess.read(cacheRoot: cacheRoot, calendar: self.fixtureCalendar).files.count
+    }
+
     private static func save(_ cache: CostUsageCache, cacheRoot: URL, killAfterFiles: Int?) -> Bool {
         if let killAfterFiles {
             CostUsageStore.saveCycleCheckpointForTesting = { persistedFiles in

--- a/Sources/CodexBarCostStoreCrashProbe/main.swift
+++ b/Sources/CodexBarCostStoreCrashProbe/main.swift
@@ -8,7 +8,10 @@ import Foundation
 //
 // Usage: CodexBarCostStoreCrashProbe <seed|save|load|crash-save> <cacheRoot> [killAfterFiles]
 
-let arguments = CommandLine.arguments
+let arguments = CommandLine.arguments.filter {
+    $0 != CostUsageStoreExecutorTestControl.suppressCurrentContextArgument
+}
+
 guard arguments.count >= 3 else {
     FileHandle.standardError.write(Data("usage: <seed|save|load|crash-save> <cacheRoot> [killAfterFiles]\n".utf8))
     exit(64)

--- a/Sources/CodexBarCostStoreCrashProbe/main.swift
+++ b/Sources/CodexBarCostStoreCrashProbe/main.swift
@@ -1,14 +1,16 @@
 import CodexBarCore
 import Foundation
 
-// Subprocess driver for CostUsageStoreCrashSafetyTests: the test SIGKILLs this process
-// mid-save to prove the store's save cycle is all-or-nothing.
+// Subprocess driver for the store tests that need a real process. CostUsageStoreCrashSafetyTests
+// SIGKILLs this process mid-save to prove the save cycle is all-or-nothing;
+// CostUsageStoreExecutorIsolationTests runs it with the legacy executor-check mode forced,
+// which only the main executable can select.
 //
-// Usage: CodexBarCostStoreCrashProbe <seed|save|crash-save> <cacheRoot> [killAfterFiles]
+// Usage: CodexBarCostStoreCrashProbe <seed|save|load|crash-save> <cacheRoot> [killAfterFiles]
 
 let arguments = CommandLine.arguments
 guard arguments.count >= 3 else {
-    FileHandle.standardError.write(Data("usage: <seed|save|crash-save> <cacheRoot> [killAfterFiles]\n".utf8))
+    FileHandle.standardError.write(Data("usage: <seed|save|load|crash-save> <cacheRoot> [killAfterFiles]\n".utf8))
     exit(64)
 }
 
@@ -19,6 +21,10 @@ case "seed":
     exit(0)
 case "save":
     CostUsageStoreCrashHarness.saveUpdate(cacheRoot: cacheRoot, killAfterFiles: nil)
+    exit(0)
+case "load":
+    let fileCount = CostUsageStoreCrashHarness.load(cacheRoot: cacheRoot)
+    FileHandle.standardOutput.write(Data("\(fileCount)\n".utf8))
     exit(0)
 case "crash-save":
     let killAfterFiles = arguments.count > 3 ? Int(arguments[3]) : 1

--- a/Tests/CodexBarTests/CostUsageStoreExecutorIsolationTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreExecutorIsolationTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+/// Launch-crash proof for the store's synchronous bridges, and the regression guard the
+/// macOS 26-only fix in #2803 could not provide.
+///
+/// `CostUsageStore` runs on a custom `DispatchQueue`-backed `SerialExecutor`, and the queue
+/// hop in `sharedExecutor.sync` is what actually establishes isolation. Asking the
+/// concurrency runtime to re-confirm that fact is what kept trapping: a binary linked
+/// against a pre-Swift-6 SDK selects the runtime's legacy executor check, and that path
+/// answers "not isolated" for a custom `SerialExecutor` without ever consulting
+/// `checkIsolated()`. Released `CodexBar.app` is exactly that binary — it carries
+/// `LC_BUILD_VERSION sdk 14.0` — so every launch died with "Incorrect actor executor
+/// assumption". macOS 26 escaped it only because that runtime asks
+/// `isIsolatingCurrentContext()` first, which is why the trap outlived #2803 on macOS 15.
+///
+/// This has to be a subprocess. The mode is resolved once per process from the *main
+/// executable*, and `swift test` runs under Apple's `xctest`, which always selects the
+/// modern path — so an in-process test passes whether or not the bug is present. Pinning the
+/// mode in a child process is what makes the failure observable from CI on any host OS.
+struct CostUsageStoreExecutorIsolationTests {
+    /// Forces the executor-check mode that `CodexBar.app`'s own SDK version selects.
+    private static let legacyExecutorMode = "SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE"
+
+    @Test
+    func `read bridge survives the legacy executor check`() throws {
+        let root = try Self.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try Self.runProbe(mode: "seed", root: root)
+        let result = try Self.runProbe(mode: "load", root: root)
+
+        // Before the fix this died with SIGTRAP on the `assumeIsolated` in syncLoadCodexCache.
+        #expect(result.reason == .exit)
+        #expect(result.status == 0)
+        #expect(result.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines) == "3")
+    }
+
+    @Test
+    func `write bridge survives the legacy executor check`() throws {
+        let root = try Self.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let result = try Self.runProbe(mode: "seed", root: root)
+
+        #expect(result.reason == .exit)
+        #expect(result.status == 0)
+        #expect(CostUsageStoreCrashHarness.load(cacheRoot: root) == 3)
+    }
+}
+
+// MARK: - Helpers
+
+extension CostUsageStoreExecutorIsolationTests {
+    private static func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBar-CostUsageStoreExecutorTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    @discardableResult
+    private static func runProbe(
+        mode: String,
+        root: URL) throws -> (reason: Process.TerminationReason, status: Int32, standardOutput: String)
+    {
+        let process = Process()
+        process.executableURL = self.probeExecutableURL
+        process.arguments = [mode, root.path]
+        process.environment = ProcessInfo.processInfo.environment
+            .merging([Self.legacyExecutorMode: "legacy"]) { _, forced in forced }
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+        try process.run()
+        let outputData = standardOutput.fileHandleForReading.readDataToEndOfFile()
+        let errorData = standardError.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        if process.terminationReason != .exit || process.terminationStatus != 0 {
+            Issue.record("""
+            probe \(mode) terminated \(process.terminationReason) \(process.terminationStatus): \
+            \(String(data: errorData, encoding: .utf8) ?? "")
+            """)
+        }
+        return (
+            process.terminationReason,
+            process.terminationStatus,
+            String(data: outputData, encoding: .utf8) ?? "")
+    }
+
+    private static var probeExecutableURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(".build/debug/CodexBarCostStoreCrashProbe")
+    }
+}

--- a/Tests/CodexBarTests/CostUsageStoreExecutorIsolationTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreExecutorIsolationTests.swift
@@ -2,26 +2,17 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
-/// Launch-crash proof for the store's synchronous bridges, and the regression guard the
-/// macOS 26-only fix in #2803 could not provide.
-///
-/// `CostUsageStore` runs on a custom `DispatchQueue`-backed `SerialExecutor`, and the queue
-/// hop in `sharedExecutor.sync` is what actually establishes isolation. Asking the
-/// concurrency runtime to re-confirm that fact is what kept trapping: a binary linked
-/// against a pre-Swift-6 SDK selects the runtime's legacy executor check, and that path
-/// answers "not isolated" for a custom `SerialExecutor` without ever consulting
-/// `checkIsolated()`. Released `CodexBar.app` is exactly that binary — it carries
-/// `LC_BUILD_VERSION sdk 14.0` — so every launch died with "Incorrect actor executor
-/// assumption". macOS 26 escaped it only because that runtime asks
-/// `isIsolatingCurrentContext()` first, which is why the trap outlived #2803 on macOS 15.
-///
-/// This has to be a subprocess. The mode is resolved once per process from the *main
-/// executable*, and `swift test` runs under Apple's `xctest`, which always selects the
-/// modern path — so an in-process test passes whether or not the bug is present. Pinning the
-/// mode in a child process is what makes the failure observable from CI on any host OS.
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Subprocess proof for the synchronous read/write bridges under the legacy executor check.
+/// The test control suppresses macOS 26's current-context answer so the legacy path is exercised.
 struct CostUsageStoreExecutorIsolationTests {
-    /// Forces the executor-check mode that `CodexBar.app`'s own SDK version selects.
     private static let legacyExecutorMode = "SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE"
+    private static let probeTimeout: DispatchTimeInterval = .seconds(15)
 
     @Test
     func `read bridge survives the legacy executor check`() throws {
@@ -67,17 +58,26 @@ extension CostUsageStoreExecutorIsolationTests {
     {
         let process = Process()
         process.executableURL = self.probeExecutableURL
-        process.arguments = [mode, root.path]
+        process.arguments = [CostUsageStoreExecutorTestControl.suppressCurrentContextArgument, mode, root.path]
         process.environment = ProcessInfo.processInfo.environment
             .merging([Self.legacyExecutorMode: "legacy"]) { _, forced in forced }
         let standardOutput = Pipe()
         let standardError = Pipe()
         process.standardOutput = standardOutput
         process.standardError = standardError
+        let completed = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in completed.signal() }
         try process.run()
+        guard completed.wait(timeout: .now() + Self.probeTimeout) == .success else {
+            process.terminate()
+            if completed.wait(timeout: .now() + .seconds(1)) == .timedOut, process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+                _ = completed.wait(timeout: .now() + .seconds(2))
+            }
+            throw ProbeError.timedOut(mode)
+        }
         let outputData = standardOutput.fileHandleForReading.readDataToEndOfFile()
         let errorData = standardError.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
 
         if process.terminationReason != .exit || process.terminationStatus != 0 {
             Issue.record("""
@@ -89,6 +89,10 @@ extension CostUsageStoreExecutorIsolationTests {
             process.terminationReason,
             process.terminationStatus,
             String(data: outputData, encoding: .utf8) ?? "")
+    }
+
+    private enum ProbeError: Error {
+        case timedOut(String)
     }
 
     private static var probeExecutableURL: URL {

--- a/Tests/CodexBarTests/CostUsageStoreTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreTests.swift
@@ -10,17 +10,15 @@ import CSQLite3
 
 struct CostUsageStoreTests {
     /// The store actor runs on a custom DispatchQueue-backed `SerialExecutor`, and its
-    /// `sync*` bridges call `assumeIsolated` from inside `queue.sync`. macOS 26+ runtimes
-    /// verify that through `SerialExecutor.isIsolatingCurrentContext()`, whose default
-    /// implementation cannot see through `DispatchQueue.sync` — without an explicit
-    /// implementation the bridge traps ("Incorrect actor executor assumption") and the app
-    /// dies on launch.
+    /// `sync*` bridges hand work to the actor from inside `queue.sync`. Getting that handoff
+    /// wrong takes the app down on launch with "Incorrect actor executor assumption", so the
+    /// bridges have to stay callable from an ordinary non-actor thread.
     ///
-    /// This covers the bridges from a non-actor thread. Note it does not by itself
-    /// reproduce the trap: whether `assumeIsolated` traps depends on the calling context's
-    /// current executor, and no test-harness context reproduced it (plain thread, Task, and
-    /// MainActor were all tried). The regression was verified against the app itself —
-    /// it died on launch with "Incorrect actor executor assumption" and starts cleanly now.
+    /// This covers that, but it cannot reproduce the trap, and the reason is worth recording:
+    /// the concurrency runtime resolves its executor-check mode once per process from the
+    /// *main executable*, and `swift test` runs under Apple's `xctest`, which always selects
+    /// the modern path. `CostUsageStoreExecutorIsolationTests` pins the legacy mode in a
+    /// subprocess and is the test that actually fails when these bridges regress.
     @Test
     func `sync bridges are callable from a plain thread`() throws {
         let fixture = try StoreFixture()

--- a/Tests/CodexBarTests/CostUsageStoreTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreTests.swift
@@ -14,11 +14,8 @@ struct CostUsageStoreTests {
     /// wrong takes the app down on launch with "Incorrect actor executor assumption", so the
     /// bridges have to stay callable from an ordinary non-actor thread.
     ///
-    /// This covers that, but it cannot reproduce the trap, and the reason is worth recording:
-    /// the concurrency runtime resolves its executor-check mode once per process from the
-    /// *main executable*, and `swift test` runs under Apple's `xctest`, which always selects
-    /// the modern path. `CostUsageStoreExecutorIsolationTests` pins the legacy mode in a
-    /// subprocess and is the test that actually fails when these bridges regress.
+    /// The subprocess coverage in `CostUsageStoreExecutorIsolationTests` exercises the legacy
+    /// runtime path that an in-process test cannot select.
     @Test
     func `sync bridges are callable from a plain thread`() throws {
         let fixture = try StoreFixture()


### PR DESCRIPTION
## Summary

`CostUsageStore`'s synchronous read/write bridges can trap on every launch in released macOS 15 builds:

```
CodexBarCore/CostUsageStore.swift: Fatal error: Incorrect actor executor assumption;
Expected same executor as CodexBarCore.CostUsageStore.
```

#2803 fixed the corresponding macOS 26 path, but released 0.49.2 still dies within seconds of launch on macOS 15.7.4.

## Root cause

The concurrency runtime resolves its executor-check mode from the main executable's linked SDK. Released `CodexBar.app` carries `LC_BUILD_VERSION sdk 14.0`, which selects the legacy comparison path. That path answers “not isolated” for this custom `SerialExecutor` without consulting `checkIsolated()`, so calling `Actor.assumeIsolated` from inside the executor's `DispatchQueue.sync` still traps.

The shared queue hop is what establishes actor isolation. The repaired bridge encapsulates that hop, Dispatch's authoritative queue check, and the same isolated-closure reabstraction used after `assumeIsolated` succeeds in one private helper. The load and save bridges cannot perform the unchecked handoff outside the shared queue.

The SDK-14 packaging stamp remains a separate follow-up; this PR does not change packaging or release infrastructure.

## Regression coverage

The existing `CodexBarCostStoreCrashProbe` now covers the launch read bridge separately from the write bridge. Each legacy read/write child does two things together:

1. enables an immutable, process-local test control that makes `isIsolatingCurrentContext()` return `nil`; and
2. sets `SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy`.

The first step matters on current macOS 26 hosts: the current-context witness otherwise returns `true` before legacy-mode handling, so the environment override alone does **not** reproduce the macOS 15 failure on every host. The test control is package-scoped, defaults off, is enabled only by the crash-probe argument, and is not persisted or mutable by app code.

Both subprocess tests have a 15-second timeout. The existing plain-thread bridge test and transaction crash-safety tests remain intact.

## Validation

Red/green proof with the corrected subprocess harness present:

- Temporarily restoring the pre-fix `Actor.assumeIsolated` bridge caused both focused cases to fail on the current macOS 26 host with child signal 5 (`SIGTRAP`):
  ```
  probe seed terminated NSTaskTerminationReason(rawValue: 2) 5:
  Fatal error: Incorrect actor executor assumption

  probe load terminated NSTaskTerminationReason(rawValue: 2) 5:
  Fatal error: Incorrect actor executor assumption
  ```
- Restoring the final queue-validated handoff: `swift test --filter CostUsageStoreExecutorIsolationTests` — 2 tests passed.
- `swift test --filter CostUsageStore` — 81 tests in 6 suites passed, including the plain-thread and crash-safety coverage.
- `make check` — parser hash, generated provider/plugin artifacts, formatting, and strict lint all passed; 0 violations.
- `make test` — all 840 discovered selections passed in 70/70 groups, with 0 retries and 0 timeouts.
- `git diff --check` — passed.
- `autoreview --mode branch --base origin/main --max-priority P2` — clean; no accepted/actionable findings.

The temporary red implementation was not committed.

### Contributor packaged proof on macOS 15

Robert's original proof was captured on macOS 15.7.4 (24G517), arm64, Xcode 26.2 / Swift 6.2.3 at contributor head `7347815bbddb1c90c6dad7836595e2b07743cf2a`.

The packaged development build was forced into legacy executor mode with cost usage enabled and `CODEX_HOME` pointed at an isolated copy of 40 real session files (216 MB). The cache directory was removed before launch. Usernames, local paths, and spend amounts were redacted.

```
== build under test ==
git HEAD: 7347815bbddb1c90c6dad7836595e2b07743cf2a
app version: 0.49.3 (117)

== LC_BUILD_VERSION of packaged main executable ==
      cmd LC_BUILD_VERSION
 platform 1
    minos 14.0
      sdk 26.2
```

On released 0.49.2 this configuration dies within seconds. The PR build stayed alive until deliberately terminated:

```
launched pid 1348 at 2026-08-11T08:14:54Z
env: SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy CODEXBAR_LOG_LEVEL=debug
     CODEX_HOME=<isolated copy of 40 recent session files>
args: -tokenCostUsageEnabled '<true/>' -debugDisableKeychainAccess '<true/>'

t=10s   alive: 1348 00:10 S   cost-usage.sqlite: 1138688 bytes
t=30s   alive: 1348 00:30 S   cost-usage.sqlite: 1138688 bytes
t=60s   alive: 1348 01:00 S   cost-usage.sqlite: 1138688 bytes
t=90s   alive: 1348 01:30 S   cost-usage.sqlite: 1138688 bytes
t=120s  alive: 1348 02:00 S   cost-usage.sqlite: 1138688 bytes

sending SIGTERM after 02:01 runtime
app exited on SIGTERM
```

The unified log shows the cost scan drove both bridges and completed, with zero fault-level or “Incorrect actor executor” lines:

```
03:14:54.785 CodexBar: [com.steipete.codexbar:app] CodexBar starting (build=117 built=2026-08-11T08:09:50Z git=7347815bb version=0.49.3)
03:14:59.237 CodexBar: [com.steipete.codexbar:token-cost] Codex cost scan applied work limits (bytesConsumed=215902866 deferredByBudget=19 deferredByTime=1 maxBytesPerRefresh=536870912 maxFileBytes=268435456 partialFiles=0)
03:14:59.457 CodexBar: [com.steipete.codexbar:token-cost] cost usage success provider=codex duration=3.18s today=<redacted> historyDays=30 windowCost=<redacted>
```

The run created and populated the cache from scratch through `syncSaveCodexCache`:

```
cost-usage.sqlite      1138688 bytes
cost-usage.sqlite-shm    32768 bytes
cost-usage.sqlite-wal        0 bytes

count(files)               = 21
count(usage_rows)          = 1665
count(file_day_aggregates) = 22
count(day_aggregates)      = 2
count(token_snapshots)     = 2021
count(scan_metadata)       = 1
meta: parser_hash|b975eb705f905b9a
```

A second launch against the populated cache exercised `syncLoadCodexCache` under the same forced legacy mode.

### Exact-head packaged proof on macOS 15

Robert repeated the packaged proof at packaged-proof head `5d849b905d495475d07dfbf493e357ee8dd9e45d` on macOS 15.7.4 (24G517), arm64, with Swift 6.2.3 / SDK 26.2. The ad-hoc release bundle ran with legacy executor mode forced, Keychain access disabled, isolated preferences/cache, and `CODEX_HOME` containing 40 recent session files totaling 308,984,452 bytes.

Current PR head `17f591426b18bdedae1ac464c8616018df95b2d5` is a rebase-only refresh onto `cdd11c3e2d4dca8bc33648e5d924f299d4875258`; all five task-owned source/test blob hashes are identical to packaged-proof head `5d849b905d495475d07dfbf493e357ee8dd9e45d`. Intervening main changes are CLI/changelog only; therefore the macOS 15 runtime proof applies to identical cost-store code.

- Cold launch started with no cache, created `cost-usage.sqlite` (1,232,896 bytes), persisted 24 files / 1,855 usage rows / 2,314 token snapshots, passed `PRAGMA quick_check`, remained alive for 2:19, and exited only after deliberate SIGTERM.
- Warm launch used fresh preferences seeded only with that populated cache, remained alive for 49 seconds, preserved the cache SHA-256 and row counts, passed `PRAGMA quick_check`, and exited only after deliberate SIGTERM.
- Across both packaged processes: zero fault-level log lines, zero `Incorrect actor executor assumption` lines, and zero fatal-error/SIGTRAP lines.

Full redacted exact-head evidence: https://github.com/steipete/CodexBar/pull/2857#issuecomment-5252006379

## Linked issue

Refs #2803 — completes that fix for runtimes older than macOS 26. No open issue tracks the macOS 15 failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code), repaired and validated by the maintainer.

