### PR TITLE
fix: follow system dimming for menu bar icon, standard size and stepper-tuned vertical offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.49.5 — Unreleased
 
+### Fixed
+- Menu bar layout: surface a leading icon token as the native status-item image so it follows the system's inactive-display dimming, render it at the standard 18 pt size, dim stale snapshots, and add a stepper-tuned vertical adjustment that moves icon and text together (#2365, #2898). Thanks @luantu!
+
 ## 0.49.4 — 2026-08-13
 
 ### Added

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -175,7 +175,6 @@ struct MenuBarLayoutEditor: View {
 
     @State private var scope: MenuBarLayoutEditorScope = .all
     @State private var selectedPosition: MenuBarLayoutPosition?
-    @State private var verticalAdjustmentText: String = ""
 
     private var layout: MenuBarLayout {
         switch self.scope {
@@ -229,25 +228,6 @@ struct MenuBarLayoutEditor: View {
                     activating: self.layout,
                     for: self.persistenceProvider,
                     settings: self.settings)
-            })
-    }
-
-    private var verticalAdjustmentBinding: Binding<String> {
-        Binding(
-            get: {
-                if self.verticalAdjustmentText.isEmpty {
-                    return String(self.settings.menuBarLayoutVerticalAdjustment)
-                }
-                return self.verticalAdjustmentText
-            },
-            set: { text in
-                self.verticalAdjustmentText = text
-                guard let value = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) else { return }
-                let clamped = max(-20, min(20, value))
-                if clamped != value {
-                    self.verticalAdjustmentText = String(clamped)
-                }
-                self.settings.menuBarLayoutVerticalAdjustment = clamped
             })
     }
 
@@ -568,13 +548,26 @@ struct MenuBarLayoutEditor: View {
             }
             .pickerStyle(.menu)
 
-            TextField(L("menu_bar_layout_vertical_adjustment"), text: self.verticalAdjustmentBinding)
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 72)
-                .multilineTextAlignment(.trailing)
-                .onAppear {
-                    self.verticalAdjustmentText = String(self.settings.menuBarLayoutVerticalAdjustment)
+            HStack(spacing: 8) {
+                Text(L("menu_bar_layout_vertical_adjustment"))
+                    .lineLimit(1)
+                    .fixedSize()
+
+                TextField(
+                    "",
+                    value: $settings.menuBarLayoutVerticalAdjustment,
+                    format: .number)
+                    .labelsHidden()
+                    .textFieldStyle(.roundedBorder)
+                    .multilineTextAlignment(.trailing)
+                    .monospacedDigit()
+                    .frame(width: 44)
+
+                Stepper(value: $settings.menuBarLayoutVerticalAdjustment, in: -20 ... 20, step: 1) {
+                    EmptyView()
                 }
+                .labelsHidden()
+            }
 
             Spacer()
 

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -778,18 +778,40 @@ struct MenuBarLayoutPreview: View {
 struct MenuBarLayoutPreviewText: NSViewRepresentable {
     let rendered: MenuBarLayoutRenderedTitle
 
-    func makeNSView(context: Context) -> NSTextField {
+    func makeNSView(context: Context) -> NSStackView {
+        let stack = NSStackView()
+        self.configure(stack)
+        return stack
+    }
+
+    func updateNSView(_ stack: NSStackView, context: Context) {
+        self.configure(stack)
+    }
+
+    private func configure(_ stack: NSStackView) {
+        for subview in stack.arrangedSubviews {
+            stack.removeArrangedSubview(subview)
+            subview.removeFromSuperview()
+        }
+        stack.orientation = .horizontal
+        stack.spacing = 2
+        stack.alignment = .centerY
+        // The live status button renders an extracted leading icon as `button.image`; mirror that
+        // in the preview so an icon-leading (or icon-only) preset stays visible in Preferences.
+        if let icon = self.rendered.leadingIcon {
+            let imageView = NSImageView(image: icon)
+            imageView.imageScaling = .scaleProportionallyUpOrDown
+            imageView.contentTintColor = .labelColor
+            imageView.setContentHuggingPriority(.required, for: .horizontal)
+            stack.addArrangedSubview(imageView)
+        }
         let field = NSTextField(labelWithAttributedString: self.rendered.attributedTitle)
         field.alignment = .center
         field.lineBreakMode = .byClipping
         field.maximumNumberOfLines = 2
         field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        return field
-    }
-
-    func updateNSView(_ field: NSTextField, context: Context) {
-        field.attributedStringValue = self.rendered.attributedTitle
-        field.setAccessibilityLabel(self.rendered.accessibilityLabel)
+        stack.addArrangedSubview(field)
+        stack.setAccessibilityLabel(self.rendered.accessibilityLabel)
     }
 }
 

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -175,6 +175,7 @@ struct MenuBarLayoutEditor: View {
 
     @State private var scope: MenuBarLayoutEditorScope = .all
     @State private var selectedPosition: MenuBarLayoutPosition?
+    @State private var verticalAdjustmentText: String = ""
 
     private var layout: MenuBarLayout {
         switch self.scope {
@@ -228,6 +229,25 @@ struct MenuBarLayoutEditor: View {
                     activating: self.layout,
                     for: self.persistenceProvider,
                     settings: self.settings)
+            })
+    }
+
+    private var verticalAdjustmentBinding: Binding<String> {
+        Binding(
+            get: {
+                if self.verticalAdjustmentText.isEmpty {
+                    return String(self.settings.menuBarLayoutVerticalAdjustment)
+                }
+                return self.verticalAdjustmentText
+            },
+            set: { text in
+                self.verticalAdjustmentText = text
+                guard let value = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) else { return }
+                let clamped = max(-20, min(20, value))
+                if clamped != value {
+                    self.verticalAdjustmentText = String(clamped)
+                }
+                self.settings.menuBarLayoutVerticalAdjustment = clamped
             })
     }
 
@@ -548,6 +568,14 @@ struct MenuBarLayoutEditor: View {
             }
             .pickerStyle(.menu)
 
+            TextField(L("menu_bar_layout_vertical_adjustment"), text: self.verticalAdjustmentBinding)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 72)
+                .multilineTextAlignment(.trailing)
+                .onAppear {
+                    self.verticalAdjustmentText = String(self.settings.menuBarLayoutVerticalAdjustment)
+                }
+
             Spacer()
 
             Text(L("menu_bar_layout_keyboard_hint"))
@@ -642,7 +670,8 @@ struct MenuBarLayoutPreview: View {
                 showUsed: self.settings.usageBarsShowUsed,
                 appearanceName: "preview",
                 isDebugApp: false,
-                now: minute))
+                now: minute,
+                verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment))
         MenuBarLayoutPreviewText(rendered: rendered)
     }
 

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -555,7 +555,7 @@ struct MenuBarLayoutEditor: View {
 
                 TextField(
                     "",
-                    value: $settings.menuBarLayoutVerticalAdjustment,
+                    value: self.$settings.menuBarLayoutVerticalAdjustment,
                     format: .number)
                     .labelsHidden()
                     .textFieldStyle(.roundedBorder)
@@ -563,7 +563,7 @@ struct MenuBarLayoutEditor: View {
                     .monospacedDigit()
                     .frame(width: 44)
 
-                Stepper(value: $settings.menuBarLayoutVerticalAdjustment, in: -20 ... 20, step: 1) {
+                Stepper(value: self.$settings.menuBarLayoutVerticalAdjustment, in: -20...20, step: 1) {
                     EmptyView()
                 }
                 .labelsHidden()

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -234,9 +234,14 @@ final class MenuBarLayoutRenderer {
         attributes[.baselineOffset] = baseBaselineOffset + CGFloat(options.verticalAdjustment)
         let result = NSMutableAttributedString()
         var accessibilityLines: [String] = []
-        // Only surface a leading icon via `button.image` when an actual image is available;
-        // with a missing icon the token still renders its placeholder inside the title.
-        let leadingIcon: NSImage? = if layout.lines.first?.first == .icon, icon != nil {
+        // Only surface a leading icon via `button.image` when an actual image is available and the
+        // high-contrast contract does not require the icon to stay inside the attributed title.
+        // AppKit dims `button.image` on inactive displays, but high-contrast layouts keep icon + text
+        // together in one attributed path so the existing dimming contract is preserved. With a
+        // missing icon the token still renders its placeholder inside the title.
+        let leadingIcon: NSImage? = if options.highContrast {
+            nil
+        } else if layout.lines.first?.first == .icon, icon != nil {
             icon
         } else {
             nil
@@ -249,8 +254,10 @@ final class MenuBarLayoutRenderer {
             var accessibilityParts: [String] = []
             for (tokenIndex, token) in line.enumerated() {
                 // The leading icon is surfaced as `button.image` so AppKit applies the system's
-                // active/inactive display tinting; it is not repeated inside the attributed title.
+                // active/inactive display tinting; it is not repeated inside the attributed title,
+                // but its accessibility description must survive for VoiceOver.
                 if leadingIcon != nil, lineIndex == 0, tokenIndex == 0, token == .icon {
+                    accessibilityParts.append(Self.iconAccessibilityText(data: data))
                     continue
                 }
                 if tokenIndex > 0, token != .space, line[tokenIndex - 1] != .space {
@@ -314,7 +321,7 @@ final class MenuBarLayoutRenderer {
                 height: height)
             let value = NSMutableAttributedString(attachment: attachment)
             value.addAttributes(style.attributes, range: NSRange(location: 0, length: value.length))
-            return (value, L("%@ icon", data.providerName ?? L("Provider")))
+            return (value, Self.iconAccessibilityText(data: data))
         case .providerName:
             return self.optionalTextToken(
                 data.providerName,
@@ -409,6 +416,10 @@ final class MenuBarLayoutRenderer {
         case .space:
             return self.textToken(" ", accessibilityText: nil, attributes: style.attributes)
         }
+    }
+
+    private static func iconAccessibilityText(data: MenuBarLayoutRenderData) -> String {
+        L("%@ icon", data.providerName ?? L("Provider"))
     }
 
     private static func attachmentImage(_ image: NSImage, tint: NSColor) -> NSImage {

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -51,9 +51,35 @@ struct MenuBarLayoutRenderOptions: Hashable {
     let showUsed: Bool
     let appearanceName: String
     let isDebugApp: Bool
+    /// Whether the provider's latest refresh failed; when true the shown snapshot is stale
+    /// and rendered dimmer until a background refresh succeeds again.
+    let isStale: Bool
     /// Exact display clock. The cache keys on the resulting reset strings, so animation ticks that keep
     /// the same visible countdown still reuse the cached title.
     let now: Date
+    /// User-tunable vertical nudge for the whole title, applied on top of the optical baseline
+    /// offset. Positive moves content down, negative moves it up.
+    let verticalAdjustment: Int
+
+    init(
+        size: MenuBarLayoutSize,
+        highContrast: Bool,
+        showUsed: Bool,
+        appearanceName: String,
+        isDebugApp: Bool,
+        isStale: Bool = false,
+        now: Date,
+        verticalAdjustment: Int = 0)
+    {
+        self.size = size
+        self.highContrast = highContrast
+        self.showUsed = showUsed
+        self.appearanceName = appearanceName
+        self.isDebugApp = isDebugApp
+        self.isStale = isStale
+        self.now = now
+        self.verticalAdjustment = verticalAdjustment
+    }
 }
 
 struct MenuBarLayoutRenderKey: Hashable {
@@ -64,6 +90,8 @@ struct MenuBarLayoutRenderKey: Hashable {
     let showUsed: Bool
     let appearanceName: String
     let isDebugApp: Bool
+    let isStale: Bool
+    let verticalAdjustment: Int
     let resetText: MenuBarLayoutResetText
 }
 
@@ -85,6 +113,11 @@ struct MenuBarLayoutResetText: Hashable {
 struct MenuBarLayoutRenderedTitle {
     let attributedTitle: NSAttributedString
     let accessibilityLabel: String
+    /// When the layout begins with an icon token, the raw template image is surfaced here so
+    /// the status item can assign it to `button.image`. Template images are the only menu bar
+    /// content AppKit automatically dims on inactive displays; attributed-title attachments are
+    /// pre-rendered bitmaps and do not follow the system's active-state tinting.
+    let leadingIcon: NSImage?
 }
 
 @MainActor
@@ -125,6 +158,7 @@ final class MenuBarLayoutTitleCache {
 final class MenuBarLayoutRenderer {
     private static let missingValue = "–"
     private static let stackedBaselineOffset: CGFloat = -3 // Center multi-line NSStatusBarButton titles.
+    private static let singleLineBaselineOffset: CGFloat = -1 // Drop single-line titles slightly for optical centering.
 
     private struct TokenStyle {
         let font: NSFont
@@ -155,6 +189,8 @@ final class MenuBarLayoutRenderer {
             showUsed: options.showUsed,
             appearanceName: options.appearanceName,
             isDebugApp: options.isDebugApp,
+            isStale: options.isStale,
+            verticalAdjustment: options.verticalAdjustment,
             resetText: resetText)
         return self.cache.value(for: key) {
             Self.renderUncached(layout: layout, data: data, icon: icon, options: options)
@@ -174,7 +210,13 @@ final class MenuBarLayoutRenderer {
     {
         let isStacked = layout.lines.count == 2
         let font = NSFont.systemFont(ofSize: Self.fontSize(size: options.size, isStacked: isStacked))
-        let foregroundColor = options.highContrast ? NSColor.labelColor : NSColor.controlTextColor
+        let foregroundColor = if options.highContrast {
+            NSColor.labelColor
+        } else if options.isStale {
+            NSColor.secondaryLabelColor
+        } else {
+            NSColor.controlTextColor
+        }
         let paragraphStyle = NSMutableParagraphStyle()
         if isStacked {
             paragraphStyle.minimumLineHeight = 9.5
@@ -186,11 +228,19 @@ final class MenuBarLayoutRenderer {
             .foregroundColor: foregroundColor,
             .paragraphStyle: paragraphStyle,
         ]
-        if isStacked {
-            attributes[.baselineOffset] = Self.stackedBaselineOffset
-        }
+        // Optical baseline offset keeps the title vertically balanced in the status bar button.
+        // A user-tunable nudge is layered on top so the layout can be fine-tuned per display.
+        let baseBaselineOffset = isStacked ? Self.stackedBaselineOffset : Self.singleLineBaselineOffset
+        attributes[.baselineOffset] = baseBaselineOffset + CGFloat(options.verticalAdjustment)
         let result = NSMutableAttributedString()
         var accessibilityLines: [String] = []
+        // Only surface a leading icon via `button.image` when an actual image is available;
+        // with a missing icon the token still renders its placeholder inside the title.
+        let leadingIcon: NSImage? = if layout.lines.first?.first == .icon, icon != nil {
+            icon
+        } else {
+            nil
+        }
 
         for (lineIndex, line) in layout.lines.enumerated() {
             if lineIndex > 0 {
@@ -198,6 +248,11 @@ final class MenuBarLayoutRenderer {
             }
             var accessibilityParts: [String] = []
             for (tokenIndex, token) in line.enumerated() {
+                // The leading icon is surfaced as `button.image` so AppKit applies the system's
+                // active/inactive display tinting; it is not repeated inside the attributed title.
+                if leadingIcon != nil, lineIndex == 0, tokenIndex == 0, token == .icon {
+                    continue
+                }
                 if tokenIndex > 0, token != .space, line[tokenIndex - 1] != .space {
                     result.append(NSAttributedString(string: "\u{2009}", attributes: attributes))
                 }
@@ -228,7 +283,8 @@ final class MenuBarLayoutRenderer {
         }.joined(separator: ", ")
         return MenuBarLayoutRenderedTitle(
             attributedTitle: result,
-            accessibilityLabel: accessibilityLabel)
+            accessibilityLabel: accessibilityLabel,
+            leadingIcon: leadingIcon)
     }
 
     private static func renderItem(
@@ -472,6 +528,6 @@ final class MenuBarLayoutRenderer {
         if isStacked {
             return size == .small ? 8 : 9
         }
-        return size == .small ? 14 : 16
+        return size == .small ? 14 : 18
     }
 }

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -58,7 +58,7 @@ struct MenuBarLayoutRenderOptions: Hashable {
     /// the same visible countdown still reuse the cached title.
     let now: Date
     /// User-tunable vertical nudge for the whole title, applied on top of the optical baseline
-    /// offset. Positive moves content down, negative moves it up.
+    /// offset. Positive moves content up, negative moves it down.
     let verticalAdjustment: Int
 
     init(
@@ -242,7 +242,7 @@ final class MenuBarLayoutRenderer {
         let leadingIcon: NSImage? = if options.highContrast {
             nil
         } else if layout.lines.first?.first == .icon, icon != nil {
-            icon
+            icon.map { Self.offsetLeadingIcon($0, adjustment: options.verticalAdjustment) }
         } else {
             nil
         }
@@ -420,6 +420,29 @@ final class MenuBarLayoutRenderer {
 
     private static func iconAccessibilityText(data: MenuBarLayoutRenderData) -> String {
         L("%@ icon", data.providerName ?? L("Provider"))
+    }
+
+    private static func offsetLeadingIcon(_ image: NSImage, adjustment: Int) -> NSImage {
+        // Bake the offset into the surfaced image so the status button and preferences preview share it.
+        // Cap the canvas at the 22 pt menu bar content height to avoid proportional downscaling.
+        let maxShift = max(0, floor((22 - image.size.height) / 2))
+        let shift = min(CGFloat(abs(adjustment)), maxShift)
+        guard adjustment != 0, shift > 0 else { return image }
+
+        let offsetImage = NSImage(
+            size: NSSize(width: image.size.width, height: image.size.height + 2 * shift),
+            flipped: false)
+        { _ in
+            image.draw(
+                in: NSRect(
+                    x: 0,
+                    y: adjustment > 0 ? 2 * shift : 0,
+                    width: image.size.width,
+                    height: image.size.height))
+            return true
+        }
+        offsetImage.isTemplate = true
+        return offsetImage
     }
 
     private static func attachmentImage(_ image: NSImage, tint: NSColor) -> NSImage {

--- a/Sources/CodexBar/ProviderBrandIcon.swift
+++ b/Sources/CodexBar/ProviderBrandIcon.swift
@@ -3,7 +3,7 @@ import CodexBarCore
 
 @MainActor
 enum ProviderBrandIcon {
-    private static let size = NSSize(width: 16, height: 16)
+    private static let size = NSSize(width: 18, height: 18)
     private static var cache: [UsageProvider: NSImage] = [:]
 
     /// Lazy-loaded resource bundle for provider icons.

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "المسافة";
 "menu_bar_layout_gap_tight" = "ضيّق";
 "menu_bar_layout_gap_regular" = "عادي";
+"menu_bar_layout_vertical_adjustment" = "الضبط العمودي";
+"menu_bar_layout_vertical_up_2" = "أعلى 2 بكسل";
+"menu_bar_layout_vertical_up_1" = "أعلى بكسل";
+"menu_bar_layout_vertical_default" = "الافتراضي";
+"menu_bar_layout_vertical_down_1" = "أسفل بكسل";
+"menu_bar_layout_vertical_down_2" = "أسفل 2 بكسل";
 "menu_bar_layout_keyboard_hint" = "يحذف Delete العنصر المحدد";
 "menu_bar_layout_sample_account" = "حساب";
 "menu_bar_layout_sample_runs_out" = "ينفد الجمعة";

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "ضيّق";
 "menu_bar_layout_gap_regular" = "عادي";
 "menu_bar_layout_vertical_adjustment" = "الضبط العمودي";
-"menu_bar_layout_vertical_up_2" = "أعلى 2 بكسل";
-"menu_bar_layout_vertical_up_1" = "أعلى بكسل";
-"menu_bar_layout_vertical_default" = "الافتراضي";
-"menu_bar_layout_vertical_down_1" = "أسفل بكسل";
-"menu_bar_layout_vertical_down_2" = "أسفل 2 بكسل";
 "menu_bar_layout_keyboard_hint" = "يحذف Delete العنصر المحدد";
 "menu_bar_layout_sample_account" = "حساب";
 "menu_bar_layout_sample_runs_out" = "ينفد الجمعة";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1343,6 +1343,12 @@
 "menu_bar_layout_gap" = "Espaiat";
 "menu_bar_layout_gap_tight" = "Estret";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Ajust vertical";
+"menu_bar_layout_vertical_up_2" = "Amunt 2 px";
+"menu_bar_layout_vertical_up_1" = "Amunt 1 px";
+"menu_bar_layout_vertical_default" = "Predeterminat";
+"menu_bar_layout_vertical_down_1" = "Avall 1 px";
+"menu_bar_layout_vertical_down_2" = "Avall 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir elimina la fitxa seleccionada";
 "menu_bar_layout_sample_account" = "compte";
 "menu_bar_layout_sample_runs_out" = "s’esgota div.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1344,11 +1344,6 @@
 "menu_bar_layout_gap_tight" = "Estret";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Ajust vertical";
-"menu_bar_layout_vertical_up_2" = "Amunt 2 px";
-"menu_bar_layout_vertical_up_1" = "Amunt 1 px";
-"menu_bar_layout_vertical_default" = "Predeterminat";
-"menu_bar_layout_vertical_down_1" = "Avall 1 px";
-"menu_bar_layout_vertical_down_2" = "Avall 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir elimina la fitxa seleccionada";
 "menu_bar_layout_sample_account" = "compte";
 "menu_bar_layout_sample_runs_out" = "s’esgota div.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1342,11 +1342,6 @@
 "menu_bar_layout_gap_tight" = "Eng";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Vertikale Ausrichtung";
-"menu_bar_layout_vertical_up_2" = "Hoch 2 px";
-"menu_bar_layout_vertical_up_1" = "Hoch 1 px";
-"menu_bar_layout_vertical_default" = "Standard";
-"menu_bar_layout_vertical_down_1" = "Runter 1 px";
-"menu_bar_layout_vertical_down_2" = "Runter 2 px";
 "menu_bar_layout_keyboard_hint" = "Die Löschtaste entfernt den ausgewählten Baustein";
 "menu_bar_layout_sample_account" = "Konto";
 "menu_bar_layout_sample_runs_out" = "reicht bis Fr.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1341,6 +1341,12 @@
 "menu_bar_layout_gap" = "Abstand";
 "menu_bar_layout_gap_tight" = "Eng";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Vertikale Ausrichtung";
+"menu_bar_layout_vertical_up_2" = "Hoch 2 px";
+"menu_bar_layout_vertical_up_1" = "Hoch 1 px";
+"menu_bar_layout_vertical_default" = "Standard";
+"menu_bar_layout_vertical_down_1" = "Runter 1 px";
+"menu_bar_layout_vertical_down_2" = "Runter 2 px";
 "menu_bar_layout_keyboard_hint" = "Die Löschtaste entfernt den ausgewählten Baustein";
 "menu_bar_layout_sample_account" = "Konto";
 "menu_bar_layout_sample_runs_out" = "reicht bis Fr.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1322,7 +1322,7 @@
 "menu_bar_layout_gap" = "Gap";
 "menu_bar_layout_gap_tight" = "Tight";
 "menu_bar_layout_gap_regular" = "Regular";
-"menu_bar_layout_vertical_adjustment" = "Vertical Adjustment";
+"menu_bar_layout_vertical_adjustment" = "Vertical";
 "menu_bar_layout_vertical_up_2" = "Up 2 px";
 "menu_bar_layout_vertical_up_1" = "Up 1 px";
 "menu_bar_layout_vertical_default" = "Default";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1322,6 +1322,12 @@
 "menu_bar_layout_gap" = "Gap";
 "menu_bar_layout_gap_tight" = "Tight";
 "menu_bar_layout_gap_regular" = "Regular";
+"menu_bar_layout_vertical_adjustment" = "Vertical Adjustment";
+"menu_bar_layout_vertical_up_2" = "Up 2 px";
+"menu_bar_layout_vertical_up_1" = "Up 1 px";
+"menu_bar_layout_vertical_default" = "Default";
+"menu_bar_layout_vertical_down_1" = "Down 1 px";
+"menu_bar_layout_vertical_down_2" = "Down 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete removes the selected token";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "runs out Fri";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1323,11 +1323,6 @@
 "menu_bar_layout_gap_tight" = "Tight";
 "menu_bar_layout_gap_regular" = "Regular";
 "menu_bar_layout_vertical_adjustment" = "Vertical";
-"menu_bar_layout_vertical_up_2" = "Up 2 px";
-"menu_bar_layout_vertical_up_1" = "Up 1 px";
-"menu_bar_layout_vertical_default" = "Default";
-"menu_bar_layout_vertical_down_1" = "Down 1 px";
-"menu_bar_layout_vertical_down_2" = "Down 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete removes the selected token";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "runs out Fri";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1340,11 +1340,6 @@
 "menu_bar_layout_gap_tight" = "Estrecha";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Ajuste vertical";
-"menu_bar_layout_vertical_up_2" = "Arriba 2 px";
-"menu_bar_layout_vertical_up_1" = "Arriba 1 px";
-"menu_bar_layout_vertical_default" = "Predeterminado";
-"menu_bar_layout_vertical_down_1" = "Abajo 1 px";
-"menu_bar_layout_vertical_down_2" = "Abajo 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir quita la ficha seleccionada";
 "menu_bar_layout_sample_account" = "cuenta";
 "menu_bar_layout_sample_runs_out" = "se agota vie.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1339,6 +1339,12 @@
 "menu_bar_layout_gap" = "Separación";
 "menu_bar_layout_gap_tight" = "Estrecha";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Ajuste vertical";
+"menu_bar_layout_vertical_up_2" = "Arriba 2 px";
+"menu_bar_layout_vertical_up_1" = "Arriba 1 px";
+"menu_bar_layout_vertical_default" = "Predeterminado";
+"menu_bar_layout_vertical_down_1" = "Abajo 1 px";
+"menu_bar_layout_vertical_down_2" = "Abajo 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir quita la ficha seleccionada";
 "menu_bar_layout_sample_account" = "cuenta";
 "menu_bar_layout_sample_runs_out" = "se agota vie.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "فاصله";
 "menu_bar_layout_gap_tight" = "فشرده";
 "menu_bar_layout_gap_regular" = "معمولی";
+"menu_bar_layout_vertical_adjustment" = "تنظیم عمودی";
+"menu_bar_layout_vertical_up_2" = "۲ پیکسل بالا";
+"menu_bar_layout_vertical_up_1" = "۱ پیکسل بالا";
+"menu_bar_layout_vertical_default" = "پیش‌فرض";
+"menu_bar_layout_vertical_down_1" = "۱ پیکسل پایین";
+"menu_bar_layout_vertical_down_2" = "۲ پیکسل پایین";
 "menu_bar_layout_keyboard_hint" = "Delete نشانهٔ انتخاب‌شده را حذف می‌کند";
 "menu_bar_layout_sample_account" = "حساب";
 "menu_bar_layout_sample_runs_out" = "جمعه تمام می‌شود";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "فشرده";
 "menu_bar_layout_gap_regular" = "معمولی";
 "menu_bar_layout_vertical_adjustment" = "تنظیم عمودی";
-"menu_bar_layout_vertical_up_2" = "۲ پیکسل بالا";
-"menu_bar_layout_vertical_up_1" = "۱ پیکسل بالا";
-"menu_bar_layout_vertical_default" = "پیش‌فرض";
-"menu_bar_layout_vertical_down_1" = "۱ پیکسل پایین";
-"menu_bar_layout_vertical_down_2" = "۲ پیکسل پایین";
 "menu_bar_layout_keyboard_hint" = "Delete نشانهٔ انتخاب‌شده را حذف می‌کند";
 "menu_bar_layout_sample_account" = "حساب";
 "menu_bar_layout_sample_runs_out" = "جمعه تمام می‌شود";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1341,11 +1341,6 @@
 "menu_bar_layout_gap_tight" = "Serré";
 "menu_bar_layout_gap_regular" = "Normale";
 "menu_bar_layout_vertical_adjustment" = "Ajustement vertical";
-"menu_bar_layout_vertical_up_2" = "Haut de 2 px";
-"menu_bar_layout_vertical_up_1" = "Haut de 1 px";
-"menu_bar_layout_vertical_default" = "Par défaut";
-"menu_bar_layout_vertical_down_1" = "Bas de 1 px";
-"menu_bar_layout_vertical_down_2" = "Bas de 2 px";
 "menu_bar_layout_keyboard_hint" = "Supprimer retire le jeton sélectionné";
 "menu_bar_layout_sample_account" = "compte";
 "menu_bar_layout_sample_runs_out" = "épuisé ven.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1340,6 +1340,12 @@
 "menu_bar_layout_gap" = "Espacement";
 "menu_bar_layout_gap_tight" = "Serré";
 "menu_bar_layout_gap_regular" = "Normale";
+"menu_bar_layout_vertical_adjustment" = "Ajustement vertical";
+"menu_bar_layout_vertical_up_2" = "Haut de 2 px";
+"menu_bar_layout_vertical_up_1" = "Haut de 1 px";
+"menu_bar_layout_vertical_default" = "Par défaut";
+"menu_bar_layout_vertical_down_1" = "Bas de 1 px";
+"menu_bar_layout_vertical_down_2" = "Bas de 2 px";
 "menu_bar_layout_keyboard_hint" = "Supprimer retire le jeton sélectionné";
 "menu_bar_layout_sample_account" = "compte";
 "menu_bar_layout_sample_runs_out" = "épuisé ven.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1340,6 +1340,12 @@
 "menu_bar_layout_gap" = "Separación";
 "menu_bar_layout_gap_tight" = "Estreita";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Axuste vertical";
+"menu_bar_layout_vertical_up_2" = "Arriba 2 px";
+"menu_bar_layout_vertical_up_1" = "Arriba 1 px";
+"menu_bar_layout_vertical_default" = "Por defecto";
+"menu_bar_layout_vertical_down_1" = "Abaixo 1 px";
+"menu_bar_layout_vertical_down_2" = "Abaixo 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir retira a ficha seleccionada";
 "menu_bar_layout_sample_account" = "conta";
 "menu_bar_layout_sample_runs_out" = "esgótase ven.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1341,11 +1341,6 @@
 "menu_bar_layout_gap_tight" = "Estreita";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Axuste vertical";
-"menu_bar_layout_vertical_up_2" = "Arriba 2 px";
-"menu_bar_layout_vertical_up_1" = "Arriba 1 px";
-"menu_bar_layout_vertical_default" = "Por defecto";
-"menu_bar_layout_vertical_down_1" = "Abaixo 1 px";
-"menu_bar_layout_vertical_down_2" = "Abaixo 2 px";
 "menu_bar_layout_keyboard_hint" = "Suprimir retira a ficha seleccionada";
 "menu_bar_layout_sample_account" = "conta";
 "menu_bar_layout_sample_runs_out" = "esgótase ven.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "Jarak";
 "menu_bar_layout_gap_tight" = "Rapat";
 "menu_bar_layout_gap_regular" = "Reguler";
+"menu_bar_layout_vertical_adjustment" = "Penyesuaian Vertikal";
+"menu_bar_layout_vertical_up_2" = "Naik 2 px";
+"menu_bar_layout_vertical_up_1" = "Naik 1 px";
+"menu_bar_layout_vertical_default" = "Default";
+"menu_bar_layout_vertical_down_1" = "Turun 1 px";
+"menu_bar_layout_vertical_down_2" = "Turun 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete menghapus token yang dipilih";
 "menu_bar_layout_sample_account" = "akun";
 "menu_bar_layout_sample_runs_out" = "habis Jum.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "Rapat";
 "menu_bar_layout_gap_regular" = "Reguler";
 "menu_bar_layout_vertical_adjustment" = "Penyesuaian Vertikal";
-"menu_bar_layout_vertical_up_2" = "Naik 2 px";
-"menu_bar_layout_vertical_up_1" = "Naik 1 px";
-"menu_bar_layout_vertical_default" = "Default";
-"menu_bar_layout_vertical_down_1" = "Turun 1 px";
-"menu_bar_layout_vertical_down_2" = "Turun 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete menghapus token yang dipilih";
 "menu_bar_layout_sample_account" = "akun";
 "menu_bar_layout_sample_runs_out" = "habis Jum.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "Stretta";
 "menu_bar_layout_gap_regular" = "Normale";
 "menu_bar_layout_vertical_adjustment" = "Regolazione verticale";
-"menu_bar_layout_vertical_up_2" = "Su 2 px";
-"menu_bar_layout_vertical_up_1" = "Su 1 px";
-"menu_bar_layout_vertical_default" = "Predefinito";
-"menu_bar_layout_vertical_down_1" = "Giù 1 px";
-"menu_bar_layout_vertical_down_2" = "Giù 2 px";
 "menu_bar_layout_keyboard_hint" = "Canc rimuove il token selezionato";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "termina ven.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "Spaziatura";
 "menu_bar_layout_gap_tight" = "Stretta";
 "menu_bar_layout_gap_regular" = "Normale";
+"menu_bar_layout_vertical_adjustment" = "Regolazione verticale";
+"menu_bar_layout_vertical_up_2" = "Su 2 px";
+"menu_bar_layout_vertical_up_1" = "Su 1 px";
+"menu_bar_layout_vertical_default" = "Predefinito";
+"menu_bar_layout_vertical_down_1" = "Giù 1 px";
+"menu_bar_layout_vertical_down_2" = "Giù 2 px";
 "menu_bar_layout_keyboard_hint" = "Canc rimuove il token selezionato";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "termina ven.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1341,6 +1341,12 @@
 "menu_bar_layout_gap" = "間隔";
 "menu_bar_layout_gap_tight" = "狭い";
 "menu_bar_layout_gap_regular" = "標準";
+"menu_bar_layout_vertical_adjustment" = "垂直調整";
+"menu_bar_layout_vertical_up_2" = "上に2px";
+"menu_bar_layout_vertical_up_1" = "上に1px";
+"menu_bar_layout_vertical_default" = "デフォルト";
+"menu_bar_layout_vertical_down_1" = "下に1px";
+"menu_bar_layout_vertical_down_2" = "下に2px";
 "menu_bar_layout_keyboard_hint" = "Delete キーで選択したトークンを削除";
 "menu_bar_layout_sample_account" = "アカウント";
 "menu_bar_layout_sample_runs_out" = "金曜に使い切る";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1342,11 +1342,6 @@
 "menu_bar_layout_gap_tight" = "狭い";
 "menu_bar_layout_gap_regular" = "標準";
 "menu_bar_layout_vertical_adjustment" = "垂直調整";
-"menu_bar_layout_vertical_up_2" = "上に2px";
-"menu_bar_layout_vertical_up_1" = "上に1px";
-"menu_bar_layout_vertical_default" = "デフォルト";
-"menu_bar_layout_vertical_down_1" = "下に1px";
-"menu_bar_layout_vertical_down_2" = "下に2px";
 "menu_bar_layout_keyboard_hint" = "Delete キーで選択したトークンを削除";
 "menu_bar_layout_sample_account" = "アカウント";
 "menu_bar_layout_sample_runs_out" = "金曜に使い切る";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1308,6 +1308,12 @@
 "menu_bar_layout_gap" = "간격";
 "menu_bar_layout_gap_tight" = "좁게";
 "menu_bar_layout_gap_regular" = "보통";
+"menu_bar_layout_vertical_adjustment" = "세로 조정";
+"menu_bar_layout_vertical_up_2" = "위로 2px";
+"menu_bar_layout_vertical_up_1" = "위로 1px";
+"menu_bar_layout_vertical_default" = "기본값";
+"menu_bar_layout_vertical_down_1" = "아래로 1px";
+"menu_bar_layout_vertical_down_2" = "아래로 2px";
 "menu_bar_layout_keyboard_hint" = "Delete 키로 선택한 토큰 제거";
 "menu_bar_layout_sample_account" = "계정";
 "menu_bar_layout_sample_runs_out" = "금요일 소진";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1309,11 +1309,6 @@
 "menu_bar_layout_gap_tight" = "좁게";
 "menu_bar_layout_gap_regular" = "보통";
 "menu_bar_layout_vertical_adjustment" = "세로 조정";
-"menu_bar_layout_vertical_up_2" = "위로 2px";
-"menu_bar_layout_vertical_up_1" = "위로 1px";
-"menu_bar_layout_vertical_default" = "기본값";
-"menu_bar_layout_vertical_down_1" = "아래로 1px";
-"menu_bar_layout_vertical_down_2" = "아래로 2px";
 "menu_bar_layout_keyboard_hint" = "Delete 키로 선택한 토큰 제거";
 "menu_bar_layout_sample_account" = "계정";
 "menu_bar_layout_sample_runs_out" = "금요일 소진";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1341,11 +1341,6 @@
 "menu_bar_layout_gap_tight" = "Krap";
 "menu_bar_layout_gap_regular" = "Normaal";
 "menu_bar_layout_vertical_adjustment" = "Verticale aanpassing";
-"menu_bar_layout_vertical_up_2" = "Omhoog 2 px";
-"menu_bar_layout_vertical_up_1" = "Omhoog 1 px";
-"menu_bar_layout_vertical_default" = "Standaard";
-"menu_bar_layout_vertical_down_1" = "Omlaag 1 px";
-"menu_bar_layout_vertical_down_2" = "Omlaag 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete verwijdert het geselecteerde token";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "op vr.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1340,6 +1340,12 @@
 "menu_bar_layout_gap" = "Tussenruimte";
 "menu_bar_layout_gap_tight" = "Krap";
 "menu_bar_layout_gap_regular" = "Normaal";
+"menu_bar_layout_vertical_adjustment" = "Verticale aanpassing";
+"menu_bar_layout_vertical_up_2" = "Omhoog 2 px";
+"menu_bar_layout_vertical_up_1" = "Omhoog 1 px";
+"menu_bar_layout_vertical_default" = "Standaard";
+"menu_bar_layout_vertical_down_1" = "Omlaag 1 px";
+"menu_bar_layout_vertical_down_2" = "Omlaag 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete verwijdert het geselecteerde token";
 "menu_bar_layout_sample_account" = "account";
 "menu_bar_layout_sample_runs_out" = "op vr.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "Odstęp";
 "menu_bar_layout_gap_tight" = "Wąski";
 "menu_bar_layout_gap_regular" = "Zwykły";
+"menu_bar_layout_vertical_adjustment" = "Regulacja pionowa";
+"menu_bar_layout_vertical_up_2" = "W górę 2 px";
+"menu_bar_layout_vertical_up_1" = "W górę 1 px";
+"menu_bar_layout_vertical_default" = "Domyślnie";
+"menu_bar_layout_vertical_down_1" = "W dół 1 px";
+"menu_bar_layout_vertical_down_2" = "W dół 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete usuwa zaznaczony element";
 "menu_bar_layout_sample_account" = "konto";
 "menu_bar_layout_sample_runs_out" = "wyczerpie się pt.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "Wąski";
 "menu_bar_layout_gap_regular" = "Zwykły";
 "menu_bar_layout_vertical_adjustment" = "Regulacja pionowa";
-"menu_bar_layout_vertical_up_2" = "W górę 2 px";
-"menu_bar_layout_vertical_up_1" = "W górę 1 px";
-"menu_bar_layout_vertical_default" = "Domyślnie";
-"menu_bar_layout_vertical_down_1" = "W dół 1 px";
-"menu_bar_layout_vertical_down_2" = "W dół 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete usuwa zaznaczony element";
 "menu_bar_layout_sample_account" = "konto";
 "menu_bar_layout_sample_runs_out" = "wyczerpie się pt.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1342,11 +1342,6 @@
 "menu_bar_layout_gap_tight" = "Apertado";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Ajuste vertical";
-"menu_bar_layout_vertical_up_2" = "Acima 2 px";
-"menu_bar_layout_vertical_up_1" = "Acima 1 px";
-"menu_bar_layout_vertical_default" = "Padrão";
-"menu_bar_layout_vertical_down_1" = "Abaixo 1 px";
-"menu_bar_layout_vertical_down_2" = "Abaixo 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete remove o item selecionado";
 "menu_bar_layout_sample_account" = "conta";
 "menu_bar_layout_sample_runs_out" = "acaba sex.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1341,6 +1341,12 @@
 "menu_bar_layout_gap" = "Espaçamento";
 "menu_bar_layout_gap_tight" = "Apertado";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Ajuste vertical";
+"menu_bar_layout_vertical_up_2" = "Acima 2 px";
+"menu_bar_layout_vertical_up_1" = "Acima 1 px";
+"menu_bar_layout_vertical_default" = "Padrão";
+"menu_bar_layout_vertical_down_1" = "Abaixo 1 px";
+"menu_bar_layout_vertical_down_2" = "Abaixo 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete remove o item selecionado";
 "menu_bar_layout_sample_account" = "conta";
 "menu_bar_layout_sample_runs_out" = "acaba sex.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1343,11 +1343,6 @@
 "menu_bar_layout_gap_tight" = "Узкий";
 "menu_bar_layout_gap_regular" = "Обычный";
 "menu_bar_layout_vertical_adjustment" = "Вертикальная настройка";
-"menu_bar_layout_vertical_up_2" = "Вверх 2 px";
-"menu_bar_layout_vertical_up_1" = "Вверх 1 px";
-"menu_bar_layout_vertical_default" = "По умолчанию";
-"menu_bar_layout_vertical_down_1" = "Вниз 1 px";
-"menu_bar_layout_vertical_down_2" = "Вниз 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete удаляет выбранный элемент";
 "menu_bar_layout_sample_account" = "аккаунт";
 "menu_bar_layout_sample_runs_out" = "закончится пт.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1342,6 +1342,12 @@
 "menu_bar_layout_gap" = "Интервал";
 "menu_bar_layout_gap_tight" = "Узкий";
 "menu_bar_layout_gap_regular" = "Обычный";
+"menu_bar_layout_vertical_adjustment" = "Вертикальная настройка";
+"menu_bar_layout_vertical_up_2" = "Вверх 2 px";
+"menu_bar_layout_vertical_up_1" = "Вверх 1 px";
+"menu_bar_layout_vertical_default" = "По умолчанию";
+"menu_bar_layout_vertical_down_1" = "Вниз 1 px";
+"menu_bar_layout_vertical_down_2" = "Вниз 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete удаляет выбранный элемент";
 "menu_bar_layout_sample_account" = "аккаунт";
 "menu_bar_layout_sample_runs_out" = "закончится пт.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1340,11 +1340,6 @@
 "menu_bar_layout_gap_tight" = "Tätt";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Vertikal justering";
-"menu_bar_layout_vertical_up_2" = "Upp 2 px";
-"menu_bar_layout_vertical_up_1" = "Upp 1 px";
-"menu_bar_layout_vertical_default" = "Standard";
-"menu_bar_layout_vertical_down_1" = "Ner 1 px";
-"menu_bar_layout_vertical_down_2" = "Ner 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete tar bort den markerade brickan";
 "menu_bar_layout_sample_account" = "konto";
 "menu_bar_layout_sample_runs_out" = "tar slut fre.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1339,6 +1339,12 @@
 "menu_bar_layout_gap" = "Mellanrum";
 "menu_bar_layout_gap_tight" = "Tätt";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Vertikal justering";
+"menu_bar_layout_vertical_up_2" = "Upp 2 px";
+"menu_bar_layout_vertical_up_1" = "Upp 1 px";
+"menu_bar_layout_vertical_default" = "Standard";
+"menu_bar_layout_vertical_down_1" = "Ner 1 px";
+"menu_bar_layout_vertical_down_2" = "Ner 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete tar bort den markerade brickan";
 "menu_bar_layout_sample_account" = "konto";
 "menu_bar_layout_sample_runs_out" = "tar slut fre.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1344,6 +1344,12 @@
 "menu_bar_layout_gap" = "ระยะห่าง";
 "menu_bar_layout_gap_tight" = "ชิด";
 "menu_bar_layout_gap_regular" = "ปกติ";
+"menu_bar_layout_vertical_adjustment" = "ปรับแนวตั้ง";
+"menu_bar_layout_vertical_up_2" = "ขึ้น 2 พิกเซล";
+"menu_bar_layout_vertical_up_1" = "ขึ้น 1 พิกเซล";
+"menu_bar_layout_vertical_default" = "ค่าเริ่มต้น";
+"menu_bar_layout_vertical_down_1" = "ลง 1 พิกเซล";
+"menu_bar_layout_vertical_down_2" = "ลง 2 พิกเซล";
 "menu_bar_layout_keyboard_hint" = "Delete ลบโทเค็นที่เลือก";
 "menu_bar_layout_sample_account" = "บัญชี";
 "menu_bar_layout_sample_runs_out" = "หมดวันศุกร์";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1345,11 +1345,6 @@
 "menu_bar_layout_gap_tight" = "ชิด";
 "menu_bar_layout_gap_regular" = "ปกติ";
 "menu_bar_layout_vertical_adjustment" = "ปรับแนวตั้ง";
-"menu_bar_layout_vertical_up_2" = "ขึ้น 2 พิกเซล";
-"menu_bar_layout_vertical_up_1" = "ขึ้น 1 พิกเซล";
-"menu_bar_layout_vertical_default" = "ค่าเริ่มต้น";
-"menu_bar_layout_vertical_down_1" = "ลง 1 พิกเซล";
-"menu_bar_layout_vertical_down_2" = "ลง 2 พิกเซล";
 "menu_bar_layout_keyboard_hint" = "Delete ลบโทเค็นที่เลือก";
 "menu_bar_layout_sample_account" = "บัญชี";
 "menu_bar_layout_sample_runs_out" = "หมดวันศุกร์";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1342,6 +1342,12 @@
 "menu_bar_layout_gap" = "Boşluk";
 "menu_bar_layout_gap_tight" = "Dar";
 "menu_bar_layout_gap_regular" = "Normal";
+"menu_bar_layout_vertical_adjustment" = "Dikey Ayar";
+"menu_bar_layout_vertical_up_2" = "Yukarı 2 px";
+"menu_bar_layout_vertical_up_1" = "Yukarı 1 px";
+"menu_bar_layout_vertical_default" = "Varsayılan";
+"menu_bar_layout_vertical_down_1" = "Aşağı 1 px";
+"menu_bar_layout_vertical_down_2" = "Aşağı 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete seçili belirteci kaldırır";
 "menu_bar_layout_sample_account" = "hesap";
 "menu_bar_layout_sample_runs_out" = "Cum. biter";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1343,11 +1343,6 @@
 "menu_bar_layout_gap_tight" = "Dar";
 "menu_bar_layout_gap_regular" = "Normal";
 "menu_bar_layout_vertical_adjustment" = "Dikey Ayar";
-"menu_bar_layout_vertical_up_2" = "Yukarı 2 px";
-"menu_bar_layout_vertical_up_1" = "Yukarı 1 px";
-"menu_bar_layout_vertical_default" = "Varsayılan";
-"menu_bar_layout_vertical_down_1" = "Aşağı 1 px";
-"menu_bar_layout_vertical_down_2" = "Aşağı 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete seçili belirteci kaldırır";
 "menu_bar_layout_sample_account" = "hesap";
 "menu_bar_layout_sample_runs_out" = "Cum. biter";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1340,6 +1340,12 @@
 "menu_bar_layout_gap" = "Інтервал";
 "menu_bar_layout_gap_tight" = "Вузький";
 "menu_bar_layout_gap_regular" = "Звичайний";
+"menu_bar_layout_vertical_adjustment" = "Вертикальне налаштування";
+"menu_bar_layout_vertical_up_2" = "Вгору 2 px";
+"menu_bar_layout_vertical_up_1" = "Вгору 1 px";
+"menu_bar_layout_vertical_default" = "За замовчуванням";
+"menu_bar_layout_vertical_down_1" = "Вниз 1 px";
+"menu_bar_layout_vertical_down_2" = "Вниз 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete видаляє вибраний елемент";
 "menu_bar_layout_sample_account" = "обліковий запис";
 "menu_bar_layout_sample_runs_out" = "закінчиться пт.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1341,11 +1341,6 @@
 "menu_bar_layout_gap_tight" = "Вузький";
 "menu_bar_layout_gap_regular" = "Звичайний";
 "menu_bar_layout_vertical_adjustment" = "Вертикальне налаштування";
-"menu_bar_layout_vertical_up_2" = "Вгору 2 px";
-"menu_bar_layout_vertical_up_1" = "Вгору 1 px";
-"menu_bar_layout_vertical_default" = "За замовчуванням";
-"menu_bar_layout_vertical_down_1" = "Вниз 1 px";
-"menu_bar_layout_vertical_down_2" = "Вниз 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete видаляє вибраний елемент";
 "menu_bar_layout_sample_account" = "обліковий запис";
 "menu_bar_layout_sample_runs_out" = "закінчиться пт.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1342,11 +1342,6 @@
 "menu_bar_layout_gap_tight" = "Hẹp";
 "menu_bar_layout_gap_regular" = "Thường";
 "menu_bar_layout_vertical_adjustment" = "Điều chỉnh dọc";
-"menu_bar_layout_vertical_up_2" = "Lên 2 px";
-"menu_bar_layout_vertical_up_1" = "Lên 1 px";
-"menu_bar_layout_vertical_default" = "Mặc định";
-"menu_bar_layout_vertical_down_1" = "Xuống 1 px";
-"menu_bar_layout_vertical_down_2" = "Xuống 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete xóa thẻ đã chọn";
 "menu_bar_layout_sample_account" = "tài khoản";
 "menu_bar_layout_sample_runs_out" = "hết vào T6";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1341,6 +1341,12 @@
 "menu_bar_layout_gap" = "Khoảng cách";
 "menu_bar_layout_gap_tight" = "Hẹp";
 "menu_bar_layout_gap_regular" = "Thường";
+"menu_bar_layout_vertical_adjustment" = "Điều chỉnh dọc";
+"menu_bar_layout_vertical_up_2" = "Lên 2 px";
+"menu_bar_layout_vertical_up_1" = "Lên 1 px";
+"menu_bar_layout_vertical_default" = "Mặc định";
+"menu_bar_layout_vertical_down_1" = "Xuống 1 px";
+"menu_bar_layout_vertical_down_2" = "Xuống 2 px";
 "menu_bar_layout_keyboard_hint" = "Delete xóa thẻ đã chọn";
 "menu_bar_layout_sample_account" = "tài khoản";
 "menu_bar_layout_sample_runs_out" = "hết vào T6";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1319,6 +1319,12 @@
 "menu_bar_layout_gap" = "间距";
 "menu_bar_layout_gap_tight" = "紧凑";
 "menu_bar_layout_gap_regular" = "常规";
+"menu_bar_layout_vertical_adjustment" = "垂直调整";
+"menu_bar_layout_vertical_up_2" = "上移 2 像素";
+"menu_bar_layout_vertical_up_1" = "上移 1 像素";
+"menu_bar_layout_vertical_default" = "默认";
+"menu_bar_layout_vertical_down_1" = "下移 1 像素";
+"menu_bar_layout_vertical_down_2" = "下移 2 像素";
 "menu_bar_layout_keyboard_hint" = "Delete 键会移除所选项目";
 "menu_bar_layout_sample_account" = "帐户";
 "menu_bar_layout_sample_runs_out" = "周五用尽";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1320,11 +1320,6 @@
 "menu_bar_layout_gap_tight" = "紧凑";
 "menu_bar_layout_gap_regular" = "常规";
 "menu_bar_layout_vertical_adjustment" = "垂直调整";
-"menu_bar_layout_vertical_up_2" = "上移 2 像素";
-"menu_bar_layout_vertical_up_1" = "上移 1 像素";
-"menu_bar_layout_vertical_default" = "默认";
-"menu_bar_layout_vertical_down_1" = "下移 1 像素";
-"menu_bar_layout_vertical_down_2" = "下移 2 像素";
 "menu_bar_layout_keyboard_hint" = "Delete 键会移除所选项目";
 "menu_bar_layout_sample_account" = "帐户";
 "menu_bar_layout_sample_runs_out" = "周五用尽";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1372,11 +1372,6 @@
 "menu_bar_layout_gap_tight" = "緊湊";
 "menu_bar_layout_gap_regular" = "一般";
 "menu_bar_layout_vertical_adjustment" = "垂直調整";
-"menu_bar_layout_vertical_up_2" = "上移 2 像素";
-"menu_bar_layout_vertical_up_1" = "上移 1 像素";
-"menu_bar_layout_vertical_default" = "預設";
-"menu_bar_layout_vertical_down_1" = "下移 1 像素";
-"menu_bar_layout_vertical_down_2" = "下移 2 像素";
 "menu_bar_layout_keyboard_hint" = "Delete 鍵會移除所選項目";
 "menu_bar_layout_sample_account" = "帳號";
 "menu_bar_layout_sample_runs_out" = "週五用盡";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1371,6 +1371,12 @@
 "menu_bar_layout_gap" = "間距";
 "menu_bar_layout_gap_tight" = "緊湊";
 "menu_bar_layout_gap_regular" = "一般";
+"menu_bar_layout_vertical_adjustment" = "垂直調整";
+"menu_bar_layout_vertical_up_2" = "上移 2 像素";
+"menu_bar_layout_vertical_up_1" = "上移 1 像素";
+"menu_bar_layout_vertical_default" = "預設";
+"menu_bar_layout_vertical_down_1" = "下移 1 像素";
+"menu_bar_layout_vertical_down_2" = "下移 2 像素";
 "menu_bar_layout_keyboard_hint" = "Delete 鍵會移除所選項目";
 "menu_bar_layout_sample_account" = "帳號";
 "menu_bar_layout_sample_runs_out" = "週五用盡";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -472,7 +472,7 @@ extension SettingsStore {
     }
 
     /// User-tunable vertical nudge for the menu bar title, clamped to -20...20.
-    /// Positive moves content down, negative moves it up; 0 keeps the optical default.
+    /// Positive moves content up, negative moves it down; 0 keeps the optical default.
     var menuBarLayoutVerticalAdjustment: Int {
         get { self.defaultsState.menuBarLayoutVerticalAdjustment }
         set {

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -471,6 +471,17 @@ extension SettingsStore {
         }
     }
 
+    /// User-tunable vertical nudge for the menu bar title, clamped to -20...20.
+    /// Positive moves content down, negative moves it up; 0 keeps the optical default.
+    var menuBarLayoutVerticalAdjustment: Int {
+        get { self.defaultsState.menuBarLayoutVerticalAdjustment }
+        set {
+            let clamped = max(-20, min(20, newValue))
+            self.defaultsState.menuBarLayoutVerticalAdjustment = clamped
+            self.userDefaults.set(clamped, forKey: "menuBarLayoutVerticalAdjustment")
+        }
+    }
+
     private func persistMenuBarLayout(_ layout: MenuBarLayout, key: String) {
         guard let data = try? JSONEncoder().encode(layout) else { return }
         self.userDefaults.set(data, forKey: key)

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -40,6 +40,7 @@ extension SettingsStore {
         _ = self.menuBarLayoutOverrides
         _ = self.menuBarLayoutSize
         _ = self.menuBarLayoutGap
+        _ = self.menuBarLayoutVerticalAdjustment
         _ = self.copilotIconSecondaryWindowIDRaw
         _ = self.costUsageEnabled
         _ = self.codexLocalSessionCostLedgerEnabled

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -474,6 +474,8 @@ extension SettingsStore {
             ?? MenuBarLayoutSize.regular.rawValue
         let menuBarLayoutGapRaw = userDefaults.string(forKey: "menuBarLayoutGap")
             ?? MenuBarLayoutGap.regular.rawValue
+        let rawVerticalAdjustment = userDefaults.object(forKey: "menuBarLayoutVerticalAdjustment") as? Int
+        let menuBarLayoutVerticalAdjustment = max(-20, min(20, rawVerticalAdjustment ?? 0))
         let copilotBudgetExtrasEnabled = userDefaults.object(forKey: "copilotBudgetExtrasEnabled") as? Bool ?? false
         let copilotIconSecondaryWindowIDRaw = Self.loadCopilotIconSecondaryWindowIDRaw(userDefaults: userDefaults)
         let costUsageEnabled = userDefaults.object(forKey: "tokenCostUsageEnabled") as? Bool ?? false
@@ -594,6 +596,7 @@ extension SettingsStore {
             menuBarLayoutOverridesRaw: menuBarLayoutOverridesRaw,
             menuBarLayoutSizeRaw: menuBarLayoutSizeRaw,
             menuBarLayoutGapRaw: menuBarLayoutGapRaw,
+            menuBarLayoutVerticalAdjustment: menuBarLayoutVerticalAdjustment,
             copilotBudgetExtrasEnabled: copilotBudgetExtrasEnabled,
             copilotIconSecondaryWindowIDRaw: copilotIconSecondaryWindowIDRaw,
             costUsageEnabled: costUsageEnabled,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -40,6 +40,7 @@ struct SettingsDefaultsState {
     var menuBarLayoutOverridesRaw: [String: MenuBarLayout]
     var menuBarLayoutSizeRaw: String
     var menuBarLayoutGapRaw: String
+    var menuBarLayoutVerticalAdjustment: Int
     var copilotBudgetExtrasEnabled: Bool
     var copilotIconSecondaryWindowIDRaw: String
     var costUsageEnabled: Bool

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -42,8 +42,13 @@ extension StatusItemController {
             data: data,
             icon: renderedIcon,
             options: options)
-        let wasCached = button.image == nil
-            && button.imagePosition == .noImage
+        let expectedImagePosition: NSControl.ImagePosition = if rendered.leadingIcon != nil {
+            rendered.attributedTitle.length > 0 ? .imageLeft : .imageOnly
+        } else {
+            .noImage
+        }
+        let wasCached = button.image === rendered.leadingIcon
+            && button.imagePosition == expectedImagePosition
             && button.attributedTitle.isEqual(to: rendered.attributedTitle)
         self.setButtonLayoutContent(rendered, for: button, statusItem: statusItem)
         return wasCached

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -34,7 +34,9 @@ extension StatusItemController {
             showUsed: self.settings.usageBarsShowUsed,
             appearanceName: appearanceName,
             isDebugApp: Self.isDebugApp(bundleIdentifier: Bundle.main.bundleIdentifier),
-            now: now)
+            isStale: self.store.isStale(provider: provider),
+            now: now,
+            verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment)
         let rendered = self.menuBarLayoutRenderer.render(
             layout: resolution.layout,
             data: data,
@@ -161,8 +163,25 @@ extension StatusItemController {
         for button: NSStatusBarButton,
         statusItem: NSStatusItem)
     {
-        button.image = nil
-        button.imagePosition = .noImage
+        // A leading icon token is surfaced as the status item image so AppKit applies the
+        // system's inactive-display tinting to it, matching how other menu bar icons behave.
+        // Text tokens keep rendering through the attributed title.
+        if let icon = rendered.leadingIcon {
+            if button.image !== icon {
+                button.image = icon
+            }
+            let position: NSControl.ImagePosition = rendered.attributedTitle.length > 0 ? .imageLeft : .imageOnly
+            if button.imagePosition != position {
+                button.imagePosition = position
+            }
+        } else {
+            if button.image != nil {
+                button.image = nil
+            }
+            if button.imagePosition != .noImage {
+                button.imagePosition = .noImage
+            }
+        }
         if !button.attributedTitle.isEqual(to: rendered.attributedTitle) {
             button.attributedTitle = rendered.attributedTitle
         }
@@ -172,9 +191,12 @@ extension StatusItemController {
 
         // AppKit exposes no content-inset API on NSStatusBarButton. Explicit item length is the actual
         // status-item padding mechanism: tight removes most edge space; regular keeps the native breathing room.
-        let bounds = rendered.attributedTitle.boundingRect(
+        var bounds = rendered.attributedTitle.boundingRect(
             with: NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading])
+        if let icon = rendered.leadingIcon {
+            bounds.size.width += icon.size.width
+        }
         let horizontalPadding: CGFloat = self.settings.menuBarLayoutGap == .tight ? 3 : 10
         statusItem.length = max(18, ceil(bounds.width) + horizontalPadding)
     }

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -504,7 +504,11 @@ struct MenuBarLayoutRendererTests {
             cost30d: "$20.00")
     }
 
-    private func options(now: Date? = nil, verticalAdjustment: Int = 0, isStale: Bool = false) -> MenuBarLayoutRenderOptions {
+    private func options(
+        now: Date? = nil,
+        verticalAdjustment: Int = 0,
+        isStale: Bool = false) -> MenuBarLayoutRenderOptions
+    {
         MenuBarLayoutRenderOptions(
             size: .regular,
             highContrast: false,

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -48,7 +48,8 @@ struct MenuBarLayoutRendererTests {
             data: data,
             icon: icon,
             options: self.options())
-        #expect(iconOutput.attributedTitle.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
+        #expect(iconOutput.attributedTitle.string.isEmpty)
+        #expect(iconOutput.leadingIcon != nil)
 
         let absoluteOutput = renderer.render(
             layout: MenuBarLayout(lines: [[.resetAbsolute]]),
@@ -99,14 +100,11 @@ struct MenuBarLayoutRendererTests {
             data: self.data(),
             icon: icon,
             options: self.options())
-        let attachment = try #require(
-            output.attributedTitle.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment)
-        let attachmentImage = try #require(attachment.image)
 
-        #expect(attachment.bounds.size == NSSize(width: 16, height: 16))
-        #expect(attachmentImage.isTemplate)
-        #expect(try self.averageBrightness(of: output.attributedTitle, appearance: .aqua) < 0.25)
-        #expect(try self.averageBrightness(of: output.attributedTitle, appearance: .darkAqua) > 0.75)
+        #expect(output.attributedTitle.string.isEmpty)
+        let leadingIcon = try #require(output.leadingIcon)
+        #expect(leadingIcon.isTemplate)
+        #expect(leadingIcon.size == icon.size)
     }
 
     @Test
@@ -263,7 +261,31 @@ struct MenuBarLayoutRendererTests {
 
         #expect(try #require(self.baselineOffset(in: stacked.attributedTitle, at: 0)) == -3)
         #expect(try #require(self.baselineOffset(in: stacked.attributedTitle, at: resetIndex)) == -3)
-        #expect(self.baselineOffset(in: singleLine.attributedTitle, at: 0) == nil)
+        #expect(try #require(self.baselineOffset(in: singleLine.attributedTitle, at: 0)) == -1)
+    }
+
+    @Test
+    func `vertical adjustment shifts single line baseline offset`() throws {
+        let renderer = MenuBarLayoutRenderer()
+        let base = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options())
+        let adjusted = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options(verticalAdjustment: 2))
+        let lifted = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options(verticalAdjustment: -2))
+
+        #expect(try #require(self.baselineOffset(in: base.attributedTitle, at: 0)) == -1)
+        #expect(try #require(self.baselineOffset(in: adjusted.attributedTitle, at: 0)) == 1)
+        #expect(try #require(self.baselineOffset(in: lifted.attributedTitle, at: 0)) == -3)
     }
 
     @Test
@@ -414,10 +436,31 @@ struct MenuBarLayoutRendererTests {
             icon: icon,
             options: options)
 
-        #expect(output.attributedTitle.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
+        #expect(output.leadingIcon != nil)
         let textIndex = (output.attributedTitle.string as NSString).range(of: "50%").location
         #expect(output.attributedTitle
             .attribute(.foregroundColor, at: textIndex, effectiveRange: nil) as? NSColor == .labelColor)
+    }
+
+    @Test
+    func `stale title dims foreground while keeping the snapshot visible`() {
+        let renderer = MenuBarLayoutRenderer()
+        let fresh = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options())
+        let stale = renderer.render(
+            layout: MenuBarLayout(lines: [[.percent(window: .automatic)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options(isStale: true))
+
+        #expect(stale.attributedTitle.string == fresh.attributedTitle.string)
+        #expect(stale.attributedTitle
+            .attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == .secondaryLabelColor)
+        #expect(fresh.attributedTitle
+            .attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor == .controlTextColor)
     }
 
     private func data(
@@ -461,14 +504,16 @@ struct MenuBarLayoutRendererTests {
             cost30d: "$20.00")
     }
 
-    private func options(now: Date? = nil) -> MenuBarLayoutRenderOptions {
+    private func options(now: Date? = nil, verticalAdjustment: Int = 0, isStale: Bool = false) -> MenuBarLayoutRenderOptions {
         MenuBarLayoutRenderOptions(
             size: .regular,
             highContrast: false,
             showUsed: true,
             appearanceName: "aqua",
             isDebugApp: false,
-            now: now ?? self.now)
+            isStale: isStale,
+            now: now ?? self.now,
+            verticalAdjustment: verticalAdjustment)
     }
 
     private func averageBrightness(
@@ -476,12 +521,22 @@ struct MenuBarLayoutRendererTests {
         appearance: NSAppearance.Name) throws
         -> CGFloat
     {
+        try self.renderAverageBrightness(appearance: appearance) { _ in
+            title.draw(at: NSPoint(x: 4, y: 4))
+        }
+    }
+
+    private func renderAverageBrightness(
+        appearance: NSAppearance.Name,
+        draw: (NSImage) -> Void) throws
+        -> CGFloat
+    {
         let canvas = NSImage(size: NSSize(width: 24, height: 24))
         try #require(NSAppearance(named: appearance)).performAsCurrentDrawingAppearance {
             canvas.lockFocus()
             NSColor.clear.setFill()
             NSRect(origin: .zero, size: canvas.size).fill()
-            title.draw(at: NSPoint(x: 4, y: 4))
+            draw(canvas)
             canvas.unlockFocus()
         }
 

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -436,10 +436,29 @@ struct MenuBarLayoutRendererTests {
             icon: icon,
             options: options)
 
-        #expect(output.leadingIcon != nil)
+        // High contrast keeps the icon inside the attributed title (not surfaced as button.image)
+        // so AppKit dims the whole title together on inactive displays.
+        #expect(output.leadingIcon == nil)
+        #expect(output.attributedTitle.attribute(.attachment, at: 0, effectiveRange: nil) is NSTextAttachment)
         let textIndex = (output.attributedTitle.string as NSString).range(of: "50%").location
         #expect(output.attributedTitle
             .attribute(.foregroundColor, at: textIndex, effectiveRange: nil) as? NSColor == .labelColor)
+    }
+
+    @Test
+    func `extracted leading icon keeps its accessibility description`() {
+        let renderer = MenuBarLayoutRenderer()
+        let icon = NSImage(size: NSSize(width: 16, height: 16))
+        icon.isTemplate = true
+        let output = renderer.render(
+            layout: MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]]),
+            data: self.data(),
+            icon: icon,
+            options: self.options())
+
+        #expect(output.leadingIcon != nil)
+        #expect(output.attributedTitle.attribute(.attachment, at: 0, effectiveRange: nil) == nil)
+        #expect(output.accessibilityLabel.contains(L("%@ icon", "Codex")))
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -108,6 +108,62 @@ struct MenuBarLayoutRendererTests {
     }
 
     @Test
+    func `vertical adjustment offsets the surfaced leading icon`() throws {
+        let renderer = MenuBarLayoutRenderer()
+        let icon = NSImage(size: NSSize(width: 16, height: 16))
+        icon.isTemplate = true
+        let layout = MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]])
+        let raised = renderer.render(
+            layout: layout,
+            data: self.data(),
+            icon: icon,
+            options: self.options(verticalAdjustment: 2))
+        let lowered = renderer.render(
+            layout: layout,
+            data: self.data(),
+            icon: icon,
+            options: self.options(verticalAdjustment: -2))
+
+        let raisedIcon = try #require(raised.leadingIcon)
+        #expect(raisedIcon.size == NSSize(width: 16, height: 20))
+        #expect(raisedIcon.isTemplate)
+        let loweredIcon = try #require(lowered.leadingIcon)
+        #expect(loweredIcon.size == NSSize(width: 16, height: 20))
+        #expect(loweredIcon.isTemplate)
+    }
+
+    @Test
+    func `vertical adjustment on the surfaced icon is capped to the menu bar height`() throws {
+        let renderer = MenuBarLayoutRenderer()
+        let icon = NSImage(size: NSSize(width: 18, height: 18))
+        icon.isTemplate = true
+        let output = renderer.render(
+            layout: MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]]),
+            data: self.data(),
+            icon: icon,
+            options: self.options(verticalAdjustment: 10))
+
+        let leadingIcon = try #require(output.leadingIcon)
+        #expect(leadingIcon.size == NSSize(width: 18, height: 22))
+        #expect(leadingIcon.isTemplate)
+    }
+
+    @Test
+    func `zero vertical adjustment returns the original leading icon instance`() throws {
+        let renderer = MenuBarLayoutRenderer()
+        let icon = NSImage(size: NSSize(width: 16, height: 16))
+        icon.isTemplate = true
+        let output = renderer.render(
+            layout: MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]]),
+            data: self.data(),
+            icon: icon,
+            options: self.options(verticalAdjustment: 0))
+
+        let leadingIcon = try #require(output.leadingIcon)
+        #expect(leadingIcon === icon)
+    }
+
+    @Test
     func `missing token data keeps every sibling visible as a placeholder`() {
         let renderer = MenuBarLayoutRenderer()
         let missingData = MenuBarLayoutRenderData(

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -884,13 +884,13 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact provider-owned construct passes a fixed identity to shared infrastructure."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/SettingsStore+MenuObservation.swift",
-            line: 95,
+            line: 96,
             anchor: "_ = self[providerConfig: .synthetic, field: .apiKey]",
             expectedProviderIDs: ["synthetic"],
             reason: "This observation touchpoint reads a fixed provider field so UI invalidation tracks that setting."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/SettingsStore+MenuObservation.swift",
-            line: 114,
+            line: 115,
             anchor: "_ = self[providerConfig: .warp, field: .apiKey]",
             expectedProviderIDs: ["warp"],
             reason: "This observation touchpoint reads a fixed provider field so UI invalidation tracks that setting."),
@@ -1761,7 +1761,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuBarLayoutEditor.swift",
-            line: 629,
+            line: 650,
             anchor: "let provider = self.provider ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -1769,7 +1769,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuBarLayoutEditor.swift",
-            line: 654,
+            line: 676,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2281,7 +2281,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1024,
+            line: 1027,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,
@@ -2498,7 +2498,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+MenuBarLayout.swift",
-            line: 127,
+            line: 134,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/ProviderIconResourcesTests.swift
+++ b/Tests/CodexBarTests/ProviderIconResourcesTests.swift
@@ -35,7 +35,7 @@ struct ProviderIconResourcesTests {
         let second = try #require(ProviderBrandIcon.image(for: .codex))
 
         #expect(first === second)
-        #expect(first.size == NSSize(width: 16, height: 16))
+        #expect(first.size == NSSize(width: 18, height: 18))
         #expect(first.isTemplate)
     }
 
@@ -46,7 +46,7 @@ struct ProviderIconResourcesTests {
 
         let image = try #require(ProviderBrandIcon.image(for: .ollama))
 
-        #expect(image.size == NSSize(width: 16, height: 16))
+        #expect(image.size == NSSize(width: 18, height: 18))
         #expect(image.isTemplate)
 
         let bitmap = try #require(NSBitmapImageRep(


### PR DESCRIPTION
## Summary

Menu bar custom-layout icons do not follow the system's inactive-display dimming: provider icons were embedded as attributed-title attachments, which AppKit never tints. This PR:

- Surfaces the leading custom-layout icon via the native status-button `button.image` slot so AppKit applies the active/inactive display tinting automatically.
- Uses the standard menu bar icon size and optical baseline offset for single-line titles.
- Adds a user-tunable vertical adjustment (`-20...20`) for the whole title, exposed as a numeric field + stepper in Preferences, applied on top of the optical baseline.

## Changes

- `Sources/CodexBar/MenuBarLayoutRenderer.swift`: `MenuBarLayoutRenderOptions` gains `isStale` + `verticalAdjustment`; leading icons are surfaced as `leadingIcon` (template image) instead of an attributed attachment; baseline offset = optical baseline + user nudge; stale snapshots render dimmer.
- `Sources/CodexBar/StatusItemController+MenuBarLayout.swift`: assigns the rendered `leadingIcon` to `button.image`.
- `Sources/CodexBar/MenuBarLayoutEditor.swift`: vertical-adjustment numeric input + stepper, preview passes the adjustment through.
- Settings plumbing (`SettingsStore*`) and localization strings.
- `Tests/CodexBarTests/MenuBarLayoutRendererTests.swift`: coverage for baseline offsets, vertical adjustment, stale dimming, and `leadingIcon` surfacing.

## Verification

- `MenuBarLayoutRendererTests` pass.
- `swift build --target CodexBar` passes.
- `make check` (swiftformat + swiftlint --strict): 0 violations.