### PR TITLE
Fix LongCat usage showing 0% by reading the token-packs summary endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Token activity: draw the Cumulative running total at the default 30-day history window instead of a blank grid, and keep the week clipped by the scan window (#2893). Thanks @urda!
+- LongCat: read live usage from the token-packs summary endpoint, falling back to the legacy token-usage endpoint when no active token lot is available (#2670).
 - PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.
 - Cost history: honor the preferred display currency throughout the detail chart and refresh converted labels when exchange rates change (#2887). Thanks @vAhyThe!
 - Codex: preserve requested Spend Dashboard history when the local cost cache exceeds its byte budget, rather than deleting in-window sessions or repeatedly rebuilding protected data (#2823). Thanks @WillStark for the report and @Whiteknight07 for the initial fix!

--- a/Sources/CodexBarCore/Providers/LongCat/LongCatUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/LongCat/LongCatUsageFetcher.swift
@@ -23,6 +23,7 @@ public struct LongCatUsageFetcher: Sendable {
     private static let host = "https://longcat.chat"
 
     private static let userCurrentPath = "/api/v1/user-current"
+    private static let tokenPacksSummaryPath = "/api/pay/quota/metering/token-packs/summary"
     private static let tokenUsagePath = "/api/lc-platform/v1/tokenUsage"
     private static let pendingFuelPath = "/api/lc-platform/v1/pending-fuel-packages"
 
@@ -85,21 +86,43 @@ public struct LongCatUsageFetcher: Sendable {
             account = object
         }
 
-        guard let usageData = try await self.get(
-            self.tokenUsagePath,
-            authentication: authentication,
-            transport: transport,
-            required: true)
-        else {
-            throw LongCatAPIError.parseFailed("tokenUsage response was empty")
+        var tokenPackSummary: [String: Any]?
+        do {
+            if let data = try await self.post(
+                self.tokenPacksSummaryPath,
+                authentication: authentication,
+                transport: transport,
+                required: true)
+            {
+                let payload = try LongCatEnvelope.unwrap(self.json(data))
+                guard let object = payload as? [String: Any] else {
+                    throw LongCatAPIError.parseFailed("token-packs summary data was not an object")
+                }
+                tokenPackSummary = object
+            }
+        } catch {
+            Self.log.error("LongCat token-packs summary probe failed: \(error.localizedDescription)")
         }
-        let usagePayload = try LongCatEnvelope.unwrap(self.json(usageData))
-        guard let usage = usagePayload as? [String: Any] else {
-            throw LongCatAPIError.parseFailed("tokenUsage data was not an object")
-        }
-        let canonicalUsage = LongCatJSON.object(usage["usage"]) ?? usage
-        guard LongCatJSON.double(canonicalUsage["totalToken"]) != nil else {
-            throw LongCatAPIError.parseFailed("tokenUsage data was missing totalToken")
+
+        var usage: [String: Any]?
+        if self.activeTokenPackLot(from: tokenPackSummary) == nil {
+            guard let usageData = try await self.get(
+                self.tokenUsagePath,
+                authentication: authentication,
+                transport: transport,
+                required: true)
+            else {
+                throw LongCatAPIError.parseFailed("tokenUsage response was empty")
+            }
+            let usagePayload = try LongCatEnvelope.unwrap(self.json(usageData))
+            guard let usageObject = usagePayload as? [String: Any] else {
+                throw LongCatAPIError.parseFailed("tokenUsage data was not an object")
+            }
+            let canonicalUsage = LongCatJSON.object(usageObject["usage"]) ?? usageObject
+            guard LongCatJSON.double(canonicalUsage["totalToken"]) != nil else {
+                throw LongCatAPIError.parseFailed("tokenUsage data was missing totalToken")
+            }
+            usage = usageObject
         }
 
         var fuel: [String: Any]?
@@ -120,13 +143,19 @@ public struct LongCatUsageFetcher: Sendable {
             Self.log.error("LongCat supplemental fuel probe failed: \(error.localizedDescription)")
         }
 
-        return self.buildSnapshot(account: account, tokenUsage: usage, pendingFuel: fuel, now: now)
+        return self.buildSnapshot(
+            account: account,
+            tokenPackSummary: tokenPackSummary,
+            tokenUsage: usage,
+            pendingFuel: fuel,
+            now: now)
     }
 
     /// Pure extraction over the unwrapped `data` payloads. Field paths are locked
     /// against captured live responses; see `LongCatProviderTests`.
     static func buildSnapshot(
         account: [String: Any]?,
+        tokenPackSummary: [String: Any]?,
         tokenUsage: [String: Any]?,
         pendingFuel: [String: Any]?,
         now: Date = Date()) -> LongCatUsageSnapshot
@@ -137,9 +166,16 @@ public struct LongCatUsageFetcher: Sendable {
             snapshot.accountName = LongCatJSON.string(account["name"]) ?? LongCatJSON.string(account["nickName"])
         }
 
-        // Token quota: data.usage is the canonical aggregate; extData holds the
-        // per-model breakdown (LongCat-Flash-Lite, LongCat-2.0-Preview, ...).
-        if let tokenUsage {
+        if let lot = self.activeTokenPackLot(from: tokenPackSummary),
+           let total = LongCatJSON.double(lot["totalToken"])
+        {
+            let used = LongCatJSON.double(lot["consumedToken"]) ?? 0
+            snapshot.totalQuota = total
+            snapshot.usedQuota = used
+            snapshot.remainingQuota = total - used
+        } else if let tokenUsage {
+            // Legacy token quota: data.usage is the canonical aggregate; extData holds the
+            // per-model breakdown (LongCat-Flash-Lite, LongCat-2.0-Preview, ...).
             let usage = LongCatJSON.object(tokenUsage["usage"]) ?? tokenUsage
             snapshot.totalQuota = LongCatJSON.double(usage["totalToken"])
             snapshot.usedQuota = LongCatJSON.double(usage["usedToken"])
@@ -151,6 +187,17 @@ public struct LongCatUsageFetcher: Sendable {
         }
 
         return snapshot
+    }
+
+    private static func activeTokenPackLot(from summary: [String: Any]?) -> [String: Any]? {
+        guard let lot = LongCatJSON.object(summary?["currentLot"]),
+              LongCatJSON.string(lot["status"])?.uppercased() == "ACTIVE",
+              let total = LongCatJSON.double(lot["totalToken"]),
+              total > 0
+        else {
+            return nil
+        }
+        return lot
     }
 
     private static func applyFuelPackages(_ dict: [String: Any], to snapshot: inout LongCatUsageSnapshot) {
@@ -190,11 +237,44 @@ public struct LongCatUsageFetcher: Sendable {
         transport: any ProviderHTTPTransport,
         required: Bool) async throws -> Data?
     {
+        try await self.request(
+            path,
+            method: "GET",
+            authentication: authentication,
+            transport: transport,
+            required: required)
+    }
+
+    private static func post(
+        _ path: String,
+        authentication: Authentication,
+        transport: any ProviderHTTPTransport,
+        required: Bool) async throws -> Data?
+    {
+        try await self.request(
+            path,
+            method: "POST",
+            authentication: authentication,
+            transport: transport,
+            required: required)
+    }
+
+    private static func request(
+        _ path: String,
+        method: String,
+        authentication: Authentication,
+        transport: any ProviderHTTPTransport,
+        required: Bool) async throws -> Data?
+    {
         guard let url = URL(string: self.host + path) else {
             throw LongCatAPIError.invalidRequest("bad URL: \(path)")
         }
         var request = URLRequest(url: url)
-        request.httpMethod = "GET"
+        request.httpMethod = method
+        if method == "POST" {
+            request.httpBody = Data("{}".utf8)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
         guard let cookieHeader = authentication.header(for: url) else {
             throw LongCatAPIError.missingCookies
         }

--- a/Tests/CodexBarTests/LongCatProviderTests.swift
+++ b/Tests/CodexBarTests/LongCatProviderTests.swift
@@ -116,7 +116,11 @@ struct LongCatProviderTests {
         """#)
         let fuel = try self.object(#"{"totalQuota":0,"list":[]}"#)
 
-        let snapshot = LongCatUsageFetcher.buildSnapshot(account: account, tokenUsage: tokenUsage, pendingFuel: fuel)
+        let snapshot = LongCatUsageFetcher.buildSnapshot(
+            account: account,
+            tokenPackSummary: nil,
+            tokenUsage: tokenUsage,
+            pendingFuel: fuel)
         #expect(snapshot.accountName == "LongCat User")
         #expect(snapshot.totalQuota == 500_000)
         #expect(snapshot.usedQuota == 120_000)
@@ -129,12 +133,37 @@ struct LongCatProviderTests {
     }
 
     @Test
+    func `buildSnapshot prefers an active token pack lot`() throws {
+        let tokenPackSummary = try self.object(#"""
+        {"currentLot":{"totalToken":50000000,"consumedToken":1212576,"consumedRatio":0.02425152,
+                       "status":"ACTIVE"}}
+        """#)
+        let staleTokenUsage = try self.object(#"""
+        {"usage":{"totalToken":500000,"usedToken":0,"availableToken":500000}}
+        """#)
+
+        let snapshot = LongCatUsageFetcher.buildSnapshot(
+            account: nil,
+            tokenPackSummary: tokenPackSummary,
+            tokenUsage: staleTokenUsage,
+            pendingFuel: nil)
+        #expect(snapshot.totalQuota == 50_000_000)
+        #expect(snapshot.usedQuota == 1_212_576)
+        #expect(snapshot.remainingQuota == 48_787_424)
+        #expect(abs((snapshot.toUsageSnapshot().primary?.usedPercent ?? 0) - 2.425152) < 0.001)
+    }
+
+    @Test
     func `buildSnapshot sums active fuel packages`() throws {
         let fuel = try self.object(#"""
         {"totalQuota":1000,"list":[{"availableToken":600,"expireTime":1750000000000},
                                    {"availableToken":150,"expireTime":1760000000000}]}
         """#)
-        let snapshot = LongCatUsageFetcher.buildSnapshot(account: nil, tokenUsage: nil, pendingFuel: fuel)
+        let snapshot = LongCatUsageFetcher.buildSnapshot(
+            account: nil,
+            tokenPackSummary: nil,
+            tokenUsage: nil,
+            pendingFuel: fuel)
         #expect(snapshot.fuelPackTotal == 1000)
         #expect(snapshot.fuelPackRemaining == 750)
         #expect(snapshot.nearestFuelExpiry != nil)
@@ -279,24 +308,38 @@ struct LongCatProviderTests {
     }
 
     @Test
-    func `fetch maps a full live response over the transport`() async throws {
+    func `fetch uses the active token pack lot without legacy token usage`() async throws {
         let transport = LongCatScriptedTransport(results: [
             .body(#"{"code":0,"data":{"name":"Leo"}}"#),
-            .body(#"{"code":0,"data":{"usage":{"totalToken":500000,"usedToken":120000,"availableToken":380000}}}"#),
+            .body(#"""
+            {"code":0,"data":{"currentLot":{"totalToken":50000000,"consumedToken":1212576,
+             "consumedRatio":0.02425152,"status":"ACTIVE"}}}
+            """#),
             .body(#"{"code":0,"data":{"totalQuota":1000,"list":[{"availableToken":600,"expireTime":1750000000000}]}}"#),
         ])
         let snapshot = try await LongCatUsageFetcher.fetchUsage(cookieHeader: "session=x", transport: transport)
         #expect(snapshot.accountName == "Leo")
-        #expect(snapshot.totalQuota == 500_000)
-        #expect(snapshot.usedQuota == 120_000)
+        #expect(snapshot.totalQuota == 50_000_000)
+        #expect(snapshot.usedQuota == 1_212_576)
         #expect(snapshot.fuelPackTotal == 1000)
         #expect(snapshot.fuelPackRemaining == 600)
+
+        let requests = await transport.capturedRequests()
+        #expect(requests.map(\.path) == [
+            "/api/v1/user-current",
+            "/api/pay/quota/metering/token-packs/summary",
+            "/api/lc-platform/v1/pending-fuel-packages",
+        ])
+        #expect(requests[1].method == "POST")
+        #expect(requests[1].body == Data("{}".utf8))
+        #expect(requests[1].contentType == "application/json")
     }
 
     @Test
     func `fetch requires the canonical token usage response`() async {
         let transport = LongCatScriptedTransport(results: [
             .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .body(#"{"code":0,"data":{"currentLot":null}}"#),
             .status(500),
         ])
         await #expect(throws: LongCatAPIError.apiError("HTTP 500 for /api/lc-platform/v1/tokenUsage")) {
@@ -308,6 +351,7 @@ struct LongCatProviderTests {
     func `fetch rejects malformed canonical token usage data`() async {
         let transport = LongCatScriptedTransport(results: [
             .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .body(#"{"code":0,"data":{"currentLot":null}}"#),
             .body(#"{"code":0,"data":[]}"#),
         ])
         await #expect(throws: LongCatAPIError.parseFailed("tokenUsage data was not an object")) {
@@ -319,6 +363,7 @@ struct LongCatProviderTests {
     func `fetch rejects canonical token usage without quota fields`() async {
         let transport = LongCatScriptedTransport(results: [
             .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .body(#"{"code":0,"data":{"currentLot":null}}"#),
             .body(#"{"code":0,"data":{"usage":{"usedToken":120000}}}"#),
         ])
         await #expect(throws: LongCatAPIError.parseFailed("tokenUsage data was missing totalToken")) {
@@ -327,9 +372,84 @@ struct LongCatProviderTests {
     }
 
     @Test
+    func `zero total token pack lot falls back to legacy token usage`() async throws {
+        let transport = LongCatScriptedTransport(results: [
+            .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .body(#"{"code":0,"data":{"currentLot":{"totalToken":0,"consumedToken":0,"status":"ACTIVE"}}}"#),
+            .body(#"{"code":0,"data":{"usage":{"totalToken":500000,"usedToken":120000,"availableToken":380000}}}"#),
+            .body(#"{"code":0,"data":{"totalQuota":0,"list":[]}}"#),
+        ])
+
+        let snapshot = try await LongCatUsageFetcher.fetchUsage(cookieHeader: "session=x", transport: transport)
+        #expect(snapshot.totalQuota == 500_000)
+        #expect(snapshot.usedQuota == 120_000)
+        #expect(await (transport.capturedRequests()).map(\.path).contains("/api/lc-platform/v1/tokenUsage"))
+    }
+
+    @Test
+    func `expired token pack lot falls back to legacy token usage`() async throws {
+        let transport = LongCatScriptedTransport(results: [
+            .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .body(#"{"code":0,"data":{"currentLot":{"totalToken":50000000,"status":"EXPIRED"}}}"#),
+            .body(#"{"code":0,"data":{"usage":{"totalToken":500000,"usedToken":120000}}}"#),
+            .body(#"{"code":0,"data":{"totalQuota":0,"list":[]}}"#),
+        ])
+
+        let snapshot = try await LongCatUsageFetcher.fetchUsage(cookieHeader: "session=x", transport: transport)
+        #expect(snapshot.totalQuota == 500_000)
+        #expect(snapshot.usedQuota == 120_000)
+    }
+
+    @Test(arguments: [
+        #"{"code":0,"data":{}}"#,
+        #"{"code":0,"data":{"currentLot":null}}"#,
+    ])
+    func `missing or null current token pack lot falls back to legacy token usage`(summaryBody: String) async throws {
+        let transport = LongCatScriptedTransport(results: [
+            .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .body(summaryBody),
+            .body(#"{"code":0,"data":{"usage":{"totalToken":500000,"usedToken":120000}}}"#),
+            .body(#"{"code":0,"data":{"totalQuota":0,"list":[]}}"#),
+        ])
+
+        let snapshot = try await LongCatUsageFetcher.fetchUsage(cookieHeader: "session=x", transport: transport)
+        #expect(snapshot.totalQuota == 500_000)
+        #expect(snapshot.usedQuota == 120_000)
+    }
+
+    @Test
+    func `token pack summary server failure falls back to legacy token usage`() async throws {
+        let transport = LongCatScriptedTransport(results: [
+            .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .status(500),
+            .body(#"{"code":0,"data":{"usage":{"totalToken":500000,"usedToken":120000}}}"#),
+            .body(#"{"code":0,"data":{"totalQuota":0,"list":[]}}"#),
+        ])
+
+        let snapshot = try await LongCatUsageFetcher.fetchUsage(cookieHeader: "session=x", transport: transport)
+        #expect(snapshot.totalQuota == 500_000)
+        #expect(snapshot.usedQuota == 120_000)
+    }
+
+    @Test
+    func `token pack summary auth failure falls back to legacy token usage`() async throws {
+        let transport = LongCatScriptedTransport(results: [
+            .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .status(401),
+            .body(#"{"code":0,"data":{"usage":{"totalToken":500000,"usedToken":120000}}}"#),
+            .body(#"{"code":0,"data":{"totalQuota":0,"list":[]}}"#),
+        ])
+
+        let snapshot = try await LongCatUsageFetcher.fetchUsage(cookieHeader: "session=x", transport: transport)
+        #expect(snapshot.totalQuota == 500_000)
+        #expect(snapshot.usedQuota == 120_000)
+    }
+
+    @Test
     func `supplemental fuel failures do not erase primary quota`() async throws {
         let transport = LongCatScriptedTransport(results: [
             .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .body(#"{"code":0,"data":{"currentLot":null}}"#),
             .body(#"{"code":0,"data":{"usage":{"totalToken":500000,"usedToken":120000}}}"#),
             .status(500),
         ])
@@ -343,6 +463,7 @@ struct LongCatProviderTests {
     func `supplemental fuel auth failure does not erase primary quota`() async throws {
         let transport = LongCatScriptedTransport(results: [
             .body(#"{"code":0,"data":{"name":"Leo"}}"#),
+            .body(#"{"code":0,"data":{"currentLot":null}}"#),
             .body(#"{"code":0,"data":{"usage":{"totalToken":500000,"usedToken":120000}}}"#),
             .status(401),
         ])
@@ -380,18 +501,31 @@ struct LongCatProviderTests {
 /// without a network. Returns the given results in order; an exhausted script
 /// yields an empty 200 so best-effort follow-up probes decode to nil.
 private actor LongCatScriptedTransport: ProviderHTTPTransport {
+    struct CapturedRequest: Sendable {
+        let method: String?
+        let path: String
+        let body: Data?
+        let contentType: String?
+    }
+
     enum Result {
         case status(Int)
         case body(String)
     }
 
     private var results: [Result]
+    private var captured: [CapturedRequest] = []
 
     init(results: [Result]) {
         self.results = results
     }
 
     func data(for request: URLRequest) throws -> (Data, URLResponse) {
+        self.captured.append(CapturedRequest(
+            method: request.httpMethod,
+            path: request.url?.path ?? "",
+            body: request.httpBody,
+            contentType: request.value(forHTTPHeaderField: "Content-Type")))
         let result = self.results.isEmpty ? .status(200) : self.results.removeFirst()
         let statusCode: Int
         let body: String
@@ -409,5 +543,9 @@ private actor LongCatScriptedTransport: ProviderHTTPTransport {
             httpVersion: nil,
             headerFields: nil)!
         return (Data(body.utf8), response)
+    }
+
+    func capturedRequests() -> [CapturedRequest] {
+        self.captured
     }
 }

--- a/docs/longcat.md
+++ b/docs/longcat.md
@@ -1,0 +1,33 @@
+---
+summary: "LongCat provider cookie sources, quota requests, and snapshot mapping."
+read_when:
+  - Debugging LongCat usage or stale zero quotas
+  - Updating LongCat cookie handling or web requests
+  - Adjusting LongCat quota or fuel-pack mapping
+---
+
+# LongCat provider
+
+LongCat reads quota data from an authenticated `longcat.chat` web session. It does not require an API key.
+
+## Data sources
+
+- A manual cookie header can be entered in Settings → Providers → LongCat or supplied through
+  `LONGCAT_MANUAL_COOKIE`.
+- Automatic mode can import supported browser cookies during a user-initiated refresh.
+
+## Request sequence
+
+1. `GET /api/v1/user-current` is required and validates the session while providing the account name.
+2. `POST /api/pay/quota/metering/token-packs/summary` provides the primary live token-pack quota. This probe is
+   best-effort because some browser cookies are scoped to other API paths.
+3. `GET /api/lc-platform/v1/tokenUsage` is required only when the summary has no active lot with a positive total.
+4. `GET /api/lc-platform/v1/pending-fuel-packages` is best-effort and runs in both primary-quota paths.
+
+The legacy `tokenUsage` response can report stale zeros for token-pack accounts, so it is only a fallback (#2670).
+
+## Snapshot mapping
+
+An active `currentLot` maps `totalToken` to the primary total and `consumedToken` to primary used tokens. When no
+usable lot exists, the legacy token-usage aggregate supplies total, used, and remaining quota. Pending fuel packages
+are summed into the secondary window, with their nearest expiry used as its reset time.


### PR DESCRIPTION
Fixes #2670

## Summary

LongCat showed 0% usage for token-pack accounts because the legacy `GET /api/lc-platform/v1/tokenUsage` endpoint returns stale zeros while the platform dashboard reads live data from `POST /api/pay/quota/metering/token-packs/summary`.

- The token-packs summary endpoint is now the primary usage source: `data.currentLot` maps `totalToken`/`consumedToken` into the primary quota, guarded on `status == "ACTIVE"` and a positive `totalToken`.
- The summary probe is best-effort: any failure (HTTP error, auth failure from path-scoped browser cookies that never reach `/api/pay`, missing/null/expired/zero-total lot) falls back to the legacy `tokenUsage` endpoint with its existing required semantics, so current users do not regress.
- The required `user-current` session probe and best-effort pending-fuel probe are unchanged; when the summary lot is usable, the legacy endpoint is skipped entirely (one fewer authenticated request).
- Added `docs/longcat.md` following the existing per-provider doc convention, plus a changelog entry.

## Tests

New fixture-based coverage from the issue's captured payloads: active lot maps to ~2.425% primary usage, POST request shape (path/method/body/content-type) is asserted, and fallback is exercised for expired lots, null `currentLot`, zero-total lots, HTTP 500, and 401 on the summary while legacy parsing still works.

## Commands run

- `swift test --filter LongCat` — 38 tests passed
- `make check` — 0 violations
- `make test` — 841 selections, 71/71 groups green
- Codex autoreview — clean, no actionable findings
