### PR TITLE
Open cost-history submenu on provider detail cards with inline cost charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.49.5 — Unreleased
 
+### Fixed
+- Merged menu: provider detail cards that render the inline token/cost chart now open the cost-history submenu on hover, matching the Overview card (#2885). Thanks @SJY051!
+
 ## 0.49.4 — 2026-08-13
 
 ### Added

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1292,8 +1292,8 @@ extension StatusItemController {
                 width: width)
             let usageSubmenu = self.makeUsageSubmenu(
                 provider: provider,
-                snapshot: self.store.snapshot(for: provider.instanceID),
                 webItems: webItems,
+                hasInlineCostDashboard: layoutModel.inlineUsageDashboard != nil,
                 width: width)
             menu.addItem(self.makeMenuCardItem(
                 usageView,
@@ -1475,8 +1475,8 @@ extension StatusItemController {
 
     private func makeUsageSubmenu(
         provider: UsageProvider,
-        snapshot: UsageSnapshot?,
         webItems: OpenAIWebMenuItems,
+        hasInlineCostDashboard: Bool,
         width: CGFloat? = nil) -> NSMenu?
     {
         if webItems.hasUsageBreakdown {
@@ -1486,11 +1486,13 @@ extension StatusItemController {
         if provider == .openai {
             return self.makeOpenAIAPIUsageSubmenu(provider: provider, width: width)
         }
-        // Mistral's top usage pane has no rate-limit bars of its own, so its cost history hangs
-        // off this row instead. Other `tokenCostRequiresProviderSnapshot` providers (e.g.
-        // opencodego) show real rate-limit bars here and get their own "Cost" row instead
-        // (see `makeCostMenuCardItem`), matching Codex/Claude's structure.
+        // Mistral's top usage pane has no rate-limit bars of its own, so its cost history always hangs
+        // off this row. Providers whose cards render an inline cost dashboard also gain cost history
+        // on the top card when the Cost Summary style permits it; Both still keeps the dedicated Cost row.
         if provider == .mistral {
+            return self.makeCostHistorySubmenu(provider: provider, width: width)
+        }
+        if hasInlineCostDashboard, self.settings.costSummaryShowsSubmenu(for: provider) {
             return self.makeCostHistorySubmenu(provider: provider, width: width)
         }
         return nil

--- a/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
+++ b/Tests/CodexBarTests/StatusMenuNativeSectionSpacingTests.swift
@@ -213,7 +213,7 @@ struct StatusMenuNativeSectionSpacingTests {
     }
 
     @Test
-    func `opencodego cost history hangs off the cost row not the usage pane`() throws {
+    func `opencodego usage card and cost row both open cost history`() throws {
         let previousRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true
         defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
@@ -279,13 +279,136 @@ struct StatusMenuNativeSectionSpacingTests {
             ($0.representedObject as? String) == "menuCardCost"
         })
 
-        // The rate-limit bars pane keeps its own submenu-free row; the cost history chart hangs
-        // off the dedicated "Cost" row instead, matching Codex/Claude's structure.
-        #expect(menu.items[usageIndex].submenu == nil)
+        #expect(menu.items[usageIndex].submenu?.items.contains {
+            ($0.representedObject as? String) == "costHistoryChart"
+        } == true)
         #expect(menu.items[usageHistoryIndex].title == "Plan Usage")
         #expect(usageIndex < usageHistoryIndex)
         #expect(usageHistoryIndex < costIndex)
         #expect(menu.items[costIndex].submenu != nil)
+    }
+
+    @Test
+    func `claude detail card with inline cost chart opens cost history`() throws {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.costUsageEnabled = true
+        settings.costSummaryDisplayStyle = .both
+        self.enableOnly(.claude, settings: settings)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setTokenSnapshotForTesting(CostUsageTokenSnapshot(
+            sessionTokens: 123,
+            sessionCostUSD: 0.12,
+            last30DaysTokens: 123,
+            last30DaysCostUSD: 1.23,
+            daily: [
+                CostUsageDailyReport.Entry(
+                    date: "2025-12-23",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 123,
+                    costUSD: 1.23,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            updatedAt: Date()), provider: .claude)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu(for: .claude)
+        controller.menuWillOpen(menu)
+        let usageItem = try #require(menu.items.first {
+            ($0.representedObject as? String) == "menuCardUsage"
+        })
+
+        #expect(usageItem.submenu?.items.contains {
+            ($0.representedObject as? String) == "costHistoryChart"
+        } == true)
+    }
+
+    @Test
+    func `codex top card keeps usage breakdown over cost history`() throws {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.costUsageEnabled = true
+        settings.costSummaryDisplayStyle = .both
+        self.enableOnly(.codex, settings: settings)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let event = CreditEvent(date: Date(), service: "CLI", creditsUsed: 1)
+        let breakdown = OpenAIDashboardSnapshot.makeDailyBreakdown(from: [event], maxDays: 30)
+        store.openAIDashboard = OpenAIDashboardSnapshot(
+            signedInEmail: "user@example.com",
+            codeReviewRemainingPercent: 100,
+            creditEvents: [event],
+            dailyBreakdown: breakdown,
+            usageBreakdown: breakdown,
+            creditsPurchaseURL: nil,
+            updatedAt: Date())
+        store.openAIDashboardAttachmentAuthorized = true
+        store.openAIDashboardRequiresLogin = false
+        store._setTokenSnapshotForTesting(CostUsageTokenSnapshot(
+            sessionTokens: 123,
+            sessionCostUSD: 0.12,
+            last30DaysTokens: 123,
+            last30DaysCostUSD: 1.23,
+            daily: [
+                CostUsageDailyReport.Entry(
+                    date: "2025-12-23",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 123,
+                    costUSD: 1.23,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            updatedAt: Date()), provider: .codex)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let usageItem = try #require(menu.items.first {
+            ($0.representedObject as? String) == "menuCardUsage"
+        })
+
+        #expect(usageItem.submenu?.items.contains {
+            ($0.representedObject as? String) == "usageBreakdownChart"
+        } == true)
+        #expect(usageItem.submenu?.items.contains {
+            ($0.representedObject as? String) == "costHistoryChart"
+        } == false)
     }
 
     private func makeSettings() -> SettingsStore {


### PR DESCRIPTION
Fixes #2885

## Summary

In the merged menu, an Overview provider card with an inline token/cost chart opens the cost-history submenu on hover, but the equivalent top card in provider detail tabs did not — no chevron, no submenu — even though it renders the same inline cost dashboard. Reproducible for Claude and OpenCode Go.

Root cause: `addMenuCardSections` asked `makeUsageSubmenu` for the detail-card submenu without telling it whether the card renders `layoutModel.inlineUsageDashboard`, and `makeUsageSubmenu` only knew three provider-specific routes (Codex web usage breakdown, OpenAI API usage, Mistral cost history). For every other provider it returned `nil`.

## Change

- `makeUsageSubmenu` gains a `hasInlineCostDashboard` parameter fed from `layoutModel.inlineUsageDashboard != nil`. After the existing precedence (usage breakdown, OpenAI API usage, Mistral cost history — unchanged), cards that visibly render the inline cost dashboard attach `makeCostHistorySubmenu` when `costSummaryShowsSubmenu(for:)` permits it.
- Codex keeps prioritizing its native usage-breakdown submenu; the new branch runs last.
- The dedicated Cost row stays in the Both display style; this only adds the same entry point the Overview card already has.
- Dropped the unused `snapshot` parameter of `makeUsageSubmenu` (bounded cleanup; single call site).

## Tests

- Updated `opencodego usage card and cost row both open cost history` (previously asserted the top card had no submenu).
- Added `claude detail card with inline cost chart opens cost history`.
- Added `codex top card keeps usage breakdown over cost history` (precedence regression).

## Commands run

- `swift test --filter StatusMenuNativeSectionSpacingTests` — 6/6 passed
- `make test` — 846/846 selections, 71/71 groups, 0 failures/retries/timeouts
- `make check` — SwiftFormat clean, SwiftLint 0 violations
- Codex autoreview — clean, no accepted findings
