### PR TITLE
fix: detect renamed Gemini desktop app in Antigravity provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Token activity: draw the Cumulative running total at the default 30-day history window instead of a blank grid, and keep the week clipped by the scan window (#2893). Thanks @urda!
+- Antigravity: detect Google's renamed Gemini desktop app (`com.google.GeminiMacOS`, `Gemini.app`) for OAuth client discovery and language-server process matching, alongside the legacy Antigravity identifiers (#2836). Thanks @wxomi for the report and diagnostics!
 - PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.
 - Cost history: honor the preferred display currency throughout the detail chart and refresh converted labels when exchange rates change (#2887). Thanks @vAhyThe!
 - Codex: preserve requested Spend Dashboard history when the local cost cache exceeds its byte budget, rather than deleting in-window sessions or repeatedly rebuilding protected data (#2823). Thanks @WillStark for the report and @Whiteknight07 for the initial fix!

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -188,7 +188,7 @@ public enum AntigravityOAuthConfig {
             fileManager: fileManager)
             where fileManager.fileExists(atPath: url.path)
         {
-            guard let data = try? Data(contentsOf: url),
+            guard let data = try? Data(contentsOf: url, options: [.mappedIfSafe]),
                   let client = Self.parseClient(fromInstalledArtifactData: data)
             else {
                 continue
@@ -217,6 +217,8 @@ public enum AntigravityOAuthConfig {
             "Contents/Resources/app/out/main.js",
             "Contents/Resources/bin/language_server",
             "Contents/Resources/bin/language_server_macos",
+            // Gemini.app is a single native binary with no Electron artifacts.
+            "Contents/MacOS/Gemini",
         ]
         return appBundleURLs.flatMap { bundleURL in
             relativePaths.map { bundleURL.appendingPathComponent($0) }
@@ -231,6 +233,13 @@ public enum AntigravityOAuthConfig {
 
         for root in applicationRoots {
             urls.append(root.appendingPathComponent("Antigravity.app", isDirectory: true))
+
+            // "Gemini.app" is a generic name, so unlike "Antigravity.app" it is
+            // only accepted when the bundle identifier confirms the renamed app.
+            let geminiURL = root.appendingPathComponent("Gemini.app", isDirectory: true)
+            if self.isAntigravityAppBundle(geminiURL) {
+                urls.append(geminiURL)
+            }
 
             let appURLs = (try? fileManager.contentsOfDirectory(
                 at: root,
@@ -253,7 +262,7 @@ public enum AntigravityOAuthConfig {
 
     private static func isAntigravityAppBundle(_ url: URL) -> Bool {
         switch Bundle(url: url)?.bundleIdentifier {
-        case "com.google.antigravity", "com.google.antigravity-ide":
+        case "com.google.antigravity", "com.google.antigravity-ide", "com.google.GeminiMacOS":
             true
         default:
             false

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -1212,6 +1212,9 @@ public struct AntigravityStatusProbe: Sendable {
     private static func isAntigravityCommandLine(_ command: String) -> Bool {
         if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
         if command.contains("antigravity.app/") || command.contains("antigravity.app\\") { return true }
+        // The renamed Gemini desktop app (#2836). Require a leading path
+        // separator so unrelated names like "notgemini.app" cannot match.
+        if command.contains("/gemini.app/") || command.contains("\\gemini.app\\") { return true }
         if command.contains("antigravity ide.app/") || command.contains("antigravity ide.app\\") { return true }
         if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
         return false

--- a/Tests/CodexBarTests/AntigravityGeminiRenameTests.swift
+++ b/Tests/CodexBarTests/AntigravityGeminiRenameTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+/// Google renamed the Antigravity desktop app to "Gemini.app" with bundle ID
+/// `com.google.GeminiMacOS` (#2836). These tests cover the renamed-app
+/// detection surfaces alongside the legacy Antigravity identifiers.
+struct AntigravityGeminiRenameTests {
+    @Test
+    func `language server under renamed gemini app path classifies as app`() {
+        let gemini = "/applications/gemini.app/contents/resources/bin/language_server --csrf_token abc"
+        #expect(AntigravityStatusProbe.antigravityProcessKind(gemini) == .app)
+    }
+
+    @Test
+    func `gemini desktop main binary does not classify as language server`() {
+        #expect(
+            AntigravityStatusProbe.antigravityProcessKind(
+                "/Applications/Gemini.app/Contents/MacOS/Gemini") == nil)
+    }
+
+    @Test
+    func `unrelated gemini cli process does not classify`() {
+        #expect(
+            AntigravityStatusProbe.antigravityProcessKind(
+                "node /usr/local/lib/node_modules/@google/gemini-cli/dist/index.js") == nil)
+    }
+
+    @Test
+    func `language server under lookalike app name does not classify`() {
+        #expect(
+            AntigravityStatusProbe.antigravityProcessKind(
+                "/applications/notgemini.app/contents/resources/bin/language_server --csrf_token abc") == nil)
+    }
+}

--- a/Tests/CodexBarTests/AntigravityOAuthCredentialsStoreTests.swift
+++ b/Tests/CodexBarTests/AntigravityOAuthCredentialsStoreTests.swift
@@ -29,6 +29,83 @@ struct AntigravityOAuthCredentialsStoreTests {
     }
 
     @Test
+    func `oauth client discovery reads renamed gemini bundle identifier`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let geminiClient = AntigravityOAuthClient(
+            clientID: self.googleClientID("gemini"),
+            clientSecret: self.googleClientSecret(repeating: "f"))
+        try self.writeAntigravityApp(
+            named: "Google Gemini.app",
+            under: root,
+            bundleIdentifier: "com.google.GeminiMacOS",
+            artifactRelativePath: "Contents/Resources/app/out/main.js",
+            artifactData: Data("""
+            out-build/vs/platform/cloudCode/common/oauthClient.js
+            clientId="\(geminiClient.clientID)";
+            clientSecret="\(geminiClient.clientSecret)";
+            """.utf8))
+
+        #expect(
+            AntigravityOAuthConfig.discoverClientFromInstalledApp(
+                applicationRoots: [root]) == geminiClient)
+    }
+
+    @Test
+    func `oauth client discovery reads gemini native binary artifact`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let geminiClient = AntigravityOAuthClient(
+            clientID: self.googleClientID("gemini-native"),
+            clientSecret: self.googleClientSecret(repeating: "g"))
+        var artifactData = Data([0xFF])
+        artifactData.append(Data(
+            """
+            \u{0}\(geminiClient.clientSecret)\u{0}oauth_data\u{0}\(geminiClient.clientID)\u{0}
+            """.utf8))
+        try self.writeAntigravityApp(
+            named: "Gemini.app",
+            under: root,
+            bundleIdentifier: "com.google.GeminiMacOS",
+            artifactRelativePath: "Contents/MacOS/Gemini",
+            artifactData: artifactData)
+
+        #expect(
+            AntigravityOAuthConfig.discoverClientFromInstalledApp(
+                applicationRoots: [root]) == geminiClient)
+    }
+
+    @Test
+    func `oauth client discovery skips gemini app with foreign bundle identifier`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let foreignClient = AntigravityOAuthClient(
+            clientID: self.googleClientID("foreign"),
+            clientSecret: self.googleClientSecret(repeating: "h"))
+        var artifactData = Data([0xFF])
+        artifactData.append(Data(
+            """
+            \u{0}\(foreignClient.clientSecret)\u{0}oauth_data\u{0}\(foreignClient.clientID)\u{0}
+            """.utf8))
+        try self.writeAntigravityApp(
+            named: "Gemini.app",
+            under: root,
+            bundleIdentifier: "com.example.other-gemini",
+            artifactRelativePath: "Contents/MacOS/Gemini",
+            artifactData: artifactData)
+
+        #expect(
+            AntigravityOAuthConfig.discoverClientFromInstalledApp(
+                applicationRoots: [root]) == nil)
+    }
+
+    @Test
     func `oauth client discovery reads standalone antigravity 2 bundle`() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
Refs #2836

## Summary

Google renamed the Antigravity desktop app to **Gemini.app** with bundle ID `com.google.GeminiMacOS`. CodexBar's Antigravity provider only recognized the legacy `com.google.antigravity` / `com.google.antigravity-ide` identifiers, so the renamed app was invisible to every bundle-keyed detection surface. This PR adds the renamed identifiers alongside the legacy ones:

- **OAuth client discovery** (`AntigravityOAuthCredentialsStore.swift`): `com.google.GeminiMacOS` is accepted in the bundle-identifier allowlist; `Gemini.app` is probed as a direct candidate in application roots, but — because the name is generic — only when the bundle identifier confirms the renamed app (legacy `Antigravity.app` keeps its unconditional path). The native main binary `Contents/MacOS/Gemini` is added as an OAuth-client artifact candidate, since per the issue diagnostics the renamed app is a single native binary with no Electron artifacts. Artifact reads now use `.mappedIfSafe` so scanning the ~174 MB binary does not copy it into memory.
- **Language-server process classification** (`AntigravityStatusProbe.swift`): commands whose path contains `/gemini.app/` (or the Windows-separator form) now classify as the app language server. The marker requires a leading path separator and is only consulted after the executable already matched the language-server pattern, so the Gemini desktop main binary, lookalike app names, and unrelated Gemini CLI processes cannot match.

## Out of scope — issue should stay open

The issue's secondary root cause (the spawned headless `agy` auth race, where `RetrieveUserQuotaSummary` returns "not logged in" during the ~5.4 s auth-initialization window and CodexBar accepts a degraded model-only snapshot before the 15 s deadline) is **not** addressed here. Per the reporter's diagnostics, the renamed Gemini.app runs no local language server at all, so on that setup the spawned-`agy` path remains the operative one and quota windows will still be missing until the fallback policy question in the ClawSweeper review is decided. This PR therefore uses "Refs" rather than "Fixes"; #2836 should stay open for the auth-race part.

## Tests

- `AntigravityOAuthCredentialsStoreTests`: renamed-bundle-identifier discovery (arbitrary app name), native-binary artifact discovery, and a negative test that a `Gemini.app` with a foreign bundle identifier is skipped.
- `AntigravityGeminiRenameTests` (new file, keeps `AntigravityStatusProbeTests` under the SwiftLint file-length cap): Gemini.app-hosted language server classifies as `.app`; the desktop main binary, `@google/gemini-cli`, and a lookalike `notgemini.app` path do not classify.

## Commands run

- `swift test --filter "AntigravityGeminiRenameTests|AntigravityOAuthCredentialsStoreTests|AntigravityStatusProbeTests"` — 71 tests, all passing
- `make check` — 0 violations
- `make test` — full sharded suite; only failures are pre-existing `GeminiStatusProbeAPITests` fnm-helper timing flakes under parallel load (unrelated to this change; the suite passes in isolation)
