### PR TITLE
fix: raise Azure v1 validation budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.3 — Unreleased
 
 ### Fixed
+- Azure OpenAI: allow enough v1 completion budget for reasoning-capable deployment validation while keeping the probe bounded (#2867). Thanks @yilinxia!
 - Codex: preserve request-level pricing tiers while reconciling forked usage, preventing day aggregates from triggering long-context rates (#2858). Thanks @thomaschow19!
 - CLI: stop standalone version lookup from walking past the filesystem root and hanging with unbounded memory on affected macOS versions (#2856). Thanks @Manwholikespie!
 - Cost store: prevent launch-time executor-assumption crashes on macOS 15 by keeping synchronous SQLite cache bridges on their validated serial queue (#2857). Thanks @Manwholikespie!

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
@@ -94,6 +94,7 @@ private struct AzureOpenAIChatCompletionResponse: Decodable {
 public enum AzureOpenAIUsageFetcher {
     private static let timeoutSeconds: TimeInterval = 20
     private static let maxErrorBodyLength = 240
+    private static let v1ValidationCompletionTokenCap = 64
 
     public static func fetchUsage(
         apiKey: String,
@@ -218,7 +219,7 @@ public enum AzureOpenAIUsageFetcher {
         ]
         if self.usesV1API(apiVersion) {
             payload["model"] = deploymentName
-            payload["max_completion_tokens"] = 1
+            payload["max_completion_tokens"] = Self.v1ValidationCompletionTokenCap
         } else {
             payload["max_tokens"] = 1
         }

--- a/Tests/CodexBarTests/AzureOpenAIUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AzureOpenAIUsageFetcherTests.swift
@@ -93,7 +93,9 @@ struct AzureOpenAIUsageFetcherTests {
             let body = try #require(request.httpBody)
             let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
             #expect(json["max_tokens"] as? Int == 1)
+            #expect(json["max_completion_tokens"] == nil)
             #expect(json["temperature"] == nil)
+            #expect(json["reasoning_effort"] == nil)
             let messages = try #require(json["messages"] as? [[String: String]])
             #expect(messages.first?["content"] == "ping")
 
@@ -164,9 +166,12 @@ struct AzureOpenAIUsageFetcherTests {
             let body = try #require(request.httpBody)
             let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
             #expect(json["model"] as? String == "chat-prod")
-            #expect(json["max_completion_tokens"] as? Int == 1)
+            let completionCap = try #require(json["max_completion_tokens"] as? Int)
+            #expect(completionCap == 64)
+            #expect(completionCap <= 64)
             #expect(json["max_tokens"] == nil)
             #expect(json["temperature"] == nil)
+            #expect(json["reasoning_effort"] == nil)
 
             let response = try HTTPURLResponse(
                 url: #require(request.url),

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1605,13 +1605,13 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Antigravity model identifiers use this token to classify a model family."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift",
-            line: 171,
+            line: 172,
             anchor: "let base = self.apiRoot(endpoint: endpoint, pathComponents: [\"openai\", \"v1\"])",
             expectedProviderIDs: ["openai"],
             reason: "Azure OpenAI's v1 REST route requires this fixed service path component."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift",
-            line: 180,
+            line: 181,
             anchor: "let base = self.apiRoot(endpoint: endpoint, pathComponents: [\"openai\"])",
             expectedProviderIDs: ["openai"],
             reason: "Azure OpenAI's deployment REST route requires this fixed service path component."),

--- a/docs/azure-openai.md
+++ b/docs/azure-openai.md
@@ -61,7 +61,8 @@ parsed only for the returned `model` field so the menu can show deployment detai
 
 Set `AZURE_OPENAI_API_VERSION` to override the API version. When it is set to `v1`, CodexBar uses Azure's
 OpenAI-compatible v1 path, includes the deployment name as the request `model`, and uses
-`max_completion_tokens: 1`:
+`max_completion_tokens: 64`. This small total completion budget leaves room for hidden reasoning tokens while keeping
+the validation probe bounded. Dated API versions continue to request at most one output token.
 
 ```http
 POST https://resource.openai.azure.com/openai/v1/chat/completions
@@ -76,8 +77,8 @@ HTTPS. CodexBar rejects explicit `http://` endpoints, user info, and encoded hos
 Endpoint paths are preserved. CodexBar avoids duplicating a trailing `/openai` for dated API versions or a trailing
 `/openai/v1` for the v1 API when building the validation URL.
 
-Each refresh with complete, valid configuration sends this real inference request and can consume billable input and
-output tokens for the configured deployment.
+Each refresh with complete, valid configuration sends this real, potentially billable inference request. The 64-token
+v1 budget is a maximum, not automatic consumption; the deployment can consume fewer input and output tokens.
 
 ## Display
 


### PR DESCRIPTION
## Problem

Azure OpenAI's `v1` Chat Completions validation used `max_completion_tokens: 1`. That total budget includes hidden reasoning tokens, so reasoning-capable deployments could exhaust it before producing a visible answer even though the deployment was reachable.

The reporter's live A/B on the affected deployment showed that a budget of 1 failed while 64 returned `pong` and consumed 5 completion tokens. This PR does not claim an independent live Azure run.

## Fix

- Add a named, bounded 64-token validation completion cap and use it only for the `v1` request payload.
- Keep dated Azure API versions unchanged at `max_tokens: 1`.
- Preserve the fixed prompt, endpoint validation, authentication headers, and response parsing.
- Document that each refresh is a real, potentially billable inference request and that 64 is a maximum rather than automatic consumption.

## Proof

- Regression red: the focused v1 request test expected 64 and captured the current payload value of 1.
- `swift test --filter AzureOpenAIUsageFetcherTests`
- `swift test --filter ProviderEndpointOverrideSecurityTests`
- `swift test --filter ProviderArchitectureGatekeeperTests`
- `swift test --filter CodexBarLinuxTests`
- `make check`
- `make test` (840 selections, 70/70 groups passed without retries)
- `git diff --check`
- Global Codex branch autoreview versus `origin/main` through P2: clean, no actionable findings.

Fixes #2867
