### PR TITLE
Avoid rewriting unchanged plan history files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.3 — Unreleased
 
 ### Fixed
+- Plan history: avoid atomically replacing byte-identical provider history files, reducing unnecessary disk writes (#2495). Thanks @guocity for the report!
 - OpenRouter: restore remaining credit balance in saved custom menu-bar layouts and preserve the legacy Automatic display during migration (#2870). Thanks @yuansaysay!
 - Claude: distinguish claude-swap account switching from ambient Claude Code sign-in in the menu without changing either action (#2874). Thanks @ynaamane!
 - Codex: avoid full SQLite cost-cache rewrites for unchanged scans while preserving retention, freshness, and concurrent saves (#2852). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/PlanUtilizationHistoryStore.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryStore.swift
@@ -249,6 +249,11 @@ struct PlanUtilizationHistoryStore: Sendable {
                     accounts: accounts,
                     sessionEquivalentWindowPairIdentities: buckets.sessionEquivalentWindowPairIdentities)
                 let data = try encoder.encode(payload)
+                if let existingData = try? Data(contentsOf: fileURL),
+                   existingData == data
+                {
+                    continue
+                }
                 try data.write(to: fileURL, options: Data.WritingOptions.atomic)
             }
         } catch {

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -1330,6 +1330,102 @@ struct UsageStorePlanUtilizationTests {
 
         #expect(store.load() == [.zai: buckets])
     }
+
+    @Test
+    func `store preserves unchanged provider file identity`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directoryURL = root
+            .appendingPathComponent("com.steipete.codexbar", isDirectory: true)
+            .appendingPathComponent("history", isDirectory: true)
+        let providerURL = directoryURL.appendingPathComponent("codex.json")
+        let store = PlanUtilizationHistoryStore(directoryURL: directoryURL)
+        let buckets = Self.persistedBuckets(usedPercent: 12)
+
+        store.save([.codex: buckets])
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1_600_000_000)],
+            ofItemAtPath: providerURL.path)
+        let before = try Self.persistedFileState(at: providerURL)
+
+        store.save([.codex: buckets])
+        let after = try Self.persistedFileState(at: providerURL)
+
+        #expect(after == before)
+    }
+
+    @Test
+    func `changing one provider leaves unchanged sibling file untouched`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directoryURL = root
+            .appendingPathComponent("com.steipete.codexbar", isDirectory: true)
+            .appendingPathComponent("history", isDirectory: true)
+        let codexURL = directoryURL.appendingPathComponent("codex.json")
+        let claudeURL = directoryURL.appendingPathComponent("claude.json")
+        let store = PlanUtilizationHistoryStore(directoryURL: directoryURL)
+        let initialCodex = Self.persistedBuckets(usedPercent: 12)
+        let changedCodex = Self.persistedBuckets(usedPercent: 64)
+        let claude = Self.persistedBuckets(usedPercent: 37)
+
+        store.save([.codex: initialCodex, .claude: claude])
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1_600_000_000)],
+            ofItemAtPath: claudeURL.path)
+        let codexBefore = try Self.persistedFileState(at: codexURL)
+        let claudeBefore = try Self.persistedFileState(at: claudeURL)
+
+        store.save([.codex: changedCodex, .claude: claude])
+
+        let loaded = store.load()
+        let codexAfter = try Self.persistedFileState(at: codexURL)
+        let claudeAfter = try Self.persistedFileState(at: claudeURL)
+        #expect(loaded[.codex] == changedCodex)
+        #expect(loaded[.claude] == claude)
+        #expect(codexAfter.data != codexBefore.data)
+        #expect(claudeAfter == claudeBefore)
+    }
+
+    @Test
+    func `saving empty provider removes existing history file`() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directoryURL = root
+            .appendingPathComponent("com.steipete.codexbar", isDirectory: true)
+            .appendingPathComponent("history", isDirectory: true)
+        let providerURL = directoryURL.appendingPathComponent("codex.json")
+        let store = PlanUtilizationHistoryStore(directoryURL: directoryURL)
+
+        store.save([.codex: Self.persistedBuckets(usedPercent: 12)])
+        #expect(FileManager.default.fileExists(atPath: providerURL.path))
+
+        store.save([:])
+
+        #expect(!FileManager.default.fileExists(atPath: providerURL.path))
+    }
+
+    @Test
+    func `saving replaces malformed provider history with canonical document`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directoryURL = root
+            .appendingPathComponent("com.steipete.codexbar", isDirectory: true)
+            .appendingPathComponent("history", isDirectory: true)
+        let providerURL = directoryURL.appendingPathComponent("codex.json")
+        let store = PlanUtilizationHistoryStore(directoryURL: directoryURL)
+        let buckets = Self.persistedBuckets(usedPercent: 12)
+        let malformed = Data("{not-json".utf8)
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true)
+        try malformed.write(to: providerURL)
+
+        store.save([.codex: buckets])
+        let rewritten = try Data(contentsOf: providerURL)
+
+        #expect(rewritten != malformed)
+        #expect(store.load() == [.codex: buckets])
+    }
 }
 
 extension UsageStorePlanUtilizationTests {
@@ -1338,6 +1434,33 @@ extension UsageStorePlanUtilizationTests {
         let preferredAccountKey: String?
         let unscoped: [PlanUtilizationSeriesHistory]
         let accounts: [String: [PlanUtilizationSeriesHistory]]
+    }
+
+    private struct PersistedFileState: Equatable {
+        let data: Data
+        let modificationDate: Date
+        let fileNumber: UInt64
+    }
+
+    private static func persistedBuckets(usedPercent: Double) -> PlanUtilizationHistoryBuckets {
+        PlanUtilizationHistoryBuckets(
+            preferredAccountKey: nil,
+            unscoped: [
+                planSeries(name: .session, windowMinutes: 300, entries: [
+                    planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: usedPercent),
+                ]),
+            ])
+    }
+
+    private static func persistedFileState(at url: URL) throws -> PersistedFileState {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let modificationDate = try #require(attributes[.modificationDate] as? Date)
+        let fileNumber = try #require(attributes[.systemFileNumber] as? NSNumber)
+        let data = try Data(contentsOf: url)
+        return PersistedFileState(
+            data: data,
+            modificationDate: modificationDate,
+            fileNumber: fileNumber.uint64Value)
     }
 
     private struct FixtureDocument: Decodable {


### PR DESCRIPTION
## Summary
- skip atomic replacement when a provider's deterministic plan-history JSON is byte-identical to the existing file
- preserve the existing write, repair, and deletion paths for changed, missing, malformed, unreadable, or empty provider histories
- verify unchanged file bytes, modification time, and inode, plus cross-provider isolation

Fixes #2495

## Root cause

`PlanUtilizationHistoryStore.save` deterministically encoded every known provider and then always called atomic `Data.write`, even when the encoded bytes exactly matched the existing provider file. Because an update to one provider saves the complete history dictionary, unchanged sibling files such as `history/claude.json` and `history/codex.json` were repeatedly replaced as well.

## Implementation

After encoding the canonical sorted payload, the store reads the current file and returns early only when the bytes are identical. A missing or failed read falls through to the existing atomic write. Empty histories still remove stale files, malformed files are replaced with valid canonical JSON, and changed providers still round-trip normally.

## Validation

- focused `UsageStorePlanUtilizationTests`: 92 tests passed
- new regression coverage proves:
  - an unchanged provider preserves bytes, modification time, and inode
  - changing one provider rewrites and reloads it without touching an unchanged sibling
  - saving an empty provider removes its prior file
  - a malformed provider file is replaced by canonical valid JSON
- `make check`: passed
- full `make test`: 840 selections across 70 groups passed with no retries or timeouts
- structured Codex autoreview: clean, no accepted or actionable findings
- TruffleHog patch scan: clean

One earlier full run hit host-load flakiness in the unrelated `BoundedChildProcessProofTests` lane: the PTY latency assertion took 25 seconds and the synthetic Grok handshake timed out. That exact three-test suite then passed in isolation in 5.3 seconds, and the complete matrix rerun passed all 70 groups without retries.
