### PR TITLE
fix(claude): disambiguate account actions when claude-swap owns presentation

### DIFF
--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -350,7 +350,11 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         if self.shouldOpenTerminalForOAuthError(store: context.store) {
             return ("Open Terminal", .openTerminal(command: "claude"))
         }
-        guard !context.hasAccount else { return nil }
+        let swapOwnsAccountPresentation = ClaudeSwapMenuPrecedence.prefersClaudeSwap(
+            provider: context.provider,
+            accountCount: context.store.claudeSwapAccountSnapshots.count,
+            showSingleAccount: context.settings.claudeSwapShowSingleAccount)
+        guard !context.hasAccount || swapOwnsAccountPresentation else { return nil }
         return (L("Sign in with Claude Code..."), .switchAccount(.claude))
     }
 

--- a/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
@@ -24,6 +24,27 @@ struct ClaudeWebRecoveryMenuTests {
             syntheticTokenStore: NoopSyntheticTokenStore())
     }
 
+    private static func claudeSwapAccounts(count: Int) -> [ProviderAccountUsageSnapshot] {
+        guard count > 0 else { return [] }
+        let now = Date(timeIntervalSince1970: 1_782_000_000)
+        return ClaudeSwapAccountProjection.accountSnapshots(
+            from: ClaudeSwapAccountList(
+                activeAccountNumber: 1,
+                accounts: (1...count).map { number in
+                    ClaudeSwapAccountRow(
+                        number: number,
+                        email: "account\(number)@example.com",
+                        isActive: number == 1,
+                        usageStatus: .ok,
+                        fiveHour: ClaudeSwapUsageWindow(
+                            usedPercent: Double(20 + number),
+                            resetsAt: now.addingTimeInterval(3600)),
+                        sevenDay: nil,
+                        scoped: [])
+                }),
+            now: now)
+    }
+
     private func actions(
         error: String? = nil,
         source: ClaudeUsageDataSource,
@@ -31,6 +52,7 @@ struct ClaudeWebRecoveryMenuTests {
         selectedSessionKey: Bool = false,
         authenticatedAccountEmail: String? = nil,
         authenticatedOAuthWithoutEmail: Bool = false,
+        claudeSwapAccountCount: Int = 0,
         attempts: [ProviderFetchAttempt] = []) -> [(String, MenuDescriptor.MenuAction)]
     {
         let settings = self.makeSettings()
@@ -44,6 +66,7 @@ struct ClaudeWebRecoveryMenuTests {
             fetcher: fetcher,
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings)
+        store.claudeSwapAccountSnapshots = Self.claudeSwapAccounts(count: claudeSwapAccountCount)
         if authenticatedAccountEmail != nil || authenticatedOAuthWithoutEmail {
             store._setSnapshotForTesting(
                 UsageSnapshot(
@@ -102,6 +125,20 @@ struct ClaudeWebRecoveryMenuTests {
             $0.0 == "Switch Account..." && $0.1 == .switchAccount(.claude)
         })
         #expect(!actions.contains { $0.0 == "Sign in with Claude Code..." })
+    }
+
+    @Test
+    func `swap account presentation disambiguates ambient Claude Code sign in`() {
+        let actions = self.actions(
+            source: .auto,
+            authenticatedAccountEmail: "claude@example.com",
+            claudeSwapAccountCount: 2)
+
+        #expect(actions.contains {
+            $0.0 == "Sign in with Claude Code..." && $0.1 == .switchAccount(.claude)
+        })
+        #expect(!actions.contains { $0.0 == "Switch Account..." })
+        #expect(!actions.contains { $0.0 == "Add Account..." })
     }
 
     @Test

--- a/docs/claude-multi-account-and-status-items.md
+++ b/docs/claude-multi-account-and-status-items.md
@@ -156,8 +156,8 @@ Icons semantics must be decided before implementation.
 
 The mock above shows the recommended mode and its Merge Icons conflict. It is intentionally a decision artifact, not
 an implementation screenshot. The following packaged synthetic-account proof verifies the bounded current behavior:
-the account action is now named “Sign in with Claude Code…” and no longer claims it will add a durable CodexBar account.
-No real credential, browser session, or provider call was used.
+the separate ambient OAuth action is named “Sign in with Claude Code…”, while inactive claude-swap cards retain their
+explicit “Switch Account…” action. No real credential, browser session, or provider call was used.
 
 ![Packaged synthetic Claude sign-in proof](screenshots/claude-sign-in-synthetic-proof.png)
 

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -162,7 +162,9 @@ The accepted multi-account design in
   cards. Active rows are marked `[active]`; no claude-swap row infers a plan badge.
 - Switching: an inactive account with usable source credentials shows “Switch Account…”. Clicking it runs exactly
   `cswap --switch-to <slot> --json`, validates the versioned result and requested slot, then refreshes both ambient
-  Claude usage and every claude-swap account card. Switches are serialized; no automatic switching occurs.
+  Claude usage and every claude-swap account card. Switches are serialized; no automatic switching occurs. While
+  claude-swap owns account presentation, the separate ambient OAuth action reads “Sign in with Claude Code…” and does
+  not add or switch a claude-swap account.
 - Expired, missing, unknown, or Keychain-inaccessible credentials stay non-actionable. A failed switch remains visible
   on that account without discarding its last successful usage. A running Claude Code process can take up to the
   claude-swap Keychain cache interval to observe the new account.


### PR DESCRIPTION
## Summary

This rewrite fixes the two identically named Claude controls without changing either action:

- Inactive claude-swap cards keep **“Switch Account...”** because they really run `cswap --switch-to <slot> --json`.
- When claude-swap owns account presentation, the separate ambient OAuth row now reads **“Sign in with Claude Code...”** while retaining its existing `.switchAccount(.claude)` action.
- Authenticated Claude menus without claude-swap presentation keep the existing **“Switch Account...”** row.

The override lives in `ClaudeProviderImplementation.loginMenuAction(context:)`, the provider-owned seam that already owns Claude login/recovery wording. The generic `MenuDescriptor`, card rendering, action handlers, subprocess behavior, localization catalogs, and highlight styling are unchanged.

## Why not “Add Account...”

That row starts ambient Claude Code OAuth and can re-authenticate the active credential; it does not add a durable claude-swap account. Calling it “Add Account...” would replace one ambiguity with an auth-UX hazard and conflict with the accepted design, which keeps add/import/export/purge operations out of scope.

## Actual menu proof

Both captures use the same Developer ID-signed debug app, isolated HOME/config, fake `cswap`, fake authenticated Claude CLI, `example.invalid` identities, disabled Keychain access, and the real AppKit status-item menu probe. No real provider credential, browser session, or personal data was used.

| Before | After |
| --- | --- |
| ![Before: swap card and ambient OAuth row both read Switch Account](https://github.com/user-attachments/assets/ea7fa6d8-6c74-488b-8340-3453d5311daf) | ![After: swap card remains Switch Account while ambient OAuth row reads Sign in with Claude Code](https://github.com/user-attachments/assets/e3a967e0-032f-4ecc-87ed-65265335a5d6) |

## Regression coverage

- Authenticated ambient Claude account + two claude-swap snapshots produces `Sign in with Claude Code...` mapped to `.switchAccount(.claude)`.
- The existing authenticated no-swap tests continue to produce `Switch Account...`.
- Existing precedence tests continue to cover zero, one opt-in, multiple, and non-Claude account sets.
- Docs now distinguish the ambient OAuth row from explicit claude-swap card activation.

## Verification

- `swift test --filter 'ClaudeWebRecoveryMenuTests|ClaudeSwapMenuPrecedenceTests|MenuCardClaudeSwapAccountTests'` — 20 tests in 3 suites passed.
- `make check` — 0 SwiftLint violations across 1,846 Swift files; formatting, localization, generated files, links, and package checks passed.
- `make test` — 840 selections in 70 groups; 70 first-pass successes, 0 failed groups, 0 retries, 0 timeouts.
- Local and full branch autoreview — no accepted/actionable P0-P2 findings; TruffleHog clean.
- Final `CodexBar.app` — signed with `Developer ID Application: Peter Steinberger (Y5PE65HELJ)`, strict deep verification passed, Gatekeeper accepted.

Contributor credit is preserved through the commit co-author and will be included in the maintainer changelog closeout after merge.
