### PR TITLE
Fix Gemini Antigravity migration guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.49.7 — Unreleased
 
+### Fixed
+- Gemini: offer the Antigravity provider migration when local OAuth recovery cannot use Gemini CLI and an `agy` or Antigravity installation is available (#2808). Thanks @axisrow!
+
 ## 0.49.6 — 2026-08-14
 
 ### Fixed

--- a/Sources/CodexBar/UsageStore+GeminiMigration.swift
+++ b/Sources/CodexBar/UsageStore+GeminiMigration.swift
@@ -2,7 +2,12 @@ import CodexBarCore
 
 extension UsageStore {
     static func isGeminiConsumerTierDeprecationError(_ error: Error?) -> Bool {
-        (error as? GeminiStatusProbeError) == .consumerTierDeprecated
+        switch error as? GeminiStatusProbeError {
+        case .consumerTierDeprecated, .oauthCredentialsUnavailableWithAntigravity:
+            true
+        default:
+            false
+        }
     }
 
     func observeGeminiConsumerTierDeprecation(from error: Error) {

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiConsumerTierMigration.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiConsumerTierMigration.swift
@@ -13,4 +13,19 @@ public enum GeminiConsumerTierMigration {
     accounts blocked by the June 2026 Gemini CLI shutdown should use CodexBar's Antigravity \
     provider instead. Workspace and education accounts should keep using Gemini.
     """
+
+    public static let localAntigravityHandoffError = """
+    Could not refresh Gemini OAuth credentials from Gemini CLI. Enable CodexBar's Antigravity \
+    provider, sign in to Antigravity or run `agy`, then refresh.
+    """
+
+    static func isAntigravityAvailable() -> Bool {
+        if BinaryLocator.resolveAntigravityBinary() != nil {
+            return true
+        }
+
+        return AntigravityOAuthConfig.candidateOAuthClientArtifactURLs().contains {
+            FileManager.default.fileExists(atPath: $0.path)
+        }
+    }
 }

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -105,6 +105,7 @@ public enum GeminiStatusProbeError: LocalizedError, Sendable, Equatable {
     case notLoggedIn
     case unsupportedAuthType(String)
     case consumerTierDeprecated
+    case oauthCredentialsUnavailableWithAntigravity
     case parseFailed(String)
     case timedOut
     case apiError(String)
@@ -119,6 +120,8 @@ public enum GeminiStatusProbeError: LocalizedError, Sendable, Equatable {
             "Gemini \(authType) auth not supported. Use Google account (OAuth) instead."
         case .consumerTierDeprecated:
             GeminiConsumerTierMigration.deprecationError
+        case .oauthCredentialsUnavailableWithAntigravity:
+            GeminiConsumerTierMigration.localAntigravityHandoffError
         case let .parseFailed(msg):
             "Could not parse Gemini usage: \(msg)"
         case .timedOut:
@@ -172,9 +175,16 @@ public enum GeminiUserTierId: String, Sendable {
 }
 
 public struct GeminiStatusProbe: Sendable {
+    private struct OAuthRecoveryContext: Sendable {
+        let oauthClientResolver: @Sendable () -> GeminiOAuthConfig.ClientCredentials?
+        let antigravityAvailability: @Sendable () -> Bool
+    }
+
     public var timeout: TimeInterval = 10.0
     public var homeDirectory: String
     public var dataLoader: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+    private var oauthClientResolver: @Sendable () -> GeminiOAuthConfig.ClientCredentials?
+    private var antigravityAvailability: @Sendable () -> Bool
     private static let log = CodexBarLog.logger(LogCategories.provider(.gemini, scope: "probe"))
     private static let quotaEndpoint = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota"
     private static let loadCodeAssistEndpoint = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist"
@@ -191,6 +201,22 @@ public struct GeminiStatusProbe: Sendable {
         self.timeout = timeout
         self.homeDirectory = homeDirectory
         self.dataLoader = dataLoader
+        self.oauthClientResolver = { Self.extractOAuthCredentials() }
+        self.antigravityAvailability = { GeminiConsumerTierMigration.isAntigravityAvailable() }
+    }
+
+    init(
+        timeout: TimeInterval = 10.0,
+        homeDirectory: String = NSHomeDirectory(),
+        dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = Self.defaultDataLoader,
+        oauthClientResolver: @escaping @Sendable () -> GeminiOAuthConfig.ClientCredentials?,
+        antigravityAvailability: @escaping @Sendable () -> Bool)
+    {
+        self.timeout = timeout
+        self.homeDirectory = homeDirectory
+        self.dataLoader = dataLoader
+        self.oauthClientResolver = oauthClientResolver
+        self.antigravityAvailability = antigravityAvailability
     }
 
     /// Reads the current Gemini auth type from settings.json
@@ -227,7 +253,9 @@ public struct GeminiStatusProbe: Sendable {
         let snap = try await Self.fetchViaAPI(
             timeout: self.timeout,
             homeDirectory: self.homeDirectory,
-            dataLoader: self.dataLoader)
+            dataLoader: self.dataLoader,
+            oauthClientResolver: self.oauthClientResolver,
+            antigravityAvailability: self.antigravityAvailability)
 
         Self.log.info("Gemini API fetch ok", metadata: [
             "dailyPercentLeft": "\(snap.dailyPercentLeft ?? -1)",
@@ -240,7 +268,9 @@ public struct GeminiStatusProbe: Sendable {
     private static func fetchViaAPI(
         timeout: TimeInterval,
         homeDirectory: String,
-        dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse)) async throws
+        dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse),
+        oauthClientResolver: @escaping @Sendable () -> GeminiOAuthConfig.ClientCredentials?,
+        antigravityAvailability: @escaping @Sendable () -> Bool) async throws
         -> GeminiStatusSnapshot
     {
         let creds = try Self.loadCredentials(homeDirectory: homeDirectory)
@@ -273,7 +303,10 @@ public struct GeminiStatusProbe: Sendable {
                 refreshToken: refreshToken,
                 timeout: timeout,
                 homeDirectory: homeDirectory,
-                dataLoader: dataLoader)
+                dataLoader: dataLoader,
+                recoveryContext: OAuthRecoveryContext(
+                    oauthClientResolver: oauthClientResolver,
+                    antigravityAvailability: antigravityAvailability))
             idToken = (try? Self.loadCredentials(homeDirectory: homeDirectory).idToken) ?? idToken
         }
         guard let accessToken else {
@@ -804,7 +837,8 @@ public struct GeminiStatusProbe: Sendable {
         refreshToken: String,
         timeout: TimeInterval,
         homeDirectory: String,
-        dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse)) async throws
+        dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse),
+        recoveryContext: OAuthRecoveryContext) async throws
         -> String
     {
         guard let url = URL(string: tokenRefreshEndpoint) else {
@@ -816,13 +850,16 @@ public struct GeminiStatusProbe: Sendable {
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = timeout
 
-        guard let oauthCreds = Self.extractOAuthCredentials() else {
+        guard let oauthCreds = recoveryContext.oauthClientResolver() else {
             Self.log.error("Could not extract OAuth credentials from Gemini CLI")
+            if recoveryContext.antigravityAvailability() {
+                throw GeminiStatusProbeError.oauthCredentialsUnavailableWithAntigravity
+            }
             throw GeminiStatusProbeError.apiError(GeminiConsumerTierMigration.oauthRecoveryError)
         }
 
         let body = [
-            "client_id=\(oauthCreds.clientId)",
+            "client_id=\(oauthCreds.clientID)",
             "client_secret=\(oauthCreds.clientSecret)",
             "refresh_token=\(refreshToken)",
             "grant_type=refresh_token",
@@ -1094,20 +1131,24 @@ public struct GeminiStatusProbe: Sendable {
 }
 
 extension GeminiStatusProbe {
-    fileprivate static func extractOAuthCredentials() -> OAuthClientCredentials? {
+    fileprivate static func extractOAuthCredentials() -> GeminiOAuthConfig.ClientCredentials? {
         if let resolved = GeminiOAuthConfig.environmentClient() {
-            return OAuthClientCredentials(clientId: resolved.clientID, clientSecret: resolved.clientSecret)
+            return resolved
         }
         if let path = GeminiOAuthConfig.configuredOAuth2JSPath,
            let credentials = Self.parseOAuthCredentials(fromFile: path)
         {
-            return credentials
+            return GeminiOAuthConfig.ClientCredentials(
+                clientID: credentials.clientId,
+                clientSecret: credentials.clientSecret)
         }
         if let credentials = Self.discoverOAuthCredentialsFromInstalledCLI() {
-            return OAuthClientCredentials(clientId: credentials.clientID, clientSecret: credentials.clientSecret)
+            return credentials
         }
         if let credentials = Self.discoverOAuthCredentialsFromKnownInstallPaths() {
-            return credentials
+            return GeminiOAuthConfig.ClientCredentials(
+                clientID: credentials.clientId,
+                clientSecret: credentials.clientSecret)
         }
         return nil
     }

--- a/Tests/CodexBarTests/GeminiOAuthRecoveryAPITests.swift
+++ b/Tests/CodexBarTests/GeminiOAuthRecoveryAPITests.swift
@@ -1,9 +1,118 @@
-import CodexBarCore
 import Foundation
 import Testing
+@testable import CodexBarCore
 
 @Suite(.serialized)
 struct GeminiOAuthRecoveryAPITests {
+    @Test
+    func `missing gemini cli with antigravity available offers migration guidance`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeCredentials(
+            accessToken: "old-token",
+            refreshToken: "refresh-token",
+            expiry: Date().addingTimeInterval(-3600),
+            idToken: nil)
+
+        let probe = GeminiStatusProbe(
+            timeout: 1,
+            homeDirectory: env.homeURL.path,
+            dataLoader: { _ in throw URLError(.badURL) },
+            oauthClientResolver: { nil },
+            antigravityAvailability: { true })
+
+        await Self.expectError(.oauthCredentialsUnavailableWithAntigravity) {
+            _ = try await probe.fetch()
+        }
+    }
+
+    @Test
+    func `missing gemini cli without antigravity keeps recovery guidance`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeCredentials(
+            accessToken: "old-token",
+            refreshToken: "refresh-token",
+            expiry: Date().addingTimeInterval(-3600),
+            idToken: nil)
+
+        let probe = GeminiStatusProbe(
+            timeout: 1,
+            homeDirectory: env.homeURL.path,
+            dataLoader: { _ in throw URLError(.badURL) },
+            oauthClientResolver: { nil },
+            antigravityAvailability: { false })
+
+        await Self.expectError(.apiError(GeminiConsumerTierMigration.oauthRecoveryError)) {
+            _ = try await probe.fetch()
+        }
+    }
+
+    @Test
+    func `available gemini cli keeps oauth refresh behavior`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeCredentials(
+            accessToken: "old-token",
+            refreshToken: "refresh-token",
+            expiry: Date().addingTimeInterval(-3600),
+            idToken: nil)
+
+        let dataLoader = GeminiAPITestHelpers.dataLoader { request in
+            guard let url = request.url, let host = url.host else {
+                throw URLError(.badURL)
+            }
+            switch host {
+            case "oauth2.googleapis.com":
+                let body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                guard body.contains("client_id=cli-client-id"),
+                      body.contains("client_secret=cli-client-secret")
+                else {
+                    return GeminiAPITestHelpers.response(url: url.absoluteString, status: 400, body: Data())
+                }
+                return GeminiAPITestHelpers.response(
+                    url: url.absoluteString,
+                    status: 200,
+                    body: GeminiAPITestHelpers.jsonData([
+                        "access_token": "new-token",
+                        "expires_in": 3600,
+                    ]))
+            case "cloudresourcemanager.googleapis.com":
+                return GeminiAPITestHelpers.response(
+                    url: url.absoluteString,
+                    status: 200,
+                    body: GeminiAPITestHelpers.jsonData(["projects": []]))
+            case "cloudcode-pa.googleapis.com":
+                if url.path == "/v1internal:loadCodeAssist" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.loadCodeAssistStandardTierResponse())
+                }
+                return GeminiAPITestHelpers.response(
+                    url: url.absoluteString,
+                    status: 200,
+                    body: GeminiAPITestHelpers.sampleQuotaResponse())
+            default:
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            }
+        }
+        let probe = GeminiStatusProbe(
+            timeout: 1,
+            homeDirectory: env.homeURL.path,
+            dataLoader: dataLoader,
+            oauthClientResolver: {
+                GeminiOAuthConfig.ClientCredentials(
+                    clientID: "cli-client-id",
+                    clientSecret: "cli-client-secret")
+            },
+            antigravityAvailability: { true })
+
+        let snapshot = try await probe.fetch()
+
+        #expect(snapshot.accountPlan == "Paid")
+    }
+
     @Test
     func `explicit oauth2 js path overrides installed gemini cli`() async throws {
         let env = try GeminiTestEnvironment()
@@ -245,5 +354,17 @@ struct GeminiOAuthRecoveryAPITests {
             to: bundleDir.appendingPathComponent("chunk-OAUTH.js"),
             atomically: true,
             encoding: .utf8)
+    }
+
+    private static func expectError(
+        _ expected: GeminiStatusProbeError,
+        operation: () async throws -> Void) async
+    {
+        do {
+            try await operation()
+            Issue.record("Expected \(expected)")
+        } catch {
+            #expect(error as? GeminiStatusProbeError == expected)
+        }
     }
 }

--- a/Tests/CodexBarTests/GeminiProviderMigrationSettingsTests.swift
+++ b/Tests/CodexBarTests/GeminiProviderMigrationSettingsTests.swift
@@ -52,8 +52,10 @@ struct GeminiProviderMigrationSettingsTests {
     }
 
     @Test
-    func `typed predicate accepts consumer tier deprecated only`() {
+    func `typed predicate accepts antigravity migration signals only`() {
         #expect(UsageStore.isGeminiConsumerTierDeprecationError(GeminiStatusProbeError.consumerTierDeprecated))
+        #expect(UsageStore.isGeminiConsumerTierDeprecationError(
+            GeminiStatusProbeError.oauthCredentialsUnavailableWithAntigravity))
         #expect(!UsageStore.isGeminiConsumerTierDeprecationError(GeminiStatusProbeError.notLoggedIn))
         #expect(!UsageStore.isGeminiConsumerTierDeprecationError(nil))
     }
@@ -81,6 +83,19 @@ struct GeminiProviderMigrationSettingsTests {
 
         #expect(actions.map(\.id) == ["gemini-antigravity-migration"])
         #expect(settings.isProviderEnabled(provider: .antigravity, metadata: antigravity) == wasEnabled)
+    }
+
+    @Test
+    func `settings action appears when local antigravity handoff was observed`() {
+        let settings = self.makeSettings()
+        let store = self.makeStore(settings: settings)
+        store.observeGeminiConsumerTierDeprecation(
+            from: GeminiStatusProbeError.oauthCredentialsUnavailableWithAntigravity)
+
+        let impl = GeminiProviderImplementation()
+        let actions = impl.settingsActions(context: self.makeContext(settings: settings, store: store))
+
+        #expect(actions.map(\.id) == ["gemini-antigravity-migration"])
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1617,7 +1617,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Azure OpenAI's deployment REST route requires this fixed service path component."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift",
-            line: 143,
+            line: 146,
             anchor: "if normalized.contains(\"migrate\"), normalized.contains(\"antigravity\"), normalized.contains(\"gemini\") {",
             expectedProviderIDs: ["antigravity"],
             reason: "Gemini's upstream deprecation response names the Antigravity migration destination."),


### PR DESCRIPTION
## Root cause

Gemini's local OAuth recovery threw a generic API error when no usable Gemini CLI OAuth client could be discovered. The existing typed consumer-tier migration observation—and therefore the **Enable Antigravity provider** action—only handled migration signals returned by Google, which this local failure occurs before.

## Scope

This is guidance-only. When local Gemini OAuth client recovery fails and CodexBar detects either the `agy` binary or an installed Antigravity/Gemini app artifact, the probe emits a typed Antigravity handoff signal and reuses the existing explicit settings action. Without Antigravity, the existing Gemini CLI recovery message remains unchanged; with usable Gemini OAuth client credentials, refresh behavior remains unchanged.

This does not change authentication behavior, auto-enable Antigravity, or read Antigravity data through the Gemini provider.

Fixes #2808

## Test proof

- `swift test --filter GeminiOAuthRecoveryAPITests`
- `swift test --filter GeminiProviderMigrationSettingsTests`
- `make check`
- `make test` — 859 selections across 72 groups, zero failures or retries
- Autoreview clean: no accepted/actionable findings
