### PR TITLE
Preserve wider Codex history across dashboard projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.5 — Unreleased
 
 ### Fixed
+- Codex: preserve wider retained cost history when Usage & Spend projects 7- or 30-day views under cache pressure (#2914).
 - Merged menu: provider detail cards that render the inline token/cost chart now open the cost-history submenu on hover, matching the Overview card (#2885). Thanks @SJY051!
 
 ## 0.49.4 — 2026-08-13

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
@@ -66,6 +66,9 @@ extension CostUsageStore {
         skipIdenticalContent: Bool = false) -> CostUsageStoreBudgetResult
     {
         let previous = self.readSnapshot()
+        let budgetProtectionWindow = Self.budgetProtectionWindow(
+            cache: cache,
+            requestedScanWindow: requestedScanWindow)
         if skipIdenticalContent,
            Self.persistedContentMatches(
                previous: previous,
@@ -77,8 +80,8 @@ extension CostUsageStore {
             let result = self.enforceBudgets(
                 maxRows: rowBudget,
                 maxFileBytes: fileBudgetBytes,
-                requestedSinceDay: requestedScanWindow.sinceKey,
-                requestedUntilDay: requestedScanWindow.untilKey,
+                requestedSinceDay: budgetProtectionWindow.sinceKey,
+                requestedUntilDay: budgetProtectionWindow.untilKey,
                 calendar: calendar)
             guard !result.catchUpRequired else { return result }
             Self.identicalContentPreLockCheckpointForTesting?()
@@ -157,8 +160,8 @@ extension CostUsageStore {
         let result = self.enforceBudgets(
             maxRows: rowBudget,
             maxFileBytes: fileBudgetBytes,
-            requestedSinceDay: requestedScanWindow.sinceKey,
-            requestedUntilDay: requestedScanWindow.untilKey,
+            requestedSinceDay: budgetProtectionWindow.sinceKey,
+            requestedUntilDay: budgetProtectionWindow.untilKey,
             calendar: calendar)
         if result.catchUpRequired, self.fetchMetadata().previousReportPayload == nil,
            let previous = Self.previousReport(cache: cache, calendar: calendar, reportWindow: reportWindow)
@@ -204,6 +207,21 @@ extension CostUsageStore {
         var usage = usage
         usage.codexScanComplete = usage.codexScanComplete ?? true
         return usage
+    }
+
+    private static func budgetProtectionWindow(
+        cache: CostUsageCache,
+        requestedScanWindow: (sinceKey: String, untilKey: String)) -> (sinceKey: String, untilKey: String)
+    {
+        // Report and dashboard windows are projections, not retention boundaries. Preserve the
+        // cache's retained coverage while still protecting any newly requested extension.
+        guard let retainedSinceKey = cache.scanSinceKey,
+              let retainedUntilKey = cache.scanUntilKey,
+              retainedSinceKey <= retainedUntilKey
+        else { return requestedScanWindow }
+        return (
+            sinceKey: min(retainedSinceKey, requestedScanWindow.sinceKey),
+            untilKey: max(retainedUntilKey, requestedScanWindow.untilKey))
     }
 }
 

--- a/Tests/CodexBarTests/CostUsageStoreTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreTests.swift
@@ -1596,6 +1596,74 @@ extension CostUsageStoreTests {
 
 extension CostUsageStoreTests {
     @Test
+    func `narrow dashboard windows preserve wider retained cache under byte pressure`() async throws {
+        let fixture = try StoreFixture()
+        defer { fixture.remove() }
+        let store = CostUsageStore(cacheRoot: fixture.root)
+        let calendar = CostUsageScanner.CostUsageDayRange.localGregorianCalendar()
+        let retainedWindow = (sinceKey: "2025-08-15", untilKey: "2026-08-14")
+        let olderDay = "2026-01-15"
+        let recentDay = "2026-08-14"
+        let model = "gpt-5.5"
+        let olderPath = "/rollouts/older.jsonl"
+        let recentPath = "/rollouts/recent.jsonl"
+
+        func usage(day: String, mtimeUnixMs: Int64) -> CostUsageFileUsage {
+            var value = CostUsageFileUsage(
+                mtimeUnixMs: mtimeUnixMs,
+                size: 500,
+                days: [day: [model: [1, 0, 0]]])
+            value.parsedBytes = 500
+            value.codexScanComplete = true
+            return value
+        }
+
+        let olderUsage = usage(day: olderDay, mtimeUnixMs: 1)
+        let recentUsage = usage(day: recentDay, mtimeUnixMs: 2)
+        var cache = CostUsageCache()
+        cache.scanSinceKey = retainedWindow.sinceKey
+        cache.scanUntilKey = retainedWindow.untilKey
+        cache.timeZoneIdentifier = calendar.timeZone.identifier
+        cache.files = [olderPath: olderUsage, recentPath: recentUsage]
+        cache.days = olderUsage.days.merging(recentUsage.days) { _, recent in recent }
+
+        let seeded = store.syncSaveCodexCache(
+            cache,
+            calendar: calendar,
+            requestedScanWindow: retainedWindow,
+            fileBudgetBytes: 1)
+        #expect(seeded.deletedRows == 0)
+        #expect(seeded.rowCount == 2)
+
+        let dashboardWindows = [
+            (sinceKey: "2026-07-16", skipIdenticalContent: true),
+            (sinceKey: "2026-08-08", skipIdenticalContent: false),
+        ]
+        for dashboardWindow in dashboardWindows {
+            let result = store.syncSaveCodexCache(
+                cache,
+                calendar: calendar,
+                requestedScanWindow: (sinceKey: dashboardWindow.sinceKey, untilKey: recentDay),
+                fileBudgetBytes: 1,
+                skipIdenticalContent: dashboardWindow.skipIdenticalContent)
+            let report = await store.readReport(
+                sinceDay: retainedWindow.sinceKey,
+                untilDay: retainedWindow.untilKey)
+            let metadata = await store.fetchMetadata()
+
+            #expect(result.catchUpRequired == false)
+            #expect(result.deletedRows == 0)
+            #expect(result.rowCount == 2)
+            #expect(result.fileBytes > 1)
+            #expect(await store.fetchFile(path: olderPath) != nil)
+            #expect(await store.fetchFile(path: recentPath) != nil)
+            #expect(report.aggregates.map(\.day) == [olderDay, recentDay])
+            #expect(metadata.scanSinceDay == retainedWindow.sinceKey)
+            #expect(metadata.scanUntilDay == retainedWindow.untilKey)
+        }
+    }
+
+    @Test
     func `row budget deletes oldest rows to cap`() async throws {
         let fixture = try StoreFixture()
         defer { fixture.remove() }


### PR DESCRIPTION
## Summary

- keep retained Codex cache coverage independent of 7- and 30-day Usage & Spend projections
- protect the union of retained and newly requested scan bounds during byte-budget enforcement
- cover both identical-content and full-save persistence paths with a synthetic regression

## Reproduction

The regression was reproduced against the v0.49.4 tag using a temporary synthetic store:

- a wider retained window was seeded with one older and one recent complete row
- 30-day and 7-day dashboard requests each evicted the older row under byte pressure
- persisted scan metadata narrowed to the dashboard boundary

No real cache, account data, credentials, or logs were used.

## Validation

- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter 'narrow dashboard windows preserve wider retained cache under byte pressure'`
- focused 118-test scanner/store group
- `make check`
- `make test` passed groups 1–61, including all cache/scanner/dashboard groups; group 62 hit an unrelated status-menu shared-state failure. Each half of that group passes independently.

This is distinct from #2864, which changes Finish now scope and progress rather than retention ownership.

Closes #2914
Refs #2823, #2825, #2861