### PR TITLE
Fix CLI resource loading through symlinks

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -399,9 +399,12 @@ jobs:
             exit 1
           fi
           cp -R "$CORE_RESOURCE_SOURCE" "$OUT_DIR/CodexBar_CodexBarCore.bundle"
-          RESOURCE_SMOKE_OUTPUT="$RUNNER_TEMP/codexbar-cli-resource-smoke-${{ matrix.name }}.txt"
-          CODEXBAR_RESOURCE_SMOKE=1 "$OUT_DIR/CodexBarCLI" > "$RESOURCE_SMOKE_OUTPUT"
-          grep -Fx "CODEXBAR_RESOURCE_SMOKE_OK" "$RESOURCE_SMOKE_OUTPUT"
+          DIRECT_RESOURCE_SMOKE_OUTPUT="$RUNNER_TEMP/codexbar-cli-resource-smoke-direct-${{ matrix.name }}.txt"
+          CODEXBAR_RESOURCE_SMOKE=1 "$OUT_DIR/CodexBarCLI" > "$DIRECT_RESOURCE_SMOKE_OUTPUT"
+          grep -Fx "CODEXBAR_RESOURCE_SMOKE_OK" "$DIRECT_RESOURCE_SMOKE_OUTPUT"
+          SYMLINK_RESOURCE_SMOKE_OUTPUT="$RUNNER_TEMP/codexbar-cli-resource-smoke-symlink-${{ matrix.name }}.txt"
+          CODEXBAR_RESOURCE_SMOKE=1 "$OUT_DIR/codexbar" > "$SYMLINK_RESOURCE_SMOKE_OUTPUT"
+          grep -Fx "CODEXBAR_RESOURCE_SMOKE_OK" "$SYMLINK_RESOURCE_SMOKE_OUTPUT"
 
           ASSET="CodexBarCLI-${SAFE_REF_NAME}-${{ matrix.asset-platform }}-${{ matrix.asset-arch }}.tar.gz"
           (cd "$OUT_DIR" && tar czf "$ASSET" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.3 — Unreleased
 
 ### Fixed
+- CLI: load bundled provider-plugin resources when `codexbar` is installed as a symlink to the packaged helper or standalone executable (#2889). Thanks @djbclark for the report!
 - Menu bar layout: restore dragging placed chips to reorder or remove them while preserving click and keyboard selection (#2582). Thanks @ikkira!
 - Plan history: avoid atomically replacing byte-identical provider history files, reducing unnecessary disk writes (#2495). Thanks @guocity for the report!
 - OpenRouter: restore remaining credit balance in saved custom menu-bar layouts and preserve the legacy Automatic display during migration (#2870). Thanks @yuansaysay!

--- a/Scripts/verify_packaged_app_launch.sh
+++ b/Scripts/verify_packaged_app_launch.sh
@@ -80,9 +80,14 @@ trap cleanup EXIT INT TERM
 cp -R "$APP_BUNDLE" "$SMOKE_DIR/CodexBar.app"
 SMOKE_BIN="$SMOKE_DIR/CodexBar.app/Contents/MacOS/CodexBar"
 CLI_BIN="$SMOKE_DIR/CodexBar.app/Contents/Helpers/CodexBarCLI"
+CLI_SYMLINK_DIR="$SMOKE_DIR/bin"
+CLI_SYMLINK="$CLI_SYMLINK_DIR/codexbar"
 SMOKE_LOG="$SMOKE_DIR/launch.log"
 PROBE_LOG="$SMOKE_DIR/probe.log"
 CLI_PROBE_LOG="$SMOKE_DIR/cli-probe.log"
+CLI_SYMLINK_PROBE_LOG="$SMOKE_DIR/cli-symlink-probe.log"
+mkdir -p "$CLI_SYMLINK_DIR"
+ln -s "$CLI_BIN" "$CLI_SYMLINK"
 SANDBOX_PROFILE="(version 1)
 (allow default)
 (deny file-read* (subpath \"${ROOT}\"))"
@@ -100,6 +105,14 @@ fail_with_cli_probe_log() {
   echo "----- CLI probe output (tail) -----" >&2
   tail -40 "$CLI_PROBE_LOG" >&2 || true
   echo "-----------------------------------" >&2
+  exit 1
+}
+
+fail_with_cli_symlink_probe_log() {
+  echo "ERROR: $1" >&2
+  echo "----- CLI symlink probe output (tail) -----" >&2
+  tail -40 "$CLI_SYMLINK_PROBE_LOG" >&2 || true
+  echo "-------------------------------------------" >&2
   exit 1
 }
 
@@ -130,6 +143,31 @@ if [[ "$CLI_PROBE_STATUS" -ne 0 ]] || ! grep -q "CODEXBAR_RESOURCE_SMOKE_OK" "$C
   fail_with_cli_probe_log "Launch smoke check FAILED: packaged Helpers CLI cannot load CodexBarCore resources without the build checkout. Exit status: ${CLI_PROBE_STATUS}."
 fi
 log "Launch smoke check: Helpers CLI resource probe OK."
+
+log "Launch smoke check: probing symlinked Helpers CLI resource loads with ${ROOT} unreadable."
+(
+  cd "$SMOKE_DIR"
+  exec env CODEXBAR_RESOURCE_SMOKE=1 sandbox-exec -p "$SANDBOX_PROFILE" "$CLI_SYMLINK"
+) >"$CLI_SYMLINK_PROBE_LOG" 2>&1 &
+SMOKE_PID=$!
+CLI_SYMLINK_PROBE_OK=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "$SMOKE_PID" 2>/dev/null; then
+    CLI_SYMLINK_PROBE_OK=1
+    break
+  fi
+  sleep 0.5
+done
+if [[ "$CLI_SYMLINK_PROBE_OK" == "0" ]]; then
+  fail_with_cli_symlink_probe_log "Launch smoke check FAILED: symlinked Helpers CLI resource probe did not finish within 30s."
+fi
+CLI_SYMLINK_PROBE_STATUS=0
+wait "$SMOKE_PID" || CLI_SYMLINK_PROBE_STATUS=$?
+SMOKE_PID=""
+if [[ "$CLI_SYMLINK_PROBE_STATUS" -ne 0 ]] || ! grep -q "CODEXBAR_RESOURCE_SMOKE_OK" "$CLI_SYMLINK_PROBE_LOG"; then
+  fail_with_cli_symlink_probe_log "Launch smoke check FAILED: symlinked packaged Helpers CLI cannot load CodexBarCore resources without the build checkout. Exit status: ${CLI_SYMLINK_PROBE_STATUS}."
+fi
+log "Launch smoke check: symlinked Helpers CLI resource probe OK."
 
 # Phase 1 (deterministic, headless-safe): CODEXBAR_RESOURCE_SMOKE=1 makes the
 # app force the resource loads that trapped in 0.48.0 and exit before any UI.

--- a/Sources/CodexBarCore/CodexBarCoreResources.swift
+++ b/Sources/CodexBarCore/CodexBarCoreResources.swift
@@ -1,3 +1,6 @@
+#if canImport(Darwin)
+import Darwin
+#endif
 import Foundation
 
 /// Safe resolver for CodexBarCore's SwiftPM resource bundle.
@@ -17,7 +20,7 @@ public enum CodexBarCoreResources {
 
     static func resolve(
         mainBundle: Bundle,
-        executableBundleURL: URL? = nil,
+        executableURL: URL? = nil,
         swiftPMBuildDirectory: URL? = Self.defaultSwiftPMBuildDirectory) -> Bundle?
     {
         let name = "CodexBar_CodexBarCore"
@@ -40,7 +43,10 @@ public enum CodexBarCoreResources {
             }
         }
 
-        let executableDirectory = executableBundleURL ?? mainBundle.bundleURL
+        let executableDirectory = (executableURL ?? Self.runningExecutableURL(bundle: mainBundle))?
+            .resolvingSymlinksInPath()
+            .deletingLastPathComponent()
+            ?? mainBundle.bundleURL
         for swiftPMBundleName in swiftPMBundleNames {
             let executableCandidate = executableDirectory.appendingPathComponent(swiftPMBundleName)
             if let bundle = Bundle(url: executableCandidate) {
@@ -60,6 +66,28 @@ public enum CodexBarCoreResources {
             }
         }
         return nil
+    }
+
+    private static func runningExecutableURL(bundle: Bundle) -> URL? {
+        if let executableURL = bundle.executableURL {
+            return executableURL
+        }
+
+        #if canImport(Darwin)
+        var size: UInt32 = 0
+        guard _NSGetExecutablePath(nil, &size) != 0 else { return nil }
+        var buffer = [Int8](repeating: 0, count: Int(size))
+        guard _NSGetExecutablePath(&buffer, &size) == 0 else { return nil }
+        let pathBytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        guard let path = String(bytes: pathBytes, encoding: .utf8) else { return nil }
+        return URL(fileURLWithPath: path)
+        #elseif os(Linux)
+        let path = "/proc/self/exe"
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        return URL(fileURLWithPath: path)
+        #else
+        return nil
+        #endif
     }
 
     private static let defaultSwiftPMBuildDirectory: URL = {

--- a/Tests/CodexBarTests/CodexBarCoreResourcesTests.swift
+++ b/Tests/CodexBarTests/CodexBarCoreResourcesTests.swift
@@ -43,10 +43,12 @@ struct CodexBarCoreResourcesTests {
         let sourceBundle = try #require(CodexBarCoreResources.bundle)
         let target = root.appendingPathComponent("CodexBar_CodexBarCore.\(pathExtension)")
         try FileManager.default.copyItem(at: sourceBundle.bundleURL.resolvingSymlinksInPath(), to: target)
+        let executableURL = root.appendingPathComponent("CodexBarCLI")
+        try Data().write(to: executableURL)
 
         let resolved = try #require(CodexBarCoreResources.resolve(
             mainBundle: .main,
-            executableBundleURL: root,
+            executableURL: executableURL,
             swiftPMBuildDirectory: nil))
         #expect(resolved.bundleURL.resolvingSymlinksInPath() == target.resolvingSymlinksInPath())
     }
@@ -60,7 +62,7 @@ struct CodexBarCoreResourcesTests {
 
         #expect(CodexBarCoreResources.resolve(
             mainBundle: .main,
-            executableBundleURL: root,
+            executableURL: root.appendingPathComponent("CodexBarCLI"),
             swiftPMBuildDirectory: nil) == nil)
     }
 

--- a/TestsPlugin/CodexBarCoreResourcesPortableTests.swift
+++ b/TestsPlugin/CodexBarCoreResourcesPortableTests.swift
@@ -34,7 +34,12 @@ struct CodexBarCoreResourcesPortableTests {
             executableURL: symlinkURL,
             swiftPMBuildDirectory: nil))
 
-        #expect(directBundle.bundleURL.resolvingSymlinksInPath() == resourceURL.resolvingSymlinksInPath())
-        #expect(symlinkBundle.bundleURL.resolvingSymlinksInPath() == resourceURL.resolvingSymlinksInPath())
+        let expectedPath = Self.canonicalPathComponents(resourceURL)
+        #expect(Self.canonicalPathComponents(directBundle.bundleURL) == expectedPath)
+        #expect(Self.canonicalPathComponents(symlinkBundle.bundleURL) == expectedPath)
+    }
+
+    private static func canonicalPathComponents(_ url: URL) -> [String] {
+        url.resolvingSymlinksInPath().standardizedFileURL.pathComponents
     }
 }

--- a/TestsPlugin/CodexBarCoreResourcesPortableTests.swift
+++ b/TestsPlugin/CodexBarCoreResourcesPortableTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct CodexBarCoreResourcesPortableTests {
+    @Test(arguments: ["bundle", "resources"])
+    func `direct and symlink executables resolve the same adjacent resources`(pathExtension: String) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarCoreResourcesPortableTests-\(UUID().uuidString)")
+        let physicalDirectory = root.appendingPathComponent("physical", isDirectory: true)
+        let symlinkDirectory = root.appendingPathComponent("links", isDirectory: true)
+        try FileManager.default.createDirectory(at: physicalDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: symlinkDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let executableURL = physicalDirectory.appendingPathComponent("CodexBarCLI")
+        try Data().write(to: executableURL)
+
+        let sourceBundle = try #require(CodexBarCoreResources.bundle)
+        let resourceURL = physicalDirectory.appendingPathComponent("CodexBar_CodexBarCore.\(pathExtension)")
+        try FileManager.default.copyItem(
+            at: sourceBundle.bundleURL.resolvingSymlinksInPath(),
+            to: resourceURL)
+
+        let symlinkURL = symlinkDirectory.appendingPathComponent("codexbar")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: executableURL)
+
+        let directBundle = try #require(CodexBarCoreResources.resolve(
+            mainBundle: .main,
+            executableURL: executableURL,
+            swiftPMBuildDirectory: nil))
+        let symlinkBundle = try #require(CodexBarCoreResources.resolve(
+            mainBundle: .main,
+            executableURL: symlinkURL,
+            swiftPMBuildDirectory: nil))
+
+        #expect(directBundle.bundleURL.resolvingSymlinksInPath() == resourceURL.resolvingSymlinksInPath())
+        #expect(symlinkBundle.bundleURL.resolvingSymlinksInPath() == resourceURL.resolvingSymlinksInPath())
+    }
+}


### PR DESCRIPTION
## Summary

- resolve the physical CLI executable before probing adjacent CodexBarCore resources
- preserve app-bundle precedence, direct helper/tarball behavior, both resource suffixes, and the guarded SwiftPM fallback
- cover documented symlink installs in portable tests, packaged-app smoke, and every release CLI artifact matrix entry

Fixes #2889

## Root cause

The documented app/Homebrew CLI install invokes `CodexBarCLI` through `/usr/local/bin/codexbar` or `/opt/homebrew/bin/codexbar`. Outside an app bundle, the resource resolver treated the uncanonicalized bundle/invocation location as the executable-adjacent directory. A symlink living outside `Contents/Helpers` therefore could not see the physical helper's adjacent `CodexBar_CodexBarCore.bundle`, so bundled JavaScript providers failed cleanly instead of loading.

## Implementation

`CodexBarCoreResources` now derives the running executable URL from `Bundle.executableURL`, Darwin `_NSGetExecutablePath`, or Linux `/proc/self/exe`, resolves symlinks, and probes the physical parent directory. App resource lookup still runs first; missing resources still return `nil`; `.bundle`, `.resources`, and the guarded development fallback remain supported.

The packaged-app smoke now invokes the helper both directly and through a symlink located outside `Contents/Helpers` while all checkout reads are denied. The release CLI workflow also exercises both `CodexBarCLI` and the packaged `codexbar` symlink for every macOS, glibc Linux, and static musl artifact.

## Validation

- existing macOS resource resolver tests updated for the executable-URL seam
- new portable test proves direct and symlink executable URLs resolve the same physical `.bundle` and `.resources` directories
- `bash -n Scripts/verify_packaged_app_launch.sh`
- `make check`: passed
- full `make test`: 841 selections across 71 groups passed with no retries or timeouts
- structured Codex autoreview: clean, no accepted or actionable finding
- TruffleHog patch scan: clean
- Developer ID-signed release package built successfully
- with the source checkout sandbox-denied:
  - direct packaged helper resource smoke passed
  - external symlink to the packaged helper resource smoke passed
  - packaged app resource smoke passed
  - packaged app survived the checkout-independent launch smoke
- `codesign --verify --deep --strict --verbose=2 CodexBar.app`
- `spctl --assess --type execute --verbose=4 CodexBar.app`

The package is signed by `Developer ID Application: Peter Steinberger (Y5PE65HELJ)` and accepted by Gatekeeper. No provider credentials or network access are required for the proof.
