### PR TITLE
Fetch EDU monthly usage limit from the spend-controls endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.49.5 — Unreleased
 
+### Fixed
+- Codex: show the administrator-defined monthly usage limit for EDU/workspace accounts by querying the spend-controls monthly-usage endpoint when wham/usage omits it (#2900). Thanks @ygnask!
+
 ## 0.49.4 — 2026-08-13
 
 ### Added

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -702,10 +702,16 @@ public struct OpenAIDashboardFetcher {
             guard status >= 200, status < 300 else { return nil }
             let decoded = try JSONDecoder().decode(CodexUsageResponse.self, from: data)
             let result = self.dashboardAPIData(from: decoded)
-            if result.hasUsageData {
+            let enrichedResult = await self.fetchSpendControlsMonthlyUsageIfNeeded(
+                result,
+                response: decoded,
+                cookieHeader: cookieHeader,
+                deadline: deadline,
+                logger: logger)
+            if enrichedResult.hasUsageData {
                 logger("usage api supplied language-independent rate/credit data")
             }
-            return result
+            return enrichedResult
         } catch {
             logger("usage api unavailable: \(error.localizedDescription)")
             return nil
@@ -957,6 +963,54 @@ extension OpenAIDashboardFetcher {
 }
 
 extension OpenAIDashboardFetcher {
+    private static func fetchSpendControlsMonthlyUsageIfNeeded(
+        _ result: DashboardAPIData,
+        response: CodexUsageResponse,
+        cookieHeader: String,
+        deadline: Date?,
+        logger: @escaping (String) -> Void) async -> DashboardAPIData
+    {
+        guard CodexSpendControlsMonthlyUsageGate.shouldFetch(response: response),
+              let accountId = response.accountId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !accountId.isEmpty
+        else { return result }
+
+        let remaining = deadline.map { self.remainingTimeout(until: $0) } ?? 4
+        guard remaining > 0 else {
+            logger("spend controls monthly usage api unavailable: request deadline expired")
+            return result
+        }
+        guard let request = self.dashboardSpendControlsMonthlyUsageAPIRequest(
+            accountId: accountId,
+            cookieHeader: cookieHeader,
+            timeout: min(4, remaining))
+        else {
+            logger("spend controls monthly usage api unavailable: invalid account id")
+            return result
+        }
+
+        do {
+            let (data, response) = try await CodexAuthenticatedHTTPTransport.current.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            guard status >= 200, status < 300 else {
+                logger("spend controls monthly usage api unavailable: status=\(status)")
+                return result
+            }
+            let decoded = try JSONDecoder().decode(CodexSpendControlsMonthlyUsageResponse.self, from: data)
+            guard let limit = decoded.codexCreditLimitSnapshot(updatedAt: Date()) else { return result }
+            return DashboardAPIData(
+                primaryLimit: result.primaryLimit,
+                secondaryLimit: result.secondaryLimit,
+                extraRateWindows: result.extraRateWindows,
+                creditsRemaining: result.creditsRemaining,
+                codexCreditLimit: limit,
+                accountPlan: result.accountPlan)
+        } catch {
+            logger("spend controls monthly usage api unavailable: \(error.localizedDescription)")
+            return result
+        }
+    }
+
     nonisolated static func requiredRemainingTimeout(
         until deadline: Date,
         now: Date = Date()) throws -> TimeInterval
@@ -972,6 +1026,36 @@ extension OpenAIDashboardFetcher {
     {
         var request = URLRequest(
             url: Self.dashboardUsageAPIURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: timeout)
+        request.httpMethod = "GET"
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    nonisolated static func dashboardSpendControlsMonthlyUsageAPIURL(accountId: String) -> URL? {
+        var allowedCharacters = CharacterSet.urlPathAllowed
+        allowedCharacters.subtract(CharacterSet(charactersIn: "/?#%"))
+        guard let encodedAccountId = accountId.addingPercentEncoding(withAllowedCharacters: allowedCharacters),
+              !encodedAccountId.isEmpty
+        else { return nil }
+        return URL(string: "https://chatgpt.com/backend-api/accounts/\(encodedAccountId)" +
+            "/spend-controls/current-user/monthly-usage")
+    }
+
+    nonisolated static func dashboardSpendControlsMonthlyUsageAPIRequest(
+        accountId: String,
+        cookieHeader: String,
+        timeout: TimeInterval = 4) -> URLRequest?
+    {
+        guard let url = self.dashboardSpendControlsMonthlyUsageAPIURL(accountId: accountId) else {
+            return nil
+        }
+        var request = URLRequest(
+            url: url,
             cachePolicy: .reloadIgnoringLocalCacheData,
             timeoutInterval: timeout)
         request.httpMethod = "GET"

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -4,6 +4,7 @@ import FoundationNetworking
 #endif
 
 public struct CodexUsageResponse: Decodable, Sendable {
+    public let accountId: String?
     public let planType: PlanType?
     public let rateLimit: RateLimitDetails?
     public let credits: CreditDetails?
@@ -12,11 +13,14 @@ public struct CodexUsageResponse: Decodable, Sendable {
     /// Kept separate from `individualLimit` so the established root → `rate_limit` precedence is preserved;
     /// consumers select this only when both of those are absent.
     public let spendControlIndividualLimit: SpendControlLimitSnapshot?
+    public let spendControlPresent: Bool
     /// Model-specific limits (e.g. GPT-5.3-Codex-Spark) that sit alongside the primary/weekly windows.
     public let additionalRateLimits: [AdditionalRateLimit]?
     let additionalRateLimitsDecodeFailed: Bool
 
     enum CodingKeys: String, CodingKey {
+        case accountId = "account_id"
+        case accountIdCamel = "accountId"
         case planType = "plan_type"
         case rateLimit = "rate_limit"
         case credits
@@ -29,6 +33,8 @@ public struct CodexUsageResponse: Decodable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.accountId = (try? container.decodeIfPresent(String.self, forKey: .accountId))
+            ?? (try? container.decodeIfPresent(String.self, forKey: .accountIdCamel))
         self.planType = try? container.decodeIfPresent(PlanType.self, forKey: .planType)
         self.rateLimit = try? container.decodeIfPresent(RateLimitDetails.self, forKey: .rateLimit)
         self.credits = try? container.decodeIfPresent(CreditDetails.self, forKey: .credits)
@@ -37,6 +43,7 @@ public struct CodexUsageResponse: Decodable, Sendable {
             forKey: .individualLimit))
             ?? (try? container.decodeIfPresent(SpendControlLimitSnapshot.self, forKey: .individualLimitCamel))
         self.spendControlIndividualLimit = Self.decodeSpendControlIndividualLimit(container: container)
+        self.spendControlPresent = container.contains(.spendControl) || container.contains(.spendControlCamel)
         // Optional and additive: missing/malformed extra limits must never disturb primary/weekly mapping.
         // Decode per element so a single malformed entry cannot discard its valid siblings; a non-array
         // value (or absent field) leaves `additionalRateLimits` nil and primary/weekly mapping untouched.
@@ -386,6 +393,7 @@ public enum CodexOAuthUsageFetcher {
     private static let chatGPTUsagePath = "/wham/usage"
     private static let codexUsagePath = "/api/codex/usage"
     private static let rateLimitResetCreditsPath = "/wham/rate-limit-reset-credits"
+    private static let spendControlsMonthlyUsagePathSuffix = "/spend-controls/current-user/monthly-usage"
 
     public static func fetchUsage(
         accessToken: String,
@@ -459,6 +467,67 @@ public enum CodexOAuthUsageFetcher {
             env: env,
             timeout: timeout,
             session: CodexAuthenticatedHTTPTransport.current)
+    }
+
+    public static func fetchSpendControlsMonthlyUsage(
+        accessToken: String,
+        accountId: String,
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        timeout: TimeInterval = 4) async throws -> CodexSpendControlsMonthlyUsageResponse
+    {
+        try await self.fetchSpendControlsMonthlyUsage(
+            accessToken: accessToken,
+            accountId: accountId,
+            env: env,
+            timeout: timeout,
+            session: CodexAuthenticatedHTTPTransport.current)
+    }
+
+    public static func fetchSpendControlsMonthlyUsage(
+        accessToken: String,
+        accountId: String,
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        timeout: TimeInterval = 4,
+        session transport: any ProviderHTTPTransport) async throws -> CodexSpendControlsMonthlyUsageResponse
+    {
+        guard let url = self.resolveSpendControlsMonthlyUsageURL(env: env, accountId: accountId) else {
+            throw CodexOAuthFetchError.invalidResponse
+        }
+        var request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: timeout)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+
+        do {
+            let response = try await transport.response(for: request)
+            switch response.statusCode {
+            case 200...299:
+                do {
+                    return try JSONDecoder().decode(CodexSpendControlsMonthlyUsageResponse.self, from: response.data)
+                } catch {
+                    throw CodexOAuthFetchError.invalidResponse
+                }
+            case 401, 403:
+                throw CodexOAuthFetchError.unauthorized
+            default:
+                let body = String(data: response.data, encoding: .utf8)
+                throw CodexOAuthFetchError.serverError(response.statusCode, body)
+            }
+        } catch let error as CodexOAuthFetchError {
+            throw error
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if Task.isCancelled || (error as? URLError)?.code == .cancelled {
+                throw CancellationError()
+            }
+            throw CodexOAuthFetchError.networkError(error)
+        }
     }
 
     public static func fetchRateLimitResetCredits(
@@ -543,6 +612,25 @@ public enum CodexOAuthUsageFetcher {
         let normalized = self.normalizeChatGPTBaseURL(baseURL)
         let full = normalized + Self.rateLimitResetCreditsPath
         return URL(string: full) ?? URL(string: Self.defaultChatGPTBaseURL + Self.rateLimitResetCreditsPath)!
+    }
+
+    private static func resolveSpendControlsMonthlyUsageURL(env: [String: String], accountId: String) -> URL? {
+        self.resolveSpendControlsMonthlyUsageURL(env: env, configContents: nil, accountId: accountId)
+    }
+
+    private static func resolveSpendControlsMonthlyUsageURL(
+        env: [String: String],
+        configContents: String?,
+        accountId: String) -> URL?
+    {
+        let baseURL = self.resolveChatGPTBaseURL(env: env, configContents: configContents)
+        let normalized = self.normalizeChatGPTBaseURL(baseURL)
+        guard normalized.contains("/backend-api") else { return nil }
+        var allowedCharacters = CharacterSet.urlPathAllowed
+        allowedCharacters.subtract(CharacterSet(charactersIn: "/?#%"))
+        let encodedAccountId = accountId.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
+        guard let encodedAccountId, !encodedAccountId.isEmpty else { return nil }
+        return URL(string: normalized + "/accounts/\(encodedAccountId)" + Self.spendControlsMonthlyUsagePathSuffix)
     }
 
     private static func resolveChatGPTBaseURL(env: [String: String], configContents: String?) -> String {
@@ -671,6 +759,23 @@ extension CodexOAuthUsageFetcher {
 
     static func _decodeUsageResponseForTesting(_ data: Data) throws -> CodexUsageResponse {
         try JSONDecoder().decode(CodexUsageResponse.self, from: data)
+    }
+
+    static func _resolveSpendControlsMonthlyUsageURLForTesting(
+        env: [String: String] = [:],
+        configContents: String? = nil,
+        accountId: String) -> URL?
+    {
+        self.resolveSpendControlsMonthlyUsageURL(
+            env: env,
+            configContents: configContents,
+            accountId: accountId)
+    }
+
+    static func _decodeSpendControlsMonthlyUsageResponseForTesting(_ data: Data) throws
+        -> CodexSpendControlsMonthlyUsageResponse
+    {
+        try JSONDecoder().decode(CodexSpendControlsMonthlyUsageResponse.self, from: data)
     }
 
     static func _resolveRateLimitResetCreditsURLForTesting(

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -342,7 +342,12 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             credentials: credentials,
             updatedAt: updatedAt,
             allowEmptyUsageForResetCreditEnrichment: Self.defersResetCreditFetchToApp(context))
-        return try await Self.replacingWithCLIMonthlyLimitIfAvailable(oauthResult, context: context)
+        let spendControlsResult = try await Self.applyingSpendControlsMonthlyLimit(
+            oauthResult,
+            usage: usage,
+            credentials: credentials,
+            context: context)
+        return try await Self.replacingWithCLIMonthlyLimitIfAvailable(spendControlsResult, context: context)
     }
 
     private static func shouldFetchResetCredits(_ context: ProviderFetchContext) -> Bool {
@@ -480,6 +485,91 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             diagnostic: oauthResult.diagnostic)
     }
 
+    private static func applyingSpendControlsMonthlyLimit(
+        _ result: ProviderFetchResult,
+        usage: CodexUsageResponse,
+        credentials: CodexOAuthCredentials,
+        context: ProviderFetchContext) async throws -> ProviderFetchResult
+    {
+        try await self.applyingSpendControlsMonthlyLimit(
+            result,
+            usage: usage,
+            credentials: credentials,
+            context: context,
+            fetcher: { accountId in
+                try await CodexOAuthUsageFetcher.fetchSpendControlsMonthlyUsage(
+                    accessToken: credentials.accessToken,
+                    accountId: accountId,
+                    env: context.env)
+            })
+    }
+
+    private static func applyingSpendControlsMonthlyLimit(
+        _ result: ProviderFetchResult,
+        usage: CodexUsageResponse,
+        credentials: CodexOAuthCredentials,
+        context: ProviderFetchContext,
+        fetcher: @escaping @Sendable (String) async throws -> CodexSpendControlsMonthlyUsageResponse) async throws
+        -> ProviderFetchResult
+    {
+        guard context.includeCredits,
+              CodexSpendControlsMonthlyUsageGate.shouldFetch(response: usage),
+              let accountId = self.firstNonEmptyAccountId(credentials.accountId, usage.accountId)
+        else { return result }
+
+        do {
+            let response = try await fetcher(accountId)
+            let updatedAt = result.credits?.updatedAt ?? result.usage.updatedAt
+            guard let limit = response.codexCreditLimitSnapshot(updatedAt: updatedAt) else { return result }
+            let credits = result.credits.map {
+                CreditsSnapshot(
+                    remaining: $0.remaining,
+                    events: $0.events,
+                    updatedAt: $0.updatedAt,
+                    codexCreditLimit: limit)
+            } ?? CreditsSnapshot(
+                remaining: 0,
+                events: [],
+                updatedAt: updatedAt,
+                codexCreditLimit: limit)
+            return Self.replacingCredits(in: result, with: credits)
+        } catch {
+            if error is CancellationError || Task.isCancelled {
+                throw CancellationError()
+            }
+            return result
+        }
+    }
+
+    private static func firstNonEmptyAccountId(_ candidates: String?...) -> String? {
+        for candidate in candidates {
+            if let candidate = candidate?.trimmingCharacters(in: .whitespacesAndNewlines), !candidate.isEmpty {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private static func replacingCredits(
+        in result: ProviderFetchResult,
+        with credits: CreditsSnapshot) -> ProviderFetchResult
+    {
+        ProviderFetchResult(
+            usage: result.usage,
+            credits: credits,
+            dashboard: result.dashboard,
+            sourceLabel: result.sourceLabel,
+            strategyID: result.strategyID,
+            strategyKind: result.strategyKind,
+            diagnostic: result.diagnostic,
+            claudeOAuthKeychainPersistentRefHash: result.claudeOAuthKeychainPersistentRefHash,
+            claudeOAuthHistoryOwnerIdentifier: result.claudeOAuthHistoryOwnerIdentifier,
+            claudeOAuthCredentialOwner: result.claudeOAuthCredentialOwner,
+            claudeOAuthKeychainCredentialMismatch: result.claudeOAuthKeychainCredentialMismatch,
+            claudeOAuthKeychainCredentialAbsent: result.claudeOAuthKeychainCredentialAbsent,
+            claudeOAuthKeychainCredentialUnavailable: result.claudeOAuthKeychainCredentialUnavailable)
+    }
+
     private static func fetchResetCreditsIfRequested(
         context: ProviderFetchContext,
         credentials: CodexOAuthCredentials) async throws -> CodexRateLimitResetCreditsSnapshot?
@@ -548,6 +638,22 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
 
 #if DEBUG
 extension CodexOAuthFetchStrategy {
+    static func _applySpendControlsMonthlyLimitForTesting(
+        _ result: ProviderFetchResult,
+        usage: CodexUsageResponse,
+        credentials: CodexOAuthCredentials,
+        context: ProviderFetchContext,
+        fetcher: @escaping @Sendable (String) async throws -> CodexSpendControlsMonthlyUsageResponse) async throws
+        -> ProviderFetchResult
+    {
+        try await self.applyingSpendControlsMonthlyLimit(
+            result,
+            usage: usage,
+            credentials: credentials,
+            context: context,
+            fetcher: fetcher)
+    }
+
     static func _fetchResetCreditsForTesting(
         context: ProviderFetchContext,
         credentials: CodexOAuthCredentials,

--- a/Sources/CodexBarCore/Providers/Codex/CodexSpendControlsMonthlyUsage.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexSpendControlsMonthlyUsage.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+public struct CodexSpendControlsMonthlyUsageResponse: Decodable, Sendable {
+    public let currentMonthUsage: Double?
+    public let effectiveMonthlyLimit: EffectiveMonthlyLimit?
+
+    enum CodingKeys: String, CodingKey {
+        case currentMonthUsage = "current_month_usage"
+        case effectiveMonthlyLimit = "effective_monthly_limit"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.currentMonthUsage = Self.decodeFlexibleDouble(container, forKey: .currentMonthUsage)
+        self.effectiveMonthlyLimit = try? container.decodeIfPresent(
+            EffectiveMonthlyLimit.self,
+            forKey: .effectiveMonthlyLimit)
+    }
+
+    public func codexCreditLimitSnapshot(updatedAt: Date) -> CodexCreditLimitSnapshot? {
+        guard let limit = self.effectiveMonthlyLimit?.limit, limit > 0 else { return nil }
+        if let enforcementMode = self.effectiveMonthlyLimit?.enforcementMode?.lowercased(),
+           ["none", "off", "disabled", "no_limit"].contains(enforcementMode)
+        {
+            return nil
+        }
+
+        let used = max(0, self.currentMonthUsage ?? 0)
+        let remainingPercent = max(0, min(100, 100 - (used / limit * 100)))
+        return CodexCreditLimitSnapshot(
+            used: used,
+            limit: limit,
+            remainingPercent: remainingPercent,
+            resetsAt: nil,
+            updatedAt: updatedAt)
+    }
+
+    public struct EffectiveMonthlyLimit: Decodable, Sendable {
+        public let limit: Double?
+        public let enforcementMode: String?
+        public let limitMode: String?
+
+        enum CodingKeys: String, CodingKey {
+            case limit
+            case enforcementMode = "enforcement_mode"
+            case limitMode = "limit_mode"
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.limit = CodexSpendControlsMonthlyUsageResponse.decodeFlexibleDouble(container, forKey: .limit)
+            self.enforcementMode = try? container.decodeIfPresent(String.self, forKey: .enforcementMode)
+            self.limitMode = try? container.decodeIfPresent(String.self, forKey: .limitMode)
+        }
+    }
+
+    private static func decodeFlexibleDouble<Key: CodingKey>(
+        _ container: KeyedDecodingContainer<Key>,
+        forKey key: Key) -> Double?
+    {
+        if let value = try? container.decodeIfPresent(Double.self, forKey: key) {
+            return value
+        }
+        if let value = try? container.decodeIfPresent(Int.self, forKey: key) {
+            return Double(value)
+        }
+        if let value = try? container.decodeIfPresent(String.self, forKey: key) {
+            return Double(value.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        return nil
+    }
+}
+
+enum CodexSpendControlsMonthlyUsageGate {
+    static func shouldFetch(response: CodexUsageResponse) -> Bool {
+        guard response.resolvedIndividualLimit?.codexCreditLimitSnapshot(updatedAt: Date()) == nil,
+              response.spendControlPresent
+        else { return false }
+
+        return switch response.planType {
+        case .team, .business, .education, .quorum, .k12, .enterprise, .edu, .freeWorkspace:
+            true
+        case .guest, .free, .go, .plus, .pro, .unknown, nil:
+            false
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodexSpendControlsMonthlyUsageTests.swift
+++ b/Tests/CodexBarTests/CodexSpendControlsMonthlyUsageTests.swift
@@ -1,0 +1,509 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite(.serialized)
+struct CodexSpendControlsMonthlyUsageTests {
+    private actor InvocationCounter {
+        private var value = 0
+
+        func increment() {
+            self.value += 1
+        }
+
+        func count() -> Int {
+            self.value
+        }
+    }
+
+    private enum ExpectedError: Error {
+        case failed
+    }
+
+    private func educationUsageJSON(
+        planType: String? = "education",
+        accountId: String? = "acct-123",
+        includeSpendControl: Bool = true,
+        individualLimit: String = "null") -> String
+    {
+        let plan = planType.map { #""plan_type":"\#($0)","# } ?? ""
+        let account = accountId.map { #""account_id":"\#($0)","# } ?? ""
+        let spendControl = includeSpendControl
+            ? #", "spend_control":{"reached":false,"individual_limit":\#(individualLimit)}"#
+            : ""
+        return """
+        {
+          \(plan)
+          \(account)
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 10,
+              "reset_at": 1786161204,
+              "limit_window_seconds": 18000
+            },
+            "secondary_window": null
+          },
+          "credits": {"has_credits": true, "unlimited": false, "balance": "14"}
+          \(spendControl)
+        }
+        """
+    }
+
+    private func monthlyUsageJSON(
+        usage: String = "3046.4506806135178",
+        limit: String = "7000",
+        enforcementMode: String? = "HARD_CAP") -> String
+    {
+        let enforcement = enforcementMode.map { #", "enforcement_mode":"\#($0)""# } ?? ""
+        return """
+        {
+          "current_month_usage": \(usage),
+          "effective_monthly_limit": {
+            "limit": \(limit)\(enforcement),
+            "limit_mode": "amount_credits"
+          }
+        }
+        """
+    }
+
+    private func decodeUsage(_ json: String) throws -> CodexUsageResponse {
+        try CodexOAuthUsageFetcher._decodeUsageResponseForTesting(Data(json.utf8))
+    }
+
+    private func decodeMonthlyUsage(_ json: String) throws -> CodexSpendControlsMonthlyUsageResponse {
+        try CodexOAuthUsageFetcher._decodeSpendControlsMonthlyUsageResponseForTesting(Data(json.utf8))
+    }
+
+    private func makeCredentials(accountId: String? = nil) -> CodexOAuthCredentials {
+        CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: accountId,
+            lastRefresh: Date())
+    }
+
+    private func makeContext(includeCredits: Bool = true) -> ProviderFetchContext {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .oauth,
+            includeCredits: includeCredits,
+            webTimeout: 60,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: nil,
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+
+    @Test
+    func `education usage fixture gates monthly endpoint and maps its response`() throws {
+        let usage = try self.decodeUsage(self.educationUsageJSON())
+        let now = Date(timeIntervalSince1970: 1_786_000_000)
+
+        #expect(usage.accountId == "acct-123")
+        #expect(usage.resolvedIndividualLimit == nil)
+        #expect(usage.resolvedIndividualLimit?.codexCreditLimitSnapshot(updatedAt: now) == nil)
+        #expect(usage.spendControlPresent)
+        #expect(CodexSpendControlsMonthlyUsageGate.shouldFetch(response: usage))
+
+        let monthlyUsage = try self.decodeMonthlyUsage(self.monthlyUsageJSON())
+        let snapshot = try #require(monthlyUsage.codexCreditLimitSnapshot(updatedAt: now))
+        #expect(abs(snapshot.used - 3046.4506806135178) < 0.000_001)
+        #expect(snapshot.limit == 7000)
+        #expect(abs(snapshot.remainingPercent - 56.479_276_0) < 0.000_001)
+        #expect(snapshot.resetsAt == nil)
+        #expect(snapshot.updatedAt == now)
+    }
+
+    @Test
+    func `active and unknown enforcement modes produce a monthly limit`() throws {
+        for mode in ["HARD_CAP", "SOFT_CAP", "future_mode"] {
+            let response = try self.decodeMonthlyUsage(self.monthlyUsageJSON(enforcementMode: mode))
+            #expect(response.codexCreditLimitSnapshot(updatedAt: Date()) != nil)
+        }
+
+        let missingMode = try self.decodeMonthlyUsage(self.monthlyUsageJSON(enforcementMode: nil))
+        #expect(missingMode.codexCreditLimitSnapshot(updatedAt: Date()) != nil)
+    }
+
+    @Test
+    func `inactive enforcement modes suppress the monthly limit case insensitively`() throws {
+        for mode in ["NONE", "disabled", "OFF", "no_limit"] {
+            let response = try self.decodeMonthlyUsage(self.monthlyUsageJSON(enforcementMode: mode))
+            #expect(response.codexCreditLimitSnapshot(updatedAt: Date()) == nil)
+        }
+    }
+
+    @Test
+    func `missing or zero limit suppresses the monthly snapshot`() throws {
+        let zero = try self.decodeMonthlyUsage(self.monthlyUsageJSON(limit: "0"))
+        let missing = try self.decodeMonthlyUsage(
+            #"{"current_month_usage":12,"effective_monthly_limit":{"enforcement_mode":"HARD_CAP"}}"#)
+
+        #expect(zero.codexCreditLimitSnapshot(updatedAt: Date()) == nil)
+        #expect(missing.codexCreditLimitSnapshot(updatedAt: Date()) == nil)
+    }
+
+    @Test
+    func `monthly usage clamps negative usage and accepts numeric strings`() throws {
+        let response = try self.decodeMonthlyUsage(self.monthlyUsageJSON(usage: #""-20""#, limit: #""7000""#))
+        let snapshot = try #require(response.codexCreditLimitSnapshot(updatedAt: Date()))
+
+        #expect(snapshot.used == 0)
+        #expect(snapshot.remainingPercent == 100)
+    }
+
+    @Test
+    func `consumer plans never gate the monthly endpoint`() throws {
+        for plan in ["plus", "pro", "free"] {
+            let response = try self.decodeUsage(self.educationUsageJSON(planType: plan))
+            #expect(!CodexSpendControlsMonthlyUsageGate.shouldFetch(response: response))
+        }
+    }
+
+    @Test
+    func `existing education individual limit prevents a second monthly limit request`() throws {
+        let individualLimit = #"{"limit":7000,"used":1000,"remaining_percent":85}"#
+        let response = try self.decodeUsage(self.educationUsageJSON(individualLimit: individualLimit))
+
+        #expect(response.resolvedIndividualLimit?.limit == 7000)
+        #expect(!CodexSpendControlsMonthlyUsageGate.shouldFetch(response: response))
+    }
+
+    @Test
+    func `education without spend control key does not gate the monthly endpoint`() throws {
+        let response = try self.decodeUsage(self.educationUsageJSON(includeSpendControl: false))
+
+        #expect(!response.spendControlPresent)
+        #expect(!CodexSpendControlsMonthlyUsageGate.shouldFetch(response: response))
+    }
+
+    @Test
+    func `missing plan does not gate the monthly endpoint`() throws {
+        let response = try self.decodeUsage(self.educationUsageJSON(planType: nil))
+
+        #expect(response.planType == nil)
+        #expect(!CodexSpendControlsMonthlyUsageGate.shouldFetch(response: response))
+    }
+
+    @Test
+    func `camel account id and null camel spend control retain presence`() throws {
+        let response = try self.decodeUsage(#"{"accountId":"camel-id","plan_type":"edu","spendControl":null}"#)
+
+        #expect(response.accountId == "camel-id")
+        #expect(response.spendControlPresent)
+        #expect(CodexSpendControlsMonthlyUsageGate.shouldFetch(response: response))
+    }
+
+    @Test
+    func `O auth helper injects monthly limit and preserves existing credit data`() async throws {
+        let usageJSON = self.educationUsageJSON()
+        let usage = try self.decodeUsage(usageJSON)
+        let original = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(usageJSON.utf8),
+            credentials: self.makeCredentials())
+        let payload = try self.decodeMonthlyUsage(self.monthlyUsageJSON())
+
+        let enriched = try await CodexOAuthFetchStrategy._applySpendControlsMonthlyLimitForTesting(
+            original,
+            usage: usage,
+            credentials: self.makeCredentials(),
+            context: self.makeContext(),
+            fetcher: { accountId in
+                #expect(accountId == "acct-123")
+                return payload
+            })
+
+        #expect(enriched.credits?.remaining == original.credits?.remaining)
+        #expect(enriched.credits?.events == original.credits?.events)
+        #expect(enriched.credits?.updatedAt == original.credits?.updatedAt)
+        #expect(enriched.credits?.codexCreditLimit?.limit == 7000)
+        #expect(enriched.sourceLabel == original.sourceLabel)
+        #expect(enriched.strategyID == original.strategyID)
+    }
+
+    @Test
+    func `O auth helper creates credits when monthly limit is the only credit data`() async throws {
+        let usageJSON = self.educationUsageJSON().replacingOccurrences(
+            of: #""credits": {"has_credits": true, "unlimited": false, "balance": "14"}"#,
+            with: #""credits": {"has_credits": true, "unlimited": false, "balance": null}"#)
+        let usage = try self.decodeUsage(usageJSON)
+        let original = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(usageJSON.utf8),
+            credentials: self.makeCredentials())
+        let payload = try self.decodeMonthlyUsage(self.monthlyUsageJSON())
+
+        let enriched = try await CodexOAuthFetchStrategy._applySpendControlsMonthlyLimitForTesting(
+            original,
+            usage: usage,
+            credentials: self.makeCredentials(accountId: "credential-account"),
+            context: self.makeContext(),
+            fetcher: { accountId in
+                #expect(accountId == "credential-account")
+                return payload
+            })
+
+        #expect(original.credits == nil)
+        #expect(enriched.credits?.remaining == 0)
+        #expect(enriched.credits?.events.isEmpty == true)
+        #expect(enriched.credits?.codexCreditLimit?.limit == 7000)
+    }
+
+    @Test
+    func `O auth helper keeps original result on enrichment error`() async throws {
+        let usageJSON = self.educationUsageJSON()
+        let usage = try self.decodeUsage(usageJSON)
+        let original = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(usageJSON.utf8),
+            credentials: self.makeCredentials())
+
+        let result = try await CodexOAuthFetchStrategy._applySpendControlsMonthlyLimitForTesting(
+            original,
+            usage: usage,
+            credentials: self.makeCredentials(accountId: "credential-account"),
+            context: self.makeContext(),
+            fetcher: { _ in throw ExpectedError.failed })
+
+        #expect(result.credits == original.credits)
+        #expect(result.sourceLabel == original.sourceLabel)
+        #expect(result.strategyID == original.strategyID)
+        #expect(result.strategyKind == original.strategyKind)
+        #expect(result.diagnostic == original.diagnostic)
+    }
+
+    @Test
+    func `O auth helper propagates cancellation`() async throws {
+        let usageJSON = self.educationUsageJSON()
+        let usage = try self.decodeUsage(usageJSON)
+        let original = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(usageJSON.utf8),
+            credentials: self.makeCredentials())
+
+        await #expect(throws: CancellationError.self) {
+            try await CodexOAuthFetchStrategy._applySpendControlsMonthlyLimitForTesting(
+                original,
+                usage: usage,
+                credentials: self.makeCredentials(accountId: "credential-account"),
+                context: self.makeContext(),
+                fetcher: { _ in throw CancellationError() })
+        }
+    }
+
+    @Test
+    func `O auth helper skips fetch when gate or credits setting is false`() async throws {
+        let counter = InvocationCounter()
+        let payload = try self.decodeMonthlyUsage(self.monthlyUsageJSON())
+        let educationJSON = self.educationUsageJSON()
+        let education = try self.decodeUsage(educationJSON)
+        let consumerJSON = self.educationUsageJSON(planType: "plus")
+        let consumer = try self.decodeUsage(consumerJSON)
+        let original = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(educationJSON.utf8),
+            credentials: self.makeCredentials())
+        let fetcher: @Sendable (String) async throws -> CodexSpendControlsMonthlyUsageResponse = { _ in
+            await counter.increment()
+            return payload
+        }
+
+        _ = try await CodexOAuthFetchStrategy._applySpendControlsMonthlyLimitForTesting(
+            original,
+            usage: consumer,
+            credentials: self.makeCredentials(accountId: "account"),
+            context: self.makeContext(),
+            fetcher: fetcher)
+        _ = try await CodexOAuthFetchStrategy._applySpendControlsMonthlyLimitForTesting(
+            original,
+            usage: education,
+            credentials: self.makeCredentials(accountId: "account"),
+            context: self.makeContext(includeCredits: false),
+            fetcher: fetcher)
+
+        #expect(await counter.count() == 0)
+    }
+
+    @Test
+    func `O auth monthly endpoint URL requires backend api base`() {
+        let defaultURL = CodexOAuthUsageFetcher._resolveSpendControlsMonthlyUsageURLForTesting(
+            configContents: #"chatgpt_base_url = "https://chatgpt.com/backend-api""#,
+            accountId: "acct-123")
+        let customURL = CodexOAuthUsageFetcher._resolveSpendControlsMonthlyUsageURLForTesting(
+            configContents: #"chatgpt_base_url = "https://example.com/api/codex""#,
+            accountId: "acct-123")
+
+        #expect(defaultURL?.absoluteString ==
+            "https://chatgpt.com/backend-api/accounts/acct-123/spend-controls/current-user/monthly-usage")
+        #expect(customURL == nil)
+    }
+
+    @Test
+    func `O auth monthly endpoint request uses bearer account and bounded timeout`() async throws {
+        let payload = Data(self.monthlyUsageJSON().utf8)
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.url?.absoluteString ==
+                "https://chatgpt.com/backend-api/accounts/acct-123/spend-controls/current-user/monthly-usage")
+            #expect(request.httpMethod == "GET")
+            #expect(request.timeoutInterval == 3)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer access")
+            #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-Id") == "acct-123")
+            #expect(request.value(forHTTPHeaderField: "User-Agent") == "CodexBar")
+            #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+            return (payload, response)
+        }
+
+        let response = try await CodexOAuthUsageFetcher.fetchSpendControlsMonthlyUsage(
+            accessToken: "access",
+            accountId: "acct-123",
+            env: ["CODEX_HOME": "/tmp/codexbar-monthly-usage-fixture-home"],
+            timeout: 3,
+            session: transport)
+
+        #expect(response.effectiveMonthlyLimit?.limit == 7000)
+        #expect(await transport.requests().count == 1)
+    }
+
+    #if os(macOS)
+    @MainActor
+    @Test
+    func `dashboard education path fetches and maps monthly usage in two requests`() async {
+        let result = await self.fetchDashboardScenario(.educationSuccess)
+
+        #expect(result?.codexCreditLimit?.limit == 7000)
+        #expect(result?.codexCreditLimit?.used == 3046.4506806135178)
+        #expect(DashboardSpendControlsURLProtocol.recordedRequests.count == 2)
+    }
+
+    @MainActor
+    @Test
+    func `dashboard consumer path does not fetch monthly usage`() async {
+        let result = await self.fetchDashboardScenario(.consumer)
+
+        #expect(result?.codexCreditLimit == nil)
+        #expect(DashboardSpendControlsURLProtocol.recordedRequests.count == 1)
+    }
+
+    @MainActor
+    @Test
+    func `dashboard monthly endpoint failure keeps original data`() async {
+        let result = await self.fetchDashboardScenario(.educationNotFound)
+
+        #expect(result?.primaryLimit?.usedPercent == 10)
+        #expect(result?.codexCreditLimit == nil)
+        #expect(DashboardSpendControlsURLProtocol.recordedRequests.count == 2)
+    }
+
+    @Test
+    func `dashboard monthly endpoint percent encodes account path component`() {
+        let url = OpenAIDashboardFetcher.dashboardSpendControlsMonthlyUsageAPIRequest(
+            accountId: "acct/a b",
+            cookieHeader: "session=test")?.url
+
+        #expect(url?.absoluteString.contains("/accounts/acct%2Fa%20b/spend-controls/") == true)
+    }
+
+    @MainActor
+    private func fetchDashboardScenario(_ scenario: DashboardSpendControlsURLProtocol.Scenario) async
+        -> OpenAIDashboardFetcher.DashboardAPIData?
+    {
+        DashboardSpendControlsURLProtocol.reset(scenario: scenario)
+        let configuration = CodexAuthenticatedHTTPTransport.makeConfiguration()
+        configuration.protocolClasses = [DashboardSpendControlsURLProtocol.self]
+        let transport = CodexAuthenticatedHTTPTransport.makeClient(configuration: configuration)
+        return await CodexAuthenticatedHTTPTransport.$overrideForTesting.withValue(transport) {
+            await OpenAIDashboardFetcher.fetchDashboardUsageAPI(
+                cookieHeader: "session=test",
+                deadline: nil,
+                logger: { _ in })
+        }
+    }
+    #endif
+}
+
+#if os(macOS)
+private final class DashboardSpendControlsURLProtocol: URLProtocol {
+    enum Scenario {
+        case educationSuccess
+        case educationNotFound
+        case consumer
+    }
+
+    private(set) nonisolated(unsafe) static var recordedRequests: [URLRequest] = []
+    private nonisolated(unsafe) static var scenario = Scenario.educationSuccess
+
+    static func reset(scenario: Scenario) {
+        self.recordedRequests = []
+        self.scenario = scenario
+    }
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.recordedRequests.append(self.request)
+        guard let url = self.request.url else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        let isMonthlyUsage = url.path.hasSuffix("/spend-controls/current-user/monthly-usage")
+        let status: Int
+        let payload: String
+        if isMonthlyUsage {
+            switch Self.scenario {
+            case .educationSuccess:
+                status = 200
+                payload = """
+                {"current_month_usage":3046.4506806135178,"effective_monthly_limit":{
+                  "limit":7000,"enforcement_mode":"HARD_CAP","limit_mode":"amount_credits"}}
+                """
+            case .educationNotFound:
+                status = 404
+                payload = #"{"error":"not found"}"#
+            case .consumer:
+                status = 500
+                payload = #"{"error":"unexpected monthly request"}"#
+            }
+        } else {
+            status = 200
+            let plan = Self.scenario == .consumer ? "plus" : "education"
+            payload = """
+            {"account_id":"acct-123","plan_type":"\(plan)","spend_control":{"individual_limit":null},
+             "rate_limit":{"primary_window":{"used_percent":10,"reset_at":1786161204,
+             "limit_window_seconds":18000},"secondary_window":null}}
+            """
+        }
+
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: status,
+            httpVersion: nil,
+            headerFields: nil)
+        else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        self.client?.urlProtocol(self, didLoad: Data(payload.utf8))
+        self.client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+#endif


### PR DESCRIPTION
Fixes #2900

## Summary

ChatGPT EDU accounts (`plan_type: "education"`) report `spend_control.individual_limit` as `null` in `wham/usage`, so the #2737 parsing has nothing to consume and CodexBar never shows the administrator-defined monthly usage limit. ChatGPT.app fetches that limit from a separate endpoint:

    GET https://chatgpt.com/backend-api/accounts/{account_id}/spend-controls/current-user/monthly-usage

This PR queries that endpoint when a monthly limit is plausible but missing, and maps the response into the existing `CodexCreditLimitSnapshot` model so the UI renders it exactly like the #2736/#2737 team-account limit:

- `effective_monthly_limit.limit` -> limit
- `current_month_usage` -> used
- remaining % computed from the two
- `effective_monthly_limit.enforcement_mode` decides whether the limit is active (`none`/`off`/`disabled`/`no_limit` suppress it; `HARD_CAP`, `SOFT_CAP`, missing, and unknown modes count as active)

## Gating (no extra request for everyone)

The extra request fires only when all of these hold:

- `wham/usage` supplied no usable monthly limit (root, `rate_limit`, and `spend_control` variants all absent/null) — an existing limit is never overwritten
- the `spend_control` key is present in the payload (even with a null individual limit), signalling a workspace with spend controls
- the plan type is workspace-managed (`team`, `business`, `education`, `quorum`, `k12`, `enterprise`, `edu`, `free_workspace`); consumer plans (`plus`, `pro`, `free`, ...) and unknown/missing plans never trigger it
- an account id is available, and (OAuth path) credits were requested

Wired into both API-first paths: the Codex OAuth strategy (Bearer + `ChatGPT-Account-Id`, custom `chatgpt_base_url` respected, non-backend-api bases skip the call) and the OpenAI web dashboard preflight (cookie-authenticated, bounded by the existing deadline).

## Fail-soft

Any endpoint failure (401/403/404/5xx, network, malformed JSON, expired deadline, invalid account id) keeps the previous behavior: no monthly row, no surfaced error. Cancellation propagates.

## Tests

`Tests/CodexBarTests/CodexSpendControlsMonthlyUsageTests.swift` (21 tests): the EDU fixture pair from the issue produces the monthly row (3046.45 of 7000, ~56.5% remaining); enforcement-mode matrix; gate negatives (consumer plans, existing limit, missing spend_control, missing plan); OAuth helper injection/error/cancellation/skip counting; dashboard path request counting (EDU = 2 requests, consumer = 1, 404 keeps original data); URL resolution + percent-encoding.

## Commands run

- `swift test --filter CodexSpendControlsMonthlyUsage` (21/21 pass)
- `swift test --filter CodexOAuthRequestTests --filter CodexOAuthCreditLimitTests --filter CodexOAuthResetCreditFetchTests` (25/25 pass)
- `make check` (0 violations)
- `make test` (full sharded suite, 0 failed groups)

Thanks @ygnask for the excellent report with the exact payload shapes!
