### PR TITLE
fix: refresh Claude CLI version after user-initiated usage fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Terminal picker: offer Ghostty 1.3+ as a default terminal for Open Terminal and provider login commands, falling back to Terminal.app when unavailable (#2830). Thanks @darwinz!
 
 ### Fixed
+- Claude: refresh the detected CLI version after a successful manual CLI usage fetch, so the provider pane no longer shows "not detected" when the gated startup probe could not run `claude --version` (#2899).
 - Token activity: draw the Cumulative running total at the default 30-day history window instead of a blank grid, and keep the week clipped by the scan window (#2893). Thanks @urda!
 - Cost history: avoid reporting partial token or cost totals when any daily row lacks that value.
 - PTY probes: bound hard-stop latency while still cleaning session-escaped output holders.

--- a/Sources/CodexBar/UsageStore+ClaudeVersionRecovery.swift
+++ b/Sources/CodexBar/UsageStore+ClaudeVersionRecovery.swift
@@ -1,0 +1,31 @@
+import CodexBarCore
+import Foundation
+
+extension UsageStore {
+    /// #2899: the startup version probe runs in a detached background task, where the Claude
+    /// opaque-child gate denies `claude --version` on a cold profile. A successful user-initiated
+    /// CLI usage fetch proves the same resolved binary works, so re-run only the Claude version
+    /// probe in that user-initiated context while the version is still missing.
+    func refreshClaudeVersionAfterUserInitiatedCLIFetch(
+        provider: UsageProvider,
+        strategyKind: ProviderFetchKind)
+    {
+        // Provider-specific by design: only Claude's gated version probe recovers from a user-initiated CLI success.
+        guard provider == .claude,
+              strategyKind == .cli,
+              ProviderInteractionContext.current == .userInitiated,
+              self.versions[provider.instanceID] == nil,
+              self.claudeVersionRefreshTask == nil,
+              let implementation = ProviderCatalog.all.first(where: { $0.id == .claude })
+        else { return }
+        let context = ProviderVersionContext(provider: .claude, browserDetection: self.browserDetection)
+        // Unstructured (not detached) so the user-initiated interaction task-local is inherited.
+        self.claudeVersionRefreshTask = Task { @MainActor [weak self] in
+            let version = await implementation.detectVersion(context: context)
+            guard let self else { return }
+            self.claudeVersionRefreshTask = nil
+            guard let version, !version.isEmpty else { return }
+            self.versions[UsageProvider.claude.instanceID] = version
+        }
+    }
+}

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -768,8 +768,8 @@ extension UsageStore {
             return backfilled
         }
         guard let backfilled else { return }
-        let isClaudeOAuthSample = provider == .claude
-            && result.strategyKind == .oauth
+        self.refreshClaudeVersionAfterUserInitiatedCLIFetch(provider: provider, strategyKind: result.strategyKind)
+        let isClaudeOAuthSample = provider == .claude && result.strategyKind == .oauth
         let claudeOAuthPersistentRefHash: String? = if isClaudeOAuthSample,
                                                        result.claudeOAuthKeychainPersistentRefHash == context
                                                            .claudeOAuthHistoryPersistentRefHash

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -198,6 +198,8 @@ final class UsageStore {
     var openAIDashboardCookieImportDebugLog: String?
     var versions: [ProviderInstanceID: String] = [:]
     @ObservationIgnored var versionDetectionProviders: Set<ProviderInstanceID> = []
+    @ObservationIgnored private(set) var versionDetectionTask: Task<Void, Never>?
+    @ObservationIgnored var claudeVersionRefreshTask: Task<Void, Never>?
     var isRefreshing = false
     var hasForcedRefreshEnrichmentInFlight = false
     var refreshingProviders: Set<ProviderInstanceID> = []
@@ -1349,9 +1351,13 @@ extension UsageStore {
         self.versionDetectionProviders = enabled
         let implementations = Self.versionDetectionImplementations(
             enabled: Set(enabled.compactMap(\.firstPartyProvider)))
+        // Provider-specific by design: only Claude's version probe is background-gated and needs recovery handling.
+        let probesClaude = implementations.contains { $0.id == .claude }
         let browserDetection = self.browserDetection
-        Task { @MainActor [weak self] in
-            let resolved = await Task.detached { () -> [UsageProvider: String] in
+        self.versionDetectionTask = Task { @MainActor [weak self] in
+            let detection = await Task.detached { () -> (
+                resolved: [UsageProvider: String],
+                claudeBinaryResolvable: Bool) in
                 var resolved: [UsageProvider: String] = [:]
                 await withTaskGroup(of: (UsageProvider, String?).self) { group in
                     for implementation in implementations {
@@ -1367,9 +1373,27 @@ extension UsageStore {
                         resolved[provider] = version
                     }
                 }
-                return resolved
+                // Provider-specific by design: disabled providers must not be probed (#2267), so the
+                // Claude binary resolves only when Claude was in this run and its probe returned nil.
+                let claudeBinaryResolvable = probesClaude
+                    && resolved[.claude] == nil
+                    && ProviderVersionDetector.claudeBinaryResolvable()
+                return (resolved, claudeBinaryResolvable)
             }.value
-            self?.versions = Dictionary(uniqueKeysWithValues: resolved.map { ($0.key.instanceID, $0.value) })
+            guard let self else { return }
+            let resolved = detection.resolved
+            var versions = Dictionary(uniqueKeysWithValues: resolved.map { ($0.key.instanceID, $0.value) })
+            let claudeID = UsageProvider.claude.instanceID
+            // A gated or failed Claude probe preserves a user-initiated recovery while the binary still resolves.
+            // A missing/uninstalled binary clears the version so stale data does not survive CLI removal.
+            if probesClaude,
+               resolved[.claude] == nil,
+               detection.claudeBinaryResolvable,
+               let recoveredClaudeVersion = self.versions[claudeID]
+            {
+                versions[claudeID] = recoveredClaudeVersion
+            }
+            self.versions = versions
         }
     }
 

--- a/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
+++ b/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
@@ -139,6 +139,17 @@ public enum ProviderVersionDetector {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    public static func claudeBinaryResolvable(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool
+    {
+        #if DEBUG
+        if let whichHook {
+            return whichHook("claude") != nil
+        }
+        #endif
+        return ClaudeCLIResolver.resolvedBinaryPath(environment: environment) != nil
+    }
+
     public static func claudeVersion(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {

--- a/Tests/CodexBarTests/ClaudeVersionRecoveryTests.swift
+++ b/Tests/CodexBarTests/ClaudeVersionRecoveryTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ClaudeVersionRecoveryTests {
+    @Test
+    func `user initiated CLI success refreshes missing Claude version`() async throws {
+        try await self.withMissingCredentialsFile {
+            let probe = ProbeState()
+            self.configureVersionProbe(probe)
+            defer { ProviderVersionDetector.resetHooksAndCache() }
+
+            let fixture = try await MainActor.run {
+                try self.makeFixture(strategyKind: .cli)
+            }
+            await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                await fixture.store.refreshProvider(.claude)
+            }
+            await fixture.store.claudeVersionRefreshTask?.value
+
+            #expect(await fixture.store.version(for: .claude) == "2.1.229 (Claude Code)")
+            #expect(probe.callCount == 1)
+        }
+    }
+
+    @Test
+    func `background CLI success leaves version probe untouched`() async throws {
+        try await self.withMissingCredentialsFile {
+            let probe = ProbeState()
+            self.configureVersionProbe(probe)
+            defer { ProviderVersionDetector.resetHooksAndCache() }
+
+            let fixture = try await MainActor.run {
+                try self.makeFixture(strategyKind: .cli)
+            }
+            await ProviderInteractionContext.$current.withValue(.background) {
+                await fixture.store.refreshProvider(.claude)
+            }
+
+            #expect(await fixture.store.claudeVersionRefreshTask == nil)
+            #expect(await fixture.store.version(for: .claude) == nil)
+            #expect(probe.callCount == 0)
+        }
+    }
+
+    @Test
+    func `user initiated OAuth success does not trigger the CLI version probe`() async throws {
+        try await self.withMissingCredentialsFile {
+            let probe = ProbeState()
+            self.configureVersionProbe(probe)
+            defer { ProviderVersionDetector.resetHooksAndCache() }
+
+            let fixture = try await MainActor.run {
+                try self.makeFixture(strategyKind: .oauth)
+            }
+            await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                await fixture.store.refreshProvider(.claude)
+            }
+
+            #expect(await fixture.store.claudeVersionRefreshTask == nil)
+            #expect(await fixture.store.version(for: .claude) == nil)
+            #expect(probe.callCount == 0)
+        }
+    }
+
+    @Test
+    func `later version detection publish preserves recovered Claude version`() async throws {
+        try await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
+            try await self.withMissingCredentialsFile {
+                let binaryPath = "/mock/bin/claude-\(UUID().uuidString)"
+                let recoveryProbe = ProbeState()
+                self.configureVersionProbe(recoveryProbe, binaryPath: binaryPath)
+                defer { ProviderVersionDetector.resetHooksAndCache() }
+
+                let fixture = try await MainActor.run {
+                    try self.makeFixture(strategyKind: .cli)
+                }
+                await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                    await fixture.store.refreshProvider(.claude)
+                }
+                await fixture.store.claudeVersionRefreshTask?.value
+                #expect(await fixture.store.version(for: .claude) == "2.1.229 (Claude Code)")
+
+                ProviderVersionDetector.resetHooksAndCache()
+                let backgroundProbe = ProbeState()
+                self.configureVersionProbe(backgroundProbe, binaryPath: binaryPath)
+                await ProviderInteractionContext.$current.withValue(.background) {
+                    await fixture.store.detectVersions()
+                    await fixture.store.versionDetectionTask?.value
+                }
+
+                #expect(await fixture.store.version(for: .claude) == "2.1.229 (Claude Code)")
+                #expect(backgroundProbe.callCount == 0)
+            }
+        }
+    }
+
+    @Test
+    func `removed Claude binary clears the recovered version on the next detection run`() async throws {
+        try await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
+            try await self.withMissingCredentialsFile {
+                let recoveryProbe = ProbeState()
+                self.configureVersionProbe(recoveryProbe)
+                defer { ProviderVersionDetector.resetHooksAndCache() }
+
+                let fixture = try await MainActor.run {
+                    try self.makeFixture(strategyKind: .cli)
+                }
+                await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                    await fixture.store.refreshProvider(.claude)
+                }
+                await fixture.store.claudeVersionRefreshTask?.value
+                #expect(await fixture.store.version(for: .claude) == "2.1.229 (Claude Code)")
+
+                ProviderVersionDetector.resetHooksAndCache()
+                ProviderVersionDetector.whichHook = { _ in nil }
+                await ProviderInteractionContext.$current.withValue(.background) {
+                    await fixture.store.detectVersions()
+                    await fixture.store.versionDetectionTask?.value
+                }
+
+                #expect(await fixture.store.version(for: .claude) == nil)
+            }
+        }
+    }
+
+    private func withMissingCredentialsFile<T>(
+        _ operation: () async throws -> T) async throws -> T
+    {
+        try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+            let missingURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+                .appendingPathComponent("missing-credentials.json")
+            return try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(missingURL) {
+                try await operation()
+            }
+        }
+    }
+
+    @MainActor
+    private func makeFixture(strategyKind: ProviderFetchKind) throws -> ClaudeVersionRecoveryFixture {
+        let settings = testSettingsStore(suiteName: "ClaudeVersionRecoveryTests")
+        settings.claudeUsageDataSource = .cli
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        let metadata = ProviderRegistry.shared.metadata
+        for provider in UsageProvider.allCases {
+            try settings.setProviderEnabled(
+                provider: provider,
+                metadata: #require(metadata[provider]),
+                enabled: provider == .claude)
+        }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+        store._test_providerFetchOutcomeOverride = { _ in
+            Self.successOutcome(strategyKind: strategyKind)
+        }
+        return ClaudeVersionRecoveryFixture(store: store)
+    }
+
+    private static func successOutcome(strategyKind: ProviderFetchKind) -> ProviderFetchOutcome {
+        ProviderFetchOutcome(
+            result: .success(ProviderFetchResult(
+                usage: UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: 20,
+                        windowMinutes: 300,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: Date(timeIntervalSince1970: 1_800_000_100),
+                    identity: ProviderIdentitySnapshot(
+                        providerID: .claude,
+                        accountEmail: "new@example.com",
+                        accountOrganization: nil,
+                        loginMethod: "Max")),
+                credits: nil,
+                dashboard: nil,
+                sourceLabel: "claude",
+                strategyID: "test.claude-success",
+                strategyKind: strategyKind,
+                claudeOAuthCredentialOwner: strategyKind == .oauth ? .claudeCLI : nil)),
+            attempts: [ProviderFetchAttempt(
+                strategyID: "test.claude-success",
+                kind: strategyKind,
+                wasAvailable: true,
+                errorDescription: nil)])
+    }
+
+    private func configureVersionProbe(
+        _ probe: ProbeState,
+        binaryPath: String = "/mock/bin/claude")
+    {
+        ProviderVersionDetector.resetHooksAndCache()
+        ProviderVersionDetector.whichHook = { _ in binaryPath }
+        ProviderVersionDetector.attributesHook = { _ in
+            [
+                .modificationDate: Date(timeIntervalSince1970: 1000),
+                .size: NSNumber(value: 5000),
+                .systemFileNumber: NSNumber(value: 99),
+            ]
+        }
+        ProviderVersionDetector.runClaudeVersionHook = { _ in
+            probe.recordCall()
+            return TTYCommandRunner.Result(
+                text: "2.1.229 (Claude Code)",
+                completion: .processExited(status: 0))
+        }
+    }
+}
+
+@MainActor
+private struct ClaudeVersionRecoveryFixture {
+    let store: UsageStore
+}
+
+private final class ProbeState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls = 0
+
+    var callCount: Int {
+        self.lock.withLock { self.calls }
+    }
+
+    func recordCall() {
+        self.lock.withLock {
+            self.calls += 1
+        }
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1275,19 +1275,19 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Claude widget quota ownership uses the selected Claude account's isolated snapshot key."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1046,
+            line: 1048,
             anchor: "provider: .deepseek,",
             expectedProviderIDs: ["deepseek"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1148,
+            line: 1150,
             anchor: "let sourceMode = self.sourceMode(for: .claude)",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1152,
+            line: 1154,
             anchor: "provider: .claude,",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -1630,6 +1630,12 @@ struct ProviderArchitectureGatekeeperTests {
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/Providers/ProviderVersionDetector.swift",
             line: 147,
+            anchor: "return whichHook(\"claude\") != nil",
+            expectedProviderIDs: ["claude"],
+            reason: "The Claude binary resolvability check asks its injected locator for the fixed executable name."),
+        SuppressedProviderReference(
+            path: "Sources/CodexBarCore/Providers/ProviderVersionDetector.swift",
+            line: 158,
             anchor: "? self.whichHook!(\"claude\")",
             expectedProviderIDs: ["claude"],
             reason: "The Claude version detector asks its injected locator for the fixed Claude executable name."),
@@ -2816,7 +2822,7 @@ struct ProviderArchitectureGatekeeperTests {
             anchor: "if provider == .gemini {",
             expectedProviderIDs: ["claude", "codex", "gemini"],
             expectedReferenceCount: 5,
-            expectedReferenceFingerprint: ["gemini@0", "codex@5", "codex@6", "codex@7", "claude@18"],
+            expectedReferenceFingerprint: ["gemini@0", "codex@5", "codex@6", "codex@7", "claude@19"],
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+Refresh.swift",
@@ -3219,7 +3225,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 587,
+            line: 589,
             anchor: "self.metadata(for: .codex).browserCookieOrder ?? Browser.defaultImportOrder",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3227,7 +3233,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 639,
+            line: 641,
             anchor: "self.providerSpecs[provider]?.style ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3235,7 +3241,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 672,
+            line: 674,
             anchor: "guard provider != .codex else { return true }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3243,7 +3249,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1020,
+            line: 1022,
             anchor: "let claudeDebugConfiguration: ClaudeDebugLogConfiguration? = if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3251,7 +3257,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1043,
+            line: 1045,
             anchor: "let deepSeekHasTokenAccount = self.settings.selectedTokenAccount(for: .deepseek) != nil",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3259,7 +3265,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1100,
+            line: 1102,
             anchor: "case .amp:",
             expectedProviderIDs: ["amp", "deepseek", "notion", "ollama", "warp"],
             expectedReferenceCount: 7,
@@ -3275,7 +3281,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1155,
+            line: 1157,
             anchor: "let claudeSettings = snapshot.claude ?? ProviderSettingsSnapshot.ClaudeProviderSettings(",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,


### PR DESCRIPTION
Fixes #2899

## Summary

The Claude provider pane showed "Version: not detected" / "claude not detected" even though a user-initiated CLI usage fetch succeeded through the same resolved binary.

**Root cause (verified, not the parser):** the version parser already accepts decorated output like `2.1.229 (Claude Code)`, and the presentation strips the parenthetical. The real problem is a lifecycle gap: `UsageStore.detectVersions()` runs inside `Task.detached`, which drops the interaction task-local, so `ProviderVersionDetector.claudeVersion` hits the opaque-child background gate (`ClaudeCLIBackgroundAvailability.allowsOpaqueChildExecution`) and returns nil on a cold profile. A later successful user-initiated CLI usage fetch establishes the availability marker but never re-ran version detection, so `versions[.claude]` stayed nil forever.

## Fix

- After a published user-initiated Claude CLI usage success, `refreshClaudeVersionAfterUserInitiatedCLIFetch` re-runs only the Claude version probe in the inherited user-initiated context (once, and only while the version is missing). The no-prompt background gate is untouched.
- `detectVersions()` no longer erases a recovered Claude version when its own background-gated probe returns nil while the binary still resolves; a removed/uninstalled binary still clears the version so stale data cannot survive CLI removal. The resolvability check is gated behind the enabled set so disabled providers are never probed (#2267).
- Added a hermetic `ProviderVersionDetector.claudeBinaryResolvable` helper that honors the existing `whichHook` test seam, plus `versionDetectionTask`/`claudeVersionRefreshTask` seams so tests can await publishes deterministically.

## Tests

New `ClaudeVersionRecoveryTests` (hermetic: stubbed version hooks, isolated availability store, missing-credentials override; no real claude binary, no Keychain):

- user initiated CLI success refreshes missing Claude version (covers `2.1.229 (Claude Code)`)
- background CLI success leaves version probe untouched
- user initiated OAuth success does not trigger the CLI version probe
- later version detection publish preserves recovered Claude version
- removed Claude binary clears the recovered version on the next detection run

## Verification

- `swift test --filter ClaudeVersionRecoveryTests` — 5/5 pass
- `swift test --filter ProviderArchitectureGatekeeperTests` — pass (anchors/fingerprints updated for shifted lines)
- `make check` — 0 violations
- `make test` — full sharded suite green (71/71 groups first pass)
