### PR TITLE
fix: tell an unscanned week apart from an unknown one in token activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.4 — Unreleased
 
 ### Fixed
+- Token activity: draw the Cumulative running total at the default 30-day history window instead of a blank grid, and keep the week clipped by the scan window (#2893). Thanks @urda!
 - PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.
 - Cost history: honor the preferred display currency throughout the detail chart and refresh converted labels when exchange rates change (#2887). Thanks @vAhyThe!
 

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -131,19 +131,26 @@ struct SpendActivitySeries {
     }
 
     func weeklyActivity() -> SpendActivityAggregateSeries {
+        let firstScannedIndex = self.daily.indices.first { self.isVisible($0) && self.isScanned[$0] }
         var values: [Int] = []
         var coverage: [Bool] = []
         var scanned: [Bool] = []
         for start in stride(from: 0, to: self.daily.count, by: Self.dayCount) {
             let indices = start..<min(start + Self.dayCount, self.daily.count)
             let visible = indices.filter(self.isVisible)
-            let scannedVisible = visible.filter { self.isScanned[$0] }
+            // The scanned region is contiguous, so unscanned days split into a leading window edge
+            // and a trailing stale suffix. Only days before the first scanned day are the window
+            // edge; they cannot make a week unavailable. Every visible day from that point on
+            // counts, so a trailing unscanned day (a stale snapshot) keeps its week — and every
+            // later running total — unavailable.
+            let counted: [Int] = if let firstScannedIndex {
+                visible.filter { $0 >= firstScannedIndex }
+            } else {
+                []
+            }
             values.append(visible.reduce(0) { Self.saturatingAdd($0, self.daily[$1]) })
-            // A week is covered when every day the scan reached is covered. Days the scan never
-            // reached cannot make the week unavailable, otherwise the week straddling the start of
-            // a 30-day window would drop even though its scanned portion is complete.
-            coverage.append(!scannedVisible.isEmpty && scannedVisible.allSatisfy { self.isCovered[$0] })
-            scanned.append(!scannedVisible.isEmpty)
+            coverage.append(!counted.isEmpty && counted.allSatisfy { self.isCovered[$0] })
+            scanned.append(!counted.isEmpty)
         }
         return SpendActivityAggregateSeries(values: values, isCovered: coverage, isScanned: scanned)
     }
@@ -162,7 +169,8 @@ struct SpendActivitySeries {
 struct SpendActivityAggregateSeries: Equatable {
     let values: [Int]
     let isCovered: [Bool]
-    /// Whether the scan window reached any day in the week.
+    /// Whether the week holds any day at or after the first scanned day. Weeks entirely before the
+    /// scan window are skipped by the running coverage; weeks at or after it participate.
     let isScanned: [Bool]
 
     init(values: [Int], isCovered: [Bool], isScanned: [Bool]? = nil) {

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -27,10 +27,31 @@ struct SpendActivitySeries {
 
     let daily: [Int]
     let isCovered: [Bool]
+    /// Whether the scan window reached the day. A day can be scanned and still uncovered when the
+    /// source data is missing, which is a real gap rather than a window edge.
+    let isScanned: [Bool]
     let start: Date
     let rangeStart: Date
     let today: Date
     let calendar: Calendar
+
+    init(
+        daily: [Int],
+        isCovered: [Bool],
+        isScanned: [Bool]? = nil,
+        start: Date,
+        rangeStart: Date,
+        today: Date,
+        calendar: Calendar)
+    {
+        self.daily = daily
+        self.isCovered = isCovered
+        self.isScanned = isScanned ?? [Bool](repeating: true, count: daily.count)
+        self.start = start
+        self.rangeStart = rangeStart
+        self.today = today
+        self.calendar = calendar
+    }
 
     static func make(
         from points: [SpendDashboardModel.TokenActivityPoint],
@@ -39,8 +60,12 @@ struct SpendActivitySeries {
     {
         var totals: [Date: Int] = [:]
         var unknownDays: Set<Date> = []
+        var unscannedDays: Set<Date> = []
         for point in points {
             let day = calendar.startOfDay(for: point.day)
+            if !point.isScanned {
+                unscannedDays.insert(day)
+            }
             guard let totalTokens = point.totalTokens else {
                 totals.removeValue(forKey: day)
                 unknownDays.insert(day)
@@ -63,12 +88,14 @@ struct SpendActivitySeries {
         let cellCount = Self.weekCount * Self.dayCount
         var daily = [Int](repeating: 0, count: cellCount)
         var isCovered = [Bool](repeating: false, count: cellCount)
+        var isScanned = [Bool](repeating: false, count: cellCount)
         for index in 0..<cellCount {
             guard let date = calendar.date(byAdding: .day, value: index, to: start),
                   rangeStart...today ~= date
             else {
                 continue
             }
+            isScanned[index] = !unscannedDays.contains(date)
             guard !unknownDays.contains(date), let total = totals[date] else { continue }
             daily[index] = total
             isCovered[index] = true
@@ -76,6 +103,7 @@ struct SpendActivitySeries {
         return Self(
             daily: daily,
             isCovered: isCovered,
+            isScanned: isScanned,
             start: start,
             rangeStart: rangeStart,
             today: today,
@@ -105,13 +133,19 @@ struct SpendActivitySeries {
     func weeklyActivity() -> SpendActivityAggregateSeries {
         var values: [Int] = []
         var coverage: [Bool] = []
+        var scanned: [Bool] = []
         for start in stride(from: 0, to: self.daily.count, by: Self.dayCount) {
             let indices = start..<min(start + Self.dayCount, self.daily.count)
             let visible = indices.filter(self.isVisible)
+            let scannedVisible = visible.filter { self.isScanned[$0] }
             values.append(visible.reduce(0) { Self.saturatingAdd($0, self.daily[$1]) })
-            coverage.append(!visible.isEmpty && visible.allSatisfy { self.isCovered[$0] })
+            // A week is covered when every day the scan reached is covered. Days the scan never
+            // reached cannot make the week unavailable, otherwise the week straddling the start of
+            // a 30-day window would drop even though its scanned portion is complete.
+            coverage.append(!scannedVisible.isEmpty && scannedVisible.allSatisfy { self.isCovered[$0] })
+            scanned.append(!scannedVisible.isEmpty)
         }
-        return SpendActivityAggregateSeries(values: values, isCovered: coverage)
+        return SpendActivityAggregateSeries(values: values, isCovered: coverage, isScanned: scanned)
     }
 
     func isVisible(_ index: Int) -> Bool {
@@ -128,19 +162,40 @@ struct SpendActivitySeries {
 struct SpendActivityAggregateSeries: Equatable {
     let values: [Int]
     let isCovered: [Bool]
+    /// Whether the scan window reached any day in the week.
+    let isScanned: [Bool]
 
+    init(values: [Int], isCovered: [Bool], isScanned: [Bool]? = nil) {
+        self.values = values
+        self.isCovered = isCovered
+        self.isScanned = isScanned ?? [Bool](repeating: true, count: values.count)
+    }
+
+    /// Running total per week. The grid always spans a full year, so a scan window shorter than
+    /// 365 days leaves an unscanned prefix. That prefix must not mark the whole series
+    /// unavailable, so the running coverage starts at the first scanned week.
+    ///
+    /// An unscanned week and an unknown week are not the same thing. A week the scan never reached
+    /// carries no information either way. A week the scan reached but could not resolve is a real
+    /// gap, and every later total is then only a lower bound, so it stays unavailable.
     func cumulative() -> Self {
         var total = 0
+        var hasStarted = false
         var coverageIsComplete = true
         var cumulativeValues: [Int] = []
         var cumulativeCoverage: [Bool] = []
         for index in self.values.indices {
             total = SpendActivitySeries.saturatingAdd(total, self.values[index])
-            coverageIsComplete = coverageIsComplete && self.isCovered[index]
+            if self.isScanned[index] {
+                hasStarted = true
+            }
+            if hasStarted {
+                coverageIsComplete = coverageIsComplete && self.isCovered[index]
+            }
             cumulativeValues.append(total)
-            cumulativeCoverage.append(coverageIsComplete)
+            cumulativeCoverage.append(hasStarted && coverageIsComplete)
         }
-        return Self(values: cumulativeValues, isCovered: cumulativeCoverage)
+        return Self(values: cumulativeValues, isCovered: cumulativeCoverage, isScanned: self.isScanned)
     }
 }
 

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -69,6 +69,16 @@ struct SpendDashboardModel: Equatable, Sendable {
         /// `nil` means at least one included source cannot establish coverage for this day.
         /// This must stay distinct from a proven zero so the heatmap does not fabricate inactivity.
         let totalTokens: Int?
+        /// `false` means at least one source never scanned this day, so the gap is a window edge
+        /// rather than missing data. A `nil` total with `true` means every source scanned the day
+        /// and still cannot report it, which is a real gap the heatmap must keep visible.
+        let isScanned: Bool
+
+        init(day: Date, totalTokens: Int?, isScanned: Bool = true) {
+            self.day = day
+            self.totalTokens = totalTokens
+            self.isScanned = isScanned
+        }
 
         var id: Date {
             self.day
@@ -196,8 +206,14 @@ struct SpendDashboardModel: Equatable, Sendable {
         let hasCompleteHistory: Bool
         let isGloballyInvalid: Bool
 
+        /// Whether the scan window reached this day at all. A day outside the window is unknown
+        /// because nobody looked; a day inside it is unknown because the data itself is missing.
+        func scanned(_ day: Date) -> Bool {
+            self.coveredInterval?.contains(day) == true
+        }
+
         func tokens(on day: Date) -> Int? {
-            guard self.coveredInterval?.contains(day) == true,
+            guard self.scanned(day),
                   !self.isGloballyInvalid,
                   !self.invalidDays.contains(day)
             else { return nil }
@@ -470,7 +486,12 @@ struct SpendDashboardModel: Equatable, Sendable {
             var total = 0
             for summary in summaries {
                 guard let tokens = summary.tokens(on: day) else {
-                    return TokenActivityPoint(day: day, totalTokens: nil)
+                    // Every source must have scanned the day before an unknown counts as a real
+                    // gap. If any source never reached it, this is the edge of a scan window.
+                    return TokenActivityPoint(
+                        day: day,
+                        totalTokens: nil,
+                        isScanned: summaries.allSatisfy { $0.scanned(day) })
                 }
                 let addition = total.addingReportingOverflow(tokens)
                 total = addition.overflow ? Int.max : addition.partialValue

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2356,7 +2356,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SpendDashboardModel.swift",
-            line: 639,
+            line: 660,
             anchor: "guard provider == .mistral else { return displayCalendar }",
             expectedProviderIDs: ["mistral"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -209,7 +209,93 @@ struct SpendActivityHeatmapTests {
         let weekly = series.weeklyActivity()
         #expect(weekly.values.prefix(2) == [7, 7])
         #expect(weekly.isCovered.prefix(2) == [false, true])
+        // Every day here was scanned, so the uncovered day is a real gap and every later running
+        // total stays a lower bound. See `cumulative activity starts at the first scanned week`
+        // for the window-edge case, which does recover.
         #expect(weekly.cumulative().isCovered.prefix(2) == [false, false])
+    }
+
+    @Test
+    func `cumulative activity starts at the first scanned week`() {
+        let weekly = SpendActivityAggregateSeries(
+            values: [3, 5, 7],
+            isCovered: [false, true, true],
+            isScanned: [false, true, true])
+
+        let cumulative = weekly.cumulative()
+
+        #expect(cumulative.isCovered == [false, true, true])
+        // Totals are unchanged: an unscanned week contributes whatever its covered days held.
+        #expect(cumulative.values == [3, 8, 15])
+    }
+
+    @Test
+    func `cumulative activity keeps a leading in window gap unavailable`() {
+        // Every week was scanned, so the leading unavailable week is missing data rather than a
+        // window edge. Later totals are lower bounds and must not read as complete.
+        let weekly = SpendActivityAggregateSeries(
+            values: [3, 5, 7],
+            isCovered: [false, true, true],
+            isScanned: [true, true, true])
+
+        let cumulative = weekly.cumulative()
+
+        #expect(cumulative.isCovered == [false, false, false])
+        #expect(cumulative.values == [3, 8, 15])
+    }
+
+    @Test
+    func `series separates an unscanned prefix from an in window gap`() throws {
+        let calendar = Self.calendar
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 8, day: 12)))
+        // A 30-day window on a 365-day grid: the first 335 days were never scanned.
+        let points = try (0..<SpendActivitySeries.rangeDayCount).map { offset -> SpendDashboardModel
+            .TokenActivityPoint in
+            let day = try #require(calendar.date(byAdding: .day, value: -offset, to: now))
+            guard offset < 30 else {
+                return .init(day: day, totalTokens: nil, isScanned: false)
+            }
+            return .init(day: day, totalTokens: 10)
+        }
+
+        let series = SpendActivitySeries.make(from: points, now: now, calendar: calendar)
+        let cumulative = series.weeklyActivity().cumulative()
+        let visibleWeeks = cumulative.isCovered.indices.filter { week in
+            (0..<SpendActivitySeries.dayCount).contains { row in
+                series.isVisible(week * SpendActivitySeries.dayCount + row)
+            }
+        }
+
+        // The unscanned prefix cannot blank the scanned window.
+        #expect(visibleWeeks.contains { cumulative.isCovered[$0] })
+        #expect(cumulative.values.last == 300)
+
+        // The same shape, but with one scanned day inside the window that cannot be resolved.
+        let gapDay = try #require(calendar.date(byAdding: .day, value: -29, to: now))
+        let withGap = points.map { point in
+            calendar.isDate(point.day, inSameDayAs: gapDay)
+                ? SpendDashboardModel.TokenActivityPoint(day: point.day, totalTokens: nil)
+                : point
+        }
+        let gapCumulative = SpendActivitySeries.make(from: withGap, now: now, calendar: calendar)
+            .weeklyActivity()
+            .cumulative()
+
+        // A real gap at the leading edge keeps every later running total unavailable.
+        #expect(!gapCumulative.isCovered.contains(true))
+    }
+
+    @Test
+    func `cumulative activity stays unavailable after a gap`() {
+        let weekly = SpendActivityAggregateSeries(
+            values: [1, 1, 1, 1],
+            isCovered: [true, false, true, true])
+
+        let cumulative = weekly.cumulative()
+
+        // A running total across a gap is a lower bound, so every later week stays unavailable.
+        #expect(cumulative.isCovered == [true, false, false, false])
+        #expect(cumulative.values == [1, 2, 3, 4])
     }
 
     @Test

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -286,6 +286,34 @@ struct SpendActivityHeatmapTests {
     }
 
     @Test
+    func `trailing unscanned days keep their week and later totals unavailable`() throws {
+        let calendar = Self.calendar
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 8, day: 12)))
+        // A stale snapshot: the scan covers now-30 ... now-2, so the two most recent days were
+        // never reached. That is missing recent data, not a window edge.
+        let points = try (0..<SpendActivitySeries.rangeDayCount).map { offset -> SpendDashboardModel
+            .TokenActivityPoint in
+            let day = try #require(calendar.date(byAdding: .day, value: -offset, to: now))
+            guard (2..<31).contains(offset) else {
+                return .init(day: day, totalTokens: nil, isScanned: false)
+            }
+            return .init(day: day, totalTokens: 10)
+        }
+
+        let series = SpendActivitySeries.make(from: points, now: now, calendar: calendar)
+        let weekly = series.weeklyActivity()
+        let cumulative = weekly.cumulative()
+
+        // The scanned interior still draws.
+        #expect(cumulative.isCovered.contains(true))
+        // The week holding the trailing unscanned days is a lower bound, so it and everything
+        // after it stay unavailable.
+        let lastWeek = weekly.isCovered.count - 1
+        #expect(weekly.isCovered[lastWeek] == false)
+        #expect(cumulative.isCovered[lastWeek] == false)
+    }
+
+    @Test
     func `model with a 30 day scan window yields a cumulative view that still draws`() throws {
         let now = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 16)))
         let formatter = DateFormatter()

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -286,6 +286,44 @@ struct SpendActivityHeatmapTests {
     }
 
     @Test
+    func `model with a 30 day scan window yields a cumulative view that still draws`() throws {
+        let now = try #require(Self.calendar.date(from: DateComponents(year: 2026, month: 7, day: 16)))
+        let formatter = DateFormatter()
+        formatter.calendar = Self.calendar
+        formatter.timeZone = Self.calendar.timeZone
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let entries = try (0..<30).map { offset in
+            let day = try #require(Self.calendar.date(byAdding: .day, value: -offset, to: now))
+            return Self.entry(day: formatter.string(from: day), cost: nil, tokens: 10)
+        }
+        let model = SpendDashboardModel.build(
+            inputs: [
+                .init(
+                    provider: .claude,
+                    displayName: "Claude",
+                    snapshot: Self.snapshot(entries: entries, historyDays: 30, last30DaysTokens: 300)),
+            ],
+            requestedDays: 30,
+            now: now,
+            calendar: Self.calendar)
+        let outsideDay = try #require(Self.calendar.date(byAdding: .day, value: -30, to: now))
+        let insideDay = try #require(Self.calendar.date(byAdding: .day, value: -29, to: now))
+
+        #expect(model.tokenActivity.first { $0.day == outsideDay }?.totalTokens == nil)
+        #expect(model.tokenActivity.first { $0.day == outsideDay }?.isScanned == false)
+        #expect(model.tokenActivity.first { $0.day == insideDay }?.totalTokens == 10)
+        #expect(model.tokenActivity.first { $0.day == insideDay }?.isScanned == true)
+
+        let series = SpendActivitySeries.make(from: model.tokenActivity, now: now, calendar: Self.calendar)
+        let cumulative = series.weeklyActivity().cumulative()
+
+        // #2893: keep Cumulative from rendering blank at the default 30-day window.
+        #expect(cumulative.isCovered.contains(true))
+        #expect(cumulative.values.last == 300)
+    }
+
+    @Test
     func `cumulative activity stays unavailable after a gap`() {
         let weekly = SpendActivityAggregateSeries(
             values: [1, 1, 1, 1],


### PR DESCRIPTION
## Summary

Fixes #2893: the Token activity "Cumulative" view rendered entirely blank at the default 30-day cost history setting.

The heatmap grid always spans 365 days, but the scan window follows the cost history setting, which defaults to 30 days. `SpendActivityAggregateSeries.cumulative()` computed coverage as a running AND over `isCovered`, so the unscanned 335-day prefix turned the flag false at week 0 and it never recovered — all 53 columns painted with the "Unavailable" fill.

The root problem is that one flag stood in for two facts. A day can be uncovered because the scan never reached it (a window edge, no information either way) or because the scan reached it and could not resolve it (a real gap, which makes every later running total a lower bound). This change threads scan provenance down to the heatmap:

- `SpendDashboardModel.TokenActivityPoint` gains `isScanned`, set only when every included source scanned the day.
- `SpendActivitySeries` and `SpendActivityAggregateSeries` carry the flag per day and per week.
- `cumulative()` starts its running coverage at the first scanned week, so the unscanned prefix no longer blanks the year, while a scanned-but-unknown week still keeps every later total unavailable.
- Weekly coverage anchors at the first visible scanned day: leading unscanned days (the window edge) cannot drop the week straddling the start of the scan window, but trailing unscanned days (a stale snapshot that stops short of today) keep their week and everything after it unavailable.

Totals are untouched; the last column still reconciles with the card header.

This adopts the diagnosis and implementation from #2895 by @urda, rebased onto current main, plus one correctness fix its review surfaced: the original rule ignored unscanned days anywhere in a week, which would have presented a stale snapshot's incomplete current week as a complete total. Contributor credit is preserved via Co-authored-by on the commits.

## Tests

- `cumulative activity starts at the first scanned week`
- `cumulative activity keeps a leading in window gap unavailable`
- `cumulative activity stays unavailable after a gap`
- `series separates an unscanned prefix from an in window gap`
- `trailing unscanned days keep their week and later totals unavailable` (new, covers the stale-snapshot case)
- `model with a 30 day scan window yields a cumulative view that still draws` (new, model-level regression through `SpendDashboardModel.build` reproducing the original 30-day symptom)

## Commands run

- `swift test --filter SpendActivityHeatmapTests` — 21 tests passed
- `make check` — 0 violations
- `make test` — full sharded suite

## Still open, deliberately

As noted in #2893, only Codex accounts receive the 365-day activity scan; other providers arrive with a snapshot scanned at `costUsageHistoryDays`, so coverage stays pinned to the smaller window. Widening that is a product decision about scan cost and stays out of this PR. With this change the view draws correctly but narrowly at the default setting.

Replaces #2895 (fork does not allow maintainer edits). Thanks @urda for the excellent investigation and fix!
