### PR TITLE
Reuse one Antigravity localhost URLSession to avoid Linux use-after-free teardown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Codex: preserve the wider retained cost history when Usage & Spend saves a 7- or 30-day projection under cache row/byte pressure, instead of pruning older rows and narrowing the persisted scan window (#2914, #2915). Thanks @thomaschow19!
+- CLI (Linux): stop creating and invalidating a URLSession per Antigravity localhost request; per-request session teardown exercised a FoundationNetworking/libdispatch socket-lifecycle race that could crash serve daemons and one-shot usage runs with a use-after-free (#2243). Thanks @psl75011 for the crash forensics!
 
 ## 0.49.5 — 2026-08-13
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -808,6 +808,23 @@ public struct AntigravityStatusProbe: Sendable {
         "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary"
     private static let unleashPath = "/exa.language_server_pb.LanguageServerService/GetUnleashData"
     private static let log = CodexBarLog.logger(LogCategories.provider(.antigravity))
+    private static let localhostDelegate = LocalhostSessionDelegate()
+    /// Reuse one process-lifetime session. Per-request invalidation exercises a FoundationNetworking/libdispatch
+    /// socket-teardown race on Linux that can manifest as a use-after-free.
+    /// See #2243 and swiftlang/swift-corelibs-foundation#4791.
+    private static let localhostSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 120
+        #if !os(Linux)
+        config.waitsForConnectivity = false
+        #endif
+        return URLSession(configuration: config, delegate: Self.localhostDelegate, delegateQueue: nil)
+    }()
+
+    static var localhostSessionForTesting: URLSession {
+        self.localhostSession
+    }
 
     public init(timeout: TimeInterval = 8.0, processScope: ProcessScope = .ideAndCLI) {
         self.timeout = timeout
@@ -1585,7 +1602,7 @@ public struct AntigravityStatusProbe: Sendable {
             deadline: context.deadline)
     }
 
-    private static func makeRequest(
+    static func makeRequest(
         payload: RequestPayload,
         context: RequestContext) async throws -> Data
     {
@@ -1673,18 +1690,7 @@ public struct AntigravityStatusProbe: Sendable {
             request.setValue(endpoint.csrfToken, forHTTPHeaderField: "X-Codeium-Csrf-Token")
         }
 
-        let config = URLSessionConfiguration.ephemeral
-        config.timeoutIntervalForRequest = timeout
-        config.timeoutIntervalForResource = timeout
-        #if !os(Linux)
-        config.waitsForConnectivity = false
-        #endif
-
-        let delegate = LocalhostSessionDelegate()
-        let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
-        defer { session.invalidateAndCancel() }
-
-        let (data, response) = try await delegate.data(for: request, session: session)
+        let (data, response) = try await self.localhostDelegate.data(for: request, session: self.localhostSession)
         guard let http = response as? HTTPURLResponse else {
             throw AntigravityStatusProbeError.apiError("Invalid response")
         }

--- a/Tests/CodexBarTests/AntigravityLocalhostSessionLifetimeTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalhostSessionLifetimeTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+@testable import CodexBarCore
+
+/// Regression coverage for #2243: the Antigravity localhost probe must reuse one
+/// process-lifetime URLSession instead of creating and invalidating a session per
+/// request, which exercised a FoundationNetworking/libdispatch socket-teardown
+/// race on Linux (swiftlang/swift-corelibs-foundation#4791).
+struct AntigravityLocalhostSessionLifetimeTests {
+    @Test
+    func `localhost requests reuse one session and delegate`() {
+        let first = AntigravityStatusProbe.localhostSessionForTesting
+        let second = AntigravityStatusProbe.localhostSessionForTesting
+
+        #expect(first === second)
+        #expect(first.delegate is LocalhostSessionDelegate)
+    }
+
+    @Test
+    func `concurrent requests to a closed localhost port all throw without teardown churn`() async throws {
+        let port = try Self.closedLoopbackPort()
+        let thrownCount = await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<32 {
+                group.addTask {
+                    do {
+                        _ = try await AntigravityStatusProbe.makeRequest(
+                            payload: AntigravityStatusProbe.RequestPayload(path: "/closed", body: [:]),
+                            context: AntigravityStatusProbe.RequestContext(
+                                endpoints: [
+                                    AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                                        scheme: "http",
+                                        port: port,
+                                        csrfToken: "",
+                                        source: .languageServer),
+                                ],
+                                timeout: 0.5))
+                        return false
+                    } catch {
+                        return true
+                    }
+                }
+            }
+
+            var count = 0
+            for await didThrow in group where didThrow {
+                count += 1
+            }
+            return count
+        }
+
+        #expect(thrownCount == 32)
+    }
+
+    /// Reserves an ephemeral loopback port and releases it so requests hit a
+    /// guaranteed-closed port (connection refused) without external traffic.
+    private static func closedLoopbackPort() throws -> Int {
+        #if canImport(Glibc)
+        let streamType = Int32(SOCK_STREAM.rawValue)
+        #else
+        let streamType = SOCK_STREAM
+        #endif
+        let fileDescriptor = socket(AF_INET, streamType, 0)
+        guard fileDescriptor >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        defer { close(fileDescriptor) }
+
+        var address = sockaddr_in()
+        #if canImport(Darwin)
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        #endif
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                bind(fileDescriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+
+        var addressLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                getsockname(fileDescriptor, socketAddress, &addressLength)
+            }
+        }
+        guard nameResult == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        return Int(UInt16(bigEndian: address.sin_port))
+    }
+}


### PR DESCRIPTION
## Summary

Bounded fix for the recurring Linux use-after-free crash reported in #2243 (SIGSEGV/GPF with the Swift freed-object clobber pattern at the fault address, victim frames in musl `free()`/mallocng `get_meta` and libdispatch `_dispatch_event_loop_drain`).

### Root-cause analysis

The captured core showed a concurrent thread executing the `$defer` teardown of `AntigravityStatusProbe.sendRequest`. That teardown is `session.invalidateAndCancel()` on a URLSession created fresh for every single HTTP attempt. On Linux, FoundationNetworking's `URLSession._MultiHandle` wraps libcurl sockets in DispatchSources, and session/socket teardown racing DispatchSource cancellation is a long-documented crash family upstream — swiftlang/swift-corelibs-foundation#4791 ("`URLSession._MultiHandle` doesn't wait for `DispatchSource` cancel handler") and SR-12079 both show exactly this signature (`_dispatch_event_loop_drain` faulting on corrupted state), with timeouts and connection-refused paths as the classic triggers. The 6.2.1 fix for #4791 (f9a54f3, "Cancel DispatchSource before closing socket") narrowed but did not eliminate the family; upstream has continued landing teardown thread-safety fixes into 2026 (swiftlang/swift-corelibs-foundation#5321, #5411, both motivated by elusive `curl_multi_cleanup` race crashes).

The Antigravity probe is the only place in the CLI that mass-produces `URLSession` create → `invalidateAndCancel()` cycles: endpoint connectivity probing (ports × schemes — Linux probes both `https` and `http`) plus per-endpoint retries means one probe run churns many sessions, each teardown re-rolling the race dice under exactly the timeout/conn-refused conditions the upstream issues name. Both reported crash modes (cron one-shot `usage --provider antigravity --source cli` and the `serve` daemon at 120 s refresh) run this same path, matching the reporter's observation that the crash is independent of daemon uptime.

This also explains why earlier detector runs on the *await-invalidation* theory came up empty: the freed object isn't the app-owned `LocalhostSessionDelegate` (Foundation retains it through `didBecomeInvalidWithError`), it's FoundationNetworking/libdispatch internals — which TSan/ASan on a different kernel/allocator and a few minutes of stress did not catch.

### Fix

Stop churning sessions. `AntigravityStatusProbe` now holds one process-lifetime `URLSession` + `LocalhostSessionDelegate` for all localhost requests, eliminating every per-request `invalidateAndCancel()` from both one-shot and serve flows. This matches how the rest of the codebase already treats sessions (`ProviderHTTPClient.shared` is long-lived). Per-attempt timeouts remain enforced through `request.timeoutInterval` (which FoundationNetworking's `HTTPURLProtocol` honors over the configuration value) plus the existing `RequestContext` deadline logic; task-level cancellation via `LocalhostSessionTaskState` is unchanged.

Because the crash is only statistically reproducible (every 1–2 days under production cron on the reporter's host), this is "Refs" rather than "Fixes": the change removes the app-owned trigger of a proven upstream race signature, but confirmation needs soak time on the affected host.

### Tests

- `AntigravityLocalhostSessionLifetimeTests`: session identity/reuse assertion, plus a CI-safe stress test firing 32 concurrent `makeRequest` calls at a guaranteed-closed loopback port (reserved via bind-to-port-0 then released), asserting all complete with errors.

### Proof

- `make check` clean (SwiftFormat + SwiftLint strict, 0 violations)
- `swift test --filter AntigravityLocalhostSessionLifetimeTests` — 2/2 pass
- `swift test --filter AntigravityStatusProbeTests` — 62/62 pass
- `make test` full sharded suite — 857 selections, all groups green (1 timed-out group recovered on retry)
- Codex autoreview clean (0.98, no findings)

Refs #2243

cc @psl75011 — if you can update to a build containing this change, your production cadence (crash every 1–2 days) is the best available verdict; the `ip:1ae21a0` kernel-trap signature disappearing over a week of soak would confirm.
