### PR TITLE
Restore OpenRouter balance in menu bar layouts

### DIFF
--- a/Sources/CodexBar/MenuBarLayout.swift
+++ b/Sources/CodexBar/MenuBarLayout.swift
@@ -223,6 +223,9 @@ extension MenuBarLayout {
     {
         _ = iconStyle // Critters and bars keep rendering through their unchanged legacy path.
         let icon: MenuBarLayoutToken = .icon
+        if provider == .openrouter, metricPreference == .automatic {
+            return MenuBarLayout(lines: [[icon, .balance]])
+        }
         switch displayMode {
         case .percent:
             if metricPreference == .primaryAndSecondary {

--- a/Sources/CodexBar/MenuBarLayout.swift
+++ b/Sources/CodexBar/MenuBarLayout.swift
@@ -62,6 +62,7 @@ enum MenuBarLayoutBalanceResolver {
         snapshot: UsageSnapshot?)
         -> String?
     {
+        // Provider-specific by design: only OpenRouter exposes its credit balance as the "Remaining" detail row.
         guard provider == .openrouter else { return nil }
         return snapshot?.detailRow(label: "Remaining")?.value
     }
@@ -223,6 +224,7 @@ extension MenuBarLayout {
     {
         _ = iconStyle // Critters and bars keep rendering through their unchanged legacy path.
         let icon: MenuBarLayoutToken = .icon
+        // Provider-specific by design: OpenRouter Automatic historically renders remaining credit balance.
         if provider == .openrouter, metricPreference == .automatic {
             return MenuBarLayout(lines: [[icon, .balance]])
         }

--- a/Sources/CodexBar/MenuBarLayout.swift
+++ b/Sources/CodexBar/MenuBarLayout.swift
@@ -20,6 +20,7 @@ enum MenuBarLayoutToken: Codable, Hashable, Sendable {
     case resetCountdown
     case resetAbsolute
     case runsOut
+    case balance
     case costToday
     case cost30d
     case separatorDot
@@ -52,6 +53,17 @@ enum MenuBarLayoutSemanticWindowResolver {
         return (snapshot.extraRateWindows ?? [])
             .filter { $0.id.hasPrefix("claude-weekly-scoped-") && !$0.window.isSyntheticPlaceholder }
             .max { $0.window.usedPercent < $1.window.usedPercent }
+    }
+}
+
+enum MenuBarLayoutBalanceResolver {
+    static func balance(
+        provider: UsageProvider,
+        snapshot: UsageSnapshot?)
+        -> String?
+    {
+        guard provider == .openrouter else { return nil }
+        return snapshot?.detailRow(label: "Remaining")?.value
     }
 }
 

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -260,7 +260,7 @@ struct MenuBarLayoutEditor: View {
             MenuBarLayoutPaletteGroup(
                 id: "money",
                 title: L("menu_bar_layout_group_money"),
-                tokens: [.costToday, .cost30d],
+                tokens: [.balance, .costToday, .cost30d],
                 includesLineBreak: false),
             MenuBarLayoutPaletteGroup(
                 id: "structure",
@@ -700,6 +700,7 @@ struct MenuBarLayoutPreview: View {
             weeklyPace: self.store.menuBarLayoutPaceText(provider: provider, window: weekly, now: now),
             automaticPace: self.store.menuBarLayoutPaceText(provider: provider, window: automatic, now: now),
             runsOut: runsOut,
+            balance: MenuBarLayoutBalanceResolver.balance(provider: provider, snapshot: snapshot),
             costToday: costToday.map {
                 UsageFormatter.currencyString($0, currencyCode: cost?.currencyCode ?? "USD")
             },
@@ -744,6 +745,7 @@ struct MenuBarLayoutPreview: View {
             weeklyPace: samplePace(weekly),
             automaticPace: samplePace(session),
             runsOut: L("menu_bar_layout_sample_runs_out"),
+            balance: provider == .openrouter ? "$12.34" : nil,
             costToday: "$1.25",
             cost30d: "$20.00")
     }
@@ -836,6 +838,7 @@ extension MenuBarLayoutToken {
         case .resetCountdown: L("menu_bar_layout_token_resets_in")
         case .resetAbsolute: L("menu_bar_layout_token_reset_at")
         case .runsOut: L("menu_bar_layout_token_runs_out")
+        case .balance: L("Balance")
         case .costToday: L("menu_bar_layout_token_cost_today")
         case .cost30d: L("menu_bar_layout_token_cost_30d")
         case .separatorDot: "·"
@@ -861,6 +864,7 @@ extension MenuBarLayoutToken {
         case .resetCountdown: "timer"
         case .resetAbsolute: "clock"
         case .runsOut: "hourglass.bottomhalf.filled"
+        case .balance: "creditcard"
         case .costToday: "dollarsign.circle"
         case .cost30d: "calendar.badge.clock"
         case .separatorDot: "smallcircle.filled.circle"

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -745,6 +745,7 @@ struct MenuBarLayoutPreview: View {
             weeklyPace: samplePace(weekly),
             automaticPace: samplePace(session),
             runsOut: L("menu_bar_layout_sample_runs_out"),
+            // Provider-specific by design: only OpenRouter previews the Balance palette token.
             balance: provider == .openrouter ? "$12.34" : nil,
             costToday: "$1.25",
             cost30d: "$20.00")

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -40,6 +40,7 @@ struct MenuBarLayoutRenderData: Hashable {
     let weeklyPace: String?
     let automaticPace: String?
     let runsOut: String?
+    let balance: String?
     let costToday: String?
     let cost30d: String?
 }
@@ -331,6 +332,11 @@ final class MenuBarLayoutRenderer {
             return self.optionalTextToken(
                 data.runsOut,
                 unavailableLabel: L("Run-out estimate unavailable"),
+                attributes: style.attributes)
+        case .balance:
+            return self.optionalTextToken(
+                data.balance,
+                unavailableLabel: L("%@ unavailable", L("Balance")),
                 attributes: style.attributes)
         case .costToday:
             return self.optionalTextToken(

--- a/Sources/CodexBar/StatusItemController+IconObservation.swift
+++ b/Sources/CodexBar/StatusItemController+IconObservation.swift
@@ -54,6 +54,9 @@ extension StatusItemController {
         let layoutPaceSignature = showBrandPercent
             ? self.storedMenuBarLayoutPaceSignature(for: provider, snapshot: snapshot)
             : nil
+        let layoutBalanceSignature = showBrandPercent
+            ? self.storedMenuBarLayoutBalanceSignature(for: provider, snapshot: snapshot)
+            : nil
 
         return [
             provider.rawValue,
@@ -71,6 +74,7 @@ extension StatusItemController {
             "layoutCost=\(layoutCostSignature ?? "nil")",
             "layoutAccount=\(layoutAccountSignature ?? "nil")",
             "layoutPace=\(layoutPaceSignature ?? "nil")",
+            "layoutBalance=\(layoutBalanceSignature ?? "nil")",
         ].joined(separator: "|")
     }
 
@@ -104,6 +108,18 @@ extension StatusItemController {
             "today=\(showsToday ? costs.today ?? "nil" : "unused")",
             "last30Days=\(showsLast30Days ? costs.last30Days ?? "nil" : "unused")",
         ].joined(separator: ",")
+    }
+
+    private func storedMenuBarLayoutBalanceSignature(
+        for provider: UsageProvider,
+        snapshot: UsageSnapshot?)
+        -> String?
+    {
+        let resolution = self.settings.menuBarLayoutResolution(for: provider)
+        guard !resolution.usesLegacyRendering,
+              resolution.layout.lines.joined().contains(.balance)
+        else { return nil }
+        return MenuBarLayoutBalanceResolver.balance(provider: provider, snapshot: snapshot)
     }
 
     /// Pace tokens change with the historical dataset, the work-day setting, and the clock — none of

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -81,6 +81,7 @@ extension StatusItemController {
                 window: windows.automatic,
                 now: now),
             runsOut: runsOut,
+            balance: MenuBarLayoutBalanceResolver.balance(provider: provider, snapshot: snapshot),
             costToday: costStrings.today,
             cost30d: costStrings.last30Days)
     }

--- a/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
@@ -170,13 +170,13 @@ struct MenuBarLayoutEditorTests {
     }
 
     @Test
-    func `balance token is provider aware`() {
+    func `balance token is provider aware`() throws {
+        let row = try ProviderDetailSection.Row(label: "Remaining", value: "$12.34")
+        let section = try ProviderDetailSection(title: "Credits", rows: [row])
         let snapshot = UsageSnapshot(
             primary: nil,
             secondary: nil,
-            details: [.makeSection(title: "Credits", rows: [
-                .makeRow(label: "Remaining", value: "$12.34"),
-            ])],
+            details: [section],
             updatedAt: Date())
 
         #expect(MenuBarLayoutBalanceResolver.balance(provider: .openrouter, snapshot: snapshot) == "$12.34")

--- a/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
@@ -144,7 +144,7 @@ struct MenuBarLayoutEditorTests {
 
     @Test
     func `drag payload codable round trips`() throws {
-        let layout = MenuBarLayout(lines: [[.icon], [.providerName, .space, .percent(window: .automatic)]])
+        let layout = MenuBarLayout(lines: [[.icon, .balance], [.providerName, .space, .percent(window: .automatic)]])
         let payload = MenuBarLayoutDragItem.placed(
             .percent(window: .automatic),
             at: MenuBarLayoutPosition(line: 1, index: 2),
@@ -167,5 +167,20 @@ struct MenuBarLayoutEditorTests {
             importing: data,
             contentType: .codexBarMenuLayoutItem)
         #expect(decoded == payload)
+    }
+
+    @Test
+    func `balance token is provider aware`() {
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            details: [.makeSection(title: "Credits", rows: [
+                .makeRow(label: "Remaining", value: "$12.34"),
+            ])],
+            updatedAt: Date())
+
+        #expect(MenuBarLayoutBalanceResolver.balance(provider: .openrouter, snapshot: snapshot) == "$12.34")
+        #expect(MenuBarLayoutBalanceResolver.balance(provider: .codex, snapshot: snapshot) == nil)
+        #expect(MenuBarLayoutToken.balance.editorLabel(provider: .openrouter) == L("Balance"))
     }
 }

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -27,6 +27,7 @@ struct MenuBarLayoutRendererTests {
             (.usageBar, "▮▮▯"),
             (.resetCountdown, "in 2h"),
             (.runsOut, "Runs out tomorrow"),
+            (.balance, "$12.34"),
             (.costToday, "$1.25"),
             (.cost30d, "$20.00"),
             (.separatorDot, "·"),
@@ -125,6 +126,7 @@ struct MenuBarLayoutRendererTests {
             weeklyPace: nil,
             automaticPace: nil,
             runsOut: nil,
+            balance: nil,
             costToday: nil,
             cost30d: nil)
         let layout = MenuBarLayout(lines: [[
@@ -142,13 +144,14 @@ struct MenuBarLayoutRendererTests {
             .resetCountdown,
             .resetAbsolute,
             .runsOut,
+            .balance,
             .costToday,
             .cost30d,
         ]])
 
         let output = renderer.render(layout: layout, data: missingData, icon: nil, options: self.options())
 
-        #expect(output.attributedTitle.string.count(where: { $0 == "–" }) == 16)
+        #expect(output.attributedTitle.string.count(where: { $0 == "–" }) == 17)
         #expect(output.accessibilityLabel.contains("unavailable"))
     }
 
@@ -192,6 +195,7 @@ struct MenuBarLayoutRendererTests {
             weeklyPace: nil,
             automaticPace: nil,
             runsOut: nil,
+            balance: nil,
             costToday: nil,
             cost30d: nil)
 
@@ -379,6 +383,7 @@ struct MenuBarLayoutRendererTests {
             weeklyPace: nil,
             automaticPace: nil,
             runsOut: nil,
+            balance: nil,
             costToday: nil,
             cost30d: nil)
 
@@ -451,6 +456,7 @@ struct MenuBarLayoutRendererTests {
             weeklyPace: "+11%",
             automaticPace: "0%",
             runsOut: "Runs out tomorrow",
+            balance: "$12.34",
             costToday: "$1.25",
             cost30d: "$20.00")
     }

--- a/Tests/CodexBarTests/MenuBarLayoutTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutTests.swift
@@ -248,6 +248,47 @@ struct MenuBarLayoutTests {
     }
 
     @Test
+    func `migration preserves OpenRouter automatic balance for every display mode`() {
+        let expected = MenuBarLayout(lines: [[.icon, .balance]])
+
+        for displayMode in MenuBarDisplayMode.allCases {
+            #expect(MenuBarLayout.migrated(
+                iconStyle: .iconAndPercent,
+                displayMode: displayMode,
+                metricPreference: .automatic,
+                resetTimeDisplayStyle: .countdown,
+                provider: .openrouter) == expected)
+        }
+
+        #expect(MenuBarLayout.migrated(
+            iconStyle: .iconAndPercent,
+            displayMode: .percent,
+            metricPreference: .primary,
+            resetTimeDisplayStyle: .countdown,
+            provider: .openrouter) == MenuBarLayout(lines: [[.icon, .percent(window: .session)]]))
+    }
+
+    @Test
+    @MainActor
+    func `editing OpenRouter legacy automatic layout persists its balance`() {
+        let settings = testSettingsStore(suiteName: "MenuBarLayoutTests-openrouter-editor-migration")
+        settings.setMenuBarMetricPreference(.automatic, for: .openrouter)
+        let migrated = settings.menuBarLayout(for: .openrouter)
+
+        #expect(!settings.hasStoredMenuBarLayout)
+        #expect(migrated == MenuBarLayout(lines: [[.icon, .balance]]))
+
+        MenuBarLayoutEditorPersistence.setGap(
+            .tight,
+            activating: migrated,
+            for: .openrouter,
+            settings: settings)
+
+        #expect(settings.menuBarLayoutOverrides[.openrouter] == migrated)
+        #expect(settings.menuBarLayout(for: .openrouter) == migrated)
+    }
+
+    @Test
     @MainActor
     func `global editing seeds the representative provider legacy layout`() throws {
         let settings = testSettingsStore(suiteName: "MenuBarLayoutTests-global-editor-migration")

--- a/Tests/CodexBarTests/MenuBarLayoutTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutTests.swift
@@ -27,6 +27,7 @@ struct MenuBarLayoutTests {
                 .resetCountdown,
                 .resetAbsolute,
                 .runsOut,
+                .balance,
                 .costToday,
                 .cost30d,
                 .separatorDot,

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1747,7 +1747,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuBarLayout.swift",
-            line: 253,
+            line: 270,
             anchor: "ProviderDescriptorRegistry.descriptor(for: provider ?? .codex).presentation.primarySemanticWindow)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,
@@ -2492,7 +2492,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+MenuBarLayout.swift",
-            line: 126,
+            line: 127,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -344,6 +344,28 @@ struct StatusItemIconObservationSignatureTests {
     }
 
     @Test
+    func `custom OpenRouter balance token changes the store icon observation signature`() throws {
+        let (settings, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-openrouter-balance",
+            menuBarLayout: MenuBarLayout(lines: [[.balance]]))
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let registry = ProviderRegistry.shared
+        let codexMetadata = try #require(registry.metadata[.codex])
+        let openRouterMetadata = try #require(registry.metadata[.openrouter])
+        settings.setProviderEnabled(provider: .codex, metadata: codexMetadata, enabled: false)
+        settings.setProviderEnabled(provider: .openrouter, metadata: openRouterMetadata, enabled: true)
+        settings.selectedMenuProvider = .openrouter
+        settings.setMenuBarMetricPreference(.primary, for: .openrouter)
+        store._setSnapshotForTesting(Self.makeBalanceSnapshot("$12.34"), provider: .openrouter)
+        let baseline = controller.storeIconObservationSignature()
+
+        store._setSnapshotForTesting(Self.makeBalanceSnapshot("$9.87"), provider: .openrouter)
+
+        #expect(controller.storeIconObservationSignature() != baseline)
+    }
+
+    @Test
     func `token cost publication enters the icon refresh path without a usage change`() async {
         let (_, store, controller) = self.makeController(
             suiteName: "StatusItemIconObservationSignatureTests-custom-cost-title",
@@ -485,6 +507,21 @@ struct StatusItemIconObservationSignatureTests {
                 accountEmail: "copilot@example.com",
                 accountOrganization: nil,
                 loginMethod: "individual"))
+    }
+
+    private static func makeBalanceSnapshot(_ balance: String) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            details: [.makeSection(title: "Credits", rows: [
+                .makeRow(label: "Remaining", value: balance),
+            ])],
+            updatedAt: Date(timeIntervalSince1970: 100),
+            identity: ProviderIdentitySnapshot(
+                providerID: .openrouter,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "api_key"))
     }
 
     private static func makeTokenSnapshot(

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -8,7 +8,8 @@ import Testing
 struct StatusItemIconObservationSignatureTests {
     private func makeController(
         suiteName: String,
-        menuBarLayout: MenuBarLayout? = nil)
+        menuBarLayout: MenuBarLayout? = nil,
+        provider: UsageProvider = .codex)
         -> (SettingsStore, UsageStore, StatusItemController)
     {
         let settings = testSettingsStore(suiteName: suiteName)
@@ -20,23 +21,35 @@ struct StatusItemIconObservationSignatureTests {
         settings.menuBarShowsHighestUsage = false
         settings.mergeIcons = true
         settings.mergedMenuLastSelectedWasOverview = false
-        settings.selectedMenuProvider = .codex
+        settings.selectedMenuProvider = provider.instanceID
         if let menuBarLayout {
             settings.menuBarShowsBrandIconWithPercent = true
             settings.setMenuBarLayout(menuBarLayout, for: nil)
         }
 
         let registry = ProviderRegistry.shared
-        if let codexMeta = registry.metadata[.codex] {
-            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        if provider != .codex, let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: false)
         }
-        if let claudeMeta = registry.metadata[.claude] {
+        if provider != .claude, let claudeMeta = registry.metadata[.claude] {
             settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: false)
+        }
+        if let providerMeta = registry.metadata[provider] {
+            settings.setProviderEnabled(provider: provider, metadata: providerMeta, enabled: true)
         }
 
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
-        store._setSnapshotForTesting(Self.makeSnapshot(provider: .codex, email: "icon@example.com"), provider: .codex)
+        let environmentBase = provider == .openrouter
+            ? [OpenRouterSettingsReader.envKey: "test-openrouter-key"]
+            : [:]
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            environmentBase: environmentBase)
+        store._setSnapshotForTesting(
+            Self.makeSnapshot(provider: provider, email: "icon@example.com"),
+            provider: provider)
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -347,15 +360,10 @@ struct StatusItemIconObservationSignatureTests {
     func `custom OpenRouter balance token changes the store icon observation signature`() throws {
         let (settings, store, controller) = self.makeController(
             suiteName: "StatusItemIconObservationSignatureTests-openrouter-balance",
-            menuBarLayout: MenuBarLayout(lines: [[.balance]]))
+            menuBarLayout: MenuBarLayout(lines: [[.balance]]),
+            provider: .openrouter)
         defer { controller.releaseStatusItemsForTesting() }
 
-        let registry = ProviderRegistry.shared
-        let codexMetadata = try #require(registry.metadata[.codex])
-        let openRouterMetadata = try #require(registry.metadata[.openrouter])
-        settings.setProviderEnabled(provider: .codex, metadata: codexMetadata, enabled: false)
-        settings.setProviderEnabled(provider: .openrouter, metadata: openRouterMetadata, enabled: true)
-        settings.selectedMenuProvider = .openrouter
         settings.setMenuBarMetricPreference(.primary, for: .openrouter)
         try store._setSnapshotForTesting(Self.makeBalanceSnapshot("$12.34"), provider: .openrouter)
         let baseline = controller.storeIconObservationSignature()

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -357,10 +357,10 @@ struct StatusItemIconObservationSignatureTests {
         settings.setProviderEnabled(provider: .openrouter, metadata: openRouterMetadata, enabled: true)
         settings.selectedMenuProvider = .openrouter
         settings.setMenuBarMetricPreference(.primary, for: .openrouter)
-        store._setSnapshotForTesting(Self.makeBalanceSnapshot("$12.34"), provider: .openrouter)
+        try store._setSnapshotForTesting(Self.makeBalanceSnapshot("$12.34"), provider: .openrouter)
         let baseline = controller.storeIconObservationSignature()
 
-        store._setSnapshotForTesting(Self.makeBalanceSnapshot("$9.87"), provider: .openrouter)
+        try store._setSnapshotForTesting(Self.makeBalanceSnapshot("$9.87"), provider: .openrouter)
 
         #expect(controller.storeIconObservationSignature() != baseline)
     }
@@ -509,13 +509,13 @@ struct StatusItemIconObservationSignatureTests {
                 loginMethod: "individual"))
     }
 
-    private static func makeBalanceSnapshot(_ balance: String) -> UsageSnapshot {
-        UsageSnapshot(
+    private static func makeBalanceSnapshot(_ balance: String) throws -> UsageSnapshot {
+        let row = try ProviderDetailSection.Row(label: "Remaining", value: balance)
+        let section = try ProviderDetailSection(title: "Credits", rows: [row])
+        return UsageSnapshot(
             primary: nil,
             secondary: nil,
-            details: [.makeSection(title: "Credits", rows: [
-                .makeRow(label: "Remaining", value: balance),
-            ])],
+            details: [section],
             updatedAt: Date(timeIntervalSince1970: 100),
             identity: ProviderIdentitySnapshot(
                 providerID: .openrouter,

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -29,7 +29,7 @@ read_when:
 | Usage | Session %, Weekly %, Scoped weekly %, Auto %, Usage bar | Window percentage or a compact three-glyph usage bar |
 | Usage | Session pace, Weekly pace, Auto pace | Signed pace delta for that window |
 | Time | Resets in, Reset at, Runs out | Relative reset, absolute reset, or pace estimate |
-| Money | Cost today, Cost 30d | Local cost estimate for the selected period |
+| Money | Balance, Cost today, Cost 30d | OpenRouter credit balance, or local cost estimate for the selected period |
 | Structure | Separator dot, Space, Line break | Spacing and optional two-line composition |
 
 The pace tokens render the same delta the menu card shows as "in deficit"/"in reserve", in the compact signed form the
@@ -38,7 +38,8 @@ behind it, `0%` on pace. Each pace token reads its own window, so `Weekly pace` 
 `Runs out`, which always estimates from the weekly (or automatic) lane. A pace token renders an en dash while pace is
 unavailable, including the first 3% of a window; see [Pace tracking](#pace-tracking).
 
-Auto % uses the same provider-aware automatic-window resolution as the legacy menu bar metric setting. If a snapshot
+Balance is available only for OpenRouter and renders the same remaining-credit value shown in its menu card. Auto %
+uses the same provider-aware automatic-window resolution as the legacy menu bar metric setting. If a snapshot
 does not provide a token's data, that token renders an en dash while its siblings remain visible. Existing installs
 derive their first layout from the prior style, display mode, metric, and reset settings; those legacy keys remain
 untouched for downgrade safety, while a saved token layout takes precedence.


### PR DESCRIPTION
## Summary
- add a provider-aware Balance token to the menu-bar layout editor
- source the value only from the active OpenRouter snapshot
- preserve the legacy OpenRouter Automatic balance when settings migrate to a stored layout
- include balance changes in the icon observation signature so stored layouts refresh immediately
- cover rendering, provider isolation, legacy migration, persistence, and refresh behavior

Fixes #2866

## Root cause and implementation

The legacy OpenRouter menu-bar path rendered the Remaining detail row for Automatic mode, but the composable layout system had no equivalent token. Saving or migrating a layout therefore lost an established provider-specific value.

This patch adds a Balance token at the shared layout boundary while keeping its value provider-scoped: only OpenRouter resolves the Remaining row. Legacy OpenRouter Automatic settings migrate to Icon plus Balance, the editor exposes a synthetic preview only for OpenRouter, and the status-item observation signature includes the balance only when a stored layout actually uses that token.

## Real behavior proof

A fresh Developer ID-signed build from head `f2f0a5a3fae8a45f04f371af6de12c6eaaf97a35` was exercised through the production stored-layout renderer and a real `NSStatusBarButton`.

- Private live proof used an actual OpenRouter API-backed snapshot and confirmed the real balance rendered in the status item. The credential and value were not captured or uploaded.
- The public artifact below uses a synthetic `$12.34` snapshot through the same production status-button path, so it is safe to share while proving the actual AppKit surface rather than only the SwiftUI editor preview.

![OpenRouter balance in the real status item](https://github.com/user-attachments/assets/ae3a6145-d893-4742-b8e4-81aaa5e8d90b)

## Validation

- `make check`
- focused layout, renderer, editor, and status-item signature tests: 65 tests across 4 suites
- provider architecture gatekeeper: 38 tests
- isolated cold-cache-sensitive project usage suite: 33 tests
- full `make test`: 840 selections across 70 groups, all passed with no retries or timeouts
- branch secret scan: clean
- independent branch review: no accepted or actionable finding
- Developer ID release package built successfully
- packaged app launch smoke passed with the checkout made unreadable
- `codesign --verify --deep --strict --verbose=4 CodexBar.app`
- `spctl --assess --type execute --verbose=4 CodexBar.app`

The final bundle is signed by Developer ID Application: Peter Steinberger (Y5PE65HELJ), accepted by Gatekeeper, and was rebuilt after all temporary proof hooks had been removed.
