### PR TITLE
Skip identical plan history writes

### DIFF
--- a/Sources/CodexBar/PlanUtilizationHistoryStore.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryStore.swift
@@ -249,6 +249,9 @@ struct PlanUtilizationHistoryStore: Sendable {
                     accounts: accounts,
                     sessionEquivalentWindowPairIdentities: buckets.sessionEquivalentWindowPairIdentities)
                 let data = try encoder.encode(payload)
+                if let existingData = try? Data(contentsOf: fileURL), existingData == data {
+                    continue
+                }
                 try data.write(to: fileURL, options: Data.WritingOptions.atomic)
             }
         } catch {

--- a/Tests/CodexBarTests/PlanUtilizationHistoryStoreTests.swift
+++ b/Tests/CodexBarTests/PlanUtilizationHistoryStoreTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct PlanUtilizationHistoryStoreTests {
+    @Test
+    func `identical provider history keeps the existing file`() throws {
+        let fixture = Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+        let buckets = Self.makeBuckets(usedPercent: 12)
+
+        fixture.store.save([.codex: buckets])
+        try FileManager.default.setAttributes(
+            [.modificationDate: fixture.sentinelDate],
+            ofItemAtPath: fixture.fileURL.path)
+        let originalData = try Data(contentsOf: fixture.fileURL)
+
+        fixture.store.save([.codex: buckets])
+
+        #expect(try Data(contentsOf: fixture.fileURL) == originalData)
+        #expect(try Self.modificationDate(of: fixture.fileURL) == fixture.sentinelDate)
+    }
+
+    @Test
+    func `changed provider history replaces the existing file`() throws {
+        let fixture = Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        fixture.store.save([.codex: Self.makeBuckets(usedPercent: 12)])
+        try FileManager.default.setAttributes(
+            [.modificationDate: fixture.sentinelDate],
+            ofItemAtPath: fixture.fileURL.path)
+        let originalData = try Data(contentsOf: fixture.fileURL)
+
+        fixture.store.save([.codex: Self.makeBuckets(usedPercent: 34)])
+
+        #expect(try Data(contentsOf: fixture.fileURL) != originalData)
+        #expect(try Self.modificationDate(of: fixture.fileURL) != fixture.sentinelDate)
+    }
+
+    @Test
+    func `empty provider history removes the existing file`() {
+        let fixture = Self.makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        fixture.store.save([.codex: Self.makeBuckets(usedPercent: 12)])
+        #expect(FileManager.default.fileExists(atPath: fixture.fileURL.path))
+
+        fixture.store.save([:])
+
+        #expect(!FileManager.default.fileExists(atPath: fixture.fileURL.path))
+    }
+
+    private static func makeFixture() -> (
+        directoryURL: URL,
+        fileURL: URL,
+        sentinelDate: Date,
+        store: PlanUtilizationHistoryStore)
+    {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PlanUtilizationHistoryStoreTests-\(UUID().uuidString)", isDirectory: true)
+        return (
+            directoryURL: directoryURL,
+            fileURL: directoryURL.appendingPathComponent("codex.json"),
+            sentinelDate: Date(timeIntervalSince1970: 1_000_000_000),
+            store: PlanUtilizationHistoryStore(directoryURL: directoryURL))
+    }
+
+    private static func makeBuckets(usedPercent: Double) -> PlanUtilizationHistoryBuckets {
+        PlanUtilizationHistoryBuckets(unscoped: [
+            PlanUtilizationSeriesHistory(
+                name: .session,
+                windowMinutes: 300,
+                entries: [
+                    PlanUtilizationHistoryEntry(
+                        capturedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                        usedPercent: usedPercent,
+                        resetsAt: nil),
+                ]),
+        ])
+    }
+
+    private static func modificationDate(of fileURL: URL) throws -> Date {
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        return try #require(attributes[.modificationDate] as? Date)
+    }
+}


### PR DESCRIPTION
Fixes #2495

## Summary

`PlanUtilizationHistoryStore` encoded stable snapshots deterministically but always replaced each provider file with an atomic write. This compares the encoded bytes with the existing file first and skips only exact matches.

Changed payloads still use the existing atomic replacement path, and empty provider history still removes the file.

## Regression coverage

- unchanged payload preserves the existing bytes and modification date
- changed payload replaces the file
- empty history deletes the file

## Live-store proof

A one-off Swift harness compiled against exact head `3f4ab7def` invoked the production `PlanUtilizationHistoryStore` against an isolated temporary store with synthetic history. No credentials or user history were read.

```text
LIVE_PROOF initial exists=true sha256=2e6e2fb87b05ba3bdd6bbab0141b20744097d6d31b5be67c241b8944fda1fae7 mtime=1000000000.0
LIVE_PROOF identical hash_preserved=true mtime_preserved=true
LIVE_PROOF changed hash_replaced=true mtime_replaced=true
LIVE_PROOF empty exists=false
Test run with 1 test in 1 suite passed after 0.015 seconds.
```

## Validation

- `swift test --filter 'PlanUtilizationHistoryStoreTests|UsageStorePlanUtilizationTests|ProviderInstanceIdentityCharacterizationTests|ProviderInstanceIDTests'`: 105 tests in 4 suites passed
- `make check`: passed with 0 formatting issues and 0 SwiftLint violations
- `make test`: did not pass locally because two existing `AdaptiveRefreshTimerTests` ended in `CancellationError()`; the same 2-of-19 failures reproduce on untouched `main` at `6e0a50001`

Compatibility risk is low: the on-disk schema and changed/deletion behavior are unchanged; only byte-identical nonempty replacements are skipped.

Review focus: the exact-byte guard in `PlanUtilizationHistoryStore.save` and the unchanged/changed/deletion contract.
