### PR TITLE
fix: escalate RPC child teardown from SIGTERM to SIGKILL to stop serve orphan leaks (#2789)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Token activity: draw the Cumulative running total at the default 30-day history window instead of a blank grid, and keep the week clipped by the scan window (#2893). Thanks @urda!
 - Cost history: avoid reporting partial token or cost totals when any daily row lacks that value.
+- CLI: escalate RPC child teardown (codex app-server, grok agent stdio) from SIGTERM to SIGKILL with a bounded wait and stdin EOF, preventing orphaned children and file-descriptor exhaustion in long-running serve (#2789). Thanks @psl75011 and @simonsteiner!
 - PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.
 - Codex: stop the hidden ChatGPT dashboard WebView from staying resident after usage refresh, so idle WebKit helper processes can return to zero.
 - Cost history: honor the preferred display currency throughout the detail chart and refresh converted labels when exchange rates change (#2887). Thanks @vAhyThe!

--- a/Sources/CodexBarCore/Host/Process/RPCChildProcessTeardown.swift
+++ b/Sources/CodexBarCore/Host/Process/RPCChildProcessTeardown.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+package enum RPCChildProcessTeardown {
+    /// Tears down a JSON-RPC child spawned via Foundation `Process`.
+    ///
+    /// Closes the child's stdin first (codex app-server and grok agent stdio exit on EOF),
+    /// then escalates SIGTERM -> bounded wait -> SIGKILL across the child's process tree via
+    /// `SubprocessRunner.terminateProcess`, so children that ignore SIGTERM cannot leak
+    /// (#2789). Foundation reaps the child once it exits, so no explicit waitpid is needed here.
+    package static func terminate(process: Process, stdinPipe: Pipe) {
+        try? stdinPipe.fileHandleForWriting.close()
+        SubprocessRunner.terminateProcess(process, processGroup: nil)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Grok/GrokRPCClient.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokRPCClient.swift
@@ -63,6 +63,7 @@ final class GrokRPCClient: @unchecked Sendable {
         let stdoutLineContinuation = self.stdoutLineContinuation
         let stdoutBuffer = BoundedLineBuffer()
         let process = self.process
+        let stdinPipe = self.stdinPipe
         stdoutHandle.readabilityHandler = { handle in
             let data = handle.availableData
             if data.isEmpty {
@@ -74,7 +75,9 @@ final class GrokRPCClient: @unchecked Sendable {
             if result.didExceedLimit {
                 Self.log.warning("Grok RPC line exceeded memory limit; terminating process")
                 handle.readabilityHandler = nil
-                process.terminate()
+                DispatchQueue.global(qos: .userInitiated).async {
+                    RPCChildProcessTeardown.terminate(process: process, stdinPipe: stdinPipe)
+                }
                 stdoutLineContinuation.finish()
                 return
             }
@@ -124,10 +127,8 @@ final class GrokRPCClient: @unchecked Sendable {
     }
 
     func shutdown() {
-        if self.process.isRunning {
-            Self.log.debug("Grok RPC stopping")
-            self.process.terminate()
-        }
+        Self.log.debug("Grok RPC stopping")
+        RPCChildProcessTeardown.terminate(process: self.process, stdinPipe: self.stdinPipe)
     }
 
     // MARK: - JSON-RPC plumbing (mirrors CodexRPCClient)
@@ -190,7 +191,13 @@ final class GrokRPCClient: @unchecked Sendable {
     private func terminateProcessForTimeout(method: String) {
         if self.process.isRunning {
             Self.log.warning("Grok RPC timed out on `\(method)`; terminating process")
-            self.process.terminate()
+        }
+        // Dispatch off the timeout task so the bounded TERM-to-KILL wait cannot delay the timeout
+        // error or let the stdout-EOF failure win the race; `shutdown()` remains the synchronous backstop.
+        let process = self.process
+        let stdinPipe = self.stdinPipe
+        DispatchQueue.global(qos: .userInitiated).async {
+            RPCChildProcessTeardown.terminate(process: process, stdinPipe: stdinPipe)
         }
     }
 

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -907,6 +907,7 @@ private final class CodexRPCClient: @unchecked Sendable {
         let stdoutLineContinuation = self.stdoutLineContinuation
         let stdoutBuffer = BoundedLineBuffer()
         let process = self.process
+        let stdinPipe = self.stdinPipe
         stdoutHandle.readabilityHandler = { handle in
             let data = handle.availableData
             if data.isEmpty {
@@ -919,7 +920,9 @@ private final class CodexRPCClient: @unchecked Sendable {
             if result.didExceedLimit {
                 Self.log.warning("Codex RPC line exceeded memory limit; terminating process")
                 handle.readabilityHandler = nil
-                process.terminate()
+                DispatchQueue.global(qos: .userInitiated).async {
+                    RPCChildProcessTeardown.terminate(process: process, stdinPipe: stdinPipe)
+                }
                 stdoutLineContinuation.finish()
                 return
             }
@@ -964,10 +967,8 @@ private final class CodexRPCClient: @unchecked Sendable {
     }
 
     func shutdown() {
-        if self.process.isRunning {
-            Self.log.debug("Codex RPC stopping")
-            self.process.terminate()
-        }
+        Self.log.debug("Codex RPC stopping")
+        RPCChildProcessTeardown.terminate(process: self.process, stdinPipe: self.stdinPipe)
     }
 
     // MARK: - JSON-RPC helpers
@@ -1037,7 +1038,13 @@ private final class CodexRPCClient: @unchecked Sendable {
     private func terminateProcessForTimeout(method: String) {
         if self.process.isRunning {
             Self.log.warning("Codex RPC timed out on `\(method)`; terminating process")
-            self.process.terminate()
+        }
+        // Dispatch off the timeout task so the bounded TERM-to-KILL wait cannot delay the timeout
+        // error or let the stdout-EOF failure win the race; `shutdown()` remains the synchronous backstop.
+        let process = self.process
+        let stdinPipe = self.stdinPipe
+        DispatchQueue.global(qos: .userInitiated).async {
+            RPCChildProcessTeardown.terminate(process: process, stdinPipe: stdinPipe)
         }
     }
 

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1503,7 +1503,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This tagged diagnostic payload encodes MiniMax details under the matching wire key."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/UsageFetcher.swift",
-            line: 1479,
+            line: 1486,
             anchor: "providerID: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),

--- a/Tests/CodexBarTests/RPCChildProcessTeardownTests.swift
+++ b/Tests/CodexBarTests/RPCChildProcessTeardownTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+@Suite(.serialized)
+struct RPCChildProcessTeardownTests {
+    @Test
+    func `Codex RPC shutdown kills an app-server child that ignores SIGTERM`() async throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        let scriptURL = temporaryDirectory.appendingPathComponent("codex-stub-\(UUID().uuidString)")
+        let pidURL = temporaryDirectory.appendingPathComponent("codex-stub-pid-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: scriptURL)
+            try? FileManager.default.removeItem(at: pidURL)
+        }
+
+        let script = """
+        #!/bin/sh
+        case " $* " in *" app-server "*) ;; *) exit 92 ;; esac
+        printf '%s\n' "$$" > "$CODEXBAR_PROOF_PID_FILE"
+        trap '' TERM
+        while IFS= read -r line; do
+          case "$line" in
+            *'"initialized"'*) ;;
+            *'"initialize"'*) printf '%s\n' '{"id":1,"result":{}}' ;;
+            *'"account/rateLimits/read"'*|*'"account\\/rateLimits\\/read"'*)
+              printf '%s\n' '{"id":2,"result":{"rateLimits":{"planType":"pro"}}}'
+              ;;
+            *'"account/read"'*|*'"account\\/read"'*)
+              printf '%s%s\n' \
+                '{"id":3,"result":{"account":{"type":"chatgpt","email":"stub@example.com",' \
+                '"planType":"pro"},"requiresOpenaiAuth":false}}'
+              ;;
+            *) printf '%s\n' '{"id":1,"result":{}}' ;;
+          esac
+        done
+        while :; do sleep 0.2; done
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let fetcher = UsageFetcher(
+            environment: [
+                "CODEX_CLI_PATH": scriptURL.path,
+                "CODEXBAR_PROOF_PID_FILE": pidURL.path,
+            ],
+            initializeTimeoutSeconds: 20.0,
+            requestTimeoutSeconds: 3.0)
+
+        _ = try await fetcher.loadLatestCLIAccountSnapshot()
+
+        let pidText = try String(contentsOf: pidURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let pid = try #require(pid_t(pidText))
+        let deadline = ContinuousClock.now.advanced(by: .seconds(3))
+        while kill(pid, 0) == 0, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(kill(pid, 0) == -1)
+        #expect(errno == ESRCH)
+    }
+
+    @Test
+    func `Grok RPC shutdown kills a stdio child that ignores SIGTERM`() async throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        let scriptURL = temporaryDirectory.appendingPathComponent("grok-stub-\(UUID().uuidString)")
+        let pidURL = temporaryDirectory.appendingPathComponent("grok-stub-pid-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: scriptURL)
+            try? FileManager.default.removeItem(at: pidURL)
+        }
+
+        let script = """
+        #!/bin/sh
+        printf '%s\n' "$$" > "$CODEXBAR_PROOF_PID_FILE"
+        trap '' TERM
+        while IFS= read -r line; do
+          case "$line" in
+            *'"initialize"'*) printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}' ;;
+            *) printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}' ;;
+          esac
+        done
+        while :; do sleep 0.2; done
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let client = try GrokRPCClient(
+            executable: scriptURL.path,
+            arguments: [],
+            environment: [
+                "PATH": "/usr/bin:/bin",
+                "GROK_CLI_PATH": scriptURL.path,
+                "CODEXBAR_PROOF_PID_FILE": pidURL.path,
+            ],
+            initializeTimeoutSeconds: 5,
+            requestTimeoutSeconds: 2)
+        try await client.initialize()
+
+        let start = ContinuousClock.now
+        client.shutdown()
+        let elapsed = start.duration(to: .now)
+        #expect(elapsed < .seconds(3))
+
+        let pidText = try String(contentsOf: pidURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let pid = try #require(pid_t(pidText))
+        let deadline = ContinuousClock.now.advanced(by: .seconds(3))
+        while kill(pid, 0) == 0, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(kill(pid, 0) == -1)
+        #expect(errno == ESRCH)
+    }
+}

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -106,8 +106,8 @@ Example:
   - `account/read`
   - `account/rateLimits/read`
 - RPC reads are bounded: initialization has a longer startup budget, and normal requests have a shorter per-method
-  timeout. On timeout, CodexBar terminates the child `codex app-server` process so the stdout reader unwinds instead
-  of leaving refresh stuck indefinitely.
+  timeout. On timeout, CodexBar closes the child `codex app-server` process's stdin and escalates from SIGTERM to
+  SIGKILL after a bounded grace period, so the stdout reader unwinds and unresponsive children cannot linger.
 - Provides:
   - Usage windows (primary + secondary) with reset timestamps.
   - Credits snapshot (balance, hasCredits, unlimited).


### PR DESCRIPTION
Fixes #2789.

## Problem

Long-running `codexbar serve` on Linux leaks orphaned `codex app-server` children (and `grok agent stdio` mirrors the same pattern): reporters measured 9-15 live orphans holding ~774 MB / ~1.7 GB RSS, and after ~4.6 days the parent hit fd exhaustion (1018/1024 fds, mostly pipes), at which point Codex and Claude usage rows silently failed while `/health` kept answering.

## Root cause

`CodexRPCClient` (in `Sources/CodexBarCore/UsageFetcher.swift`) and `GrokRPCClient` tear down their child with a bare `Process.terminate()` guarded by `process.isRunning` — no bounded wait, no SIGKILL escalation, no reap. Production data in the issue shows these children routinely survive SIGTERM for more than 2 seconds (2/2 codex, 5/5 grok in the reporter's instrumented sweeps), so fire-and-forget SIGTERM leaves them alive forever. The surviving children also hold the parent-side pipe fds open, which is the descriptor leak.

## Fix

New shared helper `RPCChildProcessTeardown.terminate(process:stdinPipe:)`:

1. closes the child's stdin first (both `codex app-server` and `grok agent stdio` exit on EOF — the gentle path that also lets app-server wind down its own MCP subtree),
2. delegates to the existing `SubprocessRunner.terminateProcess`, which signals the child and its descendants with SIGTERM, waits a bounded grace, escalates to SIGKILL, and waits again; Foundation reaps the child on exit.

All three teardown sites in both RPC clients now route through it: `shutdown()`, the request-timeout path, and the stdout overflow guard. The stale-`isRunning` hypothesis from the issue is also covered: `shutdown()` no longer gates the teardown on `isRunning`, so stdin EOF is always delivered. Timeout and overflow paths dispatch the bounded wait off the calling task/readability queue so the timeout error surfaces promptly.

## Tests

New `RPCChildProcessTeardownTests` spawn synthetic stub children that `trap '' TERM` and loop after stdin EOF — only SIGKILL can end them:

- `Codex RPC shutdown kills an app-server child that ignores SIGTERM` drives the real `UsageFetcher.loadLatestCLIAccountSnapshot()` path end to end and proves the child is gone (ESRCH) afterwards.
- `Grok RPC shutdown kills a stdio child that ignores SIGTERM` proves the same for `GrokRPCClient.shutdown()` and that shutdown returns within the bounded window.

One existing suppression anchor in `ProviderArchitectureGatekeeperTests` moved by 7 lines due to the diff.

## Commands run

- `swift build`
- `swift test --filter "RPCChildProcessTeardownTests|BoundedChildProcessProofTests|CodexUsageFetcherFallbackTests"`
- `make check` (0 violations)
- `make test` (full sharded suite, green)
