### PR TITLE
Keep known zero cost totals distinct from unavailable

### DIFF
--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -1063,13 +1063,21 @@ public struct CostUsageFetcher: Sendable {
         } else {
             nil
         }
-        // Prefer summary totals when present; fall back to summing daily entries.
+        // Prefer summary totals when present; fall back to summing daily entries. A non-empty
+        // row set where every row carries an explicit value is a known total even when it sums
+        // to zero; keep nil only for genuinely missing values.
         let totalFromSummary = daily.summary?.totalCostUSD
         let totalFromEntries = daily.data.compactMap(\.costUSD).reduce(0, +)
-        let last30DaysCostUSD = totalFromSummary ?? (totalFromEntries > 0 ? totalFromEntries : nil)
+        let allEntriesCarryCost = !daily.data.isEmpty && daily.data.allSatisfy { $0.costUSD != nil }
+        let last30DaysCostUSD = totalFromSummary
+            ?? (totalFromEntries > 0 || (allEntriesCarryCost && totalFromEntries == 0) ? totalFromEntries : nil)
         let totalTokensFromSummary = daily.summary?.totalTokens
         let totalTokensFromEntries = daily.data.compactMap(\.totalTokens).reduce(0, +)
-        let last30DaysTokens = totalTokensFromSummary ?? (totalTokensFromEntries > 0 ? totalTokensFromEntries : nil)
+        let allEntriesCarryTokens = !daily.data.isEmpty && daily.data.allSatisfy { $0.totalTokens != nil }
+        let last30DaysTokens = totalTokensFromSummary
+            ?? (totalTokensFromEntries > 0 || (allEntriesCarryTokens && totalTokensFromEntries == 0)
+                ? totalTokensFromEntries
+                : nil)
 
         return CostUsageTokenSnapshot(
             sessionTokens: sessionTokens,

--- a/Tests/CodexBarTests/CostUsageTokenSnapshotDaySelectionTests.swift
+++ b/Tests/CodexBarTests/CostUsageTokenSnapshotDaySelectionTests.swift
@@ -161,6 +161,88 @@ struct CostUsageTokenSnapshotDaySelectionTests {
         #expect(latest?.date == "2026-06-30")
     }
 
+    @Test
+    func `token snapshot keeps known zero totals when every entry carries explicit zero values`() throws {
+        let now = try Self.localNoon(year: 2026, month: 5, day: 18)
+        let report = CostUsageDailyReport(
+            data: [
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-17",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 0,
+                    costUSD: 0,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-18",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 0,
+                    costUSD: 0,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            summary: nil)
+
+        let snapshot = CostUsageFetcher.tokenSnapshot(from: report, now: now)
+
+        #expect(snapshot.last30DaysCostUSD == 0)
+        #expect(snapshot.last30DaysTokens == 0)
+    }
+
+    @Test
+    func `token snapshot keeps zero cost and unavailable tokens distinct`() throws {
+        let now = try Self.localNoon(year: 2026, month: 5, day: 18)
+        let report = CostUsageDailyReport(
+            data: [
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-18",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: nil,
+                    costUSD: 0,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            summary: nil)
+
+        let snapshot = CostUsageFetcher.tokenSnapshot(from: report, now: now)
+
+        #expect(snapshot.last30DaysCostUSD == 0)
+        #expect(snapshot.last30DaysTokens == nil)
+    }
+
+    @Test
+    func `token snapshot keeps unpriced entries unavailable instead of zero`() throws {
+        let now = try Self.localNoon(year: 2026, month: 5, day: 18)
+        let report = CostUsageDailyReport(
+            data: [
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-17",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 10,
+                    costUSD: nil,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-18",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 0,
+                    costUSD: nil,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            summary: nil)
+
+        let snapshot = CostUsageFetcher.tokenSnapshot(from: report, now: now)
+
+        #expect(snapshot.last30DaysCostUSD == nil)
+        #expect(snapshot.last30DaysTokens == 10)
+    }
+
     private static func localNoon(year: Int, month: Int, day: Int) throws -> Date {
         var components = DateComponents()
         components.calendar = Calendar.current

--- a/Tests/CodexBarTests/OpenCodeGoTokenCostTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoTokenCostTests.swift
@@ -64,6 +64,41 @@ struct OpenCodeGoTokenCostTests {
         #expect(tokenSnapshot?.last30DaysCostUSD == 1.23)
     }
 
+    @Test
+    func `zero cost local history projects known zero instead of unavailable`() {
+        let settings = Self.makeSettings()
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+
+        let zeroCostSnapshot = OpenCodeGoUsageSnapshot(
+            hasMonthlyUsage: true,
+            rollingUsagePercent: 12,
+            weeklyUsagePercent: 57,
+            monthlyUsagePercent: 34,
+            rollingResetInSec: 3600,
+            weeklyResetInSec: 86400,
+            monthlyResetInSec: 864_000,
+            daily: [
+                CostUsageDailyReport.Entry(
+                    date: "2025-12-23",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: nil,
+                    requestCount: 5,
+                    costUSD: 0,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            updatedAt: Date())
+
+        let tokenSnapshot = store.tokenSnapshot(
+            fromProviderSnapshot: zeroCostSnapshot.toUsageSnapshot(),
+            provider: .opencodego)
+
+        #expect(tokenSnapshot?.last30DaysCostUSD == 0)
+        #expect(tokenSnapshot?.last30DaysTokens == nil)
+    }
+
     private static func makeSettings() -> SettingsStore {
         let suite = "OpenCodeGoTokenCostTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -3411,7 +3411,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 1114,
+            line: 1122,
             anchor: "if provider == .vertexai {",
             expectedProviderIDs: ["claude", "vertexai"],
             expectedReferenceCount: 2,
@@ -3419,7 +3419,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 1365,
+            line: 1373,
             anchor: "if provider == .cursor {",
             expectedProviderIDs: ["cursor"],
             expectedReferenceCount: 1,


### PR DESCRIPTION
## Summary

A 30-day cost/token total is a known value when the row set is non-empty and every row carries an explicit value, even if the sum is zero. Today that zero collapses to `nil` because the fallback only accepts sums greater than zero, so a genuinely unused period renders as unavailable instead of a real 0.

This change keeps the explicit-zero total while preserving the existing unavailable contract:

- a non-empty row set where every row carries `costUSD` keeps a known 0 total
- a non-empty row set where every row carries `totalTokens` keeps a known 0 token total
- rows with missing values still keep the total unavailable, never reporting a fabricated 0
- summary totals are still preferred when present

## User impact

The menu bar can show `0` for a period with real zero usage instead of an unavailable placeholder, while `--`/unavailable still means "no data", so the two states stay distinct.

## Validation

- Patch applied cleanly on current upstream `main` (208016687)
- `CostUsageTokenSnapshotDaySelectionTests`: 9/9 passed, including new known-zero, zero-vs-unavailable, and unpriced-row cases
- `OpenCodeGoTokenCostTests`: 3/3 passed, including zero-cost local history projection
- `ProviderArchitectureGatekeeperTests`: 38/38 passed
- Tests ran with `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1`; no live account or Keychain access
