### PR TITLE
Require complete rows for cost totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Token activity: draw the Cumulative running total at the default 30-day history window instead of a blank grid, and keep the week clipped by the scan window (#2893). Thanks @urda!
+- Cost history: avoid reporting partial token or cost totals when any daily row lacks that value.
 - PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.
 - Cost history: honor the preferred display currency throughout the detail chart and refresh converted labels when exchange rates change (#2887). Thanks @vAhyThe!
 

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -1070,12 +1070,12 @@ public struct CostUsageFetcher: Sendable {
         let totalFromEntries = daily.data.compactMap(\.costUSD).reduce(0, +)
         let allEntriesCarryCost = !daily.data.isEmpty && daily.data.allSatisfy { $0.costUSD != nil }
         let last30DaysCostUSD = totalFromSummary
-            ?? (totalFromEntries > 0 || (allEntriesCarryCost && totalFromEntries == 0) ? totalFromEntries : nil)
+            ?? (allEntriesCarryCost ? totalFromEntries : nil)
         let totalTokensFromSummary = daily.summary?.totalTokens
         let totalTokensFromEntries = daily.data.compactMap(\.totalTokens).reduce(0, +)
         let allEntriesCarryTokens = !daily.data.isEmpty && daily.data.allSatisfy { $0.totalTokens != nil }
         let last30DaysTokens = totalTokensFromSummary
-            ?? (totalTokensFromEntries > 0 || (allEntriesCarryTokens && totalTokensFromEntries == 0)
+            ?? (allEntriesCarryTokens
                 ? totalTokensFromEntries
                 : nil)
 

--- a/Tests/CodexBarTests/CostUsageTokenSnapshotDaySelectionTests.swift
+++ b/Tests/CodexBarTests/CostUsageTokenSnapshotDaySelectionTests.swift
@@ -192,6 +192,66 @@ struct CostUsageTokenSnapshotDaySelectionTests {
     }
 
     @Test
+    func `token snapshot does not report a partial cost from mixed present and missing rows`() throws {
+        let now = try Self.localNoon(year: 2026, month: 5, day: 18)
+        let report = CostUsageDailyReport(
+            data: [
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-17",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 10,
+                    costUSD: 1,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-18",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 20,
+                    costUSD: nil,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            summary: nil)
+
+        let snapshot = CostUsageFetcher.tokenSnapshot(from: report, now: now)
+
+        #expect(snapshot.last30DaysCostUSD == nil)
+        #expect(snapshot.last30DaysTokens == 30)
+    }
+
+    @Test
+    func `token snapshot does not report partial tokens from mixed present and missing rows`() throws {
+        let now = try Self.localNoon(year: 2026, month: 5, day: 18)
+        let report = CostUsageDailyReport(
+            data: [
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-17",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 10,
+                    costUSD: 1,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-18",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: nil,
+                    costUSD: 2,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            summary: nil)
+
+        let snapshot = CostUsageFetcher.tokenSnapshot(from: report, now: now)
+
+        #expect(snapshot.last30DaysCostUSD == 3)
+        #expect(snapshot.last30DaysTokens == nil)
+    }
+
+    @Test
     func `token snapshot keeps zero cost and unavailable tokens distinct`() throws {
         let now = try Self.localNoon(year: 2026, month: 5, day: 18)
         let report = CostUsageDailyReport(


### PR DESCRIPTION
## Summary

- require every daily row to carry cost or token data before deriving fallback aggregate totals
- keep authoritative summary totals and complete explicit-zero totals unchanged
- add mixed present/missing row regressions and a changelog entry

Follow-up to #2896.

## Testing

- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter CostUsageTokenSnapshotDaySelectionTests`
- `make check`
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make test`
