### PR TITLE
fix: tell an unscanned week apart from an unknown one in token activity

### DIFF
--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -27,10 +27,31 @@ struct SpendActivitySeries {
 
     let daily: [Int]
     let isCovered: [Bool]
+    /// Whether the scan window reached the day. A day can be scanned and still uncovered when the
+    /// source data is missing, which is a real gap rather than a window edge.
+    let isScanned: [Bool]
     let start: Date
     let rangeStart: Date
     let today: Date
     let calendar: Calendar
+
+    init(
+        daily: [Int],
+        isCovered: [Bool],
+        isScanned: [Bool]? = nil,
+        start: Date,
+        rangeStart: Date,
+        today: Date,
+        calendar: Calendar)
+    {
+        self.daily = daily
+        self.isCovered = isCovered
+        self.isScanned = isScanned ?? [Bool](repeating: true, count: daily.count)
+        self.start = start
+        self.rangeStart = rangeStart
+        self.today = today
+        self.calendar = calendar
+    }
 
     static func make(
         from points: [SpendDashboardModel.TokenActivityPoint],
@@ -39,8 +60,12 @@ struct SpendActivitySeries {
     {
         var totals: [Date: Int] = [:]
         var unknownDays: Set<Date> = []
+        var unscannedDays: Set<Date> = []
         for point in points {
             let day = calendar.startOfDay(for: point.day)
+            if !point.isScanned {
+                unscannedDays.insert(day)
+            }
             guard let totalTokens = point.totalTokens else {
                 totals.removeValue(forKey: day)
                 unknownDays.insert(day)
@@ -63,12 +88,14 @@ struct SpendActivitySeries {
         let cellCount = Self.weekCount * Self.dayCount
         var daily = [Int](repeating: 0, count: cellCount)
         var isCovered = [Bool](repeating: false, count: cellCount)
+        var isScanned = [Bool](repeating: false, count: cellCount)
         for index in 0..<cellCount {
             guard let date = calendar.date(byAdding: .day, value: index, to: start),
                   rangeStart...today ~= date
             else {
                 continue
             }
+            isScanned[index] = !unscannedDays.contains(date)
             guard !unknownDays.contains(date), let total = totals[date] else { continue }
             daily[index] = total
             isCovered[index] = true
@@ -76,6 +103,7 @@ struct SpendActivitySeries {
         return Self(
             daily: daily,
             isCovered: isCovered,
+            isScanned: isScanned,
             start: start,
             rangeStart: rangeStart,
             today: today,
@@ -105,13 +133,19 @@ struct SpendActivitySeries {
     func weeklyActivity() -> SpendActivityAggregateSeries {
         var values: [Int] = []
         var coverage: [Bool] = []
+        var scanned: [Bool] = []
         for start in stride(from: 0, to: self.daily.count, by: Self.dayCount) {
             let indices = start..<min(start + Self.dayCount, self.daily.count)
             let visible = indices.filter(self.isVisible)
+            let scannedVisible = visible.filter { self.isScanned[$0] }
             values.append(visible.reduce(0) { Self.saturatingAdd($0, self.daily[$1]) })
-            coverage.append(!visible.isEmpty && visible.allSatisfy { self.isCovered[$0] })
+            // A week is covered when every day the scan reached is covered. Days the scan never
+            // reached cannot make the week unavailable, otherwise the week straddling the start of
+            // a 30-day window would drop even though its scanned portion is complete.
+            coverage.append(!scannedVisible.isEmpty && scannedVisible.allSatisfy { self.isCovered[$0] })
+            scanned.append(!scannedVisible.isEmpty)
         }
-        return SpendActivityAggregateSeries(values: values, isCovered: coverage)
+        return SpendActivityAggregateSeries(values: values, isCovered: coverage, isScanned: scanned)
     }
 
     func isVisible(_ index: Int) -> Bool {
@@ -128,19 +162,40 @@ struct SpendActivitySeries {
 struct SpendActivityAggregateSeries: Equatable {
     let values: [Int]
     let isCovered: [Bool]
+    /// Whether the scan window reached any day in the week.
+    let isScanned: [Bool]
 
+    init(values: [Int], isCovered: [Bool], isScanned: [Bool]? = nil) {
+        self.values = values
+        self.isCovered = isCovered
+        self.isScanned = isScanned ?? [Bool](repeating: true, count: values.count)
+    }
+
+    /// Running total per week. The grid always spans a full year, so a scan window shorter than
+    /// 365 days leaves an unscanned prefix. That prefix must not mark the whole series
+    /// unavailable, so the running coverage starts at the first scanned week.
+    ///
+    /// An unscanned week and an unknown week are not the same thing. A week the scan never reached
+    /// carries no information either way. A week the scan reached but could not resolve is a real
+    /// gap, and every later total is then only a lower bound, so it stays unavailable.
     func cumulative() -> Self {
         var total = 0
+        var hasStarted = false
         var coverageIsComplete = true
         var cumulativeValues: [Int] = []
         var cumulativeCoverage: [Bool] = []
         for index in self.values.indices {
             total = SpendActivitySeries.saturatingAdd(total, self.values[index])
-            coverageIsComplete = coverageIsComplete && self.isCovered[index]
+            if self.isScanned[index] {
+                hasStarted = true
+            }
+            if hasStarted {
+                coverageIsComplete = coverageIsComplete && self.isCovered[index]
+            }
             cumulativeValues.append(total)
-            cumulativeCoverage.append(coverageIsComplete)
+            cumulativeCoverage.append(hasStarted && coverageIsComplete)
         }
-        return Self(values: cumulativeValues, isCovered: cumulativeCoverage)
+        return Self(values: cumulativeValues, isCovered: cumulativeCoverage, isScanned: self.isScanned)
     }
 }
 

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -69,6 +69,16 @@ struct SpendDashboardModel: Equatable, Sendable {
         /// `nil` means at least one included source cannot establish coverage for this day.
         /// This must stay distinct from a proven zero so the heatmap does not fabricate inactivity.
         let totalTokens: Int?
+        /// `false` means at least one source never scanned this day, so the gap is a window edge
+        /// rather than missing data. A `nil` total with `true` means every source scanned the day
+        /// and still cannot report it, which is a real gap the heatmap must keep visible.
+        let isScanned: Bool
+
+        init(day: Date, totalTokens: Int?, isScanned: Bool = true) {
+            self.day = day
+            self.totalTokens = totalTokens
+            self.isScanned = isScanned
+        }
 
         var id: Date {
             self.day
@@ -196,8 +206,14 @@ struct SpendDashboardModel: Equatable, Sendable {
         let hasCompleteHistory: Bool
         let isGloballyInvalid: Bool
 
+        /// Whether the scan window reached this day at all. A day outside the window is unknown
+        /// because nobody looked; a day inside it is unknown because the data itself is missing.
+        func scanned(_ day: Date) -> Bool {
+            self.coveredInterval?.contains(day) == true
+        }
+
         func tokens(on day: Date) -> Int? {
-            guard self.coveredInterval?.contains(day) == true,
+            guard self.scanned(day),
                   !self.isGloballyInvalid,
                   !self.invalidDays.contains(day)
             else { return nil }
@@ -470,7 +486,12 @@ struct SpendDashboardModel: Equatable, Sendable {
             var total = 0
             for summary in summaries {
                 guard let tokens = summary.tokens(on: day) else {
-                    return TokenActivityPoint(day: day, totalTokens: nil)
+                    // Every source must have scanned the day before an unknown counts as a real
+                    // gap. If any source never reached it, this is the edge of a scan window.
+                    return TokenActivityPoint(
+                        day: day,
+                        totalTokens: nil,
+                        isScanned: summaries.allSatisfy { $0.scanned(day) })
                 }
                 let addition = total.addingReportingOverflow(tokens)
                 total = addition.overflow ? Int.max : addition.partialValue

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2356,7 +2356,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SpendDashboardModel.swift",
-            line: 639,
+            line: 660,
             anchor: "guard provider == .mistral else { return displayCalendar }",
             expectedProviderIDs: ["mistral"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -209,7 +209,93 @@ struct SpendActivityHeatmapTests {
         let weekly = series.weeklyActivity()
         #expect(weekly.values.prefix(2) == [7, 7])
         #expect(weekly.isCovered.prefix(2) == [false, true])
+        // Every day here was scanned, so the uncovered day is a real gap and every later running
+        // total stays a lower bound. See `cumulative activity starts at the first scanned week`
+        // for the window-edge case, which does recover.
         #expect(weekly.cumulative().isCovered.prefix(2) == [false, false])
+    }
+
+    @Test
+    func `cumulative activity starts at the first scanned week`() {
+        let weekly = SpendActivityAggregateSeries(
+            values: [3, 5, 7],
+            isCovered: [false, true, true],
+            isScanned: [false, true, true])
+
+        let cumulative = weekly.cumulative()
+
+        #expect(cumulative.isCovered == [false, true, true])
+        // Totals are unchanged: an unscanned week contributes whatever its covered days held.
+        #expect(cumulative.values == [3, 8, 15])
+    }
+
+    @Test
+    func `cumulative activity keeps a leading in window gap unavailable`() {
+        // Every week was scanned, so the leading unavailable week is missing data rather than a
+        // window edge. Later totals are lower bounds and must not read as complete.
+        let weekly = SpendActivityAggregateSeries(
+            values: [3, 5, 7],
+            isCovered: [false, true, true],
+            isScanned: [true, true, true])
+
+        let cumulative = weekly.cumulative()
+
+        #expect(cumulative.isCovered == [false, false, false])
+        #expect(cumulative.values == [3, 8, 15])
+    }
+
+    @Test
+    func `series separates an unscanned prefix from an in window gap`() throws {
+        let calendar = Self.calendar
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 8, day: 12)))
+        // A 30-day window on a 365-day grid: the first 335 days were never scanned.
+        let points = try (0..<SpendActivitySeries.rangeDayCount).map { offset -> SpendDashboardModel
+            .TokenActivityPoint in
+            let day = try #require(calendar.date(byAdding: .day, value: -offset, to: now))
+            guard offset < 30 else {
+                return .init(day: day, totalTokens: nil, isScanned: false)
+            }
+            return .init(day: day, totalTokens: 10)
+        }
+
+        let series = SpendActivitySeries.make(from: points, now: now, calendar: calendar)
+        let cumulative = series.weeklyActivity().cumulative()
+        let visibleWeeks = cumulative.isCovered.indices.filter { week in
+            (0..<SpendActivitySeries.dayCount).contains { row in
+                series.isVisible(week * SpendActivitySeries.dayCount + row)
+            }
+        }
+
+        // The unscanned prefix cannot blank the scanned window.
+        #expect(visibleWeeks.contains { cumulative.isCovered[$0] })
+        #expect(cumulative.values.last == 300)
+
+        // The same shape, but with one scanned day inside the window that cannot be resolved.
+        let gapDay = try #require(calendar.date(byAdding: .day, value: -29, to: now))
+        let withGap = points.map { point in
+            calendar.isDate(point.day, inSameDayAs: gapDay)
+                ? SpendDashboardModel.TokenActivityPoint(day: point.day, totalTokens: nil)
+                : point
+        }
+        let gapCumulative = SpendActivitySeries.make(from: withGap, now: now, calendar: calendar)
+            .weeklyActivity()
+            .cumulative()
+
+        // A real gap at the leading edge keeps every later running total unavailable.
+        #expect(!gapCumulative.isCovered.contains(true))
+    }
+
+    @Test
+    func `cumulative activity stays unavailable after a gap`() {
+        let weekly = SpendActivityAggregateSeries(
+            values: [1, 1, 1, 1],
+            isCovered: [true, false, true, true])
+
+        let cumulative = weekly.cumulative()
+
+        // A running total across a gap is a lower bound, so every later week stays unavailable.
+        #expect(cumulative.isCovered == [true, false, false, false])
+        #expect(cumulative.values == [1, 2, 3, 4])
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Cumulative mode of the Token activity card renders entirely blank. All 53 columns use the
unavailable fill, and every hover reports "Unavailable".

The root cause is that one flag stood in for two different facts.
`TokenActivityInputSummary.tokens(on:)` returns nil when a day falls outside `coveredInterval`,
when the provider is globally invalid, when the day is in `invalidDays`, and when the day has no
entry while `hasCompleteHistory` is false. Only the first means "never scanned". By the time the
heatmap saw the data, all four had collapsed into `isCovered == false`.

The grid always spans 365 days, while the scan window comes from `tokenCostUsageHistoryDays`, which
defaults to 30. So the first week of the grid is unscanned for every user on the default setting,
and the running AND in `cumulative()` turned false at index 0 and never recovered.

This change carries scan provenance down to the heatmap. `TokenActivityPoint` gains `isScanned`,
`SpendActivitySeries` carries it per day, and `SpendActivityAggregateSeries` carries it per week.
Three states now exist where there were two: not scanned, scanned but unknown, and covered.

- The running total starts at the first **scanned** week, so an unscanned prefix no longer blanks
  the year.
- A week that was scanned but could not be resolved is still a real gap, so every later total stays
  unavailable, because it is only a lower bound.
- A week is covered when every **scanned** day inside it is covered. The week straddling the start
  of the scan window is therefore available for its scanned portion instead of being discarded.

Totals are untouched. The accumulator still runs on every iteration, so the last column continues
to reconcile with the total in the card header.

Fixes #2893.

## Proof

Patched build, `History window` at the default of 30 days, Settings > Usage & Spend > Cumulative.

<img width="992" height="732" alt="Token activity Cumulative view drawing a running total at a 30 day history window" src="https://github.com/user-attachments/assets/74cfd113-7905-4f86-a83c-9711aa618327" />

The card header still reads `Coverage: 30 / 365`, so this is the default window, not the 365-day
workaround. Five columns draw, rising to a full column at the right edge. The five include the week
clipped by the start of the window, which the previous rule discarded.

Before, on `main`, the same view at the same setting is 53 gray columns with no value at any hover.

## Behavior

| | Before | After |
|---|---|---|
| Cumulative columns drawn | 0 of 53 | the scanned window |
| Weekly columns drawn | drops the week clipped by the window | keeps it, for its scanned portion |
| Hover in Cumulative | "Unavailable" everywhere | running totals |
| Leading in-window data gap | unavailable | still unavailable |

## Tests

- `cumulative activity starts at the first scanned week` — an unscanned prefix does not suppress the
  weeks after it.
- `cumulative activity keeps a leading in window gap unavailable` — the regression the review asked
  for. Every week scanned, the first one unresolved, so later totals stay lower bounds.
- `cumulative activity stays unavailable after a gap` — pins the same rule mid-series.
- `series separates an unscanned prefix from an in window gap` — integration level, built through
  `SpendActivitySeries.make` with a 30-day window on the 365-day grid, asserting the scanned window
  draws and that one unresolved in-window day blanks it again.
- `weekly and cumulative activity preserve unavailable coverage` — updated. Its days are all
  scanned, so it now documents the gap case rather than the window-edge case.

## Commands run

- `swift test --filter SpendActivityHeatmapTests` — 19 tests, passed
- `make check` — 0 violations across 1846 files
- `make test` — the full sharded suite passed on the previous revision of this branch and is
  running again against this one locally; CI runs it here as well

## Still open, deliberately

#2893 also notes that only Codex accounts receive the 365-day activity scan, while every other
provider arrives with a snapshot scanned at `costUsageHistoryDays`. The intersection therefore pins
coverage to the smaller window. That is a product decision about scan cost and caching, not a
patch, so it stays out of this PR. With it, the view draws correctly but narrowly at the default
setting.
