### PR TITLE
Throttle background Claude CLI usage spawns to a 15-minute floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Ollama: allow the `auto` and `web` usage sources on Linux when a non-empty manual Cookie header is configured, while keeping automatic browser-cookie imports gated to supported platforms (#2919). Thanks @dhabyx!
 - Codex: preserve the wider retained cost history when Usage & Spend saves a 7- or 30-day projection under cache row/byte pressure, instead of pruning older rows and narrowing the persisted scan window (#2914, #2915). Thanks @thomaschow19!
+- Claude: reuse the last successful CLI usage result for 15 minutes during background refreshes instead of relaunching the ~280 MB Claude Code binary on every tick, cutting background disk reads and process churn for CLI-sourced usage; manual refreshes still probe immediately (#2916).
 
 ## 0.49.5 — 2026-08-13
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLIUsageSpawnThrottle.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLIUsageSpawnThrottle.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Bounds how often background refreshes may relaunch the Claude CLI for a usage probe (#2916).
+/// Each CLI usage fetch spawns the full ~280 MB Claude Code binary, so background ticks reuse the
+/// last successful CLI result within a floor interval instead of respawning. User-initiated
+/// refreshes always spawn so the manual Refresh action stays fresh.
+enum ClaudeCLIUsageSpawnThrottle {
+    struct Key: Hashable {
+        let binary: String
+        let accountScope: String
+        let useWebExtras: Bool
+        let includePrepaidBalance: Bool
+    }
+
+    struct Entry {
+        let result: ProviderFetchResult
+        let recordedAt: Date
+    }
+
+    /// Matches the repo's existing 15-minute floor precedent for expensive local work
+    /// (`UsageStore.minimumTokenFetchTTL`).
+    static let minimumBackgroundSpawnInterval: TimeInterval = 15 * 60
+
+    final class Store: @unchecked Sendable {
+        private let lock = NSLock()
+        private var entries: [Key: Entry] = [:]
+
+        func insert(_ entry: Entry, for key: Key) {
+            self.lock.withLock {
+                self.entries[key] = entry
+            }
+        }
+
+        func lookup(_ key: Key, now: Date) -> Entry? {
+            self.lock.withLock {
+                guard let entry = self.entries[key] else { return nil }
+                guard now.timeIntervalSince(entry.recordedAt) < minimumBackgroundSpawnInterval,
+                      !ClaudeCLIUsageSpawnThrottle.anyWindowHasReset(in: entry.result.usage, now: now)
+                else {
+                    self.entries.removeValue(forKey: key)
+                    return nil
+                }
+                return entry
+            }
+        }
+
+        func removeAll() {
+            self.lock.withLock {
+                self.entries.removeAll()
+            }
+        }
+    }
+
+    private static let log = CodexBarLog.logger(LogCategories.provider(.claude, scope: "usage"))
+    private static let sharedStore = Store()
+    @TaskLocal private static var storeOverrideForTesting: Store?
+    @TaskLocal private static var nowOverrideForTesting: (@Sendable () -> Date)?
+
+    private static var store: Store {
+        self.storeOverrideForTesting ?? self.sharedStore
+    }
+
+    private static var now: Date {
+        self.nowOverrideForTesting?() ?? Date()
+    }
+
+    /// nil when the Claude profile exposes no stable account identity
+    /// (`ClaudeAccountProfile.identifiedSessionScope` returns nil) — such profiles are never cached.
+    static func key(
+        binary: String,
+        environment: [String: String],
+        useWebExtras: Bool,
+        includePrepaidBalance: Bool) -> Key?
+    {
+        guard let accountScope = ClaudeAccountProfile.identifiedSessionScope(environment: environment) else {
+            return nil
+        }
+        return Key(
+            binary: binary,
+            accountScope: accountScope,
+            useWebExtras: useWebExtras,
+            includePrepaidBalance: includePrepaidBalance)
+    }
+
+    /// Returns the cached result when it is younger than `minimumBackgroundSpawnInterval`.
+    /// A stale or missing entry returns nil (and a stale entry is removed).
+    static func cachedResult(for key: Key) -> ProviderFetchResult? {
+        let now = self.now
+        guard let entry = self.store.lookup(key, now: now) else { return nil }
+        let ageSeconds = max(0, now.timeIntervalSince(entry.recordedAt))
+        Self.log.debug(
+            "Reusing cached Claude CLI usage result",
+            metadata: ["ageSeconds": "\(ageSeconds)"])
+        return entry.result
+    }
+
+    static func record(_ result: ProviderFetchResult, for key: Key) {
+        self.store.insert(Entry(result: result, recordedAt: self.now), for: key)
+    }
+
+    /// A cached result is unusable once any of its rate windows crosses its reset boundary: the
+    /// session/weekly percentages then describe the previous window, and the reset-boundary refresh
+    /// scheduler exists precisely to publish the post-reset state promptly.
+    static func anyWindowHasReset(in usage: UsageSnapshot, now: Date) -> Bool {
+        let windows = [usage.primary, usage.secondary, usage.tertiary]
+            .compactMap(\.self)
+            + (usage.extraRateWindows?.map(\.window) ?? [])
+        return windows.contains { window in
+            guard let resetsAt = window.resetsAt else { return false }
+            return resetsAt <= now
+        }
+    }
+
+    #if DEBUG
+    static func withIsolatedStoreForTesting<T>(
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$storeOverrideForTesting.withValue(Store()) {
+            try await operation()
+        }
+    }
+
+    static func withNowOverrideForTesting<T>(
+        _ now: @escaping @Sendable () -> Date,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$nowOverrideForTesting.withValue(now) {
+            try await operation()
+        }
+    }
+    #endif
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -1008,6 +1008,22 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let binary = ClaudeCLIResolver.resolvedBinaryPath(environment: context.env)
+        let throttleKey = binary.flatMap {
+            ClaudeCLIUsageSpawnThrottle.key(
+                binary: $0,
+                environment: context.env,
+                useWebExtras: self.useWebExtras,
+                includePrepaidBalance: self.includePrepaidBalance && context.includeOptionalUsage)
+        }
+        if context.runtime == .app,
+           ProviderInteractionContext.current == .background,
+           !context.claudeOwnerCLIRecoveryOnly,
+           let throttleKey,
+           let cached = ClaudeCLIUsageSpawnThrottle.cachedResult(for: throttleKey)
+        {
+            return cached
+        }
         let keepAlive = context.settings?.debugKeepCLISessionsAlive ?? false
         let fetcher = ClaudeUsageFetcher(
             browserDetection: browserDetection,
@@ -1019,7 +1035,6 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
             webExtrasTimeout: context.webTimeout,
             includePrepaidBalance: self.includePrepaidBalance && context.includeOptionalUsage,
             keepCLISessionsAlive: keepAlive)
-        let binary = ClaudeCLIResolver.resolvedBinaryPath(environment: context.env)
         let backgroundAvailabilityMarker = binary.flatMap {
             ClaudeCLIBackgroundAvailability.captureMarker(binary: $0, environment: context.env)
         }
@@ -1041,11 +1056,15 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
         {
             ClaudeCLIBackgroundAvailability.establish(backgroundAvailabilityMarker)
         }
-        return self.makeResult(
+        let result = self.makeResult(
             // The PTY /usage panel exposes rendered percentages only, so CLI-sourced data carries an
             // explicit degraded-fidelity marker that the card surfaces as "via Claude CLI".
             usage: ClaudeOAuthFetchStrategy.snapshot(from: usage, dataConfidence: .percentOnly),
             sourceLabel: "claude")
+        if let throttleKey {
+            ClaudeCLIUsageSpawnThrottle.record(result, for: throttleKey)
+        }
+        return result
     }
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {

--- a/Tests/CodexBarTests/ClaudeCLIUsageSpawnThrottleTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLIUsageSpawnThrottleTests.swift
@@ -1,0 +1,326 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeCLIUsageSpawnThrottleTests {
+    private actor AttemptRecorder {
+        private var count = 0
+
+        func record() -> Int {
+            self.count += 1
+            return self.count
+        }
+
+        func snapshot() -> Int {
+            self.count
+        }
+    }
+
+    private final class TestClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: Date
+
+        init(_ value: Date) {
+            self.value = value
+        }
+
+        func now() -> Date {
+            self.lock.withLock { self.value }
+        }
+
+        func advance(by interval: TimeInterval) {
+            self.lock.withLock {
+                self.value = self.value.addingTimeInterval(interval)
+            }
+        }
+    }
+
+    @Test
+    func `background refresh reuses the cached CLI result within the spawn floor`() async throws {
+        let strategy = self.makeStrategy()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
+        let attempts = AttemptRecorder()
+
+        try await self.withGateStack {
+            try await ClaudeStatusProbe.$fetchOverride.withValue(self.successfulFetchOverride(attempts: attempts)) {
+                let first = try await self.fetch(strategy, context: context, interaction: .background)
+                let second = try await self.fetch(strategy, context: context, interaction: .background)
+
+                #expect(await attempts.snapshot() == 1)
+                #expect(second.usage.primary?.usedPercent == first.usage.primary?.usedPercent)
+                #expect(second.usage.secondary?.usedPercent == first.usage.secondary?.usedPercent)
+                #expect(second.usage.updatedAt == first.usage.updatedAt)
+            }
+        }
+    }
+
+    @Test
+    func `background refresh respawns the CLI after the spawn floor elapses`() async throws {
+        let strategy = self.makeStrategy()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
+        let attempts = AttemptRecorder()
+        let clock = TestClock(Date(timeIntervalSince1970: 1_000_000))
+
+        try await self.withGateStack {
+            try await ClaudeCLIUsageSpawnThrottle.withNowOverrideForTesting(clock.now) {
+                try await ClaudeStatusProbe.$fetchOverride.withValue(self.successfulFetchOverride(attempts: attempts)) {
+                    let first = try await self.fetch(strategy, context: context, interaction: .background)
+                    clock.advance(by: ClaudeCLIUsageSpawnThrottle.minimumBackgroundSpawnInterval + 1)
+                    let second = try await self.fetch(strategy, context: context, interaction: .background)
+
+                    #expect(await attempts.snapshot() == 2)
+                    #expect(second.usage.primary?.usedPercent != first.usage.primary?.usedPercent)
+                }
+            }
+        }
+    }
+
+    @Test
+    func `user initiated refresh always spawns the CLI`() async throws {
+        let strategy = self.makeStrategy()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
+        let attempts = AttemptRecorder()
+
+        try await self.withGateStack {
+            try await ClaudeStatusProbe.$fetchOverride.withValue(self.successfulFetchOverride(attempts: attempts)) {
+                _ = try await self.fetch(strategy, context: context, interaction: .background)
+                _ = try await self.fetch(strategy, context: context, interaction: .userInitiated)
+
+                #expect(await attempts.snapshot() == 2)
+            }
+        }
+    }
+
+    @Test
+    func `failed CLI fetches are not cached`() async throws {
+        let strategy = self.makeStrategy()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
+        let attempts = AttemptRecorder()
+        let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, _, _ in
+            let attempt = await attempts.record()
+            if attempt == 1 {
+                throw ExpectedFetchError.failed
+            }
+            return Self.makeStatusSnapshot(attempt: attempt)
+        }
+
+        try await self.withGateStack {
+            try await ClaudeStatusProbe.$fetchOverride.withValue(fetchOverride) {
+                await #expect(throws: ExpectedFetchError.self) {
+                    try await self.fetch(strategy, context: context, interaction: .userInitiated)
+                }
+                #expect(await attempts.snapshot() == 1)
+
+                _ = try await self.fetch(strategy, context: context, interaction: .userInitiated)
+                #expect(await attempts.snapshot() == 2)
+
+                _ = try await self.fetch(strategy, context: context, interaction: .background)
+                #expect(await attempts.snapshot() == 2)
+            }
+        }
+    }
+
+    @Test
+    func `account profile change invalidates the cached CLI result`() async throws {
+        let strategy = self.makeStrategy()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
+        let attempts = AttemptRecorder()
+
+        try await self.withGateStack {
+            try await ClaudeStatusProbe.$fetchOverride.withValue(self.successfulFetchOverride(attempts: attempts)) {
+                _ = try await self.fetch(strategy, context: context, interaction: .background)
+                try Data(#"{"oauthAccount":{"accountUuid":"account-b"}}"#.utf8)
+                    .write(to: profile.configURL, options: .atomic)
+                _ = try await self.fetch(strategy, context: context, interaction: .background)
+
+                #expect(await attempts.snapshot() == 2)
+            }
+        }
+    }
+
+    @Test
+    func `owner CLI recovery pass bypasses the cached result`() async throws {
+        let strategy = self.makeStrategy()
+        let profile = try self.makeProfile(accountID: "account-a")
+        defer { try? FileManager.default.removeItem(at: profile.root) }
+        let context = self.makeContext(environment: profile.environment)
+        let recoveryContext = self.makeContext(
+            environment: profile.environment,
+            claudeOwnerCLIRecoveryOnly: true)
+        let attempts = AttemptRecorder()
+
+        try await self.withGateStack {
+            try await ClaudeStatusProbe.$fetchOverride.withValue(self.successfulFetchOverride(attempts: attempts)) {
+                _ = try await self.fetch(strategy, context: context, interaction: .background)
+                _ = try await self.fetch(strategy, context: recoveryContext, interaction: .background)
+
+                #expect(await attempts.snapshot() == 2)
+            }
+        }
+    }
+
+    @Test
+    func `a session reset boundary invalidates the cached CLI result before the spawn floor elapses`() async {
+        let start = Date(timeIntervalSince1970: 1_000_000)
+        let clock = TestClock(start)
+        // The cached session window resets two minutes out — well inside the 15-minute spawn floor.
+        let result = Self.makeFetchResult(sessionResetsAt: start.addingTimeInterval(2 * 60))
+        let key = ClaudeCLIUsageSpawnThrottle.Key(
+            binary: "/bin/echo",
+            accountScope: "scope-a",
+            useWebExtras: false,
+            includePrepaidBalance: false)
+
+        await ClaudeCLIUsageSpawnThrottle.withIsolatedStoreForTesting {
+            await ClaudeCLIUsageSpawnThrottle.withNowOverrideForTesting(clock.now) {
+                ClaudeCLIUsageSpawnThrottle.record(result, for: key)
+                clock.advance(by: 60)
+                #expect(ClaudeCLIUsageSpawnThrottle.cachedResult(for: key) != nil)
+
+                clock.advance(by: 5 * 60)
+                #expect(ClaudeCLIUsageSpawnThrottle.cachedResult(for: key) == nil)
+            }
+        }
+    }
+
+    @Test
+    func `unidentified profiles are never cached`() async throws {
+        let strategy = self.makeStrategy()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-claude-throttle-unidentified-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let context = self.makeContext(environment: ["CLAUDE_CONFIG_DIR": root.path])
+        let attempts = AttemptRecorder()
+
+        try await self.withGateStack {
+            try await ClaudeStatusProbe.$fetchOverride.withValue(self.successfulFetchOverride(attempts: attempts)) {
+                _ = try await self.fetch(strategy, context: context, interaction: .background)
+                _ = try await self.fetch(strategy, context: context, interaction: .background)
+
+                #expect(await attempts.snapshot() == 2)
+            }
+        }
+    }
+
+    private enum ExpectedFetchError: Error {
+        case failed
+    }
+
+    private func makeStrategy() -> ClaudeCLIFetchStrategy {
+        ClaudeCLIFetchStrategy(
+            useWebExtras: false,
+            includePrepaidBalance: false,
+            manualCookieHeader: nil,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            hasWebFallback: false)
+    }
+
+    private func makeContext(
+        environment: [String: String],
+        claudeOwnerCLIRecoveryOnly: Bool = false) -> ProviderFetchContext
+    {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .cli,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: environment,
+            settings: nil,
+            fetcher: UsageFetcher(environment: environment),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection, environment: environment),
+            browserDetection: browserDetection,
+            claudeOwnerCLIRecoveryOnly: claudeOwnerCLIRecoveryOnly)
+    }
+
+    private func makeProfile(accountID: String) throws -> (
+        root: URL,
+        configURL: URL,
+        environment: [String: String])
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-claude-throttle-profile-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let configURL = root.appendingPathComponent(".config.json")
+        try Data(#"{"oauthAccount":{"accountUuid":"\#(accountID)"}}"#.utf8)
+            .write(to: configURL, options: .atomic)
+        return (
+            root: root,
+            configURL: configURL,
+            environment: ["CLAUDE_CONFIG_DIR": root.path])
+    }
+
+    private func fetch(
+        _ strategy: ClaudeCLIFetchStrategy,
+        context: ProviderFetchContext,
+        interaction: ProviderInteraction) async throws -> ProviderFetchResult
+    {
+        try await ProviderInteractionContext.$current.withValue(interaction) {
+            try await strategy.fetch(context)
+        }
+    }
+
+    private func successfulFetchOverride(attempts: AttemptRecorder) -> ClaudeStatusProbe.FetchOverride {
+        { _, _, _ in
+            let attempt = await attempts.record()
+            return Self.makeStatusSnapshot(attempt: attempt)
+        }
+    }
+
+    private static func makeFetchResult(sessionResetsAt: Date?) -> ProviderFetchResult {
+        let usage = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 40,
+                windowMinutes: 5 * 60,
+                resetsAt: sessionResetsAt,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_000_000))
+        return ProviderFetchResult(
+            usage: usage,
+            credits: nil,
+            dashboard: nil,
+            sourceLabel: "claude",
+            strategyID: "claude.cli",
+            strategyKind: .cli)
+    }
+
+    private static func makeStatusSnapshot(attempt: Int) -> ClaudeStatusSnapshot {
+        ClaudeStatusSnapshot(
+            sessionPercentLeft: 90 - attempt,
+            weeklyPercentLeft: 80 - attempt,
+            opusPercentLeft: nil,
+            accountEmail: "cli@example.com",
+            accountOrganization: "CLI Org",
+            loginMethod: "cli",
+            primaryResetDescription: nil,
+            secondaryResetDescription: nil,
+            opusResetDescription: nil,
+            rawText: "probe raw")
+    }
+
+    private func withGateStack<T>(
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await ClaudeCLIUsageSpawnThrottle.withIsolatedStoreForTesting {
+            try await ClaudeCLIBackgroundAvailability.withIsolatedStoreForTesting {
+                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/bin/echo") {
+                    try await operation()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2916

## What actually spawns, and how often

The issue claims CodexBar spawns the ~272 MB Claude Code CLI on every 5-minute refresh. Verified against the code — this is accurate, but only for a specific configuration slice:

- **Who hits it:** users whose Claude usage source is **CLI**, or **Auto** resolving to CLI (no OAuth credentials, no web session), *and* who have opted into background CLI execution (Keychain disabled, or prompt policy `always`, or a prior successful foreground CLI fetch establishing the background availability marker — the #2813 gate). OAuth- and web-sourced users never hit this path.
- **What each cycle costs:** `ClaudeStatusProbe.fetch()` runs the interactive CLI through a PTY for `/usage` and again for `/status` (identity enrichment), so one refresh is typically **2 launches** of the ~280 MB Node binary (`~/.local/share/claude/versions/…`), 3 on a startup-looking retry. At the 5-minute default that's ~576 process launches/day.
- **What was already bounded:** `claude --version` probes were fixed by the 30-minute fingerprinted cache in `ProviderVersionDetector` (plus #2911's one-shot recovery); `claude auth status` only runs on the CLI-runtime path and Auto planning; the rate-limit gate only bounds the failure lane.

On real disk I/O the issue's arithmetic (~34 GB/day) overstates the steady-state cost: repeated reads of the same binary are served from the macOS unified page cache, so most cycles do not hit disk. What *is* real: the first read after eviction, the constant page-cache pressure of re-faulting a ~280 MB image every few minutes (which evicts other data and causes I/O elsewhere), and the CPU/energy cost of cold-starting Node+V8 ~576×/day. The PR body of the fix is honest about this: the win is process-spawn cost and cache pressure, with true disk-read savings dependent on memory pressure.

## The fix

`ClaudeCLIUsageSpawnThrottle` caches the last **successful** CLI fetch result keyed by (binary path, identified account scope, web-extras flag, prepaid-balance flag) and serves it to **background app refreshes** within a **15-minute floor** — the same floor the repo already uses for expensive local work (`UsageStore.minimumTokenFetchTTL`).

The cached result is bypassed/invalidated when it must be:

- **User-initiated refreshes always spawn** (menu Refresh, settings probes) — manual freshness is untouched.
- **CLI-runtime invocations** (`codexbar usage`) always spawn.
- The **owner-CLI recovery pass** (`claudeOwnerCLIRecoveryOnly`) always spawns — it exists to get an authoritative read after an OAuth account mismatch.
- A cached entry whose **rate window crosses its reset boundary** is dropped, so the reset-boundary refresh scheduler still publishes post-reset state promptly.
- An **account/profile swap** changes the key (`ClaudeAccountProfile.identifiedSessionScope`), so stale-account data can never be served; unidentified profiles are never cached.
- **Failures are never cached** — the failure gates and CLI rate-limit gate keep owning that lane.
- The cached snapshot keeps its original `updatedAt`, so menu staleness display stays honest.

## Tradeoff

Users on CLI source with a 1–5-minute refresh interval now get background CLI data at most every 15 minutes (manual refresh unaffected). Rationale: the CLI path is already the lowest-fidelity source (rendered percentages only, `percentOnly` confidence), the PTY probe itself takes 12–60 s per attempt, and the repo already applies exactly this 15-minute floor to token-cost scans for the same energy reason. Reset boundaries — the moment short-interval users actually care about — bypass the cache. OAuth/web users (the recommended sources) keep their configured cadence entirely.

Effect for affected users: ~576 CLI launches/day → ~96/day at default settings (~6× fewer), and proportionally less page-cache churn.

## Proof

- `swift test --filter ClaudeCLIUsageSpawnThrottleTests` — 8 new regression tests through the strategy seam (stubbed `ClaudeStatusProbe.fetchOverride`, spawn counting across simulated refresh cycles, clock override for the floor, profile-swap invalidation, reset-boundary invalidation).
- `make test` — full sharded suite: 857 selections, 72/72 groups green, 0 retries.
- `make check` — SwiftFormat + SwiftLint strict: clean.
- Codex autoreview: clean, no accepted findings.
