### PR TITLE
perf: stop hidden OpenAI dashboard WebView from burning idle CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.
+- Codex: stop the hidden ChatGPT dashboard WebView from staying resident after usage refresh, so idle WebKit helper processes can return to zero.
 - Cost history: honor the preferred display currency throughout the detail chart and refresh converted labels when exchange rates change (#2887). Thanks @vAhyThe!
 
 ## 0.49.3 — 2026-08-12

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -9,7 +9,7 @@ extension StatusItemController {
     static let loadingAnimationFPS: Double = 30.0
     static let loadingAnimationPhaseIncrement: Double =
         2.7 / StatusItemController.loadingAnimationFPS
-    private static let loadingAnimationMaxContinuousDuration: TimeInterval = 30.0
+    private nonisolated static let loadingAnimationMaxContinuousDuration: TimeInterval = 30.0
     func needsMenuBarIconAnimation() -> Bool {
         if self.shouldMergeIcons {
             let primaryProvider = self.primaryProviderForUnifiedIcon()
@@ -1536,9 +1536,7 @@ extension StatusItemController {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
         #endif
-        if let startedAt = self.animationStartedAt,
-           Date().timeIntervalSince(startedAt) > Self.loadingAnimationMaxContinuousDuration
-        {
+        if Self.loadingAnimationHasExceededContinuousCap(startedAt: self.animationStartedAt, now: Date()) {
             self.animationStartedAt = .distantPast
             self.stopLoadingAnimation(resetStart: false)
             return
@@ -1549,6 +1547,14 @@ extension StatusItemController {
         } else {
             UsageProvider.allCases.forEach { self.applyIcon(for: $0, phase: self.animationPhase) }
         }
+    }
+
+    nonisolated static func loadingAnimationHasExceededContinuousCap(
+        startedAt: Date?,
+        now: Date) -> Bool
+    {
+        guard let startedAt, startedAt != .distantPast else { return false }
+        return now.timeIntervalSince(startedAt) > Self.loadingAnimationMaxContinuousDuration
     }
 
     nonisolated static func brandImageWithStatusOverlay(

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -18,6 +18,17 @@ extension StatusItemController {
         return UsageProvider.allCases.contains { self.shouldAnimate(provider: $0) }
     }
 
+    func activeLoadingAnimationPhase() -> Double? {
+        guard self.needsMenuBarIconAnimation(), self.animationDriver != nil else { return nil }
+        return self.animationPhase
+    }
+
+    func anyEnabledProviderNeedsLoadingAnimation() -> Bool {
+        UsageProvider.allCases.contains {
+            self.isEnabled($0) && self.shouldAnimate(provider: $0, mergeIcons: false)
+        }
+    }
+
     func updateBlinkingState() {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
@@ -66,7 +77,7 @@ extension StatusItemController {
         self.blinkTask?.cancel()
         self.blinkTask = nil
         self.blinkAmounts.removeAll()
-        let phase: Double? = self.needsMenuBarIconAnimation() ? self.animationPhase : nil
+        let phase: Double? = self.activeLoadingAnimationPhase()
         if self.shouldMergeIcons {
             self.applyIcon(phase: phase)
         } else {
@@ -1471,36 +1482,49 @@ extension StatusItemController {
 
     func updateAnimationState() {
         let needsAnimation = self.needsMenuBarIconAnimation()
-        if needsAnimation {
-            if self.animationDriver == nil {
-                if let forced = self.settings.debugLoadingPattern {
-                    self.animationPattern = forced
-                } else if !LoadingPattern.allCases.contains(self.animationPattern) {
-                    self.animationPattern = .knightRider
-                }
-                self.animationPhase = 0
-                self.animationStartedAt = Date()
-                let driver = DisplayLinkDriver(onTick: { [weak self] in
-                    self?.updateAnimationFrame()
-                })
-                self.animationDriver = driver
-                driver.start(fps: Self.loadingAnimationFPS)
-            } else if let forced = self.settings.debugLoadingPattern,
-                      forced != self.animationPattern
-            {
-                self.animationPattern = forced
-                self.animationPhase = 0
+        let stillLoading = self.anyEnabledProviderNeedsLoadingAnimation()
+        if self.animationStartedAt == .distantPast {
+            if !stillLoading {
+                self.animationStartedAt = nil
             }
-        } else {
+            if !needsAnimation {
+                self.stopLoadingAnimation(resetStart: false)
+            }
+            return
+        }
+        if !needsAnimation {
+            self.animationStartedAt = nil
             self.stopLoadingAnimation()
+            return
+        }
+        if self.animationDriver == nil {
+            if let forced = self.settings.debugLoadingPattern {
+                self.animationPattern = forced
+            } else if !LoadingPattern.allCases.contains(self.animationPattern) {
+                self.animationPattern = .knightRider
+            }
+            self.animationPhase = 0
+            self.animationStartedAt = Date()
+            let driver = DisplayLinkDriver(onTick: { [weak self] in
+                self?.updateAnimationFrame()
+            })
+            self.animationDriver = driver
+            driver.start(fps: Self.loadingAnimationFPS)
+        } else if let forced = self.settings.debugLoadingPattern,
+                  forced != self.animationPattern
+        {
+            self.animationPattern = forced
+            self.animationPhase = 0
         }
     }
 
-    private func stopLoadingAnimation() {
+    private func stopLoadingAnimation(resetStart: Bool = true) {
         self.animationDriver?.stop()
         self.animationDriver = nil
         self.animationPhase = 0
-        self.animationStartedAt = nil
+        if resetStart {
+            self.animationStartedAt = nil
+        }
         if self.shouldMergeIcons {
             self.applyIcon(phase: nil)
         } else {
@@ -1515,7 +1539,8 @@ extension StatusItemController {
         if let startedAt = self.animationStartedAt,
            Date().timeIntervalSince(startedAt) > Self.loadingAnimationMaxContinuousDuration
         {
-            self.stopLoadingAnimation()
+            self.animationStartedAt = .distantPast
+            self.stopLoadingAnimation(resetStart: false)
             return
         }
         self.animationPhase += Self.loadingAnimationPhaseIncrement

--- a/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
@@ -31,7 +31,7 @@ extension StatusItemController {
     private func refreshProviderSelectionRendering() {
         self.updateAnimationState()
         self.updateBlinkingState()
-        let phase: Double? = self.needsMenuBarIconAnimation() ? self.animationPhase : nil
+        let phase: Double? = self.activeLoadingAnimationPhase()
         self.applyIcon(phase: phase)
     }
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -724,7 +724,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
         // Avoid flicker: when an animation driver is active, store updates can call `updateIcons()` and
         // briefly overwrite the animated frame with the static (phase=nil) icon.
-        let phase: Double? = self.needsMenuBarIconAnimation() ? self.animationPhase : nil
+        let phase: Double? = self.activeLoadingAnimationPhase()
         if self.shouldMergeIcons {
             let skippedMergedRender = self.applyIcon(phase: phase)
             if skippedMergedRender,

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -584,7 +584,8 @@ extension UsageStore {
                 accountEmail: effectiveEmail,
                 logger: log,
                 allowNavigationTimeoutRetry: context.force,
-                timeout: Self.openAIWebDashboardFetchTimeout(didImportCookies: didImportCookiesForRefresh))
+                timeout: Self.openAIWebDashboardFetchTimeout(didImportCookies: didImportCookiesForRefresh),
+                force: context.force)
             guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
 
             if self.dashboardEmailMismatch(expected: normalized, actual: dash.signedInEmail) {
@@ -600,7 +601,8 @@ extension UsageStore {
                     accountEmail: effectiveEmail,
                     logger: log,
                     allowNavigationTimeoutRetry: context.force,
-                    timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true))
+                    timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true),
+                    force: context.force)
                 guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
             }
 
@@ -642,6 +644,8 @@ extension UsageStore {
                 refreshTaskToken: context.refreshTaskToken,
                 routingTargetEmail: context.targetEmail)
         }
+
+        OpenAIDashboardFetcher.evictIdleCachedWebViews()
     }
 
     private func retryOpenAIDashboardAfterTimeout(
@@ -688,7 +692,8 @@ extension UsageStore {
                 accountEmail: effectiveEmail,
                 logger: logger,
                 allowNavigationTimeoutRetry: context.force,
-                timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true))
+                timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true),
+                force: context.force)
             guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
             await self.applyOpenAIDashboard(
                 dash,
@@ -740,7 +745,8 @@ extension UsageStore {
                 accountEmail: effectiveEmail,
                 logger: logger,
                 allowNavigationTimeoutRetry: context.force,
-                timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true))
+                timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true),
+                force: context.force)
             guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
             await self.applyOpenAIDashboard(
                 dash,
@@ -804,7 +810,8 @@ extension UsageStore {
                 accountEmail: effectiveEmail,
                 logger: logger,
                 allowNavigationTimeoutRetry: context.force,
-                timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true))
+                timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true),
+                force: context.force)
             guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
             await self.applyOpenAIDashboard(
                 dash,
@@ -864,6 +871,7 @@ extension UsageStore {
             self.lastOpenAIDashboardAttachmentAuthorized = false
             self.lastOpenAIDashboardError = nil
             self.lastOpenAIDashboardAttemptAt = nil
+            self.lastOpenAIDashboardPageScrapeAt = nil
             self.openAIDashboardRequiresLogin = true
             self.openAIDashboardCookieImportStatus = L("Codex account changed; importing browser cookies…")
             self.lastOpenAIDashboardCookieImportAttemptAt = nil
@@ -1038,18 +1046,35 @@ extension UsageStore {
         accountEmail: String?,
         logger: @escaping (String) -> Void,
         allowNavigationTimeoutRetry: Bool,
-        timeout: TimeInterval) async throws -> OpenAIDashboardSnapshot
+        timeout: TimeInterval,
+        force: Bool) async throws -> OpenAIDashboardSnapshot
     {
         if let override = self._test_openAIDashboardLoaderOverride {
             return try await override(accountEmail, logger, allowNavigationTimeoutRetry, timeout)
         }
-        return try await OpenAIDashboardFetcher().loadLatestDashboard(
+        let previousSnapshot = self.openAIDashboard ?? self.lastOpenAIDashboardSnapshot
+        let allowPageScrape = Self.shouldAllowOpenAIDashboardPageScrape(.init(
+            force: force,
+            userInitiated: ProviderInteractionContext.current == .userInitiated,
+            hasHistory: Self.dashboardHasPageHistory(previousSnapshot),
+            lastPageScrapeAt: self.lastOpenAIDashboardPageScrapeAt,
+            historyUpdatedAt: previousSnapshot?.updatedAt,
+            now: Date(),
+            refreshInterval: self.openAIWebRefreshIntervalSeconds()))
+        logger("dashboard page scrape=\(allowPageScrape ? "1" : "0")")
+        let snapshot = try await OpenAIDashboardFetcher().loadLatestDashboard(
             accountEmail: accountEmail,
             cacheScope: self.codexCookieCacheScopeForOpenAIWeb(),
             logger: logger,
             debugDumpHTML: timeout != Self.openAIWebPrimaryFetchTimeout,
             allowNavigationTimeoutRetry: allowNavigationTimeoutRetry,
-            timeout: timeout)
+            timeout: timeout,
+            previousSnapshot: previousSnapshot,
+            allowPageScrape: allowPageScrape)
+        if allowPageScrape, Self.dashboardHasPageHistory(snapshot) {
+            self.lastOpenAIDashboardPageScrapeAt = Date()
+        }
+        return snapshot
     }
 
     private func failClosedForUnreadableManagedCodexStore() async -> String? {
@@ -1343,6 +1368,7 @@ extension UsageStore {
         self.lastOpenAIDashboardTargetEmail = nil
         self.lastOpenAIDashboardTargetIsolationKey = nil
         self.lastOpenAIDashboardAttemptAt = nil
+        self.lastOpenAIDashboardPageScrapeAt = nil
         self.openAIDashboardRequiresLogin = false
         self.openAIDashboardCookieImportStatus = nil
         self.openAIDashboardCookieImportDebugLog = nil
@@ -1468,6 +1494,34 @@ extension UsageStore {
             return true
         }
         return false
+    }
+
+    struct OpenAIDashboardPageScrapeGate {
+        let force: Bool
+        let userInitiated: Bool
+        let hasHistory: Bool
+        let lastPageScrapeAt: Date?
+        let historyUpdatedAt: Date?
+        let now: Date
+        let refreshInterval: TimeInterval
+    }
+
+    nonisolated static func shouldAllowOpenAIDashboardPageScrape(_ gate: OpenAIDashboardPageScrapeGate) -> Bool {
+        if !gate.hasHistory {
+            return true
+        }
+        if gate.force, gate.userInitiated {
+            return true
+        }
+        guard let lastPageScrapeAt = gate.lastPageScrapeAt ?? gate.historyUpdatedAt else {
+            return false
+        }
+        return gate.now.timeIntervalSince(lastPageScrapeAt) >= gate.refreshInterval
+    }
+
+    nonisolated static func dashboardHasPageHistory(_ snapshot: OpenAIDashboardSnapshot?) -> Bool {
+        guard let snapshot else { return false }
+        return !snapshot.dailyBreakdown.isEmpty || !snapshot.usageBreakdown.isEmpty
     }
 
     nonisolated static func shouldSkipOpenAIWebEmptyHistoryRetry(_ context: OpenAIWebRefreshGateContext) -> Bool {

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -226,6 +226,7 @@ final class UsageStore {
     @ObservationIgnored var lastOpenAIDashboardTargetEmail: String?
     @ObservationIgnored var lastOpenAIDashboardTargetIsolationKey: String?
     @ObservationIgnored var lastOpenAIDashboardAttemptAt: Date?
+    @ObservationIgnored var lastOpenAIDashboardPageScrapeAt: Date?
     @ObservationIgnored var lastOpenAIDashboardCookieImportAttemptAt: Date?
     @ObservationIgnored var lastOpenAIDashboardCookieImportEmail: String?
     @ObservationIgnored var lastCodexAccountScopedRefreshGuard: CodexAccountScopedRefreshGuard?

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+PageScrape.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+PageScrape.swift
@@ -47,6 +47,7 @@ extension OpenAIDashboardFetcher {
         var codeReviewFirstSeenAt: Date?
         var anyDashboardSignalAt: Date?
         var creditsHeaderVisibleAt: Date?
+        var usageBreakdownErrorFirstSeenAt: Date?
         var lastUsageBreakdownError: String?
 
         while Date() < deadline {
@@ -138,11 +139,21 @@ extension OpenAIDashboardFetcher {
             log("dashboard phase=extract elapsed=\(Self.phaseElapsed(since: startedAt))")
             let scrape = try await self.scrape(webView: webView)
             lastBody = scrape.bodyText ?? lastBody
-            lastUsageBreakdownError = scrape.usageBreakdownError ?? lastUsageBreakdownError
             let dashboardData = Self.parseDashboardScrape(
                 scrape,
                 apiData: apiData,
                 verifiedSignedInEmail: verifiedSignedInEmail)
+
+            if Self.updateAndShouldWaitForUsageBreakdownRecovery(
+                usageBreakdown: dashboardData.usageBreakdown,
+                error: scrape.usageBreakdownError,
+                firstSeenAt: &usageBreakdownErrorFirstSeenAt,
+                lastError: &lastUsageBreakdownError,
+                logger: log)
+            {
+                try await Self.sleepForDashboardPoll(.milliseconds(400))
+                continue
+            }
 
             if dashboardData.hasReturnableData,
                dashboardData.hasDashboardPageSignal || apiHasReturnableData
@@ -165,7 +176,8 @@ extension OpenAIDashboardFetcher {
                         codexCreditLimit: dashboardData.codexCreditLimit,
                         accountPlan: dashboardData.accountPlan,
                         subscription: subscription)),
-                    from: previousSnapshot)
+                    from: previousSnapshot,
+                    subscription: subscription)
             }
 
             try await Self.sleepForDashboardPoll(.milliseconds(500))
@@ -184,6 +196,26 @@ extension OpenAIDashboardFetcher {
             Self.writeDebugArtifacts(html: html, bodyText: lastBody, logger: log)
         }
         throw FetchError.noDashboardData(body: lastUsageBreakdownError ?? lastBody ?? "")
+    }
+
+    nonisolated static func updateAndShouldWaitForUsageBreakdownRecovery(
+        usageBreakdown: [OpenAIDashboardDailyBreakdown],
+        error: String?,
+        firstSeenAt: inout Date?,
+        lastError: inout String?,
+        logger: (String) -> Void) -> Bool
+    {
+        updateUsageBreakdownErrorState(
+            usageBreakdown: usageBreakdown,
+            error: error,
+            firstSeenAt: &firstSeenAt,
+            lastError: &lastError,
+            logger: logger)
+
+        guard usageBreakdown.isEmpty, let error, !error.isEmpty else { return false }
+        return Self.shouldWaitForUsageBreakdownRecovery(.init(
+            now: Date(),
+            errorFirstSeenAt: firstSeenAt))
     }
 }
 #endif

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+PageScrape.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+PageScrape.swift
@@ -110,13 +110,10 @@ extension OpenAIDashboardFetcher {
                     try await Self.sleepForDashboardPoll(.milliseconds(600))
                     continue
                 }
-                if Self.shouldWaitForCreditsHistory(.init(
-                    now: Date(),
+                if Self.shouldWaitForCreditsHistory(
+                    probe: probe,
                     anyDashboardSignalAt: anyDashboardSignalAt,
-                    creditsHeaderVisibleAt: creditsHeaderVisibleAt,
-                    creditsHeaderPresent: probe.creditsHeaderPresent,
-                    creditsHeaderInViewport: probe.creditsHeaderInViewport,
-                    didScrollToCredits: probe.didScrollToCredits))
+                    creditsHeaderVisibleAt: creditsHeaderVisibleAt)
                 {
                     try await Self.sleepForDashboardPoll(.milliseconds(400))
                     continue
@@ -155,29 +152,29 @@ extension OpenAIDashboardFetcher {
                 continue
             }
 
+            // Placeholder rows can make rowCount > 0 before real credit rows hydrate; keep the
+            // pre-extract grace keyed on parsed events like the pre-refactor loop did.
+            if dashboardData.events.isEmpty,
+               Self.shouldWaitForCreditsHistory(
+                   probe: probe,
+                   anyDashboardSignalAt: anyDashboardSignalAt,
+                   creditsHeaderVisibleAt: creditsHeaderVisibleAt)
+            {
+                try await Self.sleepForDashboardPoll(.milliseconds(400))
+                continue
+            }
+
             if dashboardData.hasReturnableData,
                dashboardData.hasDashboardPageSignal || apiHasReturnableData
             {
                 if let purchaseURL = scrape.creditsPurchaseURL {
                     log("credits purchase url: \(purchaseURL)")
                 }
-                return Self.fillingMissingPageFields(
-                    Self.makeDashboardSnapshot(.init(
-                        signedInEmail: dashboardData.signedInEmail,
-                        scrape: scrape,
-                        codeReview: dashboardData.codeReview,
-                        codeReviewLimit: dashboardData.codeReviewLimit,
-                        events: dashboardData.events,
-                        breakdown: dashboardData.breakdown,
-                        usageBreakdown: dashboardData.usageBreakdown,
-                        rateLimits: dashboardData.rateLimits,
-                        extraRateWindows: dashboardData.extraRateWindows,
-                        creditsRemaining: dashboardData.creditsRemaining,
-                        codexCreditLimit: dashboardData.codexCreditLimit,
-                        accountPlan: dashboardData.accountPlan,
-                        subscription: subscription)),
-                    from: previousSnapshot,
-                    subscription: subscription)
+                return Self.makePageSnapshot(
+                    scrape: scrape,
+                    dashboardData: dashboardData,
+                    subscription: subscription,
+                    previousSnapshot: previousSnapshot)
             }
 
             try await Self.sleepForDashboardPoll(.milliseconds(500))
@@ -196,6 +193,46 @@ extension OpenAIDashboardFetcher {
             Self.writeDebugArtifacts(html: html, bodyText: lastBody, logger: log)
         }
         throw FetchError.noDashboardData(body: lastUsageBreakdownError ?? lastBody ?? "")
+    }
+
+    nonisolated static func makePageSnapshot(
+        scrape: ScrapeResult,
+        dashboardData: DashboardScrapeData,
+        subscription: OpenAISubscriptionMetadata?,
+        previousSnapshot: OpenAIDashboardSnapshot?) -> OpenAIDashboardSnapshot
+    {
+        self.fillingMissingPageFields(
+            self.makeDashboardSnapshot(.init(
+                signedInEmail: dashboardData.signedInEmail,
+                scrape: scrape,
+                codeReview: dashboardData.codeReview,
+                codeReviewLimit: dashboardData.codeReviewLimit,
+                events: dashboardData.events,
+                breakdown: dashboardData.breakdown,
+                usageBreakdown: dashboardData.usageBreakdown,
+                rateLimits: dashboardData.rateLimits,
+                extraRateWindows: dashboardData.extraRateWindows,
+                creditsRemaining: dashboardData.creditsRemaining,
+                codexCreditLimit: dashboardData.codexCreditLimit,
+                accountPlan: dashboardData.accountPlan,
+                subscription: subscription)),
+            from: previousSnapshot,
+            subscription: subscription)
+    }
+
+    nonisolated static func shouldWaitForCreditsHistory(
+        probe: ReadinessProbe,
+        anyDashboardSignalAt: Date?,
+        creditsHeaderVisibleAt: Date?,
+        now: Date = Date()) -> Bool
+    {
+        self.shouldWaitForCreditsHistory(.init(
+            now: now,
+            anyDashboardSignalAt: anyDashboardSignalAt,
+            creditsHeaderVisibleAt: creditsHeaderVisibleAt,
+            creditsHeaderPresent: probe.creditsHeaderPresent,
+            creditsHeaderInViewport: probe.creditsHeaderInViewport,
+            didScrollToCredits: probe.didScrollToCredits))
     }
 
     nonisolated static func updateAndShouldWaitForUsageBreakdownRecovery(

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+PageScrape.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+PageScrape.swift
@@ -1,0 +1,189 @@
+#if os(macOS)
+import Foundation
+import WebKit
+
+extension OpenAIDashboardFetcher {
+    struct PageScrapeContext {
+        let webView: WKWebView
+        let apiData: DashboardAPIData?
+        let verifiedSignedInEmail: String?
+        let subscription: OpenAISubscriptionMetadata?
+        let previousSnapshot: OpenAIDashboardSnapshot?
+        let deadline: Date
+        let startedAt: Date
+        let debugDumpHTML: Bool
+        let log: (String) -> Void
+    }
+
+    struct ReadinessProbe {
+        let loginRequired: Bool
+        let workspacePicker: Bool
+        let cloudflareInterstitial: Bool
+        let href: String?
+        let signedInEmail: String?
+        let authStatus: String?
+        let creditsHeaderPresent: Bool
+        let creditsHeaderInViewport: Bool
+        let didScrollToCredits: Bool
+        let rowCount: Int
+        let usageBreakdownReady: Bool
+        let hasCodeReviewSignal: Bool
+        let hasDashboardSignal: Bool
+    }
+
+    func collectPageSnapshot(_ context: PageScrapeContext) async throws -> OpenAIDashboardSnapshot {
+        let webView = context.webView
+        let apiData = context.apiData
+        let verifiedSignedInEmail = context.verifiedSignedInEmail
+        let subscription = context.subscription
+        let previousSnapshot = context.previousSnapshot
+        let deadline = context.deadline
+        let startedAt = context.startedAt
+        let debugDumpHTML = context.debugDumpHTML
+        let log = context.log
+        var lastBody: String?
+        var lastHref: String?
+        var lastFlags: (loginRequired: Bool, workspacePicker: Bool, cloudflare: Bool)?
+        var codeReviewFirstSeenAt: Date?
+        var anyDashboardSignalAt: Date?
+        var creditsHeaderVisibleAt: Date?
+        var lastUsageBreakdownError: String?
+
+        while Date() < deadline {
+            try Task.checkCancellation()
+            let probe = try await self.probeReadiness(webView: webView)
+
+            if probe.href != lastHref
+                || lastFlags?.loginRequired != probe.loginRequired
+                || lastFlags?.workspacePicker != probe.workspacePicker
+                || lastFlags?.cloudflare != probe.cloudflareInterstitial
+            {
+                lastHref = probe.href
+                lastFlags = (probe.loginRequired, probe.workspacePicker, probe.cloudflareInterstitial)
+                let href = probe.href ?? "nil"
+                log(
+                    "href=\(href) login=\(probe.loginRequired) " +
+                        "workspace=\(probe.workspacePicker) cloudflare=\(probe.cloudflareInterstitial)")
+            }
+
+            if probe.workspacePicker {
+                try await Self.sleepForDashboardPoll(.milliseconds(500))
+                continue
+            }
+
+            try await self.handleBlockingReadinessState(
+                probe,
+                webView: webView,
+                debugDumpHTML: debugDumpHTML,
+                logger: log)
+
+            if Self.shouldReloadUsageRoute(
+                href: probe.href,
+                loginRequired: probe.loginRequired,
+                workspacePicker: probe.workspacePicker,
+                cloudflareInterstitial: probe.cloudflareInterstitial)
+            {
+                _ = webView.load(Self.usageURLRequest(url: self.usageURL))
+                try await Self.sleepForDashboardPoll(.milliseconds(500))
+                continue
+            }
+
+            if probe.hasDashboardSignal, anyDashboardSignalAt == nil {
+                anyDashboardSignalAt = Date()
+            }
+            if probe.hasCodeReviewSignal, codeReviewFirstSeenAt == nil {
+                codeReviewFirstSeenAt = Date()
+            }
+            if probe.creditsHeaderPresent, probe.creditsHeaderInViewport, creditsHeaderVisibleAt == nil {
+                creditsHeaderVisibleAt = Date()
+            }
+
+            let apiHasReturnableData = apiData?.hasUsageData == true
+            if probe.rowCount == 0, probe.hasDashboardSignal || apiHasReturnableData {
+                log(
+                    "credits header present=\(probe.creditsHeaderPresent) " +
+                        "inViewport=\(probe.creditsHeaderInViewport) didScroll=\(probe.didScrollToCredits) " +
+                        "rows=\(probe.rowCount)")
+                if probe.didScrollToCredits {
+                    log("scrollIntoView(Credits usage history) requested; waiting…")
+                    try await Self.sleepForDashboardPoll(.milliseconds(600))
+                    continue
+                }
+                if Self.shouldWaitForCreditsHistory(.init(
+                    now: Date(),
+                    anyDashboardSignalAt: anyDashboardSignalAt,
+                    creditsHeaderVisibleAt: creditsHeaderVisibleAt,
+                    creditsHeaderPresent: probe.creditsHeaderPresent,
+                    creditsHeaderInViewport: probe.creditsHeaderInViewport,
+                    didScrollToCredits: probe.didScrollToCredits))
+                {
+                    try await Self.sleepForDashboardPoll(.milliseconds(400))
+                    continue
+                }
+            }
+
+            if probe.hasCodeReviewSignal, !probe.usageBreakdownReady {
+                let elapsed = Date().timeIntervalSince(codeReviewFirstSeenAt ?? Date())
+                if elapsed < 6 {
+                    try await Self.sleepForDashboardPoll(.milliseconds(400))
+                    continue
+                }
+            }
+
+            if !probe.hasDashboardSignal, !apiHasReturnableData {
+                try await Self.sleepForDashboardPoll(.milliseconds(500))
+                continue
+            }
+
+            log("dashboard phase=extract elapsed=\(Self.phaseElapsed(since: startedAt))")
+            let scrape = try await self.scrape(webView: webView)
+            lastBody = scrape.bodyText ?? lastBody
+            lastUsageBreakdownError = scrape.usageBreakdownError ?? lastUsageBreakdownError
+            let dashboardData = Self.parseDashboardScrape(
+                scrape,
+                apiData: apiData,
+                verifiedSignedInEmail: verifiedSignedInEmail)
+
+            if dashboardData.hasReturnableData,
+               dashboardData.hasDashboardPageSignal || apiHasReturnableData
+            {
+                if let purchaseURL = scrape.creditsPurchaseURL {
+                    log("credits purchase url: \(purchaseURL)")
+                }
+                return Self.fillingMissingPageFields(
+                    Self.makeDashboardSnapshot(.init(
+                        signedInEmail: dashboardData.signedInEmail,
+                        scrape: scrape,
+                        codeReview: dashboardData.codeReview,
+                        codeReviewLimit: dashboardData.codeReviewLimit,
+                        events: dashboardData.events,
+                        breakdown: dashboardData.breakdown,
+                        usageBreakdown: dashboardData.usageBreakdown,
+                        rateLimits: dashboardData.rateLimits,
+                        extraRateWindows: dashboardData.extraRateWindows,
+                        creditsRemaining: dashboardData.creditsRemaining,
+                        codexCreditLimit: dashboardData.codexCreditLimit,
+                        accountPlan: dashboardData.accountPlan,
+                        subscription: subscription)),
+                    from: previousSnapshot)
+            }
+
+            try await Self.sleepForDashboardPoll(.milliseconds(500))
+        }
+
+        if let apiData, apiData.hasUsageData, let verifiedSignedInEmail {
+            log("usage api snapshot returned after WebView deadline")
+            return Self.snapshotByMergingAPI(
+                apiData: apiData,
+                verifiedEmail: verifiedSignedInEmail,
+                subscription: subscription,
+                previous: previousSnapshot)
+        }
+
+        if debugDumpHTML, let html = try? await self.fetchDebugHTML(webView: webView) {
+            Self.writeDebugArtifacts(html: html, bodyText: lastBody, logger: log)
+        }
+        throw FetchError.noDashboardData(body: lastUsageBreakdownError ?? lastBody ?? "")
+    }
+}
+#endif

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+ReturnableData.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+ReturnableData.swift
@@ -55,7 +55,8 @@ extension OpenAIDashboardFetcher {
                 : apiData.extraRateWindows,
             creditsRemaining: apiData.creditsRemaining ?? previous?.creditsRemaining,
             codexCreditLimit: apiData.codexCreditLimit ?? previous?.codexCreditLimit,
-            accountPlan: apiData.accountPlan ?? previous?.accountPlan,
+            // Prefer the page-derived plan (more specific, e.g. Pro Lite) over the generic API plan_type.
+            accountPlan: previous?.accountPlan ?? apiData.accountPlan,
             subscriptionExpiresAt: subscription == nil
                 ? previous?.subscriptionExpiresAt
                 : subscription?.expiresAt,

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+ReturnableData.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+ReturnableData.swift
@@ -56,16 +56,27 @@ extension OpenAIDashboardFetcher {
             creditsRemaining: apiData.creditsRemaining ?? previous?.creditsRemaining,
             codexCreditLimit: apiData.codexCreditLimit ?? previous?.codexCreditLimit,
             accountPlan: apiData.accountPlan ?? previous?.accountPlan,
-            subscriptionExpiresAt: subscription?.expiresAt ?? previous?.subscriptionExpiresAt,
-            subscriptionRenewsAt: subscription?.renewsAt ?? previous?.subscriptionRenewsAt,
+            subscriptionExpiresAt: subscription == nil
+                ? previous?.subscriptionExpiresAt
+                : subscription?.expiresAt,
+            subscriptionRenewsAt: subscription == nil
+                ? previous?.subscriptionRenewsAt
+                : subscription?.renewsAt,
             updatedAt: updatedAt)
     }
 
     nonisolated static func fillingMissingPageFields(
         _ snapshot: OpenAIDashboardSnapshot,
-        from previous: OpenAIDashboardSnapshot?) -> OpenAIDashboardSnapshot
+        from previous: OpenAIDashboardSnapshot?,
+        subscription: OpenAISubscriptionMetadata? = nil) -> OpenAIDashboardSnapshot
     {
         guard let previous else { return snapshot }
+        let subscriptionExpiresAt = subscription == nil
+            ? snapshot.subscriptionExpiresAt ?? previous.subscriptionExpiresAt
+            : snapshot.subscriptionExpiresAt
+        let subscriptionRenewsAt = subscription == nil
+            ? snapshot.subscriptionRenewsAt ?? previous.subscriptionRenewsAt
+            : snapshot.subscriptionRenewsAt
         return OpenAIDashboardSnapshot(
             signedInEmail: snapshot.signedInEmail ?? previous.signedInEmail,
             codeReviewRemainingPercent: snapshot.codeReviewRemainingPercent
@@ -81,8 +92,8 @@ extension OpenAIDashboardFetcher {
             creditsRemaining: snapshot.creditsRemaining ?? previous.creditsRemaining,
             codexCreditLimit: snapshot.codexCreditLimit ?? previous.codexCreditLimit,
             accountPlan: snapshot.accountPlan ?? previous.accountPlan,
-            subscriptionExpiresAt: snapshot.subscriptionExpiresAt ?? previous.subscriptionExpiresAt,
-            subscriptionRenewsAt: snapshot.subscriptionRenewsAt ?? previous.subscriptionRenewsAt,
+            subscriptionExpiresAt: subscriptionExpiresAt,
+            subscriptionRenewsAt: subscriptionRenewsAt,
             updatedAt: snapshot.updatedAt)
     }
 }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+ReturnableData.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher+ReturnableData.swift
@@ -26,5 +26,64 @@ extension OpenAIDashboardFetcher {
     {
         hasReturnableData || creditsHeaderPresent
     }
+
+    /// Skip the hidden ChatGPT WebView unless the caller asked for a DOM scrape.
+    nonisolated static func shouldSkipPageScrape(allowPageScrape: Bool) -> Bool {
+        !allowPageScrape
+    }
+
+    nonisolated static func snapshotByMergingAPI(
+        apiData: DashboardAPIData,
+        verifiedEmail: String,
+        subscription: OpenAISubscriptionMetadata?,
+        previous: OpenAIDashboardSnapshot?,
+        updatedAt: Date = Date()) -> OpenAIDashboardSnapshot
+    {
+        let email = verifiedEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+        return OpenAIDashboardSnapshot(
+            signedInEmail: email.isEmpty ? previous?.signedInEmail : email,
+            codeReviewRemainingPercent: previous?.codeReviewRemainingPercent,
+            codeReviewLimit: previous?.codeReviewLimit,
+            creditEvents: previous?.creditEvents ?? [],
+            dailyBreakdown: previous?.dailyBreakdown ?? [],
+            usageBreakdown: previous?.usageBreakdown ?? [],
+            creditsPurchaseURL: previous?.creditsPurchaseURL,
+            primaryLimit: apiData.primaryLimit ?? previous?.primaryLimit,
+            secondaryLimit: apiData.secondaryLimit ?? previous?.secondaryLimit,
+            extraRateWindows: apiData.extraRateWindows.isEmpty
+                ? previous?.extraRateWindows
+                : apiData.extraRateWindows,
+            creditsRemaining: apiData.creditsRemaining ?? previous?.creditsRemaining,
+            codexCreditLimit: apiData.codexCreditLimit ?? previous?.codexCreditLimit,
+            accountPlan: apiData.accountPlan ?? previous?.accountPlan,
+            subscriptionExpiresAt: subscription?.expiresAt ?? previous?.subscriptionExpiresAt,
+            subscriptionRenewsAt: subscription?.renewsAt ?? previous?.subscriptionRenewsAt,
+            updatedAt: updatedAt)
+    }
+
+    nonisolated static func fillingMissingPageFields(
+        _ snapshot: OpenAIDashboardSnapshot,
+        from previous: OpenAIDashboardSnapshot?) -> OpenAIDashboardSnapshot
+    {
+        guard let previous else { return snapshot }
+        return OpenAIDashboardSnapshot(
+            signedInEmail: snapshot.signedInEmail ?? previous.signedInEmail,
+            codeReviewRemainingPercent: snapshot.codeReviewRemainingPercent
+                ?? previous.codeReviewRemainingPercent,
+            codeReviewLimit: snapshot.codeReviewLimit ?? previous.codeReviewLimit,
+            creditEvents: snapshot.creditEvents.isEmpty ? previous.creditEvents : snapshot.creditEvents,
+            dailyBreakdown: snapshot.dailyBreakdown.isEmpty ? previous.dailyBreakdown : snapshot.dailyBreakdown,
+            usageBreakdown: snapshot.usageBreakdown.isEmpty ? previous.usageBreakdown : snapshot.usageBreakdown,
+            creditsPurchaseURL: snapshot.creditsPurchaseURL ?? previous.creditsPurchaseURL,
+            primaryLimit: snapshot.primaryLimit ?? previous.primaryLimit,
+            secondaryLimit: snapshot.secondaryLimit ?? previous.secondaryLimit,
+            extraRateWindows: snapshot.extraRateWindows ?? previous.extraRateWindows,
+            creditsRemaining: snapshot.creditsRemaining ?? previous.creditsRemaining,
+            codexCreditLimit: snapshot.codexCreditLimit ?? previous.codexCreditLimit,
+            accountPlan: snapshot.accountPlan ?? previous.accountPlan,
+            subscriptionExpiresAt: snapshot.subscriptionExpiresAt ?? previous.subscriptionExpiresAt,
+            subscriptionRenewsAt: snapshot.subscriptionRenewsAt ?? previous.subscriptionRenewsAt,
+            updatedAt: snapshot.updatedAt)
+    }
 }
 #endif

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -19,9 +19,11 @@ public struct OpenAIDashboardFetcher {
         }
     }
 
-    private let usageURL = URL(string: "https://chatgpt.com/codex/cloud/settings/analytics#usage")!
+    let usageURL = URL(string: "https://chatgpt.com/codex/cloud/settings/analytics#usage")!
     private nonisolated static let dashboardAcceptLanguage = "en-US,en;q=0.9"
     private nonisolated static let dashboardUsageAPIURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
+    private nonisolated static let dashboardSubscriptionAPIURL =
+        URL(string: "https://chatgpt.com/backend-api/subscriptions")!
 
     public init() {}
 
@@ -44,7 +46,7 @@ public struct OpenAIDashboardFetcher {
         0.001
     }
 
-    private struct DashboardSnapshotComponents {
+    struct DashboardSnapshotComponents {
         let signedInEmail: String?
         let scrape: ScrapeResult
         let codeReview: Double?
@@ -60,7 +62,7 @@ public struct OpenAIDashboardFetcher {
         let subscription: OpenAISubscriptionMetadata?
     }
 
-    private struct DashboardScrapeData {
+    struct DashboardScrapeData {
         let signedInEmail: String?
         let codeReview: Double?
         let codeReviewLimit: RateWindow?
@@ -76,7 +78,7 @@ public struct OpenAIDashboardFetcher {
         let hasReturnableData: Bool
     }
 
-    private nonisolated static func makeDashboardSnapshot(_ components: DashboardSnapshotComponents)
+    nonisolated static func makeDashboardSnapshot(_ components: DashboardSnapshotComponents)
         -> OpenAIDashboardSnapshot
     {
         OpenAIDashboardSnapshot(
@@ -98,7 +100,7 @@ public struct OpenAIDashboardFetcher {
             updatedAt: Date())
     }
 
-    private static func parseDashboardScrape(
+    static func parseDashboardScrape(
         _ scrape: ScrapeResult,
         apiData: DashboardAPIData?,
         verifiedSignedInEmail: String?) -> DashboardScrapeData
@@ -212,7 +214,7 @@ public struct OpenAIDashboardFetcher {
         return true
     }
 
-    private nonisolated static func sleepForDashboardPoll(_ duration: Duration) async throws {
+    nonisolated static func sleepForDashboardPoll(_ duration: Duration) async throws {
         try? await Task.sleep(for: duration)
         try Task.checkCancellation()
     }
@@ -223,7 +225,9 @@ public struct OpenAIDashboardFetcher {
         logger: ((String) -> Void)? = nil,
         debugDumpHTML: Bool = false,
         allowNavigationTimeoutRetry: Bool = true,
-        timeout: TimeInterval = 60) async throws -> OpenAIDashboardSnapshot
+        timeout: TimeInterval = 60,
+        previousSnapshot: OpenAIDashboardSnapshot? = nil,
+        allowPageScrape: Bool = true) async throws -> OpenAIDashboardSnapshot
     {
         let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail, scope: cacheScope)
         return try await self.loadLatestDashboard(
@@ -231,7 +235,9 @@ public struct OpenAIDashboardFetcher {
             logger: logger,
             debugDumpHTML: debugDumpHTML,
             allowNavigationTimeoutRetry: allowNavigationTimeoutRetry,
-            timeout: timeout)
+            timeout: timeout,
+            previousSnapshot: previousSnapshot,
+            allowPageScrape: allowPageScrape)
     }
 
     public func loadLatestDashboard(
@@ -239,176 +245,62 @@ public struct OpenAIDashboardFetcher {
         logger: ((String) -> Void)? = nil,
         debugDumpHTML: Bool = false,
         allowNavigationTimeoutRetry: Bool = true,
-        timeout: TimeInterval = 60) async throws -> OpenAIDashboardSnapshot
+        timeout: TimeInterval = 60,
+        previousSnapshot: OpenAIDashboardSnapshot? = nil,
+        allowPageScrape: Bool = true) async throws -> OpenAIDashboardSnapshot
     {
-        let deadline = Self.deadline(startingAt: Date(), timeout: timeout)
+        let startedAt = Date()
+        let deadline = Self.deadline(startingAt: startedAt, timeout: timeout)
+        let logLine: (String) -> Void = { logger?($0) }
+        logLine("dashboard phase=api_preflight")
         let preflight = try await Self.fetchDashboardAPIPreflight(
             websiteDataStore: websiteDataStore,
             deadline: deadline,
-            logger: { logger?($0) })
+            logger: logLine)
         try Task.checkCancellation()
-        let (apiData, verifiedSignedInEmail) = (preflight.apiData, preflight.verifiedSignedInEmail)
-        let remainingTimeout = try Self.requiredRemainingTimeout(until: deadline)
+        let (apiData, verifiedSignedInEmail, subscription) =
+            (preflight.apiData, preflight.verifiedSignedInEmail, preflight.subscription)
+        logLine("dashboard phase=api_preflight_done elapsed=\(Self.phaseElapsed(since: startedAt))")
 
+        if Self.shouldSkipPageScrape(allowPageScrape: allowPageScrape) {
+            if let apiData, apiData.hasUsageData, let verifiedSignedInEmail {
+                logLine("usage api supplied verified dashboard data; skipping WebView")
+                return Self.snapshotByMergingAPI(
+                    apiData: apiData,
+                    verifiedEmail: verifiedSignedInEmail,
+                    subscription: subscription,
+                    previous: previousSnapshot)
+            }
+            if let previousSnapshot {
+                logLine("page scrape disabled; returning previous dashboard snapshot")
+                return previousSnapshot
+            }
+            throw FetchError.noDashboardData(body: "OpenAI dashboard APIs unavailable and page scrape disabled.")
+        }
+
+        let remainingTimeout = try Self.requiredRemainingTimeout(until: deadline)
+        logLine("dashboard phase=webview_acquire")
         let lease = try await self.makeWebView(
             websiteDataStore: websiteDataStore,
             logger: logger,
             timeout: remainingTimeout,
             allowNavigationTimeoutRetry: allowNavigationTimeoutRetry)
-        defer { lease.release() }
-        let webView = lease.webView
-        let log = lease.log
-
-        var lastBody: String?
-        var lastHref: String?
-        var lastFlags: (loginRequired: Bool, workspacePicker: Bool, cloudflare: Bool)?
-        var codeReviewFirstSeenAt: Date?
-        var anyDashboardSignalAt: Date?
-        var creditsHeaderVisibleAt: Date?
-        var usageBreakdownErrorFirstSeenAt: Date?
-        var lastUsageBreakdownDebug: String?
-        var lastUsageBreakdownError: String?
-        var lastCreditsPurchaseURL: String?
-        while Date() < deadline {
-            try Task.checkCancellation()
-            let scrape = try await self.scrape(webView: webView)
-            lastBody = scrape.bodyText ?? lastBody
-
-            if scrape.href != lastHref
-                || lastFlags?.loginRequired != scrape.loginRequired
-                || lastFlags?.workspacePicker != scrape.workspacePicker
-                || lastFlags?.cloudflare != scrape.cloudflareInterstitial
-            {
-                lastHref = scrape.href
-                lastFlags = (scrape.loginRequired, scrape.workspacePicker, scrape.cloudflareInterstitial)
-                let href = scrape.href ?? "nil"
-                log(
-                    "href=\(href) login=\(scrape.loginRequired) " +
-                        "workspace=\(scrape.workspacePicker) cloudflare=\(scrape.cloudflareInterstitial)")
-            }
-
-            if scrape.workspacePicker {
-                try await Self.sleepForDashboardPoll(.milliseconds(500))
-                continue
-            }
-
-            try await self.handleBlockingScrapeState(
-                scrape,
-                webView: webView,
-                debugDumpHTML: debugDumpHTML,
-                logger: log)
-
-            // The page is a SPA and can land on ChatGPT UI or other routes; keep forcing the usage URL.
-            if Self.shouldReloadUsageRoute(scrape) {
-                _ = webView.load(Self.usageURLRequest(url: self.usageURL))
-                try await Self.sleepForDashboardPoll(.milliseconds(500))
-                continue
-            }
-
-            let dashboardData = Self.parseDashboardScrape(
-                scrape,
-                apiData: apiData,
-                verifiedSignedInEmail: verifiedSignedInEmail)
-            let codeReview = dashboardData.codeReview
-            let events = dashboardData.events
-            let usageBreakdown = dashboardData.usageBreakdown
-            let hasDashboardPageSignal = dashboardData.hasDashboardPageSignal
-            let hasReturnableData = dashboardData.hasReturnableData
-
-            if codeReview != nil, codeReviewFirstSeenAt == nil { codeReviewFirstSeenAt = Date() }
-            if anyDashboardSignalAt == nil, hasDashboardPageSignal { anyDashboardSignalAt = Date() }
-            if codeReview != nil, usageBreakdown.isEmpty,
-               let debug = scrape.usageBreakdownDebug, !debug.isEmpty,
-               debug != lastUsageBreakdownDebug
-            {
-                lastUsageBreakdownDebug = debug
-                log("usage breakdown debug: \(debug)")
-            }
-            Self.updateUsageBreakdownErrorState(
-                usageBreakdown: usageBreakdown,
-                error: scrape.usageBreakdownError,
-                firstSeenAt: &usageBreakdownErrorFirstSeenAt,
-                lastError: &lastUsageBreakdownError,
-                logger: log)
-            if let purchaseURL = scrape.creditsPurchaseURL, purchaseURL != lastCreditsPurchaseURL {
-                lastCreditsPurchaseURL = purchaseURL
-                log("credits purchase url: \(purchaseURL)")
-            }
-            if events.isEmpty,
-               hasReturnableData,
-               hasDashboardPageSignal
-            {
-                log(
-                    "credits header present=\(scrape.creditsHeaderPresent) " +
-                        "inViewport=\(scrape.creditsHeaderInViewport) didScroll=\(scrape.didScrollToCredits) " +
-                        "rows=\(scrape.rows.count)")
-                if scrape.didScrollToCredits {
-                    log("scrollIntoView(Credits usage history) requested; waiting…")
-                    try await Self.sleepForDashboardPoll(.milliseconds(600))
-                    continue
-                }
-
-                // Avoid returning early when the usage breakdown chart hydrates before the (often virtualized)
-                // credits table. When we detect a dashboard signal, give credits history a moment to appear.
-                if scrape.creditsHeaderPresent, scrape.creditsHeaderInViewport, creditsHeaderVisibleAt == nil {
-                    creditsHeaderVisibleAt = Date()
-                }
-                if Self.shouldWaitForCreditsHistory(.init(
-                    now: Date(),
-                    anyDashboardSignalAt: anyDashboardSignalAt,
-                    creditsHeaderVisibleAt: creditsHeaderVisibleAt,
-                    creditsHeaderPresent: scrape.creditsHeaderPresent,
-                    creditsHeaderInViewport: scrape.creditsHeaderInViewport,
-                    didScrollToCredits: scrape.didScrollToCredits))
-                {
-                    try await Self.sleepForDashboardPoll(.milliseconds(400))
-                    continue
-                }
-            }
-
-            if hasReturnableData, hasDashboardPageSignal {
-                if usageBreakdown.isEmpty,
-                   let error = scrape.usageBreakdownError, !error.isEmpty,
-                   Self.shouldWaitForUsageBreakdownRecovery(.init(
-                       now: Date(),
-                       errorFirstSeenAt: usageBreakdownErrorFirstSeenAt))
-                {
-                    try await Self.sleepForDashboardPoll(.milliseconds(400))
-                    continue
-                }
-
-                // The usage breakdown chart is hydrated asynchronously. When code review is already present,
-                // give it a moment to populate so the menu can show it.
-                if codeReview != nil, usageBreakdown.isEmpty {
-                    let elapsed = Date().timeIntervalSince(codeReviewFirstSeenAt ?? Date())
-                    if elapsed < 6 {
-                        try await Self.sleepForDashboardPoll(.milliseconds(400))
-                        continue
-                    }
-                }
-                return try await Self.makeDashboardSnapshot(.init(
-                    signedInEmail: dashboardData.signedInEmail,
-                    scrape: scrape,
-                    codeReview: codeReview,
-                    codeReviewLimit: dashboardData.codeReviewLimit,
-                    events: events,
-                    breakdown: dashboardData.breakdown,
-                    usageBreakdown: usageBreakdown,
-                    rateLimits: dashboardData.rateLimits,
-                    extraRateWindows: dashboardData.extraRateWindows,
-                    creditsRemaining: dashboardData.creditsRemaining,
-                    codexCreditLimit: dashboardData.codexCreditLimit,
-                    accountPlan: dashboardData.accountPlan,
-                    subscription: OpenAISubscription.fetch(webView, deadline: deadline, logger: log)))
-            }
-
-            try await Self.sleepForDashboardPoll(.milliseconds(500))
+        defer {
+            lease.setPreserveLoadedPageOnRelease(false)
+            lease.release()
+            logLine("dashboard phase=webview_released elapsed=\(Self.phaseElapsed(since: startedAt))")
         }
-
-        if debugDumpHTML, let html = try? await self.fetchDebugHTML(webView: webView) {
-            Self.writeDebugArtifacts(html: html, bodyText: lastBody, logger: log)
-        }
-        throw FetchError.noDashboardData(body: lastUsageBreakdownError ?? lastBody ?? "")
+        logLine("dashboard phase=hydrate elapsed=\(Self.phaseElapsed(since: startedAt))")
+        return try await self.collectPageSnapshot(.init(
+            webView: lease.webView,
+            apiData: apiData,
+            verifiedSignedInEmail: verifiedSignedInEmail,
+            subscription: subscription,
+            previousSnapshot: previousSnapshot,
+            deadline: deadline,
+            startedAt: startedAt,
+            debugDumpHTML: debugDumpHTML,
+            log: lease.log))
     }
 
     public func clearSessionData(
@@ -456,26 +348,31 @@ public struct OpenAIDashboardFetcher {
         let webView = lease.webView
         let log = lease.log
 
-        var lastBody: String?
         var lastHref: String?
+        var lastEmail: String?
         var usageRouteSeenAt: Date?
         var dashboardSignalSeenAt: Date?
 
         while Date() < deadline {
             try Task.checkCancellation()
-            let scrape = try await self.scrape(webView: webView)
-            lastBody = scrape.bodyText ?? lastBody
-            lastHref = scrape.href ?? lastHref
+            let probe = try await self.probeReadiness(webView: webView)
+            lastHref = probe.href ?? lastHref
+            lastEmail = probe.signedInEmail ?? lastEmail
 
-            if scrape.workspacePicker {
+            if probe.workspacePicker {
                 try await Self.sleepForDashboardPoll(.milliseconds(500))
                 continue
             }
 
-            Self.logBlockingStateIfNeeded(scrape, logger: log)
-            try Self.throwIfBlockingScrapeState(scrape)
+            Self.logBlockingStateIfNeeded(probe, logger: log)
+            try Self.throwIfBlockingReadinessState(probe)
 
-            if Self.shouldReloadUsageRoute(scrape) {
+            if Self.shouldReloadUsageRoute(
+                href: probe.href,
+                loginRequired: probe.loginRequired,
+                workspacePicker: probe.workspacePicker,
+                cloudflareInterstitial: probe.cloudflareInterstitial)
+            {
                 usageRouteSeenAt = nil
                 dashboardSignalSeenAt = nil
                 _ = webView.load(Self.usageURLRequest(url: self.usageURL))
@@ -483,22 +380,11 @@ public struct OpenAIDashboardFetcher {
                 continue
             }
 
-            let normalizedEmail = scrape.signedInEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let bodyText = scrape.bodyText ?? ""
-            let rateLimits = OpenAIDashboardParser.parseRateLimits(bodyText: bodyText)
-            let hasDashboardSignal = normalizedEmail?.isEmpty == false ||
-                !scrape.rows.isEmpty ||
-                !scrape.usageBreakdown.isEmpty ||
-                scrape.creditsHeaderPresent ||
-                OpenAIDashboardParser.parseCodeReviewRemainingPercent(bodyText: bodyText) != nil ||
-                OpenAIDashboardParser.parseCreditsRemaining(bodyText: bodyText) != nil ||
-                rateLimits.primary != nil ||
-                rateLimits.secondary != nil
-
+            let normalizedEmail = probe.signedInEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
             if usageRouteSeenAt == nil {
                 usageRouteSeenAt = Date()
             }
-            if hasDashboardSignal, dashboardSignalSeenAt == nil {
+            if probe.hasDashboardSignal, dashboardSignalSeenAt == nil {
                 dashboardSignalSeenAt = Date()
             }
             if Self.shouldWaitForProbeReadiness(.init(
@@ -506,19 +392,19 @@ public struct OpenAIDashboardFetcher {
                 usageRouteSeenAt: usageRouteSeenAt,
                 dashboardSignalSeenAt: dashboardSignalSeenAt,
                 signedInEmail: normalizedEmail,
-                hasDashboardSignal: hasDashboardSignal))
+                hasDashboardSignal: probe.hasDashboardSignal))
             {
                 try await Self.sleepForDashboardPoll(.milliseconds(400))
                 continue
             }
 
             let result = ProbeResult(
-                href: scrape.href,
-                loginRequired: scrape.loginRequired,
-                workspacePicker: scrape.workspacePicker,
-                cloudflareInterstitial: scrape.cloudflareInterstitial,
+                href: probe.href,
+                loginRequired: probe.loginRequired,
+                workspacePicker: probe.workspacePicker,
+                cloudflareInterstitial: probe.cloudflareInterstitial,
                 signedInEmail: normalizedEmail,
-                bodyText: scrape.bodyText)
+                bodyText: nil)
             lease.setPreserveLoadedPageOnRelease(
                 preserveLoadedPageForReuse && Self.shouldPreserveLoadedPageAfterProbe(result))
             return result
@@ -530,15 +416,15 @@ public struct OpenAIDashboardFetcher {
             loginRequired: false,
             workspacePicker: false,
             cloudflareInterstitial: false,
-            signedInEmail: nil,
-            bodyText: lastBody)
+            signedInEmail: lastEmail,
+            bodyText: nil)
         lease.setPreserveLoadedPageOnRelease(false)
         return result
     }
 
     // MARK: - JS scrape
 
-    private struct ScrapeResult {
+    struct ScrapeResult {
         let loginRequired: Bool
         let workspacePicker: Bool
         let cloudflareInterstitial: Bool
@@ -560,7 +446,50 @@ public struct OpenAIDashboardFetcher {
         let didScrollToCredits: Bool
     }
 
-    private func scrape(webView: WKWebView) async throws -> ScrapeResult {
+    func probeReadiness(webView: WKWebView) async throws -> ReadinessProbe {
+        let any = try await webView.evaluateJavaScript(openAIDashboardReadinessScript)
+        guard let dict = any as? [String: Any] else {
+            return ReadinessProbe(
+                loginRequired: true,
+                workspacePicker: false,
+                cloudflareInterstitial: false,
+                href: nil,
+                signedInEmail: nil,
+                authStatus: nil,
+                creditsHeaderPresent: false,
+                creditsHeaderInViewport: false,
+                didScrollToCredits: false,
+                rowCount: 0,
+                usageBreakdownReady: false,
+                hasCodeReviewSignal: false,
+                hasDashboardSignal: false)
+        }
+
+        var loginRequired = (dict["loginRequired"] as? Bool) ?? false
+        let authStatus = (dict["authStatus"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let authStatus, !authStatus.isEmpty, authStatus.lowercased() != "logged_in" {
+            loginRequired = true
+        }
+        let signedInEmail = (dict["signedInEmail"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return ReadinessProbe(
+            loginRequired: loginRequired,
+            workspacePicker: (dict["workspacePicker"] as? Bool) ?? false,
+            cloudflareInterstitial: (dict["cloudflareInterstitial"] as? Bool) ?? false,
+            href: dict["href"] as? String,
+            signedInEmail: signedInEmail,
+            authStatus: authStatus,
+            creditsHeaderPresent: (dict["creditsHeaderPresent"] as? Bool) ?? false,
+            creditsHeaderInViewport: (dict["creditsHeaderInViewport"] as? Bool) ?? false,
+            didScrollToCredits: (dict["didScrollToCredits"] as? Bool) ?? false,
+            rowCount: (dict["rowCount"] as? NSNumber)?.intValue ?? 0,
+            usageBreakdownReady: (dict["usageBreakdownReady"] as? Bool) ?? false,
+            hasCodeReviewSignal: (dict["hasCodeReviewSignal"] as? Bool) ?? false,
+            hasDashboardSignal: (dict["hasDashboardSignal"] as? Bool) ?? false)
+    }
+
+    func scrape(webView: WKWebView) async throws -> ScrapeResult {
         let any = try await webView.evaluateJavaScript(openAIDashboardScrapeScript)
         guard let dict = any as? [String: Any] else {
             return ScrapeResult(
@@ -637,17 +566,7 @@ public struct OpenAIDashboardFetcher {
             didScrollToCredits: (dict["didScrollToCredits"] as? Bool) ?? false)
     }
 
-    private static func throwIfBlockingScrapeState(_ scrape: ScrapeResult) throws {
-        if scrape.loginRequired {
-            throw FetchError.loginRequired
-        }
-
-        if scrape.cloudflareInterstitial {
-            throw FetchError.noDashboardData(body: "Cloudflare challenge detected in WebView.")
-        }
-    }
-
-    private func fetchDebugHTML(webView: WKWebView) async throws -> String? {
+    func fetchDebugHTML(webView: WKWebView) async throws -> String? {
         try await webView.evaluateJavaScript(
             "document.documentElement ? String(document.documentElement.outerHTML || '') : ''") as? String
     }
@@ -702,14 +621,6 @@ public struct OpenAIDashboardFetcher {
         return !self.isUsageRoute(href)
     }
 
-    private nonisolated static func shouldReloadUsageRoute(_ scrape: ScrapeResult) -> Bool {
-        self.shouldReloadUsageRoute(
-            href: scrape.href,
-            loginRequired: scrape.loginRequired,
-            workspacePicker: scrape.workspacePicker,
-            cloudflareInterstitial: scrape.cloudflareInterstitial)
-    }
-
     nonisolated static func usageURLRequest(url: URL) -> URLRequest {
         var request = URLRequest(url: url)
         request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
@@ -731,7 +642,10 @@ public struct OpenAIDashboardFetcher {
         websiteDataStore: WKWebsiteDataStore,
         deadline: Date,
         logger: @escaping (String) -> Void)
-        async throws -> (apiData: DashboardAPIData?, verifiedSignedInEmail: String?)
+        async throws -> (
+            apiData: DashboardAPIData?,
+            verifiedSignedInEmail: String?,
+            subscription: OpenAISubscriptionMetadata?)
     {
         let cookieHeader = try await self.chatGPTCookieHeader(in: websiteDataStore, deadline: deadline)
         let apiData = await self.fetchDashboardUsageAPI(
@@ -746,11 +660,19 @@ public struct OpenAIDashboardFetcher {
         } else {
             nil
         }
+        let subscription: OpenAISubscriptionMetadata? = if apiData?.hasUsageData == true {
+            await self.fetchSubscriptionFromAPI(
+                cookieHeader: cookieHeader,
+                deadline: deadline,
+                logger: logger)
+        } else {
+            nil
+        }
 
         if apiData?.hasUsageData == true, verifiedEmail != nil {
-            logger("usage api supplied verified dashboard data; continuing WebView scrape")
+            logger("usage api supplied verified dashboard data")
         }
-        return (apiData, verifiedEmail)
+        return (apiData, verifiedEmail, subscription)
     }
 
     private static func fetchDashboardUsageAPI(
@@ -825,6 +747,41 @@ public struct OpenAIDashboardFetcher {
         return nil
     }
 
+    static func fetchSubscriptionFromAPI(
+        cookieHeader: String,
+        deadline: Date?,
+        logger: @escaping (String) -> Void) async -> OpenAISubscriptionMetadata?
+    {
+        guard !cookieHeader.isEmpty else { return nil }
+        let remaining = deadline.map { self.remainingTimeout(until: $0) } ?? 2
+        guard remaining > 0 else { return nil }
+
+        do {
+            let (data, response) = try await CodexAuthenticatedHTTPTransport.current.data(
+                for: self.dashboardSubscriptionAPIRequest(
+                    cookieHeader: cookieHeader,
+                    timeout: min(2, remaining)))
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            logger("subscription api status=\(status)")
+            guard status >= 200, status < 300 else { return nil }
+            let metadata = self.subscriptionMetadata(from: data)
+            if metadata != nil {
+                logger("subscription api supplied renewal data")
+            }
+            return metadata
+        } catch {
+            logger("subscription api unavailable: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    nonisolated static func subscriptionMetadata(from data: Data) -> OpenAISubscriptionMetadata? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        let activeUntil = (json["active_until"] as? String) ?? (json["activeUntil"] as? String)
+        let willRenew = (json["will_renew"] as? Bool) ?? (json["willRenew"] as? Bool)
+        return OpenAISubscriptionMetadata.parse(activeUntil: activeUntil, willRenew: willRenew)
+    }
+
     private static func chatGPTCookieHeader(in store: WKWebsiteDataStore, deadline: Date?) async throws -> String {
         let cookies = try await OpenAIDashboardBrowserCookieImporter.runBoundedValueCallback(
             deadline: deadline)
@@ -878,12 +835,14 @@ public struct OpenAIDashboardFetcher {
     private nonisolated static func firstNonEmpty(_ candidates: String?...) -> String? {
         for candidate in candidates {
             let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed?.isEmpty == false { return trimmed }
+            if trimmed?.isEmpty == false {
+                return trimmed
+            }
         }
         return nil
     }
 
-    private static func writeDebugArtifacts(html: String, bodyText: String?, logger: (String) -> Void) {
+    static func writeDebugArtifacts(html: String, bodyText: String?, logger: (String) -> Void) {
         let stamp = Int(Date().timeIntervalSince1970)
         let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let htmlURL = dir.appendingPathComponent("codex-openai-dashboard-\(stamp).html")
@@ -917,7 +876,9 @@ extension OpenAIDashboardFetcher {
     }
 
     nonisolated static func shouldWaitForCreditsHistory(_ context: CreditsHistoryWaitContext) -> Bool {
-        if context.didScrollToCredits { return true }
+        if context.didScrollToCredits {
+            return true
+        }
 
         // When the header is visible but rows are still empty, wait briefly for the table to render.
         if context.creditsHeaderPresent, context.creditsHeaderInViewport {
@@ -986,7 +947,9 @@ extension OpenAIDashboardFetcher {
             firstSeenAt = nil
             return
         }
-        if firstSeenAt == nil { firstSeenAt = now }
+        if firstSeenAt == nil {
+            firstSeenAt = now
+        }
         guard error != lastError else { return }
         lastError = error
         logger("usage breakdown error: \(error)")
@@ -1036,28 +999,57 @@ extension OpenAIDashboardFetcher {
         return request
     }
 
-    private static func logBlockingStateIfNeeded(_ scrape: ScrapeResult, logger: (String) -> Void) {
-        guard scrape.loginRequired || scrape.cloudflareInterstitial else { return }
-        let route = self.isUsageRoute(scrape.href) ? "usage" : "other"
-        logger(
-            "blocking state before route reload route=\(route) " +
-                "login=\(scrape.loginRequired) cloudflare=\(scrape.cloudflareInterstitial)")
+    nonisolated static func dashboardSubscriptionAPIRequest(
+        cookieHeader: String,
+        timeout: TimeInterval = 2) -> URLRequest
+    {
+        var request = URLRequest(
+            url: Self.dashboardSubscriptionAPIURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: timeout)
+        request.httpMethod = "GET"
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+        return request
     }
 
-    private func handleBlockingScrapeState(
-        _ scrape: ScrapeResult,
+    nonisolated static func phaseElapsed(since start: Date, now: Date = Date()) -> String {
+        String(format: "%.2fs", now.timeIntervalSince(start))
+    }
+
+    static func logBlockingStateIfNeeded(_ probe: ReadinessProbe, logger: (String) -> Void) {
+        guard probe.loginRequired || probe.cloudflareInterstitial else { return }
+        let route = self.isUsageRoute(probe.href) ? "usage" : "other"
+        logger(
+            "blocking state before route reload route=\(route) " +
+                "login=\(probe.loginRequired) cloudflare=\(probe.cloudflareInterstitial)")
+    }
+
+    static func throwIfBlockingReadinessState(_ probe: ReadinessProbe) throws {
+        if probe.loginRequired {
+            throw FetchError.loginRequired
+        }
+        if probe.cloudflareInterstitial {
+            throw FetchError.noDashboardData(body: "Cloudflare challenge detected in WebView.")
+        }
+    }
+
+    func handleBlockingReadinessState(
+        _ probe: ReadinessProbe,
         webView: WKWebView,
         debugDumpHTML: Bool,
         logger: (String) -> Void) async throws
     {
         if debugDumpHTML,
-           scrape.loginRequired || scrape.cloudflareInterstitial,
+           probe.loginRequired || probe.cloudflareInterstitial,
            let html = try? await self.fetchDebugHTML(webView: webView)
         {
-            Self.writeDebugArtifacts(html: html, bodyText: scrape.bodyText, logger: logger)
+            Self.writeDebugArtifacts(html: html, bodyText: nil, logger: logger)
         }
-        Self.logBlockingStateIfNeeded(scrape, logger: logger)
-        try Self.throwIfBlockingScrapeState(scrape)
+        Self.logBlockingStateIfNeeded(probe, logger: logger)
+        try Self.throwIfBlockingReadinessState(probe)
     }
 }
 #else
@@ -1087,7 +1079,9 @@ public struct OpenAIDashboardFetcher {
         logger _: ((String) -> Void)? = nil,
         debugDumpHTML _: Bool = false,
         allowNavigationTimeoutRetry _: Bool = true,
-        timeout _: TimeInterval = 60) async throws -> OpenAIDashboardSnapshot
+        timeout _: TimeInterval = 60,
+        previousSnapshot _: OpenAIDashboardSnapshot? = nil,
+        allowPageScrape _: Bool = true) async throws -> OpenAIDashboardSnapshot
     {
         throw FetchError.noDashboardData(body: "OpenAI web dashboard fetch is only supported on macOS.")
     }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardReadinessScript.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardReadinessScript.swift
@@ -1,21 +1,35 @@
 #if os(macOS)
-/// Cheap dashboard readiness probe. Returns flags only — never `document.body.innerText`.
+/// Cheap dashboard readiness probe. Returns flags only and avoids whole-document rendered text.
 let openAIDashboardReadinessScript = """
 
     (() => {
       const textOf = el => {
-        const raw = el && (el.innerText || el.textContent) ? String(el.innerText || el.textContent) : '';
+        const raw = el && typeof el.textContent === 'string' ? el.textContent : '';
         return raw.trim();
+      };
+      const textFrom = selector => {
+        try {
+          return Array.from(document.querySelectorAll(selector))
+            .map(textOf)
+            .filter(Boolean)
+            .join(' ');
+        } catch {
+          return '';
+        }
       };
       const href = window.location ? String(window.location.href || '') : '';
       const title = document.title ? String(document.title || '') : '';
-      const sample = document.body ? String(document.body.innerText || '').slice(0, 2000) : '';
-      const lower = sample.toLowerCase();
-      const workspacePicker = sample.includes('Select a workspace');
+      const semanticText = textFrom(
+        'h1,h2,h3,h4,p,button,a,[role="button"],[role="heading"],[role="alert"],[role="status"],label');
+      const lower = semanticText.toLowerCase();
+      const workspaceText = textFrom('[role="dialog"],[role="listbox"],[role="option"]');
+      const workspacePicker =
+        lower.includes('select a workspace') || workspaceText.toLowerCase().includes('select a workspace');
       const cloudflareInterstitial =
         title.toLowerCase().includes('just a moment') ||
         lower.includes('checking your browser') ||
-        lower.includes('cloudflare');
+        lower.includes('cloudflare') ||
+        !!document.querySelector('#challenge-running,#challenge-stage,.cf-chl-widget,[data-ray]');
       const authSelector = [
         'input[type="email"]',
         'input[type="password"]',
@@ -38,7 +52,7 @@ let openAIDashboardReadinessScript = """
         try {
           const el = document.getElementById(id);
           if (!el) return null;
-          return JSON.parse(el.textContent || el.innerText || '');
+          return JSON.parse(typeof el.textContent === 'string' ? el.textContent : '');
         } catch {
           return null;
         }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardReadinessScript.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardReadinessScript.swift
@@ -1,0 +1,137 @@
+#if os(macOS)
+/// Cheap dashboard readiness probe. Returns flags only — never `document.body.innerText`.
+let openAIDashboardReadinessScript = """
+
+    (() => {
+      const textOf = el => {
+        const raw = el && (el.innerText || el.textContent) ? String(el.innerText || el.textContent) : '';
+        return raw.trim();
+      };
+      const href = window.location ? String(window.location.href || '') : '';
+      const title = document.title ? String(document.title || '') : '';
+      const sample = document.body ? String(document.body.innerText || '').slice(0, 2000) : '';
+      const lower = sample.toLowerCase();
+      const workspacePicker = sample.includes('Select a workspace');
+      const cloudflareInterstitial =
+        title.toLowerCase().includes('just a moment') ||
+        lower.includes('checking your browser') ||
+        lower.includes('cloudflare');
+      const authSelector = [
+        'input[type="email"]',
+        'input[type="password"]',
+        'input[name="username"]'
+      ].join(', ');
+      const hasAuthInputs = !!document.querySelector(authSelector);
+      const loginCTA =
+        lower.includes('sign in') ||
+        lower.includes('log in') ||
+        lower.includes('continue with google') ||
+        lower.includes('continue with apple') ||
+        lower.includes('continue with microsoft');
+      let loginRequired =
+        href.includes('/auth/') ||
+        href.includes('/login') ||
+        (hasAuthInputs && loginCTA) ||
+        (!hasAuthInputs && loginCTA && href.includes('chatgpt.com'));
+
+      const parseJSONScript = (id) => {
+        try {
+          const el = document.getElementById(id);
+          if (!el) return null;
+          return JSON.parse(el.textContent || el.innerText || '');
+        } catch {
+          return null;
+        }
+      };
+
+      let signedInEmail = null;
+      let authStatus = null;
+      try {
+        const next = window.__NEXT_DATA__ || null;
+        const props = (next && next.props && next.props.pageProps) ? next.props.pageProps : null;
+        const userEmail = (props && props.user) ? props.user.email : null;
+        const sessionEmail = (props && props.session && props.session.user) ? props.session.user.email : null;
+        signedInEmail = userEmail || sessionEmail || null;
+      } catch {}
+      const clientBootstrap = parseJSONScript('client-bootstrap');
+      if (clientBootstrap) {
+        try {
+          authStatus = typeof clientBootstrap.authStatus === 'string' ? clientBootstrap.authStatus : null;
+          if (!signedInEmail) {
+            const session = clientBootstrap.session || null;
+            const user = (session && session.user) || clientBootstrap.user || null;
+            const email = user && typeof user.email === 'string' ? user.email : null;
+            if (email && email.includes('@')) signedInEmail = email;
+          }
+        } catch {}
+      }
+      if (authStatus && String(authStatus).toLowerCase() !== 'logged_in') {
+        loginRequired = true;
+      }
+
+      const viewportHeight = (typeof window.innerHeight === 'number') ? window.innerHeight : 0;
+      const scrollHeight = document.documentElement ? (document.documentElement.scrollHeight || 0) : 0;
+      let creditsHeaderPresent = false;
+      let creditsHeaderInViewport = false;
+      let didScrollToCredits = false;
+      let rowCount = 0;
+      try {
+        const headings = Array.from(document.querySelectorAll('h1,h2,h3'));
+        const header = headings.find(h => textOf(h).toLowerCase() === 'credits usage history');
+        if (header) {
+          creditsHeaderPresent = true;
+          const rect = header.getBoundingClientRect();
+          creditsHeaderInViewport = rect.top >= 0 && rect.top <= viewportHeight;
+          const container = header.closest('section') || header.parentElement || document;
+          const table = container.querySelector('table') || null;
+          rowCount = (table || container).querySelectorAll('tbody tr').length;
+          if (rowCount === 0 && !window.__codexbarDidScrollToCredits) {
+            window.__codexbarDidScrollToCredits = true;
+            header.scrollIntoView({ block: 'start', inline: 'nearest' });
+            if (creditsHeaderInViewport) {
+              window.scrollBy(0, Math.max(220, viewportHeight * 0.6));
+            }
+            didScrollToCredits = true;
+          }
+        } else if (!window.__codexbarDidScrollToCredits && scrollHeight > viewportHeight * 1.5) {
+          window.__codexbarDidScrollToCredits = true;
+          window.scrollTo(0, Math.max(0, scrollHeight - viewportHeight - 40));
+          didScrollToCredits = true;
+        }
+      } catch {}
+
+      let usageBreakdownReady = false;
+      try {
+        usageBreakdownReady = Boolean(window.__codexbarUsageBreakdownJSON) ||
+          document.querySelectorAll('g.recharts-bar-rectangle path.recharts-rectangle').length > 0;
+      } catch {}
+
+      const hasCodeReviewSignal = lower.includes('code review');
+      const hasDashboardSignal =
+        Boolean(signedInEmail) ||
+        creditsHeaderPresent ||
+        rowCount > 0 ||
+        usageBreakdownReady ||
+        hasCodeReviewSignal ||
+        lower.includes('credits remaining') ||
+        lower.includes('rate limit');
+
+      return {
+        loginRequired,
+        workspacePicker,
+        cloudflareInterstitial,
+        href,
+        signedInEmail,
+        authStatus,
+        creditsHeaderPresent,
+        creditsHeaderInViewport,
+        didScrollToCredits,
+        rowCount,
+        usageBreakdownReady,
+        hasCodeReviewSignal,
+        hasDashboardSignal
+      };
+    })();
+
+"""
+#endif

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -118,17 +118,6 @@ final class OpenAIDashboardWebViewCache {
     #endif
     /// Reuse the validated analytics page only for the immediate next handoff.
     private let preservedPageHandoffTimeout: TimeInterval = 5
-    private let blankURL = URL(string: "about:blank")!
-    private let idlePageClearScript = """
-    (() => {
-      try {
-        document.documentElement.innerHTML = '';
-        return true;
-      } catch {
-        return false;
-      }
-    })();
-    """
     private let reusablePageResetScript = """
     (() => {
       try {
@@ -173,28 +162,28 @@ final class OpenAIDashboardWebViewCache {
 
     private func releaseCachedEntry(_ entry: Entry, preserveLoadedPage: Bool) {
         entry.isBusy = false
-        let now = Date()
-        entry.lastUsedAt = now
-        self.updatePreservedPageState(for: entry, preserveLoadedPage: preserveLoadedPage)
-        self.prepareCachedWebViewForIdle(
-            entry.webView,
-            host: entry.host,
-            preserveLoadedPage: preserveLoadedPage)
-        self.prune(now: now)
-        self.scheduleNextIdlePrune(now: now)
+        entry.lastUsedAt = Date()
+        if preserveLoadedPage {
+            self.updatePreservedPageState(for: entry, preserveLoadedPage: true)
+            entry.host.hide()
+            self.scheduleNextIdlePrune()
+            return
+        }
+        self.evictEntry(entry)
     }
 
-    private func releaseNewEntry(_ entry: Entry, webView: WKWebView, preserveLoadedPage: Bool) {
-        entry.isBusy = false
-        let now = Date()
-        entry.lastUsedAt = now
-        self.updatePreservedPageState(for: entry, preserveLoadedPage: preserveLoadedPage)
-        self.prepareCachedWebViewForIdle(
-            webView,
-            host: entry.host,
-            preserveLoadedPage: preserveLoadedPage)
-        self.prune(now: now)
-        self.scheduleNextIdlePrune(now: now)
+    private func releaseNewEntry(_ entry: Entry, webView _: WKWebView, preserveLoadedPage: Bool) {
+        self.releaseCachedEntry(entry, preserveLoadedPage: preserveLoadedPage)
+    }
+
+    private func evictEntry(_ entry: Entry) {
+        entry.clearPreservedPage()
+        entry.host.close()
+        if let key = self.entries.first(where: { $0.value === entry })?.key {
+            self.entries.removeValue(forKey: key)
+        }
+        Self.log.debug("OpenAI webview evicted after release")
+        self.scheduleNextIdlePrune()
     }
 
     // MARK: - Testing support
@@ -484,26 +473,6 @@ final class OpenAIDashboardWebViewCache {
         self.scheduleNextIdlePrune()
     }
 
-    private func prepareCachedWebViewForIdle(
-        _ webView: WKWebView,
-        host: OffscreenWebViewHost,
-        preserveLoadedPage: Bool)
-    {
-        webView.navigationDelegate = nil
-        webView.codexNavigationDelegate = nil
-        if preserveLoadedPage {
-            host.hide()
-            return
-        }
-
-        // Detach the heavyweight ChatGPT SPA as soon as a scrape completes. Keeping the WebView object around
-        // still helps with immediate reuse, but letting chatgpt.com remain the active document is too expensive.
-        webView.stopLoading()
-        webView.evaluateJavaScript(self.idlePageClearScript, completionHandler: nil)
-        _ = webView.load(URLRequest(url: self.blankURL))
-        host.hide()
-    }
-
     /// Schedule against the oldest idle entry so later releases cannot postpone its eviction.
     private func scheduleNextIdlePrune(now: Date = Date()) {
         self.cancelIdlePrune()
@@ -545,22 +514,20 @@ final class OpenAIDashboardWebViewCache {
     }
 
     private func prune(now: Date) {
-        for entry in self.entries.values where !entry.isBusy && entry.hasExpiredPreservedPage(now: now) {
-            entry.clearPreservedPage()
-            self.prepareCachedWebViewForIdle(
-                entry.webView,
-                host: entry.host,
-                preserveLoadedPage: false)
+        let expiredPreserved = self.entries.values.filter { entry in
+            !entry.isBusy && entry.hasExpiredPreservedPage(now: now)
+        }
+        for entry in expiredPreserved {
             Self.log.debug("OpenAI webview preserved page expired")
+            self.evictEntry(entry)
         }
 
         let expired = self.entries.filter { _, entry in
             !entry.isBusy && now.timeIntervalSince(entry.lastUsedAt) >= self.idleTimeout
         }
-        for (key, entry) in expired {
-            entry.host.close()
-            self.entries.removeValue(forKey: key)
+        for (_, entry) in expired {
             Self.log.debug("OpenAI webview pruned")
+            self.evictEntry(entry)
         }
     }
 
@@ -572,10 +539,6 @@ final class OpenAIDashboardWebViewCache {
             source: self.preferredLanguageScript,
             injectionTime: .atDocumentStart,
             forMainFrameOnly: false))
-        userContentController.addUserScript(WKUserScript(
-            source: openAISubscriptionCaptureScript,
-            injectionTime: .atDocumentStart,
-            forMainFrameOnly: true))
         config.userContentController = userContentController
         if #available(macOS 14.0, *) {
             config.preferences.inactiveSchedulingPolicy = .suspend
@@ -701,13 +664,8 @@ final class OpenAIDashboardWebViewCache {
             return
         }
 
-        entry.clearPreservedPage()
-        self.prepareCachedWebViewForIdle(
-            entry.webView,
-            host: entry.host,
-            preserveLoadedPage: false)
         Self.log.debug("OpenAI webview preserved page expired")
-        self.prune(now: Date())
+        self.evictEntry(entry)
     }
 
     private func resetReusablePageState(_ webView: WKWebView) async -> Bool {

--- a/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
@@ -349,6 +349,67 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
     }
 
     @Test
+    func `api merge prefers the page derived plan over the generic api plan`() {
+        let previous = OpenAIDashboardSnapshot(
+            signedInEmail: "user@example.com",
+            codeReviewRemainingPercent: nil,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            accountPlan: "Pro 5x",
+            updatedAt: Date(timeIntervalSince1970: 1))
+        let apiData = OpenAIDashboardFetcher.DashboardAPIData(
+            primaryLimit: RateWindow(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondaryLimit: nil,
+            extraRateWindows: [],
+            creditsRemaining: nil,
+            codexCreditLimit: nil,
+            accountPlan: "pro")
+
+        let snapshot = OpenAIDashboardFetcher.snapshotByMergingAPI(
+            apiData: apiData,
+            verifiedEmail: "user@example.com",
+            subscription: nil,
+            previous: previous,
+            updatedAt: Date(timeIntervalSince1970: 2))
+
+        #expect(snapshot.accountPlan == "Pro 5x")
+    }
+
+    @Test
+    func `placeholder rows still wait for parsed credit events before extract accepts`() {
+        let now = Date()
+        // rowCount > 0 in the readiness probe skipped the pre-extract wait; the post-extract
+        // guard must still hold while parsed events are empty and the grace window is open.
+        let probe = OpenAIDashboardFetcher.ReadinessProbe(
+            loginRequired: false,
+            workspacePicker: false,
+            cloudflareInterstitial: false,
+            href: "https://chatgpt.com/codex/cloud/settings/analytics#usage",
+            signedInEmail: "user@example.com",
+            authStatus: "logged_in",
+            creditsHeaderPresent: true,
+            creditsHeaderInViewport: true,
+            didScrollToCredits: false,
+            rowCount: 3,
+            usageBreakdownReady: true,
+            hasCodeReviewSignal: false,
+            hasDashboardSignal: true)
+
+        #expect(OpenAIDashboardFetcher.shouldWaitForCreditsHistory(
+            probe: probe,
+            anyDashboardSignalAt: now.addingTimeInterval(-1),
+            creditsHeaderVisibleAt: now.addingTimeInterval(-1),
+            now: now))
+        #expect(!OpenAIDashboardFetcher.shouldWaitForCreditsHistory(
+            probe: probe,
+            anyDashboardSignalAt: now.addingTimeInterval(-10),
+            creditsHeaderVisibleAt: now.addingTimeInterval(-3),
+            now: now))
+    }
+
+    @Test
     func `page scrape is skipped whenever the caller disables it`() {
         #expect(OpenAIDashboardFetcher.shouldSkipPageScrape(allowPageScrape: false))
         #expect(!OpenAIDashboardFetcher.shouldSkipPageScrape(allowPageScrape: true))

--- a/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
@@ -347,4 +347,129 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
 
         #expect(OpenAIDashboardFetcher.findFirstEmail(inJSONData: Data(json.utf8)) == "nested@example.com")
     }
+
+    @Test
+    func `page scrape is skipped whenever the caller disables it`() {
+        #expect(OpenAIDashboardFetcher.shouldSkipPageScrape(allowPageScrape: false))
+        #expect(!OpenAIDashboardFetcher.shouldSkipPageScrape(allowPageScrape: true))
+    }
+
+    @Test
+    func `api snapshot keeps previous credits history and overwrites live usage`() {
+        let previous = OpenAIDashboardSnapshot(
+            signedInEmail: "old@example.com",
+            codeReviewRemainingPercent: 81,
+            creditEvents: [
+                CreditEvent(date: Date(timeIntervalSince1970: 1_700_000_000), service: "Codex", creditsUsed: 2),
+            ],
+            dailyBreakdown: [
+                OpenAIDashboardDailyBreakdown(
+                    day: "2026-04-19",
+                    services: [OpenAIDashboardServiceUsage(service: "Codex", creditsUsed: 2)],
+                    totalCreditsUsed: 2),
+            ],
+            usageBreakdown: [
+                OpenAIDashboardDailyBreakdown(
+                    day: "2026-04-19",
+                    services: [OpenAIDashboardServiceUsage(service: "Codex", creditsUsed: 2)],
+                    totalCreditsUsed: 2),
+            ],
+            creditsPurchaseURL: "https://chatgpt.com/checkout",
+            primaryLimit: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            creditsRemaining: 10,
+            updatedAt: Date(timeIntervalSince1970: 1))
+        let apiData = OpenAIDashboardFetcher.DashboardAPIData(
+            primaryLimit: RateWindow(usedPercent: 44, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondaryLimit: nil,
+            extraRateWindows: [],
+            creditsRemaining: 7.5,
+            codexCreditLimit: nil,
+            accountPlan: "pro")
+        let subscription = OpenAISubscriptionMetadata.parse(
+            activeUntil: "2026-08-20T14:30:07Z",
+            willRenew: true)
+
+        let snapshot = OpenAIDashboardFetcher.snapshotByMergingAPI(
+            apiData: apiData,
+            verifiedEmail: "new@example.com",
+            subscription: subscription,
+            previous: previous,
+            updatedAt: Date(timeIntervalSince1970: 2))
+
+        #expect(snapshot.signedInEmail == "new@example.com")
+        #expect(snapshot.primaryLimit?.usedPercent == 44)
+        #expect(snapshot.creditsRemaining == 7.5)
+        #expect(snapshot.accountPlan == "pro")
+        #expect(snapshot.creditEvents.count == 1)
+        #expect(snapshot.dailyBreakdown.count == 1)
+        #expect(snapshot.usageBreakdown.count == 1)
+        #expect(snapshot.codeReviewRemainingPercent == 81)
+        #expect(snapshot.creditsPurchaseURL == "https://chatgpt.com/checkout")
+        #expect(snapshot.subscriptionRenewsAt != nil)
+    }
+
+    @Test
+    func `empty scrape keeps previous page history`() {
+        let previous = OpenAIDashboardSnapshot(
+            signedInEmail: "keep@example.com",
+            codeReviewRemainingPercent: 70,
+            creditEvents: [
+                CreditEvent(date: Date(timeIntervalSince1970: 1_700_000_000), service: "Codex", creditsUsed: 3),
+            ],
+            dailyBreakdown: [
+                OpenAIDashboardDailyBreakdown(
+                    day: "2026-04-19",
+                    services: [OpenAIDashboardServiceUsage(service: "Codex", creditsUsed: 3)],
+                    totalCreditsUsed: 3),
+            ],
+            usageBreakdown: [
+                OpenAIDashboardDailyBreakdown(
+                    day: "2026-04-19",
+                    services: [OpenAIDashboardServiceUsage(service: "Codex", creditsUsed: 3)],
+                    totalCreditsUsed: 3),
+            ],
+            creditsPurchaseURL: "https://chatgpt.com/checkout",
+            creditsRemaining: 8,
+            subscriptionRenewsAt: Date(timeIntervalSince1970: 1_800_000_000),
+            updatedAt: Date(timeIntervalSince1970: 1))
+        let incoming = OpenAIDashboardSnapshot(
+            signedInEmail: nil,
+            codeReviewRemainingPercent: nil,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            primaryLimit: RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            creditsRemaining: 6,
+            updatedAt: Date(timeIntervalSince1970: 2))
+
+        let snapshot = OpenAIDashboardFetcher.fillingMissingPageFields(incoming, from: previous)
+        #expect(snapshot.signedInEmail == "keep@example.com")
+        #expect(snapshot.codeReviewRemainingPercent == 70)
+        #expect(snapshot.creditEvents.count == 1)
+        #expect(snapshot.dailyBreakdown.count == 1)
+        #expect(snapshot.usageBreakdown.count == 1)
+        #expect(snapshot.creditsPurchaseURL == "https://chatgpt.com/checkout")
+        #expect(snapshot.primaryLimit?.usedPercent == 50)
+        #expect(snapshot.creditsRemaining == 6)
+        #expect(snapshot.subscriptionRenewsAt != nil)
+    }
+
+    @Test
+    func `subscription api request carries cookies and English localization`() {
+        let request = OpenAIDashboardFetcher.dashboardSubscriptionAPIRequest(cookieHeader: "a=b")
+        #expect(request.url?.absoluteString == "https://chatgpt.com/backend-api/subscriptions")
+        #expect(request.value(forHTTPHeaderField: "Cookie") == "a=b")
+        #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+        #expect(request.value(forHTTPHeaderField: "Accept-Language") == "en-US,en;q=0.9")
+        #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
+    }
+
+    @Test
+    func `subscription api payload maps renewal date`() {
+        let json = #"{"active_until":"2026-08-20T14:30:07Z","will_renew":true}"#
+        let metadata = OpenAIDashboardFetcher.subscriptionMetadata(from: Data(json.utf8))
+        #expect(metadata?.renewsAt != nil)
+        #expect(metadata?.expiresAt == nil)
+    }
 }

--- a/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
@@ -409,6 +409,72 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
     }
 
     @Test
+    func `subscription replacement clears the mutually exclusive previous date`() {
+        let previous = OpenAIDashboardSnapshot(
+            signedInEmail: "user@example.com",
+            codeReviewRemainingPercent: nil,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            subscriptionRenewsAt: Date(timeIntervalSince1970: 1_800_000_000),
+            updatedAt: Date(timeIntervalSince1970: 1))
+        let apiData = OpenAIDashboardFetcher.DashboardAPIData(
+            primaryLimit: nil,
+            secondaryLimit: nil,
+            extraRateWindows: [],
+            creditsRemaining: nil,
+            codexCreditLimit: nil,
+            accountPlan: nil)
+        let subscription = OpenAISubscriptionMetadata.parse(
+            activeUntil: "2026-08-20T14:30:07Z",
+            willRenew: false)
+
+        let snapshot = OpenAIDashboardFetcher.snapshotByMergingAPI(
+            apiData: apiData,
+            verifiedEmail: "user@example.com",
+            subscription: subscription,
+            previous: previous,
+            updatedAt: Date(timeIntervalSince1970: 2))
+
+        #expect(snapshot.subscriptionExpiresAt != nil)
+        #expect(snapshot.subscriptionRenewsAt == nil)
+    }
+
+    @Test
+    func `page field subscription replacement clears the mutually exclusive previous date`() {
+        let previous = OpenAIDashboardSnapshot(
+            signedInEmail: "user@example.com",
+            codeReviewRemainingPercent: nil,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            subscriptionRenewsAt: Date(timeIntervalSince1970: 1_800_000_000),
+            updatedAt: Date(timeIntervalSince1970: 1))
+        let incoming = OpenAIDashboardSnapshot(
+            signedInEmail: "user@example.com",
+            codeReviewRemainingPercent: nil,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            subscriptionExpiresAt: Date(timeIntervalSince1970: 1_900_000_000),
+            updatedAt: Date(timeIntervalSince1970: 2))
+        let subscription = OpenAISubscriptionMetadata.parse(
+            activeUntil: "2026-08-20T14:30:07Z",
+            willRenew: false)
+
+        let snapshot = OpenAIDashboardFetcher.fillingMissingPageFields(
+            incoming,
+            from: previous,
+            subscription: subscription)
+
+        #expect(snapshot.subscriptionExpiresAt != nil)
+        #expect(snapshot.subscriptionRenewsAt == nil)
+    }
+
+    @Test
     func `empty scrape keeps previous page history`() {
         let previous = OpenAIDashboardSnapshot(
             signedInEmail: "keep@example.com",

--- a/Tests/CodexBarTests/OpenAIDashboardScrapeScriptTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardScrapeScriptTests.swift
@@ -8,6 +8,13 @@ import WebKit
 @Suite(.serialized)
 struct OpenAIDashboardScrapeScriptTests {
     @Test
+    func `readiness probe avoids whole document rendered text extraction`() {
+        #expect(!openAIDashboardReadinessScript.contains("document.body"))
+        #expect(!openAIDashboardReadinessScript.contains("innerText"))
+        #expect(openAIDashboardReadinessScript.contains("textContent"))
+    }
+
+    @Test
     func `scraper returns structured account fields without full html`() async throws {
         if Self.shouldSkipOnCI() { return }
 

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -49,7 +49,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `WKWebsiteDataStore should return same instance for same email`() {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         OpenAIDashboardWebsiteDataStore.clearCacheForTesting()
 
         let store1 = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: "test@example.com")
@@ -106,8 +108,10 @@ struct OpenAIDashboardWebViewCacheTests {
     // MARK: - WebView Reuse Tests
 
     @Test
-    func `WebView should be cached after release, not destroyed`() async throws {
-        if self.shouldSkipOnCI() { return }
+    func `WebView is destroyed after release unless the page is preserved`() async throws {
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
         let url = try #require(URL(string: "about:blank"))
@@ -119,21 +123,18 @@ struct OpenAIDashboardWebViewCacheTests {
             logger: nil)
         let webView1 = lease1.webView
 
-        // Release - should hide, not destroy
         lease1.release()
 
-        // Entry should still be in cache
-        #expect(cache.hasCachedEntry(for: store), "WebView should remain cached after release")
-        #expect(cache.entryCount == 1, "Should have exactly one cached entry")
+        #expect(!cache.hasCachedEntry(for: store), "Unpreserved WebView should be evicted on release")
+        #expect(cache.entryCount == 0, "Should have no cached entries after release")
 
-        // Second acquire should reuse the same WebView
         let lease2 = try await cache.acquire(
             websiteDataStore: store,
             usageURL: url,
             logger: nil)
         let webView2 = lease2.webView
 
-        #expect(webView1 === webView2, "Should reuse the same WebView instance")
+        #expect(webView1 !== webView2, "Next acquire should create a fresh WebView")
 
         lease2.release()
         cache.clearAllForTesting()
@@ -141,7 +142,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Different data stores should have separate cached WebViews`() async throws {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store1 = WKWebsiteDataStore.nonPersistent()
         let store2 = WKWebsiteDataStore.nonPersistent()
@@ -164,7 +167,7 @@ struct OpenAIDashboardWebViewCacheTests {
         lease2.release()
 
         #expect(webView1 !== webView2, "Different data stores should have different WebViews")
-        #expect(cache.entryCount == 2, "Should have two cached entries")
+        #expect(cache.entryCount == 0, "Unpreserved releases should evict both WebViews")
 
         cache.clearAllForTesting()
     }
@@ -173,7 +176,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `WebView should be pruned after idle timeout`() {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
         cache.cacheEntryForTesting(websiteDataStore: store)
@@ -190,7 +195,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Recently used WebView should not be pruned`() {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
         cache.cacheEntryForTesting(websiteDataStore: store)
@@ -205,7 +212,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Preserved page handoff is consumed only once`() {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
         cache.cacheEntryForTesting(websiteDataStore: store)
@@ -224,7 +233,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Expired preserved page is cleared before idle eviction`() {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
         cache.cacheEntryForTesting(websiteDataStore: store)
@@ -236,45 +247,41 @@ struct OpenAIDashboardWebViewCacheTests {
         cache.pruneForTesting(now: afterExpiry)
 
         #expect(!cache.hasPreservedPageForTesting(for: store), "Expired preserved page should be cleared")
-        #expect(cache.hasCachedEntry(for: store), "Entry should remain cached after page handoff expires")
+        #expect(!cache.hasCachedEntry(for: store), "Expired handoff should evict the WebView")
 
         cache.clearAllForTesting()
     }
 
     @Test
-    func `Preserved page expiry is scheduled without future cache activity`() async throws {
-        if self.shouldSkipOnCI() { return }
+    func `Preserved page expiry is scheduled without future cache activity`() async {
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
-        let webView = cache.cacheEntryForTesting(websiteDataStore: store)
-
-        _ = webView.loadHTMLString("<html><body>alive</body></html>", baseURL: nil)
-        try? await Task.sleep(for: .milliseconds(150))
-
+        cache.cacheEntryForTesting(websiteDataStore: store)
         cache.markPreservedPageForTesting(
             websiteDataStore: store,
             expiresAt: Date().addingTimeInterval(0.2))
 
         #expect(cache.hasPreservedPageForTesting(for: store), "Expected preserved page handoff to be armed")
 
-        var bodyText: String?
         let deadline = Date().addingTimeInterval(2)
-        repeat {
+        while cache.hasCachedEntry(for: store), Date() < deadline {
             try? await Task.sleep(for: .milliseconds(100))
-            bodyText = try await webView.evaluateJavaScript(
-                "document.body ? String(document.body.innerText || '') : ''") as? String
-        } while (cache.hasPreservedPageForTesting(for: store) || bodyText?.isEmpty != true) && Date() < deadline
+        }
 
-        #expect(!cache.hasPreservedPageForTesting(for: store), "Expected scheduled expiry to clear preserved page")
-        #expect(bodyText?.isEmpty == true, "Expected scheduled expiry to detach the preserved page to about:blank")
+        #expect(!cache.hasCachedEntry(for: store), "Expected scheduled expiry to evict the preserved WebView")
 
         cache.clearAllForTesting()
     }
 
     @Test
-    func `Idle prune is scheduled without future cache activity`() async throws {
-        if self.shouldSkipOnCI() { return }
-        let cache = OpenAIDashboardWebViewCache(idleTimeout: 0.2)
+    func `Unpreserved release evicts immediately without waiting for idle prune`() async throws {
+        if self.shouldSkipOnCI() {
+            return
+        }
+        let cache = OpenAIDashboardWebViewCache(idleTimeout: 5)
         let store = WKWebsiteDataStore.nonPersistent()
         let url = try #require(URL(string: "about:blank"))
 
@@ -285,55 +292,39 @@ struct OpenAIDashboardWebViewCacheTests {
         lease?.release()
         lease = nil
 
-        #expect(cache.hasCachedEntry(for: store), "WebView should remain cached right after release")
-
-        let deadline = Date().addingTimeInterval(5)
-        while cache.hasCachedEntry(for: store), Date() < deadline {
-            try? await Task.sleep(for: .milliseconds(100))
-        }
-
-        #expect(
-            !cache.hasCachedEntry(for: store),
-            "Expected the scheduled idle prune to evict the WebView without any further cache activity")
+        #expect(!cache.hasCachedEntry(for: store), "Unpreserved release should evict immediately")
 
         cache.clearAllForTesting()
     }
 
     @Test
-    func `Later release does not postpone an older idle entry`() async throws {
-        if self.shouldSkipOnCI() { return }
+    func `Preserved handoff keeps the WebView only until expiry`() async throws {
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache(idleTimeout: 5)
-        let firstStore = WKWebsiteDataStore.nonPersistent()
-        let secondStore = WKWebsiteDataStore.nonPersistent()
+        let store = WKWebsiteDataStore.nonPersistent()
         let url = try #require(URL(string: "about:blank"))
 
-        let firstLease = try await cache.acquire(
-            websiteDataStore: firstStore,
+        let lease = try await cache.acquire(
+            websiteDataStore: store,
             usageURL: url,
-            logger: nil)
-        firstLease.release()
-        let firstDeadline = try #require(cache.idlePruneDeadlineForTesting)
+            logger: nil,
+            preserveLoadedPageOnRelease: true)
+        lease.setPreserveLoadedPageOnRelease(true)
+        lease.release()
 
-        try await Task.sleep(for: .milliseconds(50))
+        #expect(cache.hasCachedEntry(for: store), "Preserved handoff should keep the WebView briefly")
+        #expect(cache.hasPreservedPageForTesting(for: store))
 
-        let secondLease = try await cache.acquire(
-            websiteDataStore: secondStore,
-            usageURL: url,
-            logger: nil)
-        secondLease.release()
-        let rescheduledDeadline = try #require(cache.idlePruneDeadlineForTesting)
-
-        #expect(
-            abs(rescheduledDeadline.timeIntervalSince(firstDeadline)) < 0.001,
-            "A later release should keep the prune scheduled for the oldest idle entry")
-        #expect(cache.hasCachedEntry(for: firstStore))
-        #expect(cache.hasCachedEntry(for: secondStore), "A later release should keep its own idle window")
         cache.clearAllForTesting()
     }
 
     @Test
     func `Reused page reset clears one shot scraper globals`() async throws {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
         let url = try #require(URL(string: "about:blank"))
@@ -370,7 +361,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Evict should remove specific WebView from cache`() async throws {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store1 = WKWebsiteDataStore.nonPersistent()
         let store2 = WKWebsiteDataStore.nonPersistent()
@@ -379,8 +372,10 @@ struct OpenAIDashboardWebViewCacheTests {
         // Cache two WebViews
         let lease1 = try await cache.acquire(websiteDataStore: store1, usageURL: url, logger: nil)
         lease1.release()
+        cache.cacheEntryForTesting(websiteDataStore: store1)
         let lease2 = try await cache.acquire(websiteDataStore: store2, usageURL: url, logger: nil)
         lease2.release()
+        cache.cacheEntryForTesting(websiteDataStore: store2)
 
         #expect(cache.entryCount == 2, "Should have two cached entries")
 
@@ -396,7 +391,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Evicted WebView should not be reused on next acquire`() async throws {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
         let url = try #require(URL(string: "about:blank"))
@@ -418,7 +415,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Evict all should remove every cached WebView`() async throws {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store1 = WKWebsiteDataStore.nonPersistent()
         let store2 = WKWebsiteDataStore.nonPersistent()
@@ -426,8 +425,10 @@ struct OpenAIDashboardWebViewCacheTests {
 
         let lease1 = try await cache.acquire(websiteDataStore: store1, usageURL: url, logger: nil)
         lease1.release()
+        cache.cacheEntryForTesting(websiteDataStore: store1)
         let lease2 = try await cache.acquire(websiteDataStore: store2, usageURL: url, logger: nil)
         lease2.release()
+        cache.cacheEntryForTesting(websiteDataStore: store2)
 
         #expect(cache.entryCount == 2, "Should have two cached entries")
 
@@ -440,7 +441,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Evict idle removes idle WebViews without interrupting busy WebViews`() {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let idleStore = WKWebsiteDataStore.nonPersistent()
         let busyStore = WKWebsiteDataStore.nonPersistent()
@@ -459,7 +462,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Memory pressure monitor evicts idle shared WebViews without interrupting busy WebViews`() {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache.shared
         cache.clearAllForTesting()
         defer { cache.clearAllForTesting() }
@@ -500,7 +505,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Busy WebView should create temporary WebView for concurrent access`() async throws {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
         let url = try #require(URL(string: "about:blank"))
@@ -535,34 +542,28 @@ struct OpenAIDashboardWebViewCacheTests {
     // MARK: - Network Traffic Regression Prevention
 
     @Test
-    func `Multiple sequential fetches should reuse same WebView (network optimization)`() async throws {
-        if self.shouldSkipOnCI() { return }
+    func `Multiple sequential fetches destroy the WebView after each release`() async throws {
+        if self.shouldSkipOnCI() {
+            return
+        }
         let cache = OpenAIDashboardWebViewCache()
         let store = WKWebsiteDataStore.nonPersistent()
         let url = try #require(URL(string: "about:blank"))
 
         var webViews: [WKWebView] = []
 
-        // Simulate 5 sequential fetches (like 5 refresh cycles)
-        for _ in 0..<5 {
+        for _ in 0..<3 {
             let lease = try await cache.acquire(
                 websiteDataStore: store,
                 usageURL: url,
                 logger: nil)
             webViews.append(lease.webView)
             lease.release()
+            #expect(cache.entryCount == 0, "Each unpreserved release should evict the WebView")
         }
 
-        // All should be the same WebView instance
-        let firstWebView = webViews[0]
-        for (index, webView) in webViews.enumerated() {
-            #expect(
-                webView === firstWebView,
-                "Fetch \(index + 1) should reuse the same WebView instance")
-        }
-
-        // Only one entry should exist in cache
-        #expect(cache.entryCount == 1, "Should maintain single cached entry across all fetches")
+        #expect(webViews[0] !== webViews[1])
+        #expect(webViews[1] !== webViews[2])
 
         cache.clearAllForTesting()
     }
@@ -571,7 +572,9 @@ struct OpenAIDashboardWebViewCacheTests {
 
     @Test
     func `Sequential fetches with OpenAIDashboardWebsiteDataStore should reuse WebView`() async throws {
-        if self.shouldSkipOnCI() { return }
+        if self.shouldSkipOnCI() {
+            return
+        }
         OpenAIDashboardWebsiteDataStore.clearCacheForTesting()
         let cache = OpenAIDashboardWebViewCache()
         let url = try #require(URL(string: "about:blank"))
@@ -591,15 +594,9 @@ struct OpenAIDashboardWebViewCacheTests {
             lease.release()
         }
 
-        // All should be the same WebView instance
-        let firstWebView = webViews[0]
-        for (index, webView) in webViews.enumerated() {
-            #expect(
-                webView === firstWebView,
-                "Fetch \(index + 1) with real data store factory should reuse same WebView")
-        }
-
-        #expect(cache.entryCount == 1, "Should have single cached entry")
+        #expect(webViews[0] !== webViews[1])
+        #expect(webViews[1] !== webViews[2])
+        #expect(cache.entryCount == 0, "Unpreserved sequential fetches should not keep a WebView resident")
 
         cache.clearAllForTesting()
         OpenAIDashboardWebsiteDataStore.clearCacheForTesting()

--- a/Tests/CodexBarTests/OpenAIWebRefreshGateTests.swift
+++ b/Tests/CodexBarTests/OpenAIWebRefreshGateTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
 struct OpenAIWebRefreshGateTests {
     @Test
@@ -168,6 +169,109 @@ struct OpenAIWebRefreshGateTests {
             refreshInterval: 300))
 
         #expect(shouldSkip == true)
+    }
+
+    @Test
+    func `code review alone is not dashboard page history`() {
+        let snapshot = OpenAIDashboardSnapshot(
+            signedInEmail: "user@example.com",
+            codeReviewRemainingPercent: 80,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            updatedAt: Date())
+
+        #expect(!UsageStore.dashboardHasPageHistory(snapshot))
+    }
+
+    @Test
+    func `cached history without an in memory scrape stamp does not scrape`() {
+        let now = Date()
+        let shouldScrape = UsageStore.shouldAllowOpenAIDashboardPageScrape(.init(
+            force: false,
+            userInitiated: false,
+            hasHistory: true,
+            lastPageScrapeAt: nil,
+            historyUpdatedAt: now.addingTimeInterval(-60),
+            now: now,
+            refreshInterval: 300))
+
+        #expect(!shouldScrape)
+    }
+
+    @Test
+    func `page scrape stays on when history has never been collected`() {
+        let shouldScrape = UsageStore.shouldAllowOpenAIDashboardPageScrape(.init(
+            force: false,
+            userInitiated: false,
+            hasHistory: false,
+            lastPageScrapeAt: nil,
+            historyUpdatedAt: nil,
+            now: Date(),
+            refreshInterval: 300))
+
+        #expect(shouldScrape)
+    }
+
+    @Test
+    func `page scrape is skipped when recent history already exists`() {
+        let now = Date()
+        let shouldScrape = UsageStore.shouldAllowOpenAIDashboardPageScrape(.init(
+            force: false,
+            userInitiated: false,
+            hasHistory: true,
+            lastPageScrapeAt: now.addingTimeInterval(-60),
+            historyUpdatedAt: now.addingTimeInterval(-60),
+            now: now,
+            refreshInterval: 300))
+
+        #expect(!shouldScrape)
+    }
+
+    @Test
+    func `user initiated force refresh still scrapes recent history`() {
+        let now = Date()
+        let shouldScrape = UsageStore.shouldAllowOpenAIDashboardPageScrape(.init(
+            force: true,
+            userInitiated: true,
+            hasHistory: true,
+            lastPageScrapeAt: now.addingTimeInterval(-60),
+            historyUpdatedAt: now.addingTimeInterval(-60),
+            now: now,
+            refreshInterval: 300))
+
+        #expect(shouldScrape)
+    }
+
+    @Test
+    func `background force refresh does not scrape recent history`() {
+        let now = Date()
+        let shouldScrape = UsageStore.shouldAllowOpenAIDashboardPageScrape(.init(
+            force: true,
+            userInitiated: false,
+            hasHistory: true,
+            lastPageScrapeAt: now.addingTimeInterval(-60),
+            historyUpdatedAt: now.addingTimeInterval(-60),
+            now: now,
+            refreshInterval: 300))
+
+        #expect(!shouldScrape)
+    }
+
+    @Test
+    func `page scrape returns after the dashboard interval`() {
+        let now = Date()
+        let shouldScrape = UsageStore.shouldAllowOpenAIDashboardPageScrape(.init(
+            force: false,
+            userInitiated: false,
+            hasHistory: true,
+            lastPageScrapeAt: now.addingTimeInterval(-301),
+            historyUpdatedAt: now.addingTimeInterval(-301),
+            now: now,
+            refreshInterval: 300))
+
+        #expect(shouldScrape)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1275,19 +1275,19 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Claude widget quota ownership uses the selected Claude account's isolated snapshot key."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1045,
+            line: 1046,
             anchor: "provider: .deepseek,",
             expectedProviderIDs: ["deepseek"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1147,
+            line: 1148,
             anchor: "let sourceMode = self.sourceMode(for: .claude)",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1151,
+            line: 1152,
             anchor: "provider: .claude,",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -1515,7 +1515,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Gemini login cleanup addresses the CLI's fixed default configuration directory."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+OpenAIWeb.swift",
-            line: 1518,
+            line: 1572,
             anchor: "&& (lower.contains(\"about\") || lower.contains(\"openai\") || lower.contains(\"chatgpt\"))",
             expectedProviderIDs: ["openai"],
             reason: "This logged-out-page classifier matches OpenAI's public landing-page brand token."),
@@ -2428,7 +2428,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Animation.swift",
-            line: 561,
+            line: 572,
             anchor: "guard isLoading, style == .warp, let phase else {",
             expectedProviderIDs: ["warp"],
             expectedReferenceCount: 1,
@@ -2436,7 +2436,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Animation.swift",
-            line: 915,
+            line: 926,
             anchor: "if provider == .kiro {",
             expectedProviderIDs: ["cursor", "kiro"],
             expectedReferenceCount: 2,
@@ -3219,7 +3219,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 586,
+            line: 587,
             anchor: "self.metadata(for: .codex).browserCookieOrder ?? Browser.defaultImportOrder",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3227,7 +3227,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 638,
+            line: 639,
             anchor: "self.providerSpecs[provider]?.style ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3235,7 +3235,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 671,
+            line: 672,
             anchor: "guard provider != .codex else { return true }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3243,7 +3243,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1019,
+            line: 1020,
             anchor: "let claudeDebugConfiguration: ClaudeDebugLogConfiguration? = if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3251,7 +3251,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1042,
+            line: 1043,
             anchor: "let deepSeekHasTokenAccount = self.settings.selectedTokenAccount(for: .deepseek) != nil",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3259,7 +3259,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1099,
+            line: 1100,
             anchor: "case .amp:",
             expectedProviderIDs: ["amp", "deepseek", "notion", "ollama", "warp"],
             expectedReferenceCount: 7,
@@ -3275,7 +3275,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1154,
+            line: 1155,
             anchor: "let claudeSettings = snapshot.claude ?? ProviderSettingsSnapshot.ClaudeProviderSettings(",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/StatusItemAnimationCapTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationCapTests.swift
@@ -1,0 +1,121 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct StatusItemAnimationCapTests {
+    private func makeStatusBarForTesting() -> NSStatusBar {
+        .system
+    }
+
+    @Test
+    func `loading animation does not restart after the continuous cap until state resets`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationCapTests"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let meta = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: meta, enabled: provider == .claude)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        store._setSnapshotForTesting(nil, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+        controller.updateAnimationState()
+        #expect(controller.animationDriver != nil)
+
+        controller.animationStartedAt = .distantPast
+        controller.animationDriver?.stop()
+        controller.animationDriver = nil
+        controller.updateAnimationState()
+        #expect(controller.animationDriver == nil)
+        #expect(controller.animationStartedAt == .distantPast)
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        controller.updateAnimationState()
+        #expect(controller.animationStartedAt != .distantPast)
+
+        store._setSnapshotForTesting(nil, provider: .claude)
+        controller.updateAnimationState()
+        #expect(controller.animationDriver != nil)
+        controller.animationDriver?.stop()
+        controller.animationDriver = nil
+    }
+
+    @Test
+    func `capped animation stays off after switching away from a still loading provider`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationCapTests-tab-switch"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        if let claudeMeta = ProviderRegistry.shared.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+        if let codexMeta = ProviderRegistry.shared.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 10, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .codex)
+        store._setSnapshotForTesting(nil, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.updateAnimationState()
+        #expect(controller.animationDriver != nil)
+        controller.animationStartedAt = .distantPast
+        controller.animationDriver?.stop()
+        controller.animationDriver = nil
+
+        settings.selectedMenuProvider = .codex
+        controller.updateAnimationState()
+        #expect(controller.animationDriver == nil)
+        #expect(controller.animationStartedAt == .distantPast)
+        #expect(controller.activeLoadingAnimationPhase() == nil)
+
+        settings.selectedMenuProvider = .claude
+        controller.updateAnimationState()
+        #expect(controller.animationDriver == nil)
+        #expect(controller.animationStartedAt == .distantPast)
+    }
+}

--- a/Tests/CodexBarTests/StatusItemAnimationCapTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationCapTests.swift
@@ -1,121 +1,29 @@
-import AppKit
-import CodexBarCore
+import Foundation
 import Testing
 @testable import CodexBar
 
-@MainActor
 struct StatusItemAnimationCapTests {
-    private func makeStatusBarForTesting() -> NSStatusBar {
-        .system
+    @Test
+    func `loading animation cap expires only after thirty seconds`() {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+
+        #expect(!StatusItemController.loadingAnimationHasExceededContinuousCap(
+            startedAt: now.addingTimeInterval(-30),
+            now: now))
+        #expect(StatusItemController.loadingAnimationHasExceededContinuousCap(
+            startedAt: now.addingTimeInterval(-30.001),
+            now: now))
     }
 
     @Test
-    func `loading animation does not restart after the continuous cap until state resets`() {
-        let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: "StatusItemAnimationCapTests"),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
-        settings.statusChecksEnabled = false
-        settings.refreshFrequency = .manual
-        settings.mergeIcons = true
-        settings.selectedMenuProvider = .claude
+    func `capped animation marker does not qualify as a fresh cap`() {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let meta = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: meta, enabled: provider == .claude)
-        }
-
-        let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: fetcher.loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: self.makeStatusBarForTesting())
-        defer { controller.releaseStatusItemsForTesting() }
-
-        store._setSnapshotForTesting(nil, provider: .claude)
-        store._setErrorForTesting(nil, provider: .claude)
-        controller.updateAnimationState()
-        #expect(controller.animationDriver != nil)
-
-        controller.animationStartedAt = .distantPast
-        controller.animationDriver?.stop()
-        controller.animationDriver = nil
-        controller.updateAnimationState()
-        #expect(controller.animationDriver == nil)
-        #expect(controller.animationStartedAt == .distantPast)
-
-        let snapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 20, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            updatedAt: Date())
-        store._setSnapshotForTesting(snapshot, provider: .claude)
-        controller.updateAnimationState()
-        #expect(controller.animationStartedAt != .distantPast)
-
-        store._setSnapshotForTesting(nil, provider: .claude)
-        controller.updateAnimationState()
-        #expect(controller.animationDriver != nil)
-        controller.animationDriver?.stop()
-        controller.animationDriver = nil
-    }
-
-    @Test
-    func `capped animation stays off after switching away from a still loading provider`() {
-        let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: "StatusItemAnimationCapTests-tab-switch"),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
-        settings.statusChecksEnabled = false
-        settings.refreshFrequency = .manual
-        settings.mergeIcons = true
-        settings.selectedMenuProvider = .claude
-        if let claudeMeta = ProviderRegistry.shared.metadata[.claude] {
-            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
-        }
-        if let codexMeta = ProviderRegistry.shared.metadata[.codex] {
-            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
-        }
-
-        let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
-        store._setSnapshotForTesting(
-            UsageSnapshot(
-                primary: RateWindow(usedPercent: 10, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
-                secondary: nil,
-                updatedAt: Date()),
-            provider: .codex)
-        store._setSnapshotForTesting(nil, provider: .claude)
-        store._setErrorForTesting(nil, provider: .claude)
-
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: fetcher.loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: self.makeStatusBarForTesting())
-        defer { controller.releaseStatusItemsForTesting() }
-
-        controller.updateAnimationState()
-        #expect(controller.animationDriver != nil)
-        controller.animationStartedAt = .distantPast
-        controller.animationDriver?.stop()
-        controller.animationDriver = nil
-
-        settings.selectedMenuProvider = .codex
-        controller.updateAnimationState()
-        #expect(controller.animationDriver == nil)
-        #expect(controller.animationStartedAt == .distantPast)
-        #expect(controller.activeLoadingAnimationPhase() == nil)
-
-        settings.selectedMenuProvider = .claude
-        controller.updateAnimationState()
-        #expect(controller.animationDriver == nil)
-        #expect(controller.animationStartedAt == .distantPast)
+        #expect(!StatusItemController.loadingAnimationHasExceededContinuousCap(
+            startedAt: .distantPast,
+            now: now))
+        #expect(!StatusItemController.loadingAnimationHasExceededContinuousCap(
+            startedAt: nil,
+            now: now))
     }
 }


### PR DESCRIPTION
## Summary

The hidden ChatGPT usage dashboard WebView was staying technically visible after scrape so WebKit would keep running the page. Activity Monitor then showed CodexBar's WebContent, Networking, and GPU helpers, with the `about:` content process alone around 35% CPU. Those children disappeared when the spike ended, but the app had already accumulated tens of minutes of CPU time.

This keeps the same dashboard fields and refresh schedule, and makes the WebView a short-lived fallback instead of a cached live tab.

## Root cause

- CodexBar scrapes chatgpt.com in an almost-offscreen window that is kept "visible" so the SPA hydrates.
- While hydrating it polled the full DOM every 400–600 ms, including `document.body.innerText`.
- After extract it navigated to `about:blank` and cached the WebView for up to 60 seconds. WebKit did not reliably suspend that process.
- Menu-open / refresh-all plus the 30 FPS loading animation made the expensive path easier to trigger and compounded main-thread work.

## Change

- Fetch `/backend-api/wham/usage`, identity, and `/backend-api/subscriptions` first.
- Skip the WebView when a scrape is not allowed: merge API data over the previous snapshot, or fail closed if there is nothing to return.
- Scrape the page only when credits/usage history is missing, the scrape interval has elapsed, or the user force-refreshes.
- While scraping, poll a cheap readiness probe and run the heavy extractor once.
- Destroy unpreserved WebViews on release. No 60s `about:blank` retain. Cookie-import handoff can keep a page for 5 seconds.
- Empty scrapes no longer wipe last-known history, charts, or subscription dates.
- The 30 FPS loading animation stops after 30 seconds and does not restart on tab switch until every enabled provider leaves first-load.

Deliberately unchanged: menu data, five-minute refresh, refresh-all-on-open, and the existing dashboard cooldown/coalesce gates.

## Validation

- `make check` on the touched files: 0 violations.
- Focused suites: dashboard fetch/API merge, WebView eviction, scrape gating, animation cap — 80 tests passed, then 24 follow-up tests after review fixes.
- `make test`: 842 selections across 71 groups, first-pass clean, no retries or timeouts.
- Architecture gatekeeper anchors updated for the shifted UsageStore / animation lines.
- Runtime: the previously installed app was at 69.3% with WebKit helpers. A worktree package of this head launched with **no young WebContent/GPU/Networking children**. `./Scripts/compile_and_run.sh` built the release binary but failed later in the signing `xattr` helper (`cffi` missing), so this is not a Developer ID / Gatekeeper proof.

No screenshots: no UI change. The remaining first-launch main-process burst on this machine was provider refresh (`agy` child), not the hidden ChatGPT SPA.## After-fix runtime proof

- Current branch is rebased onto `main` at `8518b14e`; the PR reports `MERGEABLE` and `CLEAN`. Head: `6c3c6b8b7d8eda2d6df184f1aa594386f061ac69`.
- The exact-head release package was rebuilt from that commit. `CFBundleVersion=118`, `CodexGitCommit=6c3c6b8b`, `codesign --verify --deep --strict` passed, and the package smoke launch completed.
- A visible authenticated browser session loaded the OpenAI usage dashboard route and rendered the balance, usage breakdown, and credits-history sections. Account identifiers and live values are intentionally omitted from this public trace.
- Redacted Activity Monitor / process trace immediately after launching the exact-head bundle:

  ```text
  exact_head=13913
  13913  1  0.0  /Users/stephenwalker/.codex/worktrees/high-cpu-usage/CodexBar/CodexBar.app/Contents/MacOS/CodexBar
  direct_children=<none>
  matching WebKit helpers with PPID=1: pre-existing processes, all 0.0% CPU
  ```

  The exact-head process had no WebContent, Networking, or GPU child. The filtered process view showed the exact-head app at 0.0% CPU; the older installed app and its pre-existing helper processes were separate PIDs.
- `make check`: passed with 0 SwiftFormat and SwiftLint violations.
- `make test`: 842 selections across 71 groups, 71 first-pass successes, 0 failures, 0 retries, 0 timeouts.