### PR TITLE
fix: follow system dimming for menu bar icon, standard size and stepper-tuned vertical offset

### DIFF
--- a/LOCAL_PATCHES.MD
+++ b/LOCAL_PATCHES.MD
@@ -1,0 +1,143 @@
+# LOCAL_PATCHES — 本地未上游修改记录
+
+> 记录本仓库相对于上游 `steipete/CodexBar` 的全部本地改动，供后续重放 / 提 PR / 迁移使用。
+> 生成时间：2026-08-13
+
+## 1. Git 分支状态（已同步上游）
+
+| 分支 | behind origin/main | ahead | 说明 |
+|---|---|---|---|
+| `main` | 0 | 5 | 4 个本地提交 + 1 个 merge commit（见 §3） |
+| `feature/menubar-icon-dimming` | 0 | 4 | 本地 4 个提交已 rebase 到上游 |
+| `feature/codex-quota-notifications` | 0 | 0 | 已 fast-forward |
+
+- 上游 `origin` = https://github.com/steipete/CodexBar.git
+- fork `fork` = https://github.com/luantu/CodexBar.git
+
+---
+
+## 2. 修复：Codex 周额度重置死锁（未提交，位于工作区）
+
+**状态**：未 commit，位于 `feature/menubar-icon-dimming` 工作区（`git diff` 可见）。
+
+**问题**：`CodexWeeklyResetConfirmation.confirmationDecision` 在旧窗口尚未到期时观测到"提前重置"，要求证明消耗了一张手动重置券（`confirmsManualResetCreditConsumption`）。当账户**明确拥有 0 张可用重置券**（`availableCount == 0`）时该证明永远无法成立 → 每次刷新都被 `.preservePrevious` 挡住，新值永远不发布，UI 停留在旧快照。
+
+**修复**：当上一次快照明确记录为 0 张可用重置券时，两次一致观测（initial + confirmation）本身即为充分确认，不再要求券消耗证明；未知/缺失的券信息仍保持保守。
+
+### 2.1 `Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift`
+
+```diff
+         let previouslyAvailableCredits = previousCredits.availableCredits(at: previousCredits.updatedAt)
+-        guard !previouslyAvailableCredits.isEmpty else { return false }
++        // An explicitly observed zero-credit inventory means there was no manual reset credit to
++        // consume. Requiring consumption proof here would deadlock: the two consistent observations
++        // (initial + confirmation) are the only signal a server-side early reset has, so trust them.
++        // A nil/unknown previous inventory stays conservative and keeps demanding consumption proof.
++        guard !previouslyAvailableCredits.isEmpty else {
++            return previousCredits.availableCount == 0
++        }
+         return previouslyAvailableCredits.contains { previousCredit in
+```
+
+### 2.2 `Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift`
+
+新增测试 `zero available reset credits confirm a server-side early weekly reset by observation`（完全复现线上时序：98%→1%，8/18→8/20，可用券 0）：
+
+```diff
+     @Test
++    func `zero available reset credits confirm a server-side early weekly reset by observation`() throws {
++        let formatter = ISO8601DateFormatter()
++        let previousCapturedAt = try #require(formatter.date(from: "2026-08-13T03:36:16Z"))
++        let previousReset = try #require(formatter.date(from: "2026-08-18T00:49:16Z"))
++        let initialCapturedAt = try #require(formatter.date(from: "2026-08-13T03:41:46Z"))
++        let initialReset = try #require(formatter.date(from: "2026-08-20T03:38:06Z"))
++        let previous = self.snapshot(
++            capturedAt: previousCapturedAt,
++            weeklyUsed: 98,
++            weeklyReset: previousReset,
++            resetCredits: self.emptyResetCredits(capturedAt: previousCapturedAt))
++        let initial = self.snapshot(
++            capturedAt: initialCapturedAt,
++            weeklyUsed: 1,
++            weeklyReset: initialReset,
++            resetCredits: self.emptyResetCredits(capturedAt: initialCapturedAt))
++        let confirmation = self.snapshot(
++            capturedAt: initialCapturedAt.addingTimeInterval(30),
++            weeklyUsed: 1,
++            weeklyReset: initialReset.addingTimeInterval(30),
++            resetCredits: self.emptyResetCredits(capturedAt: initialCapturedAt.addingTimeInterval(30)))
++
++        #expect(
++            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: initial)
++                == .requiresConfirmation)
++        #expect(
++            CodexWeeklyResetConfirmation.confirmationDecision(
++                previous: previous,
++                initial: initial,
++                confirmation: confirmation)
++                == .publishConfirmation)
++    }
++
++    @Test
+     func `one missing reset credit inventory does not confirm an early manual weekly reset`() throws {
+```
+
+### 2.3 验证
+
+- `CodexWeeklyResetConfirmationTests` 20/20 通过（含新增用例）。
+- `make check` 全仓 1846 文件 0 lint 违规。
+- 已打包替换 `/Applications/CodexBar.app`，线上验证快照恢复实时刷新。
+
+---
+
+## 3. main 分支：merge 冲突解决（已 commit：`98c93bf96`）
+
+同步 `main` → `origin/main` 时 3 个文件冲突，已手动解决并合并。
+
+### 3.1 `Sources/CodexBar/MenuBarLayoutRenderer.swift`
+
+本地 `isStale` / `verticalAdjustment` 字段 + 上游 `now` 注释并存；渲染逻辑取并集：
+
+- `MenuBarLayoutRenderOptions` 增加 `isStale: Bool`、`verticalAdjustment: Int`（均带默认值）
+- `foregroundColor` 在 stale 时用 `.secondaryLabelColor`
+- baseline offset = 光学基线 + 用户 nudge
+
+### 3.2 `Sources/CodexBar/StatusItemController+MenuBarLayout.swift`
+
+合并决议：保留本地 `isStale` + `verticalAdjustment` 传参，`now` 采用上游的 `now: now`（精确时钟）：
+
+```diff
+-            isStale: self.store.isStale(provider: provider),
+-            now: minute,
+-            verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment)
++            isStale: self.store.isStale(provider: provider),
++            now: now,
++            verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment)
+```
+
+### 3.3 `Tests/CodexBarTests/MenuBarLayoutRendererTests.swift`
+
+Helper 签名合并以兼容两侧调用点：
+
+- `data(automaticUsedPercent:provider:automaticResetAt:)`（上游版）
+- `options(verticalAdjustment:isStale:now:)`（本地参数 ∪ 上游 `now`）
+- 新增 `vertical adjustment shifts single line baseline offset`、`stale title dims foreground while keeping the snapshot visible` 等测试；图标断言从 `NSTextAttachment` 改为 `leadingIcon`
+
+---
+
+## 4. 分支同步操作记录
+
+1. `git fetch origin`
+2. `feature/menubar-icon-dimming`：`git rebase origin/main`（4 个本地提交，MenuBarLayoutEditor.swift 自动合并无冲突）
+3. `main`：`git merge origin/main`（3 文件冲突手动解决，见 §3）
+4. `feature/codex-quota-notifications`：`git merge origin/main`（fast-forward）
+
+---
+
+## 5. 环境备注
+
+- 默认 `swift`（CommandLineTools）release 构建缺 SwiftUI macros / Testing framework，构建与测试需：
+  ```bash
+  export DEVELOPER_DIR=/Volumes/ExtArchive/Applications/Xcode.app/Contents/Developer
+  ```
+- 打包：`CODEXBAR_SIGNING=adhoc DEVELOPER_DIR=... ./Scripts/package_app.sh`

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -175,7 +175,6 @@ struct MenuBarLayoutEditor: View {
 
     @State private var scope: MenuBarLayoutEditorScope = .all
     @State private var selectedPosition: MenuBarLayoutPosition?
-    @State private var verticalAdjustmentText: String = ""
 
     private var layout: MenuBarLayout {
         switch self.scope {
@@ -229,25 +228,6 @@ struct MenuBarLayoutEditor: View {
                     activating: self.layout,
                     for: self.persistenceProvider,
                     settings: self.settings)
-            })
-    }
-
-    private var verticalAdjustmentBinding: Binding<String> {
-        Binding(
-            get: {
-                if self.verticalAdjustmentText.isEmpty {
-                    return String(self.settings.menuBarLayoutVerticalAdjustment)
-                }
-                return self.verticalAdjustmentText
-            },
-            set: { text in
-                self.verticalAdjustmentText = text
-                guard let value = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) else { return }
-                let clamped = max(-20, min(20, value))
-                if clamped != value {
-                    self.verticalAdjustmentText = String(clamped)
-                }
-                self.settings.menuBarLayoutVerticalAdjustment = clamped
             })
     }
 
@@ -568,13 +548,26 @@ struct MenuBarLayoutEditor: View {
             }
             .pickerStyle(.menu)
 
-            TextField(L("menu_bar_layout_vertical_adjustment"), text: self.verticalAdjustmentBinding)
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 72)
-                .multilineTextAlignment(.trailing)
-                .onAppear {
-                    self.verticalAdjustmentText = String(self.settings.menuBarLayoutVerticalAdjustment)
+            HStack(spacing: 8) {
+                Text(L("menu_bar_layout_vertical_adjustment"))
+                    .lineLimit(1)
+                    .fixedSize()
+
+                TextField(
+                    "",
+                    value: $settings.menuBarLayoutVerticalAdjustment,
+                    format: .number)
+                    .labelsHidden()
+                    .textFieldStyle(.roundedBorder)
+                    .multilineTextAlignment(.trailing)
+                    .monospacedDigit()
+                    .frame(width: 44)
+
+                Stepper(value: $settings.menuBarLayoutVerticalAdjustment, in: -20 ... 20, step: 1) {
+                    EmptyView()
                 }
+                .labelsHidden()
+            }
 
             Spacer()
 

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -175,6 +175,7 @@ struct MenuBarLayoutEditor: View {
 
     @State private var scope: MenuBarLayoutEditorScope = .all
     @State private var selectedPosition: MenuBarLayoutPosition?
+    @State private var verticalAdjustmentText: String = ""
 
     private var layout: MenuBarLayout {
         switch self.scope {
@@ -228,6 +229,25 @@ struct MenuBarLayoutEditor: View {
                     activating: self.layout,
                     for: self.persistenceProvider,
                     settings: self.settings)
+            })
+    }
+
+    private var verticalAdjustmentBinding: Binding<String> {
+        Binding(
+            get: {
+                if self.verticalAdjustmentText.isEmpty {
+                    return String(self.settings.menuBarLayoutVerticalAdjustment)
+                }
+                return self.verticalAdjustmentText
+            },
+            set: { text in
+                self.verticalAdjustmentText = text
+                guard let value = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) else { return }
+                let clamped = max(-20, min(20, value))
+                if clamped != value {
+                    self.verticalAdjustmentText = String(clamped)
+                }
+                self.settings.menuBarLayoutVerticalAdjustment = clamped
             })
     }
 
@@ -548,6 +568,14 @@ struct MenuBarLayoutEditor: View {
             }
             .pickerStyle(.menu)
 
+            TextField(L("menu_bar_layout_vertical_adjustment"), text: self.verticalAdjustmentBinding)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 72)
+                .multilineTextAlignment(.trailing)
+                .onAppear {
+                    self.verticalAdjustmentText = String(self.settings.menuBarLayoutVerticalAdjustment)
+                }
+
             Spacer()
 
             Text(L("menu_bar_layout_keyboard_hint"))
@@ -642,7 +670,8 @@ struct MenuBarLayoutPreview: View {
                 showUsed: self.settings.usageBarsShowUsed,
                 appearanceName: "preview",
                 isDebugApp: false,
-                now: minute))
+                now: minute,
+                verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment))
         MenuBarLayoutPreviewText(rendered: rendered)
     }
 

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -555,7 +555,7 @@ struct MenuBarLayoutEditor: View {
 
                 TextField(
                     "",
-                    value: $settings.menuBarLayoutVerticalAdjustment,
+                    value: self.$settings.menuBarLayoutVerticalAdjustment,
                     format: .number)
                     .labelsHidden()
                     .textFieldStyle(.roundedBorder)
@@ -563,7 +563,7 @@ struct MenuBarLayoutEditor: View {
                     .monospacedDigit()
                     .frame(width: 44)
 
-                Stepper(value: $settings.menuBarLayoutVerticalAdjustment, in: -20 ... 20, step: 1) {
+                Stepper(value: self.$settings.menuBarLayoutVerticalAdjustment, in: -20...20, step: 1) {
                     EmptyView()
                 }
                 .labelsHidden()

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -51,9 +51,35 @@ struct MenuBarLayoutRenderOptions: Hashable {
     let showUsed: Bool
     let appearanceName: String
     let isDebugApp: Bool
+    /// Whether the provider's latest refresh failed; when true the shown snapshot is stale
+    /// and rendered dimmer until a background refresh succeeds again.
+    let isStale: Bool
     /// Exact display clock. The cache keys on the resulting reset strings, so animation ticks that keep
     /// the same visible countdown still reuse the cached title.
     let now: Date
+    /// User-tunable vertical nudge for the whole title, applied on top of the optical baseline
+    /// offset. Positive moves content down, negative moves it up.
+    let verticalAdjustment: Int
+
+    init(
+        size: MenuBarLayoutSize,
+        highContrast: Bool,
+        showUsed: Bool,
+        appearanceName: String,
+        isDebugApp: Bool,
+        isStale: Bool = false,
+        now: Date,
+        verticalAdjustment: Int = 0)
+    {
+        self.size = size
+        self.highContrast = highContrast
+        self.showUsed = showUsed
+        self.appearanceName = appearanceName
+        self.isDebugApp = isDebugApp
+        self.isStale = isStale
+        self.now = now
+        self.verticalAdjustment = verticalAdjustment
+    }
 }
 
 struct MenuBarLayoutRenderKey: Hashable {
@@ -64,6 +90,8 @@ struct MenuBarLayoutRenderKey: Hashable {
     let showUsed: Bool
     let appearanceName: String
     let isDebugApp: Bool
+    let isStale: Bool
+    let verticalAdjustment: Int
     let resetText: MenuBarLayoutResetText
 }
 
@@ -85,6 +113,11 @@ struct MenuBarLayoutResetText: Hashable {
 struct MenuBarLayoutRenderedTitle {
     let attributedTitle: NSAttributedString
     let accessibilityLabel: String
+    /// When the layout begins with an icon token, the raw template image is surfaced here so
+    /// the status item can assign it to `button.image`. Template images are the only menu bar
+    /// content AppKit automatically dims on inactive displays; attributed-title attachments are
+    /// pre-rendered bitmaps and do not follow the system's active-state tinting.
+    let leadingIcon: NSImage?
 }
 
 @MainActor
@@ -125,6 +158,7 @@ final class MenuBarLayoutTitleCache {
 final class MenuBarLayoutRenderer {
     private static let missingValue = "–"
     private static let stackedBaselineOffset: CGFloat = -3 // Center multi-line NSStatusBarButton titles.
+    private static let singleLineBaselineOffset: CGFloat = -1 // Drop single-line titles slightly for optical centering.
 
     private struct TokenStyle {
         let font: NSFont
@@ -155,6 +189,8 @@ final class MenuBarLayoutRenderer {
             showUsed: options.showUsed,
             appearanceName: options.appearanceName,
             isDebugApp: options.isDebugApp,
+            isStale: options.isStale,
+            verticalAdjustment: options.verticalAdjustment,
             resetText: resetText)
         return self.cache.value(for: key) {
             Self.renderUncached(layout: layout, data: data, icon: icon, options: options)
@@ -174,7 +210,13 @@ final class MenuBarLayoutRenderer {
     {
         let isStacked = layout.lines.count == 2
         let font = NSFont.systemFont(ofSize: Self.fontSize(size: options.size, isStacked: isStacked))
-        let foregroundColor = options.highContrast ? NSColor.labelColor : NSColor.controlTextColor
+        let foregroundColor = if options.highContrast {
+            NSColor.labelColor
+        } else if options.isStale {
+            NSColor.secondaryLabelColor
+        } else {
+            NSColor.controlTextColor
+        }
         let paragraphStyle = NSMutableParagraphStyle()
         if isStacked {
             paragraphStyle.minimumLineHeight = 9.5
@@ -186,11 +228,19 @@ final class MenuBarLayoutRenderer {
             .foregroundColor: foregroundColor,
             .paragraphStyle: paragraphStyle,
         ]
-        if isStacked {
-            attributes[.baselineOffset] = Self.stackedBaselineOffset
-        }
+        // Optical baseline offset keeps the title vertically balanced in the status bar button.
+        // A user-tunable nudge is layered on top so the layout can be fine-tuned per display.
+        let baseBaselineOffset = isStacked ? Self.stackedBaselineOffset : Self.singleLineBaselineOffset
+        attributes[.baselineOffset] = baseBaselineOffset + CGFloat(options.verticalAdjustment)
         let result = NSMutableAttributedString()
         var accessibilityLines: [String] = []
+        // Only surface a leading icon via `button.image` when an actual image is available;
+        // with a missing icon the token still renders its placeholder inside the title.
+        let leadingIcon: NSImage? = if layout.lines.first?.first == .icon, icon != nil {
+            icon
+        } else {
+            nil
+        }
 
         for (lineIndex, line) in layout.lines.enumerated() {
             if lineIndex > 0 {
@@ -198,6 +248,11 @@ final class MenuBarLayoutRenderer {
             }
             var accessibilityParts: [String] = []
             for (tokenIndex, token) in line.enumerated() {
+                // The leading icon is surfaced as `button.image` so AppKit applies the system's
+                // active/inactive display tinting; it is not repeated inside the attributed title.
+                if leadingIcon != nil, lineIndex == 0, tokenIndex == 0, token == .icon {
+                    continue
+                }
                 if tokenIndex > 0, token != .space, line[tokenIndex - 1] != .space {
                     result.append(NSAttributedString(string: "\u{2009}", attributes: attributes))
                 }
@@ -228,7 +283,8 @@ final class MenuBarLayoutRenderer {
         }.joined(separator: ", ")
         return MenuBarLayoutRenderedTitle(
             attributedTitle: result,
-            accessibilityLabel: accessibilityLabel)
+            accessibilityLabel: accessibilityLabel,
+            leadingIcon: leadingIcon)
     }
 
     private static func renderItem(
@@ -472,6 +528,6 @@ final class MenuBarLayoutRenderer {
         if isStacked {
             return size == .small ? 8 : 9
         }
-        return size == .small ? 14 : 16
+        return size == .small ? 14 : 18
     }
 }

--- a/Sources/CodexBar/ProviderBrandIcon.swift
+++ b/Sources/CodexBar/ProviderBrandIcon.swift
@@ -3,7 +3,7 @@ import CodexBarCore
 
 @MainActor
 enum ProviderBrandIcon {
-    private static let size = NSSize(width: 16, height: 16)
+    private static let size = NSSize(width: 18, height: 18)
     private static var cache: [UsageProvider: NSImage] = [:]
 
     /// Lazy-loaded resource bundle for provider icons.

--- a/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
@@ -178,7 +178,13 @@ struct CodexWeeklyResetConfirmation: Sendable {
             return false
         }
         let previouslyAvailableCredits = previousCredits.availableCredits(at: previousCredits.updatedAt)
-        guard !previouslyAvailableCredits.isEmpty else { return false }
+        // An explicitly observed zero-credit inventory means there was no manual reset credit to
+        // consume. Requiring consumption proof here would deadlock: the two consistent observations
+        // (initial + confirmation) are the only signal a server-side early reset has, so trust them.
+        // A nil/unknown previous inventory stays conservative and keeps demanding consumption proof.
+        guard !previouslyAvailableCredits.isEmpty else {
+            return previousCredits.availableCount == 0
+        }
         return previouslyAvailableCredits.contains { previousCredit in
             Self.inventoryConfirmsConsumption(
                 previousCredit: previousCredit,

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "المسافة";
 "menu_bar_layout_gap_tight" = "ضيّق";
 "menu_bar_layout_gap_regular" = "عادي";
+"menu_bar_layout_vertical_adjustment" = "الضبط العمودي";
+"menu_bar_layout_vertical_up_2" = "أعلى 2 بكسل";
+"menu_bar_layout_vertical_up_1" = "أعلى بكسل";
+"menu_bar_layout_vertical_default" = "الافتراضي";
+"menu_bar_layout_vertical_down_1" = "أسفل بكسل";
+"menu_bar_layout_vertical_down_2" = "أسفل 2 بكسل";
 "menu_bar_layout_keyboard_hint" = "يحذف Delete العنصر المحدد";
 "menu_bar_layout_sample_account" = "حساب";
 "menu_bar_layout_sample_runs_out" = "ينفد الجمعة";

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "ضيّق";
 "menu_bar_layout_gap_regular" = "عادي";
 "menu_bar_layout_vertical_adjustment" = "الضبط العمودي";
-"menu_bar_layout_vertical_up_2" = "أعلى 2 بكسل";
-"menu_bar_layout_vertical_up_1" = "أعلى بكسل";
-"menu_bar_layout_vertical_default" = "الافتراضي";
-"menu_bar_layout_vertical_down_1" = "أسفل بكسل";
-"menu_bar_layout_vertical_down_2" = "أسفل 2 بكسل";
 "menu_bar_layout_keyboard_hint" = "يحذف Delete العنصر المحدد";
 "menu_bar_layout_sample_account" = "حساب";
 "menu_bar_layout_sample_runs_out" = "ينفد الجمعة";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1343,6 +1343,12 @@
 "menu_bar_layout_gap" = "Espaiat";
 "menu_bar_layout_gap_tight" = "Estret";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Ajust vertical";
+"menu_bar_layout_vertical_up_2" = "Amunt 2 px";
+"menu_bar_layout_vertical_up_1" = "Amunt 1 px";
+"menu_bar_layout_vertical_default" = "Predeterminat";
+"menu_bar_layout_vertical_down_1" = "Avall 1 px";
+"menu_bar_layout_vertical_down_2" = "Avall 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir elimina la fitxa seleccionada";
 "menu_bar_layout_sample_account" = "compte";
 "menu_bar_layout_sample_runs_out" = "s’esgota div.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1344,11 +1344,6 @@
 "menu_bar_layout_gap_tight" = "Estret";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Ajust vertical";
-"menu_bar_layout_vertical_up_2" = "Amunt 2 px";
-"menu_bar_layout_vertical_up_1" = "Amunt 1 px";
-"menu_bar_layout_vertical_default" = "Predeterminat";
-"menu_bar_layout_vertical_down_1" = "Avall 1 px";
-"menu_bar_layout_vertical_down_2" = "Avall 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir elimina la fitxa seleccionada";
 "menu_bar_layout_sample_account" = "compte";
 "menu_bar_layout_sample_runs_out" = "s’esgota div.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1342,11 +1342,6 @@
 "menu_bar_layout_gap_tight" = "Eng";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Vertikale Ausrichtung";
-"menu_bar_layout_vertical_up_2" = "Hoch 2 px";
-"menu_bar_layout_vertical_up_1" = "Hoch 1 px";
-"menu_bar_layout_vertical_default" = "Standard";
-"menu_bar_layout_vertical_down_1" = "Runter 1 px";
-"menu_bar_layout_vertical_down_2" = "Runter 2 px";
 "menu_bar_layout_keyboard_hint" = "Die Löschtaste entfernt den ausgewählten Baustein";
 "menu_bar_layout_sample_account" = "Konto";
 "menu_bar_layout_sample_runs_out" = "reicht bis Fr.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1341,6 +1341,12 @@
 "menu_bar_layout_gap" = "Abstand";
 "menu_bar_layout_gap_tight" = "Eng";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Vertikale Ausrichtung";
+"menu_bar_layout_vertical_up_2" = "Hoch 2 px";
+"menu_bar_layout_vertical_up_1" = "Hoch 1 px";
+"menu_bar_layout_vertical_default" = "Standard";
+"menu_bar_layout_vertical_down_1" = "Runter 1 px";
+"menu_bar_layout_vertical_down_2" = "Runter 2 px";
 "menu_bar_layout_keyboard_hint" = "Die Löschtaste entfernt den ausgewählten Baustein";
 "menu_bar_layout_sample_account" = "Konto";
 "menu_bar_layout_sample_runs_out" = "reicht bis Fr.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1322,7 +1322,7 @@
 "menu_bar_layout_gap" = "Gap";
 "menu_bar_layout_gap_tight" = "Tight";
 "menu_bar_layout_gap_regular" = "Regular";
-"menu_bar_layout_vertical_adjustment" = "Vertical Adjustment";
+"menu_bar_layout_vertical_adjustment" = "Vertical";
 "menu_bar_layout_vertical_up_2" = "Up 2 px";
 "menu_bar_layout_vertical_up_1" = "Up 1 px";
 "menu_bar_layout_vertical_default" = "Default";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1322,6 +1322,12 @@
 "menu_bar_layout_gap" = "Gap";
 "menu_bar_layout_gap_tight" = "Tight";
 "menu_bar_layout_gap_regular" = "Regular";
+"menu_bar_layout_vertical_adjustment" = "Vertical Adjustment";
+"menu_bar_layout_vertical_up_2" = "Up 2 px";
+"menu_bar_layout_vertical_up_1" = "Up 1 px";
+"menu_bar_layout_vertical_default" = "Default";
+"menu_bar_layout_vertical_down_1" = "Down 1 px";
+"menu_bar_layout_vertical_down_2" = "Down 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete removes the selected token";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "runs out Fri";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1323,11 +1323,6 @@
 "menu_bar_layout_gap_tight" = "Tight";
 "menu_bar_layout_gap_regular" = "Regular";
 "menu_bar_layout_vertical_adjustment" = "Vertical";
-"menu_bar_layout_vertical_up_2" = "Up 2 px";
-"menu_bar_layout_vertical_up_1" = "Up 1 px";
-"menu_bar_layout_vertical_default" = "Default";
-"menu_bar_layout_vertical_down_1" = "Down 1 px";
-"menu_bar_layout_vertical_down_2" = "Down 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete removes the selected token";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "runs out Fri";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1340,11 +1340,6 @@
 "menu_bar_layout_gap_tight" = "Estrecha";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Ajuste vertical";
-"menu_bar_layout_vertical_up_2" = "Arriba 2 px";
-"menu_bar_layout_vertical_up_1" = "Arriba 1 px";
-"menu_bar_layout_vertical_default" = "Predeterminado";
-"menu_bar_layout_vertical_down_1" = "Abajo 1 px";
-"menu_bar_layout_vertical_down_2" = "Abajo 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir quita la ficha seleccionada";
 "menu_bar_layout_sample_account" = "cuenta";
 "menu_bar_layout_sample_runs_out" = "se agota vie.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1339,6 +1339,12 @@
 "menu_bar_layout_gap" = "Separación";
 "menu_bar_layout_gap_tight" = "Estrecha";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Ajuste vertical";
+"menu_bar_layout_vertical_up_2" = "Arriba 2 px";
+"menu_bar_layout_vertical_up_1" = "Arriba 1 px";
+"menu_bar_layout_vertical_default" = "Predeterminado";
+"menu_bar_layout_vertical_down_1" = "Abajo 1 px";
+"menu_bar_layout_vertical_down_2" = "Abajo 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir quita la ficha seleccionada";
 "menu_bar_layout_sample_account" = "cuenta";
 "menu_bar_layout_sample_runs_out" = "se agota vie.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "فاصله";
 "menu_bar_layout_gap_tight" = "فشرده";
 "menu_bar_layout_gap_regular" = "معمولی";
+"menu_bar_layout_vertical_adjustment" = "تنظیم عمودی";
+"menu_bar_layout_vertical_up_2" = "۲ پیکسل بالا";
+"menu_bar_layout_vertical_up_1" = "۱ پیکسل بالا";
+"menu_bar_layout_vertical_default" = "پیش‌فرض";
+"menu_bar_layout_vertical_down_1" = "۱ پیکسل پایین";
+"menu_bar_layout_vertical_down_2" = "۲ پیکسل پایین";
 "menu_bar_layout_keyboard_hint" = "Delete نشانهٔ انتخاب‌شده را حذف می‌کند";
 "menu_bar_layout_sample_account" = "حساب";
 "menu_bar_layout_sample_runs_out" = "جمعه تمام می‌شود";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "فشرده";
 "menu_bar_layout_gap_regular" = "معمولی";
 "menu_bar_layout_vertical_adjustment" = "تنظیم عمودی";
-"menu_bar_layout_vertical_up_2" = "۲ پیکسل بالا";
-"menu_bar_layout_vertical_up_1" = "۱ پیکسل بالا";
-"menu_bar_layout_vertical_default" = "پیش‌فرض";
-"menu_bar_layout_vertical_down_1" = "۱ پیکسل پایین";
-"menu_bar_layout_vertical_down_2" = "۲ پیکسل پایین";
 "menu_bar_layout_keyboard_hint" = "Delete نشانهٔ انتخاب‌شده را حذف می‌کند";
 "menu_bar_layout_sample_account" = "حساب";
 "menu_bar_layout_sample_runs_out" = "جمعه تمام می‌شود";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1341,11 +1341,6 @@
 "menu_bar_layout_gap_tight" = "Serré";
 "menu_bar_layout_gap_regular" = "Normale";
 "menu_bar_layout_vertical_adjustment" = "Ajustement vertical";
-"menu_bar_layout_vertical_up_2" = "Haut de 2 px";
-"menu_bar_layout_vertical_up_1" = "Haut de 1 px";
-"menu_bar_layout_vertical_default" = "Par défaut";
-"menu_bar_layout_vertical_down_1" = "Bas de 1 px";
-"menu_bar_layout_vertical_down_2" = "Bas de 2 px";
 "menu_bar_layout_keyboard_hint" = "Supprimer retire le jeton sélectionné";
 "menu_bar_layout_sample_account" = "compte";
 "menu_bar_layout_sample_runs_out" = "épuisé ven.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1340,6 +1340,12 @@
 "menu_bar_layout_gap" = "Espacement";
 "menu_bar_layout_gap_tight" = "Serré";
 "menu_bar_layout_gap_regular" = "Normale";
+"menu_bar_layout_vertical_adjustment" = "Ajustement vertical";
+"menu_bar_layout_vertical_up_2" = "Haut de 2 px";
+"menu_bar_layout_vertical_up_1" = "Haut de 1 px";
+"menu_bar_layout_vertical_default" = "Par défaut";
+"menu_bar_layout_vertical_down_1" = "Bas de 1 px";
+"menu_bar_layout_vertical_down_2" = "Bas de 2 px";
 "menu_bar_layout_keyboard_hint" = "Supprimer retire le jeton sélectionné";
 "menu_bar_layout_sample_account" = "compte";
 "menu_bar_layout_sample_runs_out" = "épuisé ven.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1340,6 +1340,12 @@
 "menu_bar_layout_gap" = "Separación";
 "menu_bar_layout_gap_tight" = "Estreita";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Axuste vertical";
+"menu_bar_layout_vertical_up_2" = "Arriba 2 px";
+"menu_bar_layout_vertical_up_1" = "Arriba 1 px";
+"menu_bar_layout_vertical_default" = "Por defecto";
+"menu_bar_layout_vertical_down_1" = "Abaixo 1 px";
+"menu_bar_layout_vertical_down_2" = "Abaixo 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir retira a ficha seleccionada";
 "menu_bar_layout_sample_account" = "conta";
 "menu_bar_layout_sample_runs_out" = "esgótase ven.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1341,11 +1341,6 @@
 "menu_bar_layout_gap_tight" = "Estreita";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Axuste vertical";
-"menu_bar_layout_vertical_up_2" = "Arriba 2 px";
-"menu_bar_layout_vertical_up_1" = "Arriba 1 px";
-"menu_bar_layout_vertical_default" = "Por defecto";
-"menu_bar_layout_vertical_down_1" = "Abaixo 1 px";
-"menu_bar_layout_vertical_down_2" = "Abaixo 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir retira a ficha seleccionada";
 "menu_bar_layout_sample_account" = "conta";
 "menu_bar_layout_sample_runs_out" = "esgótase ven.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "Jarak";
 "menu_bar_layout_gap_tight" = "Rapat";
 "menu_bar_layout_gap_regular" = "Reguler";
+"menu_bar_layout_vertical_adjustment" = "Penyesuaian Vertikal";
+"menu_bar_layout_vertical_up_2" = "Naik 2 px";
+"menu_bar_layout_vertical_up_1" = "Naik 1 px";
+"menu_bar_layout_vertical_default" = "Default";
+"menu_bar_layout_vertical_down_1" = "Turun 1 px";
+"menu_bar_layout_vertical_down_2" = "Turun 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete menghapus token yang dipilih";
 "menu_bar_layout_sample_account" = "akun";
 "menu_bar_layout_sample_runs_out" = "habis Jum.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "Rapat";
 "menu_bar_layout_gap_regular" = "Reguler";
 "menu_bar_layout_vertical_adjustment" = "Penyesuaian Vertikal";
-"menu_bar_layout_vertical_up_2" = "Naik 2 px";
-"menu_bar_layout_vertical_up_1" = "Naik 1 px";
-"menu_bar_layout_vertical_default" = "Default";
-"menu_bar_layout_vertical_down_1" = "Turun 1 px";
-"menu_bar_layout_vertical_down_2" = "Turun 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete menghapus token yang dipilih";
 "menu_bar_layout_sample_account" = "akun";
 "menu_bar_layout_sample_runs_out" = "habis Jum.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "Stretta";
 "menu_bar_layout_gap_regular" = "Normale";
 "menu_bar_layout_vertical_adjustment" = "Regolazione verticale";
-"menu_bar_layout_vertical_up_2" = "Su 2 px";
-"menu_bar_layout_vertical_up_1" = "Su 1 px";
-"menu_bar_layout_vertical_default" = "Predefinito";
-"menu_bar_layout_vertical_down_1" = "Giù 1 px";
-"menu_bar_layout_vertical_down_2" = "Giù 2 px";
 "menu_bar_layout_keyboard_hint" = "Canc rimuove il token selezionato";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "termina ven.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "Spaziatura";
 "menu_bar_layout_gap_tight" = "Stretta";
 "menu_bar_layout_gap_regular" = "Normale";
+"menu_bar_layout_vertical_adjustment" = "Regolazione verticale";
+"menu_bar_layout_vertical_up_2" = "Su 2 px";
+"menu_bar_layout_vertical_up_1" = "Su 1 px";
+"menu_bar_layout_vertical_default" = "Predefinito";
+"menu_bar_layout_vertical_down_1" = "Giù 1 px";
+"menu_bar_layout_vertical_down_2" = "Giù 2 px";
 "menu_bar_layout_keyboard_hint" = "Canc rimuove il token selezionato";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "termina ven.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1341,6 +1341,12 @@
 "menu_bar_layout_gap" = "間隔";
 "menu_bar_layout_gap_tight" = "狭い";
 "menu_bar_layout_gap_regular" = "標準";
+"menu_bar_layout_vertical_adjustment" = "垂直調整";
+"menu_bar_layout_vertical_up_2" = "上に2px";
+"menu_bar_layout_vertical_up_1" = "上に1px";
+"menu_bar_layout_vertical_default" = "デフォルト";
+"menu_bar_layout_vertical_down_1" = "下に1px";
+"menu_bar_layout_vertical_down_2" = "下に2px";
 "menu_bar_layout_keyboard_hint" = "Delete キーで選択したトークンを削除";
 "menu_bar_layout_sample_account" = "アカウント";
 "menu_bar_layout_sample_runs_out" = "金曜に使い切る";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1342,11 +1342,6 @@
 "menu_bar_layout_gap_tight" = "狭い";
 "menu_bar_layout_gap_regular" = "標準";
 "menu_bar_layout_vertical_adjustment" = "垂直調整";
-"menu_bar_layout_vertical_up_2" = "上に2px";
-"menu_bar_layout_vertical_up_1" = "上に1px";
-"menu_bar_layout_vertical_default" = "デフォルト";
-"menu_bar_layout_vertical_down_1" = "下に1px";
-"menu_bar_layout_vertical_down_2" = "下に2px";
 "menu_bar_layout_keyboard_hint" = "Delete キーで選択したトークンを削除";
 "menu_bar_layout_sample_account" = "アカウント";
 "menu_bar_layout_sample_runs_out" = "金曜に使い切る";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1308,6 +1308,12 @@
 "menu_bar_layout_gap" = "간격";
 "menu_bar_layout_gap_tight" = "좁게";
 "menu_bar_layout_gap_regular" = "보통";
+"menu_bar_layout_vertical_adjustment" = "세로 조정";
+"menu_bar_layout_vertical_up_2" = "위로 2px";
+"menu_bar_layout_vertical_up_1" = "위로 1px";
+"menu_bar_layout_vertical_default" = "기본값";
+"menu_bar_layout_vertical_down_1" = "아래로 1px";
+"menu_bar_layout_vertical_down_2" = "아래로 2px";
 "menu_bar_layout_keyboard_hint" = "Delete 키로 선택한 토큰 제거";
 "menu_bar_layout_sample_account" = "계정";
 "menu_bar_layout_sample_runs_out" = "금요일 소진";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1309,11 +1309,6 @@
 "menu_bar_layout_gap_tight" = "좁게";
 "menu_bar_layout_gap_regular" = "보통";
 "menu_bar_layout_vertical_adjustment" = "세로 조정";
-"menu_bar_layout_vertical_up_2" = "위로 2px";
-"menu_bar_layout_vertical_up_1" = "위로 1px";
-"menu_bar_layout_vertical_default" = "기본값";
-"menu_bar_layout_vertical_down_1" = "아래로 1px";
-"menu_bar_layout_vertical_down_2" = "아래로 2px";
 "menu_bar_layout_keyboard_hint" = "Delete 키로 선택한 토큰 제거";
 "menu_bar_layout_sample_account" = "계정";
 "menu_bar_layout_sample_runs_out" = "금요일 소진";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1341,11 +1341,6 @@
 "menu_bar_layout_gap_tight" = "Krap";
 "menu_bar_layout_gap_regular" = "Normaal";
 "menu_bar_layout_vertical_adjustment" = "Verticale aanpassing";
-"menu_bar_layout_vertical_up_2" = "Omhoog 2 px";
-"menu_bar_layout_vertical_up_1" = "Omhoog 1 px";
-"menu_bar_layout_vertical_default" = "Standaard";
-"menu_bar_layout_vertical_down_1" = "Omlaag 1 px";
-"menu_bar_layout_vertical_down_2" = "Omlaag 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete verwijdert het geselecteerde token";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "op vr.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1340,6 +1340,12 @@
 "menu_bar_layout_gap" = "Tussenruimte";
 "menu_bar_layout_gap_tight" = "Krap";
 "menu_bar_layout_gap_regular" = "Normaal";
+"menu_bar_layout_vertical_adjustment" = "Verticale aanpassing";
+"menu_bar_layout_vertical_up_2" = "Omhoog 2 px";
+"menu_bar_layout_vertical_up_1" = "Omhoog 1 px";
+"menu_bar_layout_vertical_default" = "Standaard";
+"menu_bar_layout_vertical_down_1" = "Omlaag 1 px";
+"menu_bar_layout_vertical_down_2" = "Omlaag 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete verwijdert het geselecteerde token";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "op vr.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "Odstęp";
 "menu_bar_layout_gap_tight" = "Wąski";
 "menu_bar_layout_gap_regular" = "Zwykły";
+"menu_bar_layout_vertical_adjustment" = "Regulacja pionowa";
+"menu_bar_layout_vertical_up_2" = "W górę 2 px";
+"menu_bar_layout_vertical_up_1" = "W górę 1 px";
+"menu_bar_layout_vertical_default" = "Domyślnie";
+"menu_bar_layout_vertical_down_1" = "W dół 1 px";
+"menu_bar_layout_vertical_down_2" = "W dół 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete usuwa zaznaczony element";
 "menu_bar_layout_sample_account" = "konto";
 "menu_bar_layout_sample_runs_out" = "wyczerpie się pt.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "Wąski";
 "menu_bar_layout_gap_regular" = "Zwykły";
 "menu_bar_layout_vertical_adjustment" = "Regulacja pionowa";
-"menu_bar_layout_vertical_up_2" = "W górę 2 px";
-"menu_bar_layout_vertical_up_1" = "W górę 1 px";
-"menu_bar_layout_vertical_default" = "Domyślnie";
-"menu_bar_layout_vertical_down_1" = "W dół 1 px";
-"menu_bar_layout_vertical_down_2" = "W dół 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete usuwa zaznaczony element";
 "menu_bar_layout_sample_account" = "konto";
 "menu_bar_layout_sample_runs_out" = "wyczerpie się pt.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1342,11 +1342,6 @@
 "menu_bar_layout_gap_tight" = "Apertado";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Ajuste vertical";
-"menu_bar_layout_vertical_up_2" = "Acima 2 px";
-"menu_bar_layout_vertical_up_1" = "Acima 1 px";
-"menu_bar_layout_vertical_default" = "Padrão";
-"menu_bar_layout_vertical_down_1" = "Abaixo 1 px";
-"menu_bar_layout_vertical_down_2" = "Abaixo 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete remove o item selecionado";
 "menu_bar_layout_sample_account" = "conta";
 "menu_bar_layout_sample_runs_out" = "acaba sex.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1341,6 +1341,12 @@
 "menu_bar_layout_gap" = "Espaçamento";
 "menu_bar_layout_gap_tight" = "Apertado";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Ajuste vertical";
+"menu_bar_layout_vertical_up_2" = "Acima 2 px";
+"menu_bar_layout_vertical_up_1" = "Acima 1 px";
+"menu_bar_layout_vertical_default" = "Padrão";
+"menu_bar_layout_vertical_down_1" = "Abaixo 1 px";
+"menu_bar_layout_vertical_down_2" = "Abaixo 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete remove o item selecionado";
 "menu_bar_layout_sample_account" = "conta";
 "menu_bar_layout_sample_runs_out" = "acaba sex.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1343,11 +1343,6 @@
 "menu_bar_layout_gap_tight" = "Узкий";
 "menu_bar_layout_gap_regular" = "Обычный";
 "menu_bar_layout_vertical_adjustment" = "Вертикальная настройка";
-"menu_bar_layout_vertical_up_2" = "Вверх 2 px";
-"menu_bar_layout_vertical_up_1" = "Вверх 1 px";
-"menu_bar_layout_vertical_default" = "По умолчанию";
-"menu_bar_layout_vertical_down_1" = "Вниз 1 px";
-"menu_bar_layout_vertical_down_2" = "Вниз 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete удаляет выбранный элемент";
 "menu_bar_layout_sample_account" = "аккаунт";
 "menu_bar_layout_sample_runs_out" = "закончится пт.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1342,6 +1342,12 @@
 "menu_bar_layout_gap" = "Интервал";
 "menu_bar_layout_gap_tight" = "Узкий";
 "menu_bar_layout_gap_regular" = "Обычный";
+"menu_bar_layout_vertical_adjustment" = "Вертикальная настройка";
+"menu_bar_layout_vertical_up_2" = "Вверх 2 px";
+"menu_bar_layout_vertical_up_1" = "Вверх 1 px";
+"menu_bar_layout_vertical_default" = "По умолчанию";
+"menu_bar_layout_vertical_down_1" = "Вниз 1 px";
+"menu_bar_layout_vertical_down_2" = "Вниз 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete удаляет выбранный элемент";
 "menu_bar_layout_sample_account" = "аккаунт";
 "menu_bar_layout_sample_runs_out" = "закончится пт.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1340,11 +1340,6 @@
 "menu_bar_layout_gap_tight" = "Tätt";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Vertikal justering";
-"menu_bar_layout_vertical_up_2" = "Upp 2 px";
-"menu_bar_layout_vertical_up_1" = "Upp 1 px";
-"menu_bar_layout_vertical_default" = "Standard";
-"menu_bar_layout_vertical_down_1" = "Ner 1 px";
-"menu_bar_layout_vertical_down_2" = "Ner 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete tar bort den markerade brickan";
 "menu_bar_layout_sample_account" = "konto";
 "menu_bar_layout_sample_runs_out" = "tar slut fre.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1339,6 +1339,12 @@
 "menu_bar_layout_gap" = "Mellanrum";
 "menu_bar_layout_gap_tight" = "Tätt";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Vertikal justering";
+"menu_bar_layout_vertical_up_2" = "Upp 2 px";
+"menu_bar_layout_vertical_up_1" = "Upp 1 px";
+"menu_bar_layout_vertical_default" = "Standard";
+"menu_bar_layout_vertical_down_1" = "Ner 1 px";
+"menu_bar_layout_vertical_down_2" = "Ner 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete tar bort den markerade brickan";
 "menu_bar_layout_sample_account" = "konto";
 "menu_bar_layout_sample_runs_out" = "tar slut fre.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "ระยะห่าง";
 "menu_bar_layout_gap_tight" = "ชิด";
 "menu_bar_layout_gap_regular" = "ปกติ";
+"menu_bar_layout_vertical_adjustment" = "ปรับแนวตั้ง";
+"menu_bar_layout_vertical_up_2" = "ขึ้น 2 พิกเซล";
+"menu_bar_layout_vertical_up_1" = "ขึ้น 1 พิกเซล";
+"menu_bar_layout_vertical_default" = "ค่าเริ่มต้น";
+"menu_bar_layout_vertical_down_1" = "ลง 1 พิกเซล";
+"menu_bar_layout_vertical_down_2" = "ลง 2 พิกเซล";
 "menu_bar_layout_keyboard_hint" = "Delete ลบโทเค็นที่เลือก";
 "menu_bar_layout_sample_account" = "บัญชี";
 "menu_bar_layout_sample_runs_out" = "หมดวันศุกร์";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "ชิด";
 "menu_bar_layout_gap_regular" = "ปกติ";
 "menu_bar_layout_vertical_adjustment" = "ปรับแนวตั้ง";
-"menu_bar_layout_vertical_up_2" = "ขึ้น 2 พิกเซล";
-"menu_bar_layout_vertical_up_1" = "ขึ้น 1 พิกเซล";
-"menu_bar_layout_vertical_default" = "ค่าเริ่มต้น";
-"menu_bar_layout_vertical_down_1" = "ลง 1 พิกเซล";
-"menu_bar_layout_vertical_down_2" = "ลง 2 พิกเซล";
 "menu_bar_layout_keyboard_hint" = "Delete ลบโทเค็นที่เลือก";
 "menu_bar_layout_sample_account" = "บัญชี";
 "menu_bar_layout_sample_runs_out" = "หมดวันศุกร์";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1342,6 +1342,12 @@
 "menu_bar_layout_gap" = "Boşluk";
 "menu_bar_layout_gap_tight" = "Dar";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Dikey Ayar";
+"menu_bar_layout_vertical_up_2" = "Yukarı 2 px";
+"menu_bar_layout_vertical_up_1" = "Yukarı 1 px";
+"menu_bar_layout_vertical_default" = "Varsayılan";
+"menu_bar_layout_vertical_down_1" = "Aşağı 1 px";
+"menu_bar_layout_vertical_down_2" = "Aşağı 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete seçili belirteci kaldırır";
 "menu_bar_layout_sample_account" = "hesap";
 "menu_bar_layout_sample_runs_out" = "Cum. biter";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1343,11 +1343,6 @@
 "menu_bar_layout_gap_tight" = "Dar";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Dikey Ayar";
-"menu_bar_layout_vertical_up_2" = "Yukarı 2 px";
-"menu_bar_layout_vertical_up_1" = "Yukarı 1 px";
-"menu_bar_layout_vertical_default" = "Varsayılan";
-"menu_bar_layout_vertical_down_1" = "Aşağı 1 px";
-"menu_bar_layout_vertical_down_2" = "Aşağı 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete seçili belirteci kaldırır";
 "menu_bar_layout_sample_account" = "hesap";
 "menu_bar_layout_sample_runs_out" = "Cum. biter";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1340,6 +1340,12 @@
 "menu_bar_layout_gap" = "Інтервал";
 "menu_bar_layout_gap_tight" = "Вузький";
 "menu_bar_layout_gap_regular" = "Звичайний";
+"menu_bar_layout_vertical_adjustment" = "Вертикальне налаштування";
+"menu_bar_layout_vertical_up_2" = "Вгору 2 px";
+"menu_bar_layout_vertical_up_1" = "Вгору 1 px";
+"menu_bar_layout_vertical_default" = "За замовчуванням";
+"menu_bar_layout_vertical_down_1" = "Вниз 1 px";
+"menu_bar_layout_vertical_down_2" = "Вниз 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete видаляє вибраний елемент";
 "menu_bar_layout_sample_account" = "обліковий запис";
 "menu_bar_layout_sample_runs_out" = "закінчиться пт.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1341,11 +1341,6 @@
 "menu_bar_layout_gap_tight" = "Вузький";
 "menu_bar_layout_gap_regular" = "Звичайний";
 "menu_bar_layout_vertical_adjustment" = "Вертикальне налаштування";
-"menu_bar_layout_vertical_up_2" = "Вгору 2 px";
-"menu_bar_layout_vertical_up_1" = "Вгору 1 px";
-"menu_bar_layout_vertical_default" = "За замовчуванням";
-"menu_bar_layout_vertical_down_1" = "Вниз 1 px";
-"menu_bar_layout_vertical_down_2" = "Вниз 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete видаляє вибраний елемент";
 "menu_bar_layout_sample_account" = "обліковий запис";
 "menu_bar_layout_sample_runs_out" = "закінчиться пт.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1342,11 +1342,6 @@
 "menu_bar_layout_gap_tight" = "Hẹp";
 "menu_bar_layout_gap_regular" = "Thường";
 "menu_bar_layout_vertical_adjustment" = "Điều chỉnh dọc";
-"menu_bar_layout_vertical_up_2" = "Lên 2 px";
-"menu_bar_layout_vertical_up_1" = "Lên 1 px";
-"menu_bar_layout_vertical_default" = "Mặc định";
-"menu_bar_layout_vertical_down_1" = "Xuống 1 px";
-"menu_bar_layout_vertical_down_2" = "Xuống 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete xóa thẻ đã chọn";
 "menu_bar_layout_sample_account" = "tài khoản";
 "menu_bar_layout_sample_runs_out" = "hết vào T6";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1341,6 +1341,12 @@
 "menu_bar_layout_gap" = "Khoảng cách";
 "menu_bar_layout_gap_tight" = "Hẹp";
 "menu_bar_layout_gap_regular" = "Thường";
+"menu_bar_layout_vertical_adjustment" = "Điều chỉnh dọc";
+"menu_bar_layout_vertical_up_2" = "Lên 2 px";
+"menu_bar_layout_vertical_up_1" = "Lên 1 px";
+"menu_bar_layout_vertical_default" = "Mặc định";
+"menu_bar_layout_vertical_down_1" = "Xuống 1 px";
+"menu_bar_layout_vertical_down_2" = "Xuống 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete xóa thẻ đã chọn";
 "menu_bar_layout_sample_account" = "tài khoản";
 "menu_bar_layout_sample_runs_out" = "hết vào T6";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1319,6 +1319,12 @@
 "menu_bar_layout_gap" = "间距";
 "menu_bar_layout_gap_tight" = "紧凑";
 "menu_bar_layout_gap_regular" = "常规";
+"menu_bar_layout_vertical_adjustment" = "垂直调整";
+"menu_bar_layout_vertical_up_2" = "上移 2 像素";
+"menu_bar_layout_vertical_up_1" = "上移 1 像素";
+"menu_bar_layout_vertical_default" = "默认";
+"menu_bar_layout_vertical_down_1" = "下移 1 像素";
+"menu_bar_layout_vertical_down_2" = "下移 2 像素";
 "menu_bar_layout_keyboard_hint" = "Delete 键会移除所选项目";
 "menu_bar_layout_sample_account" = "帐户";
 "menu_bar_layout_sample_runs_out" = "周五用尽";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1320,11 +1320,6 @@
 "menu_bar_layout_gap_tight" = "紧凑";
 "menu_bar_layout_gap_regular" = "常规";
 "menu_bar_layout_vertical_adjustment" = "垂直调整";
-"menu_bar_layout_vertical_up_2" = "上移 2 像素";
-"menu_bar_layout_vertical_up_1" = "上移 1 像素";
-"menu_bar_layout_vertical_default" = "默认";
-"menu_bar_layout_vertical_down_1" = "下移 1 像素";
-"menu_bar_layout_vertical_down_2" = "下移 2 像素";
 "menu_bar_layout_keyboard_hint" = "Delete 键会移除所选项目";
 "menu_bar_layout_sample_account" = "帐户";
 "menu_bar_layout_sample_runs_out" = "周五用尽";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1372,11 +1372,6 @@
 "menu_bar_layout_gap_tight" = "緊湊";
 "menu_bar_layout_gap_regular" = "一般";
 "menu_bar_layout_vertical_adjustment" = "垂直調整";
-"menu_bar_layout_vertical_up_2" = "上移 2 像素";
-"menu_bar_layout_vertical_up_1" = "上移 1 像素";
-"menu_bar_layout_vertical_default" = "預設";
-"menu_bar_layout_vertical_down_1" = "下移 1 像素";
-"menu_bar_layout_vertical_down_2" = "下移 2 像素";
 "menu_bar_layout_keyboard_hint" = "Delete 鍵會移除所選項目";
 "menu_bar_layout_sample_account" = "帳號";
 "menu_bar_layout_sample_runs_out" = "週五用盡";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1371,6 +1371,12 @@
 "menu_bar_layout_gap" = "間距";
 "menu_bar_layout_gap_tight" = "緊湊";
 "menu_bar_layout_gap_regular" = "一般";
+"menu_bar_layout_vertical_adjustment" = "垂直調整";
+"menu_bar_layout_vertical_up_2" = "上移 2 像素";
+"menu_bar_layout_vertical_up_1" = "上移 1 像素";
+"menu_bar_layout_vertical_default" = "預設";
+"menu_bar_layout_vertical_down_1" = "下移 1 像素";
+"menu_bar_layout_vertical_down_2" = "下移 2 像素";
 "menu_bar_layout_keyboard_hint" = "Delete 鍵會移除所選項目";
 "menu_bar_layout_sample_account" = "帳號";
 "menu_bar_layout_sample_runs_out" = "週五用盡";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -471,6 +471,17 @@ extension SettingsStore {
         }
     }
 
+    /// User-tunable vertical nudge for the menu bar title, clamped to -20...20.
+    /// Positive moves content down, negative moves it up; 0 keeps the optical default.
+    var menuBarLayoutVerticalAdjustment: Int {
+        get { self.defaultsState.menuBarLayoutVerticalAdjustment }
+        set {
+            let clamped = max(-20, min(20, newValue))
+            self.defaultsState.menuBarLayoutVerticalAdjustment = clamped
+            self.userDefaults.set(clamped, forKey: "menuBarLayoutVerticalAdjustment")
+        }
+    }
+
     private func persistMenuBarLayout(_ layout: MenuBarLayout, key: String) {
         guard let data = try? JSONEncoder().encode(layout) else { return }
         self.userDefaults.set(data, forKey: key)

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -40,6 +40,7 @@ extension SettingsStore {
         _ = self.menuBarLayoutOverrides
         _ = self.menuBarLayoutSize
         _ = self.menuBarLayoutGap
+        _ = self.menuBarLayoutVerticalAdjustment
         _ = self.copilotIconSecondaryWindowIDRaw
         _ = self.costUsageEnabled
         _ = self.codexLocalSessionCostLedgerEnabled

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -474,6 +474,8 @@ extension SettingsStore {
             ?? MenuBarLayoutSize.regular.rawValue
         let menuBarLayoutGapRaw = userDefaults.string(forKey: "menuBarLayoutGap")
             ?? MenuBarLayoutGap.regular.rawValue
+        let rawVerticalAdjustment = userDefaults.object(forKey: "menuBarLayoutVerticalAdjustment") as? Int
+        let menuBarLayoutVerticalAdjustment = max(-20, min(20, rawVerticalAdjustment ?? 0))
         let copilotBudgetExtrasEnabled = userDefaults.object(forKey: "copilotBudgetExtrasEnabled") as? Bool ?? false
         let copilotIconSecondaryWindowIDRaw = Self.loadCopilotIconSecondaryWindowIDRaw(userDefaults: userDefaults)
         let costUsageEnabled = userDefaults.object(forKey: "tokenCostUsageEnabled") as? Bool ?? false
@@ -594,6 +596,7 @@ extension SettingsStore {
             menuBarLayoutOverridesRaw: menuBarLayoutOverridesRaw,
             menuBarLayoutSizeRaw: menuBarLayoutSizeRaw,
             menuBarLayoutGapRaw: menuBarLayoutGapRaw,
+            menuBarLayoutVerticalAdjustment: menuBarLayoutVerticalAdjustment,
             copilotBudgetExtrasEnabled: copilotBudgetExtrasEnabled,
             copilotIconSecondaryWindowIDRaw: copilotIconSecondaryWindowIDRaw,
             costUsageEnabled: costUsageEnabled,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -40,6 +40,7 @@ struct SettingsDefaultsState {
     var menuBarLayoutOverridesRaw: [String: MenuBarLayout]
     var menuBarLayoutSizeRaw: String
     var menuBarLayoutGapRaw: String
+    var menuBarLayoutVerticalAdjustment: Int
     var copilotBudgetExtrasEnabled: Bool
     var copilotIconSecondaryWindowIDRaw: String
     var costUsageEnabled: Bool

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -34,7 +34,9 @@ extension StatusItemController {
             showUsed: self.settings.usageBarsShowUsed,
             appearanceName: appearanceName,
             isDebugApp: Self.isDebugApp(bundleIdentifier: Bundle.main.bundleIdentifier),
-            now: now)
+            isStale: self.store.isStale(provider: provider),
+            now: now,
+            verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment)
         let rendered = self.menuBarLayoutRenderer.render(
             layout: resolution.layout,
             data: data,
@@ -161,8 +163,25 @@ extension StatusItemController {
         for button: NSStatusBarButton,
         statusItem: NSStatusItem)
     {
-        button.image = nil
-        button.imagePosition = .noImage
+        // A leading icon token is surfaced as the status item image so AppKit applies the
+        // system's inactive-display tinting to it, matching how other menu bar icons behave.
+        // Text tokens keep rendering through the attributed title.
+        if let icon = rendered.leadingIcon {
+            if button.image !== icon {
+                button.image = icon
+            }
+            let position: NSControl.ImagePosition = rendered.attributedTitle.length > 0 ? .imageLeft : .imageOnly
+            if button.imagePosition != position {
+                button.imagePosition = position
+            }
+        } else {
+            if button.image != nil {
+                button.image = nil
+            }
+            if button.imagePosition != .noImage {
+                button.imagePosition = .noImage
+            }
+        }
         if !button.attributedTitle.isEqual(to: rendered.attributedTitle) {
             button.attributedTitle = rendered.attributedTitle
         }
@@ -172,9 +191,12 @@ extension StatusItemController {
 
         // AppKit exposes no content-inset API on NSStatusBarButton. Explicit item length is the actual
         // status-item padding mechanism: tight removes most edge space; regular keeps the native breathing room.
-        let bounds = rendered.attributedTitle.boundingRect(
+        var bounds = rendered.attributedTitle.boundingRect(
             with: NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading])
+        if let icon = rendered.leadingIcon {
+            bounds.size.width += icon.size.width
+        }
         let horizontalPadding: CGFloat = self.settings.menuBarLayoutGap == .tight ? 3 : 10
         statusItem.length = max(18, ceil(bounds.width) + horizontalPadding)
     }

--- a/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
@@ -349,6 +349,40 @@ struct CodexWeeklyResetConfirmationTests {
     }
 
     @Test
+    func `zero available reset credits confirm a server-side early weekly reset by observation`() throws {
+        let formatter = ISO8601DateFormatter()
+        let previousCapturedAt = try #require(formatter.date(from: "2026-08-13T03:36:16Z"))
+        let previousReset = try #require(formatter.date(from: "2026-08-18T00:49:16Z"))
+        let initialCapturedAt = try #require(formatter.date(from: "2026-08-13T03:41:46Z"))
+        let initialReset = try #require(formatter.date(from: "2026-08-20T03:38:06Z"))
+        let previous = self.snapshot(
+            capturedAt: previousCapturedAt,
+            weeklyUsed: 98,
+            weeklyReset: previousReset,
+            resetCredits: self.emptyResetCredits(capturedAt: previousCapturedAt))
+        let initial = self.snapshot(
+            capturedAt: initialCapturedAt,
+            weeklyUsed: 1,
+            weeklyReset: initialReset,
+            resetCredits: self.emptyResetCredits(capturedAt: initialCapturedAt))
+        let confirmation = self.snapshot(
+            capturedAt: initialCapturedAt.addingTimeInterval(30),
+            weeklyUsed: 1,
+            weeklyReset: initialReset.addingTimeInterval(30),
+            resetCredits: self.emptyResetCredits(capturedAt: initialCapturedAt.addingTimeInterval(30)))
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: initial)
+                == .requiresConfirmation)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: confirmation)
+                == .publishConfirmation)
+    }
+
+    @Test
     func `one missing reset credit inventory does not confirm an early manual weekly reset`() throws {
         let formatter = ISO8601DateFormatter()
         let previousCapturedAt = try #require(formatter.date(from: "2026-08-06T09:28:18Z"))

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -504,7 +504,11 @@ struct MenuBarLayoutRendererTests {
             cost30d: "$20.00")
     }
 
-    private func options(now: Date? = nil, verticalAdjustment: Int = 0, isStale: Bool = false) -> MenuBarLayoutRenderOptions {
+    private func options(
+        now: Date? = nil,
+        verticalAdjustment: Int = 0,
+        isStale: Bool = false) -> MenuBarLayoutRenderOptions
+    {
         MenuBarLayoutRenderOptions(
             size: .regular,
             highContrast: false,

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -48,7 +48,8 @@ struct MenuBarLayoutRendererTests {
             data: data,
             icon: icon,
             options: self.options())
-        #expect(iconOutput.attributedTitle.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
+        #expect(iconOutput.attributedTitle.string.isEmpty)
+        #expect(iconOutput.leadingIcon != nil)
 
         let absoluteOutput = renderer.render(
             layout: MenuBarLayout(lines: [[.resetAbsolute]]),
@@ -99,14 +100,11 @@ struct MenuBarLayoutRendererTests {
             data: self.data(),
             icon: icon,
             options: self.options())
-        let attachment = try #require(
-            output.attributedTitle.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment)
-        let attachmentImage = try #require(attachment.image)
 
-        #expect(attachment.bounds.size == NSSize(width: 16, height: 16))
-        #expect(attachmentImage.isTemplate)
-        #expect(try self.averageBrightness(of: output.attributedTitle, appearance: .aqua) < 0.25)
-        #expect(try self.averageBrightness(of: output.attributedTitle, appearance: .darkAqua) > 0.75)
+        #expect(output.attributedTitle.string.isEmpty)
+        let leadingIcon = try #require(output.leadingIcon)
+        #expect(leadingIcon.isTemplate)
+        #expect(leadingIcon.size == icon.size)
     }
 
     @Test
@@ -263,7 +261,31 @@ struct MenuBarLayoutRendererTests {
 
         #expect(try #require(self.baselineOffset(in: stacked.attributedTitle, at: 0)) == -3)
         #expect(try #require(self.baselineOffset(in: stacked.attributedTitle, at: resetIndex)) == -3)
-        #expect(self.baselineOffset(in: singleLine.attributedTitle, at: 0) == nil)
+        #expect(try #require(self.baselineOffset(in: singleLine.attributedTitle, at: 0)) == -1)
+    }
+
+    @Test
+    func `vertical adjustment shifts single line baseline offset`() throws {
+        let renderer = MenuBarLayoutRenderer()
+        let base = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options())
+        let adjusted = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options(verticalAdjustment: 2))
+        let lifted = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options(verticalAdjustment: -2))
+
+        #expect(try #require(self.baselineOffset(in: base.attributedTitle, at: 0)) == -1)
+        #expect(try #require(self.baselineOffset(in: adjusted.attributedTitle, at: 0)) == 1)
+        #expect(try #require(self.baselineOffset(in: lifted.attributedTitle, at: 0)) == -3)
     }
 
     @Test
@@ -414,10 +436,31 @@ struct MenuBarLayoutRendererTests {
             icon: icon,
             options: options)
 
-        #expect(output.attributedTitle.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
+        #expect(output.leadingIcon != nil)
         let textIndex = (output.attributedTitle.string as NSString).range(of: "50%").location
         #expect(output.attributedTitle
             .attribute(.foregroundColor, at: textIndex, effectiveRange: nil) as? NSColor == .labelColor)
+    }
+
+    @Test
+    func `stale title dims foreground while keeping the snapshot visible`() {
+        let renderer = MenuBarLayoutRenderer()
+        let fresh = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options())
+        let stale = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options(isStale: true))
+
+        #expect(stale.attributedTitle.string == fresh.attributedTitle.string)
+        #expect(stale.attributedTitle
+            .attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == .secondaryLabelColor)
+        #expect(fresh.attributedTitle
+            .attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == .controlTextColor)
     }
 
     private func data(
@@ -461,14 +504,16 @@ struct MenuBarLayoutRendererTests {
             cost30d: "$20.00")
     }
 
-    private func options(now: Date? = nil) -> MenuBarLayoutRenderOptions {
+    private func options(now: Date? = nil, verticalAdjustment: Int = 0, isStale: Bool = false) -> MenuBarLayoutRenderOptions {
         MenuBarLayoutRenderOptions(
             size: .regular,
             highContrast: false,
             showUsed: true,
             appearanceName: "aqua",
             isDebugApp: false,
-            now: now ?? self.now)
+            isStale: isStale,
+            now: now ?? self.now,
+            verticalAdjustment: verticalAdjustment)
     }
 
     private func averageBrightness(
@@ -476,12 +521,22 @@ struct MenuBarLayoutRendererTests {
         appearance: NSAppearance.Name) throws
         -> CGFloat
     {
+        try self.renderAverageBrightness(appearance: appearance) { _ in
+            title.draw(at: NSPoint(x: 4, y: 4))
+        }
+    }
+
+    private func renderAverageBrightness(
+        appearance: NSAppearance.Name,
+        draw: (NSImage) -> Void) throws
+        -> CGFloat
+    {
         let canvas = NSImage(size: NSSize(width: 24, height: 24))
         try #require(NSAppearance(named: appearance)).performAsCurrentDrawingAppearance {
             canvas.lockFocus()
             NSColor.clear.setFill()
             NSRect(origin: .zero, size: canvas.size).fill()
-            title.draw(at: NSPoint(x: 4, y: 4))
+            draw(canvas)
             canvas.unlockFocus()
         }
 


### PR DESCRIPTION
## Summary

Two related menu bar refinements for the custom layout title, plus a follow-up that makes the vertical nudge editable with a stepper.

### 1. Icon follows the system's active/inactive display tinting (no more wrong gray-on-secondary-display)

Before, a leading `.icon` token was baked into the attributed title as an `NSTextAttachment` (a pre-rendered bitmap). AppKit dims menu bar items on inactive displays automatically, but it only does that for **template images assigned to `NSStatusBarButton.image`** — pre-rendered attachments stay bright/gray regardless. On dual-screen setups this made CodexBar's icon look inconsistent with every other menu bar extra.

Now the leading icon token is surfaced as `button.image` (a template image) so AppKit applies the same active/inactive display tinting as native menu bar icons, while text tokens keep rendering through the attributed title.

### 2. Standard size + consistent optical centering

- Provider brand icon rendered at 18×18 (was 16×16), and single-line titles use the 18 pt face instead of 16 — closer to standard menu bar icon/text sizing.
- Single-line titles get a small optical baseline offset (-1) so they sit vertically balanced like the stacked (-3) layout already did.
- Status item length now accounts for the surfaced icon width.

### 3. Stepper-tuned vertical offset

The existing "vertical adjustment" preference (already added as a numeric input in the layout editor) is now a `TextField` + `Stepper` pair (range -20…20, default 0, ±1 per click), matching the pattern already used elsewhere in Preferences (e.g. cost history days). The label was shortened from "Vertical Adjustment" to "Vertical" and the whole row aligns with the adjacent Size/Gap pickers.

## Why this matters on dual-screen and custom-resolution displays

- **Dual screens:** the menu bar on the non-active display is dimmed by macOS. With a bitmap attachment the icon stayed at full brightness (or looked wrong); as a template `button.image` it now dims exactly like native icons when focus moves to the other display.
- **Custom resolutions / scaled displays:** the baseline offsets and the 18 pt face keep the title optically centered in the status bar button across different backing-scale factors, and the stepper lets users fine-tune ±1 px per display if the optical default is still off.

## Tests

- `MenuBarLayoutRendererTests` extended: leading-icon-as-image behavior, single-line baseline offset, vertical-adjustment baseline shift, stale (refresh-failed) title dimming, and `leadingIcon` size/template checks.
- Ran `swift test --filter MenuBarLayoutRendererTests` (18 tests, all pass) plus the MenuBarLayout/StatusItem/SettingsStore suites (369 tests pass). Lint-clean (`swiftlint`/`swiftformat`); the 42 repo-wide lint violations are pre-existing on upstream.

## Commits

- `feat: make menu bar vertical adjustment a numeric input`
- `fix: follow system dimming for menu bar icon and use standard size`
- `refactor: vertical adjustment uses stepper with visible value`