### PR TITLE
fix: confirm Codex weekly reset with zero available credits

### DIFF
--- a/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
@@ -178,7 +178,13 @@ struct CodexWeeklyResetConfirmation: Sendable {
             return false
         }
         let previouslyAvailableCredits = previousCredits.availableCredits(at: previousCredits.updatedAt)
-        guard !previouslyAvailableCredits.isEmpty else { return false }
+        // An explicitly observed zero-credit inventory means there was no manual reset credit to
+        // consume. Requiring consumption proof here would deadlock: the two consistent observations
+        // (initial + confirmation) are the only signal a server-side early reset has, so trust them.
+        // A nil/unknown previous inventory stays conservative and keeps demanding consumption proof.
+        guard !previouslyAvailableCredits.isEmpty else {
+            return previousCredits.availableCount == 0
+        }
         return previouslyAvailableCredits.contains { previousCredit in
             Self.inventoryConfirmsConsumption(
                 previousCredit: previousCredit,

--- a/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
@@ -349,6 +349,40 @@ struct CodexWeeklyResetConfirmationTests {
     }
 
     @Test
+    func `zero available reset credits confirm a server-side early weekly reset by observation`() throws {
+        let formatter = ISO8601DateFormatter()
+        let previousCapturedAt = try #require(formatter.date(from: "2026-08-13T03:36:16Z"))
+        let previousReset = try #require(formatter.date(from: "2026-08-18T00:49:16Z"))
+        let initialCapturedAt = try #require(formatter.date(from: "2026-08-13T03:41:46Z"))
+        let initialReset = try #require(formatter.date(from: "2026-08-20T03:38:06Z"))
+        let previous = self.snapshot(
+            capturedAt: previousCapturedAt,
+            weeklyUsed: 98,
+            weeklyReset: previousReset,
+            resetCredits: self.emptyResetCredits(capturedAt: previousCapturedAt))
+        let initial = self.snapshot(
+            capturedAt: initialCapturedAt,
+            weeklyUsed: 1,
+            weeklyReset: initialReset,
+            resetCredits: self.emptyResetCredits(capturedAt: initialCapturedAt))
+        let confirmation = self.snapshot(
+            capturedAt: initialCapturedAt.addingTimeInterval(30),
+            weeklyUsed: 1,
+            weeklyReset: initialReset.addingTimeInterval(30),
+            resetCredits: self.emptyResetCredits(capturedAt: initialCapturedAt.addingTimeInterval(30)))
+
+        #expect(
+            CodexWeeklyResetConfirmation.initialDecision(previous: previous, initial: initial)
+                == .requiresConfirmation)
+        #expect(
+            CodexWeeklyResetConfirmation.confirmationDecision(
+                previous: previous,
+                initial: initial,
+                confirmation: confirmation)
+                == .publishConfirmation)
+    }
+
+    @Test
     func `one missing reset credit inventory does not confirm an early manual weekly reset`() throws {
         let formatter = ISO8601DateFormatter()
         let previousCapturedAt = try #require(formatter.date(from: "2026-08-06T09:28:18Z"))


### PR DESCRIPTION
## Summary

CodexBar can get stuck showing a stale weekly usage percentage forever when a Codex weekly quota reset is observed *before* the previous reset boundary and the account has **zero available reset credits** (`availableCount == 0`).

`CodexWeeklyResetConfirmation.confirmationDecision` requires proof that a manual reset credit was consumed (`confirmsManualResetCreditConsumption`). That proof can never hold when the previous snapshot explicitly reported an empty reset-credit inventory, so every refresh re-evaluates to `.preservePrevious` and the fresh value is never published.

This changes `confirmsManualResetCreditConsumption` so an *explicitly observed* zero-credit inventory (`previousCredits.availableCount == 0`) trusts the two consistent observations (initial + confirmation) that are the only signal a server-side early reset has. A `nil`/unknown previous inventory stays conservative and still demands consumption proof, so the existing false-positive protection (transient low readings, missing/expired credits) is unchanged.

## Changes

- `Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift`: when the previous snapshot has an explicitly known-zero credit inventory, return `true` from `confirmsManualResetCreditConsumption` instead of deadlocking.
- `Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift`: new test `zero available reset credits confirm a server-side early weekly reset by observation` reproducing the live failure (98% → 1%, boundary 8/18 → 8/20, zero credits).

## Repro

- Live account at 98% used / reset 2026-08-18, no reset credits available (`codexResetCredits.availableCount == 0`, `credits == []`).
- Weekly limit reset server-side to 1% used / reset 2026-08-20 (observed well before the old boundary).
- CodexBar refreshed every minute, fetched the new value, but `confirmationDecision` returned `.preservePrevious` indefinitely → status-bar icon stuck at the old value.

## Verification

- `CodexWeeklyResetConfirmationTests`: 20/20 pass (including the new case; existing conservative cases like "one missing reset credit inventory does not confirm" and "expired omitted reset credit does not confirm" still pass).
- `swift build --target CodexBarCore` passes.
- `make check` (swiftformat + swiftlint --strict): 0 violations.

## Related

- Upstream logic introduced in #2710 / #2728.