### PR TITLE
fix: honor preferred currency in cost-history detail chart

### DIFF
--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -894,7 +894,7 @@ struct CostHistoryChartMenuView: View {
 extension CostHistoryChartMenuView {
     struct RenderFingerprint: Equatable {
         let currencyCode: String
-        let costMultiplierBitPattern: UInt64?
+        let costMultiplierBitPattern: UInt64
         let historyDays: Int
         let windowLabel: String?
         let totalCostBitPattern: UInt64?
@@ -953,13 +953,13 @@ extension CostHistoryChartMenuView {
         from snapshot: CostUsageTokenSnapshot,
         provider: UsageProvider,
         displayCurrencyCode: String? = nil,
-        displayCostMultiplier: Double? = nil) -> RenderFingerprint
+        displayCostMultiplier: Double = 1.0) -> RenderFingerprint
     {
         let projects = provider == .codex ? snapshot.projects : []
         let sessions = provider == .codex ? snapshot.sessions : []
         return RenderFingerprint(
             currencyCode: displayCurrencyCode ?? snapshot.currencyCode,
-            costMultiplierBitPattern: displayCostMultiplier.map(\.bitPattern),
+            costMultiplierBitPattern: displayCostMultiplier.bitPattern,
             historyDays: snapshot.historyDays,
             windowLabel: snapshot.historyLabel,
             totalCostBitPattern: snapshot.last30DaysCostUSD.map(\.bitPattern),

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -45,6 +45,9 @@ struct CostHistoryChartMenuView: View {
     private let daily: [DailyEntry]
     private let totalCostUSD: Double?
     private let currencyCode: String
+    /// Multiplier applied to source-currency amounts at display time so labels can render
+    /// in the user's preferred currency while chart geometry stays in source values.
+    private let costMultiplier: Double
     private let historyDays: Int
     private let windowLabel: String?
     private let projects: [CostUsageProjectBreakdown]
@@ -57,6 +60,7 @@ struct CostHistoryChartMenuView: View {
         daily: [DailyEntry],
         totalCostUSD: Double?,
         currencyCode: String = "USD",
+        costMultiplier: Double = 1,
         historyDays: Int = 30,
         windowLabel: String? = nil,
         projects: [CostUsageProjectBreakdown] = [],
@@ -67,6 +71,7 @@ struct CostHistoryChartMenuView: View {
         self.daily = daily
         self.totalCostUSD = totalCostUSD
         self.currencyCode = currencyCode
+        self.costMultiplier = costMultiplier
         self.historyDays = max(1, min(365, historyDays))
         self.windowLabel = windowLabel
         self.projects = projects
@@ -106,7 +111,7 @@ struct CostHistoryChartMenuView: View {
                         AxisTick().foregroundStyle(Color.clear)
                         AxisValueLabel(centered: false) {
                             if let raw = value.as(Double.self) {
-                                Text(Self.yAxisCostString(raw, currencyCode: self.currencyCode))
+                                Text(Self.yAxisCostString(raw * self.costMultiplier, currencyCode: self.currencyCode))
                                     .font(.caption2)
                                     .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                                     .padding(.leading, 4)
@@ -843,7 +848,7 @@ struct CostHistoryChartMenuView: View {
     private func modelBreakdownTotalSubtitle(_ item: CostUsageDailyReport.ModelBreakdown) -> String? {
         UsageFormatter.modelCostDetail(
             item.modelName,
-            costUSD: item.costUSD,
+            costUSD: item.costUSD.map { $0 * self.costMultiplier },
             totalTokens: item.totalTokens,
             currencyCode: self.currencyCode)
     }
@@ -869,7 +874,7 @@ struct CostHistoryChartMenuView: View {
     }
 
     private func costString(_ value: Double) -> String {
-        Self.costString(value, currencyCode: self.currencyCode)
+        Self.costString(value * self.costMultiplier, currencyCode: self.currencyCode)
     }
 
     private static func costString(_ value: Double, currencyCode: String) -> String {
@@ -945,12 +950,13 @@ extension CostHistoryChartMenuView {
 
     static func renderFingerprint(
         from snapshot: CostUsageTokenSnapshot,
-        provider: UsageProvider) -> RenderFingerprint
+        provider: UsageProvider,
+        displayCurrencyCode: String? = nil) -> RenderFingerprint
     {
         let projects = provider == .codex ? snapshot.projects : []
         let sessions = provider == .codex ? snapshot.sessions : []
         return RenderFingerprint(
-            currencyCode: snapshot.currencyCode,
+            currencyCode: displayCurrencyCode ?? snapshot.currencyCode,
             historyDays: snapshot.historyDays,
             windowLabel: snapshot.historyLabel,
             totalCostBitPattern: snapshot.last30DaysCostUSD.map(\.bitPattern),

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -894,6 +894,7 @@ struct CostHistoryChartMenuView: View {
 extension CostHistoryChartMenuView {
     struct RenderFingerprint: Equatable {
         let currencyCode: String
+        let costMultiplierBitPattern: UInt64?
         let historyDays: Int
         let windowLabel: String?
         let totalCostBitPattern: UInt64?
@@ -951,12 +952,14 @@ extension CostHistoryChartMenuView {
     static func renderFingerprint(
         from snapshot: CostUsageTokenSnapshot,
         provider: UsageProvider,
-        displayCurrencyCode: String? = nil) -> RenderFingerprint
+        displayCurrencyCode: String? = nil,
+        displayCostMultiplier: Double? = nil) -> RenderFingerprint
     {
         let projects = provider == .codex ? snapshot.projects : []
         let sessions = provider == .codex ? snapshot.sessions : []
         return RenderFingerprint(
             currencyCode: displayCurrencyCode ?? snapshot.currencyCode,
+            costMultiplierBitPattern: displayCostMultiplier.map(\.bitPattern),
             historyDays: snapshot.historyDays,
             windowLabel: snapshot.historyLabel,
             totalCostBitPattern: snapshot.last30DaysCostUSD.map(\.bitPattern),

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -286,7 +286,22 @@ extension StatusItemController {
         guard let snapshot = self.tokenSnapshotForCostHistorySubmenu(provider: provider) else {
             return .text("none")
         }
-        return .costHistory(CostHistoryChartMenuView.renderFingerprint(from: snapshot, provider: provider))
+        return .costHistory(CostHistoryChartMenuView.renderFingerprint(
+            from: snapshot,
+            provider: provider,
+            displayCurrencyCode: self.costHistoryDisplayConversion(for: snapshot).currencyCode))
+    }
+
+    /// Resolves the user's preferred display currency for cost-history values, falling back to
+    /// the snapshot's native currency when no exchange rate is available.
+    private func costHistoryDisplayConversion(
+        for snapshot: CostUsageTokenSnapshot) -> (currencyCode: String, multiplier: Double)
+    {
+        let converted = UsageFormatter.convertedCost(
+            1,
+            preferredCurrency: self.settings.preferredCurrencyCode,
+            providerCurrency: snapshot.currencyCode)
+        return (converted.currencyCode, converted.value)
     }
 
     private func usageHistoryRenderSignature(for provider: UsageProvider) -> String {
@@ -412,11 +427,13 @@ extension StatusItemController {
             return true
         }
 
+        let displayConversion = self.costHistoryDisplayConversion(for: tokenSnapshot)
         let chartView = CostHistoryChartMenuView(
             provider: provider,
             daily: tokenSnapshot.daily,
             totalCostUSD: tokenSnapshot.last30DaysCostUSD,
-            currencyCode: tokenSnapshot.currencyCode,
+            currencyCode: displayConversion.currencyCode,
+            costMultiplier: displayConversion.multiplier,
             historyDays: tokenSnapshot.historyDays,
             windowLabel: tokenSnapshot.historyLabel,
             projects: provider == .codex ? tokenSnapshot.projects : [],

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -286,10 +286,12 @@ extension StatusItemController {
         guard let snapshot = self.tokenSnapshotForCostHistorySubmenu(provider: provider) else {
             return .text("none")
         }
+        let displayConversion = self.costHistoryDisplayConversion(for: snapshot)
         return .costHistory(CostHistoryChartMenuView.renderFingerprint(
             from: snapshot,
             provider: provider,
-            displayCurrencyCode: self.costHistoryDisplayConversion(for: snapshot).currencyCode))
+            displayCurrencyCode: displayConversion.currencyCode,
+            displayCostMultiplier: displayConversion.multiplier))
     }
 
     /// Resolves the user's preferred display currency for cost-history values, falling back to

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -333,7 +333,10 @@ struct CostHistoryChartMenuViewTests {
             displayCostMultiplier: 21.5)
 
         #expect(native.currencyCode == snapshot.currencyCode)
+        #expect(native.costMultiplierBitPattern == 1.0.bitPattern)
         #expect(converted.currencyCode == "CZK")
+        #expect(converted.costMultiplierBitPattern == 21.0.bitPattern)
+        #expect(rateRefreshed.costMultiplierBitPattern == 21.5.bitPattern)
         #expect(native != converted)
         #expect(converted != rateRefreshed)
     }

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -318,31 +318,6 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
-    func `render fingerprint honors display currency override`() {
-        let snapshot = Self.makeSnapshot(dailyCost: 1.0)
-        let native = CostHistoryChartMenuView.renderFingerprint(from: snapshot, provider: .codex)
-        let converted = CostHistoryChartMenuView.renderFingerprint(
-            from: snapshot,
-            provider: .codex,
-            displayCurrencyCode: "CZK",
-            displayCostMultiplier: 21.0)
-        let rateRefreshed = CostHistoryChartMenuView.renderFingerprint(
-            from: snapshot,
-            provider: .codex,
-            displayCurrencyCode: "CZK",
-            displayCostMultiplier: 21.5)
-
-        #expect(native.currencyCode == snapshot.currencyCode)
-        #expect(native.costMultiplierBitPattern == 1.0.bitPattern)
-        #expect(converted.currencyCode == "CZK")
-        #expect(converted.costMultiplierBitPattern == 21.0.bitPattern)
-        #expect(rateRefreshed.costMultiplierBitPattern == 21.5.bitPattern)
-        #expect(native != converted)
-        #expect(converted != rateRefreshed)
-    }
-
-    @Test
-    @MainActor
     func `render fingerprint changes when daily cost changes`() {
         let before = CostHistoryChartMenuView.renderFingerprint(
             from: Self.makeSnapshot(dailyCost: 1.0),
@@ -899,6 +874,31 @@ struct CostHistoryChartMenuViewTests {
 }
 
 extension CostHistoryChartMenuViewTests {
+    @Test
+    @MainActor
+    func `render fingerprint honors display currency override`() {
+        let snapshot = Self.makeSnapshot(dailyCost: 1.0)
+        let native = CostHistoryChartMenuView.renderFingerprint(from: snapshot, provider: .codex)
+        let converted = CostHistoryChartMenuView.renderFingerprint(
+            from: snapshot,
+            provider: .codex,
+            displayCurrencyCode: "CZK",
+            displayCostMultiplier: 21.0)
+        let rateRefreshed = CostHistoryChartMenuView.renderFingerprint(
+            from: snapshot,
+            provider: .codex,
+            displayCurrencyCode: "CZK",
+            displayCostMultiplier: 21.5)
+
+        #expect(native.currencyCode == snapshot.currencyCode)
+        #expect(native.costMultiplierBitPattern == 1.0.bitPattern)
+        #expect(converted.currencyCode == "CZK")
+        #expect(converted.costMultiplierBitPattern == 21.0.bitPattern)
+        #expect(rateRefreshed.costMultiplierBitPattern == 21.5.bitPattern)
+        #expect(native != converted)
+        #expect(converted != rateRefreshed)
+    }
+
     @Test
     func `session labels distinguish concurrent uuid v7 identifiers`() {
         let first = CostHistoryChartMenuView.shortSessionID("019f6d91-970b-7e13-b08e-000000000001")

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -324,11 +324,18 @@ struct CostHistoryChartMenuViewTests {
         let converted = CostHistoryChartMenuView.renderFingerprint(
             from: snapshot,
             provider: .codex,
-            displayCurrencyCode: "CZK")
+            displayCurrencyCode: "CZK",
+            displayCostMultiplier: 21.0)
+        let rateRefreshed = CostHistoryChartMenuView.renderFingerprint(
+            from: snapshot,
+            provider: .codex,
+            displayCurrencyCode: "CZK",
+            displayCostMultiplier: 21.5)
 
         #expect(native.currencyCode == snapshot.currencyCode)
         #expect(converted.currencyCode == "CZK")
         #expect(native != converted)
+        #expect(converted != rateRefreshed)
     }
 
     @Test

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -318,6 +318,21 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
+    func `render fingerprint honors display currency override`() {
+        let snapshot = Self.makeSnapshot(dailyCost: 1.0)
+        let native = CostHistoryChartMenuView.renderFingerprint(from: snapshot, provider: .codex)
+        let converted = CostHistoryChartMenuView.renderFingerprint(
+            from: snapshot,
+            provider: .codex,
+            displayCurrencyCode: "CZK")
+
+        #expect(native.currencyCode == snapshot.currencyCode)
+        #expect(converted.currencyCode == "CZK")
+        #expect(native != converted)
+    }
+
+    @Test
+    @MainActor
     func `render fingerprint changes when daily cost changes`() {
         let before = CostHistoryChartMenuView.renderFingerprint(
             from: Self.makeSnapshot(dailyCost: 1.0),

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1707,7 +1707,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/CostHistoryChartMenuView.swift",
-            line: 950,
+            line: 958,
             anchor: "let projects = provider == .codex ? snapshot.projects : []",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,
@@ -2460,7 +2460,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+HostedSubmenus.swift",
-            line: 422,
+            line: 441,
             anchor: "projects: provider == .codex ? tokenSnapshot.projects : [],",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,


### PR DESCRIPTION
## Summary

The cost-history detail submenu ignored Settings → General → Currency and always rendered its labels in the snapshot's native currency. Other cost surfaces already use `UsageFormatter.convertedCost`, so users selecting GBP, EUR, CNY, or another supported currency saw converted values everywhere except this submenu.

## Change

Display-time conversion only; stored snapshots and chart geometry stay in provider-native values.

- `CostHistoryChartMenuView` receives one display currency and multiplier. Its existing formatting paths apply that multiplier to the total, day detail, model total and Standard/Fast rows, project/source rows, session rows, and Y-axis labels.
- `StatusItemController+HostedSubmenus` resolves the display conversion through `UsageFormatter.convertedCost`, preserving the shared fallback contract: `auto`, same-currency, and unavailable exchange rates remain in the source currency with multiplier 1.
- The hosted-view render fingerprint includes both the effective display currency and the exact `Double.bitPattern` of the multiplier. A rate refresh therefore invalidates an already-hydrated chart even when the selected currency code is unchanged.
- Existing Codex-only project/session presentation remains unchanged and its architecture-gatekeeper anchors were updated only for shifted line numbers.

Deliberately unchanged: provider-native balances and other surfaces that intentionally keep native currencies separate.

## Validation

- `swift test --filter CostHistoryChartMenuView` — 30/30 passed.
- Regression: identical provider, snapshot, and display currency with multipliers `21.0` and `21.5` produce different render fingerprints; the exact bit patterns are asserted.
- `swift test --filter ProviderArchitectureGatekeeperTests` — 38/38 passed.
- `make check` passed.
- Full local matrix: 841 selections across 71 groups passed with zero retries or timeouts.
- Structured Codex autoreview and TruffleHog passed with no accepted/actionable finding.

## Runtime and visual proof

A Developer ID-signed debug bundle (`com.steipete.codexbar.debug`) was built from this head and launched with:

- a disposable HOME and Codex home;
- Keychain access disabled;
- all network access denied;
- a deterministic cached USD→CNY multiplier of 21;
- synthetic Codex JSONL only.

The packaged CLI exercised the production scanner and loaded two days, two synthetic projects, three synthetic sessions, and two model rows for the latest day. The exact production `CostHistoryChartMenuView` was then rendered offscreen with that data. The image shows CNY conversion across every affected label path while bar proportions remain source-value based.

![Synthetic production-view proof showing CNY axis, day/model rows, total, projects, and conversations](https://github.com/user-attachments/assets/61e51177-795e-404f-a2e5-42c114cf284e)

The host desktop was locked during proof capture, so this is explicitly an offscreen production-view render rather than a screenshot of the live popup. The signed app process, bundle signature, isolated scanner path, and deterministic refresh regression were verified separately.

Contributor authorship and co-author trailers are preserved in the reconstructed commits.
