### PR TITLE
Add daily token view to cost history menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.49.7 — Unreleased
 
+### Added
+- Cost history: add a Tokens/Cost switch to daily status-menu charts, defaulting Codex to exact local token totals and marking incomplete local history as refreshing (#2930). Thanks @Carl723000!
+
 ### Fixed
 - Codex: show Business accounts' monthly credit remaining in the provider switcher when no session or weekly rate-limit window is available, and keep quota indicators visible on the selected provider tab (#2926). Thanks @jey3dayo!
 - Gemini: offer the Antigravity provider migration when local OAuth recovery cannot use Gemini CLI and an `agy` or Antigravity installation is available (#2808). Thanks @axisrow!

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -3,6 +3,7 @@ import CodexBarCore
 import SwiftUI
 
 @MainActor
+// swiftlint:disable:next type_body_length
 struct CostHistoryChartMenuView: View {
     typealias DailyEntry = CostUsageDailyReport.Entry
 

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -686,6 +686,7 @@ struct CostHistoryChartMenuView: View {
 
     private static func defaultMetric(provider: UsageProvider, daily: [DailyEntry]) -> ChartMetric {
         let available = self.availableMetrics(provider: provider, daily: daily)
+        // Provider-specific by design: Codex exposes exact local token totals, so its chart defaults to tokens.
         if provider == .codex, available.contains(.tokens) {
             return .tokens
         }
@@ -700,6 +701,7 @@ struct CostHistoryChartMenuView: View {
         metric: ChartMetric,
         historyCoverageIsEstablished: Bool) -> Bool
     {
+        // Provider-specific by design: only Codex exposes incremental local-history coverage for token scans.
         provider == .codex && metric == .tokens && !historyCoverageIsEstablished
     }
 

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -56,6 +56,12 @@ struct CostHistoryChartMenuView: View {
         let rows: [DetailRow]
     }
 
+    private struct DetailLayout {
+        let viewportRowCount: Int
+        let hasOverflow: Bool
+        let rowHeight: CGFloat
+    }
+
     private let provider: UsageProvider
     private let daily: [DailyEntry]
     private let totalCostUSD: Double?
@@ -546,6 +552,7 @@ struct CostHistoryChartMenuView: View {
         metric: ChartMetric) -> Model
     {
         let sorted = daily.sorted { lhs, rhs in lhs.date < rhs.date }
+        let detailLayout = self.detailLayout(provider: provider, daily: sorted)
         var points: [Point] = []
         points.reserveCapacity(sorted.count)
 
@@ -560,10 +567,10 @@ struct CostHistoryChartMenuView: View {
 
         var peak: (key: String, value: Double)?
         var maxValue: Double = 0
-        var maxDetailRows = 0
-        var hasModeDetails = false
         for entry in sorted {
-            guard let (value, date) = self.chartPointInput(for: entry, metric: metric) else { continue }
+            guard let (value, date) = self.chartPointInput(for: entry, provider: provider, metric: metric) else {
+                continue
+            }
             let point = Point(
                 date: date,
                 value: value,
@@ -574,9 +581,6 @@ struct CostHistoryChartMenuView: View {
             pointsByKey[entry.date] = point
             entriesByKey[entry.date] = entry
             dateKeys.append((entry.date, date))
-            let modelBreakdowns = entry.modelBreakdowns ?? []
-            maxDetailRows = max(maxDetailRows, modelBreakdowns.count)
-            hasModeDetails = hasModeDetails || modelBreakdowns.contains { Self.hasModeSubtitle($0) }
             if let cur = peak {
                 if value > cur.value {
                     peak = (entry.date, value)
@@ -605,9 +609,9 @@ struct CostHistoryChartMenuView: View {
             barColor: barColor,
             peakKey: maxValue > 0 ? peak?.key : nil,
             maxValue: maxValue,
-            detailViewportRowCount: min(maxDetailRows, self.maxVisibleDetailLines),
-            hasDetailOverflow: maxDetailRows > self.maxVisibleDetailLines,
-            detailRowHeight: hasModeDetails ? self.expandedDetailRowHeight : self.compactDetailRowHeight)
+            detailViewportRowCount: detailLayout.viewportRowCount,
+            hasDetailOverflow: detailLayout.hasOverflow,
+            detailRowHeight: detailLayout.rowHeight)
     }
 
     private static func axisLabelPlacement(for dates: [Date]) -> AxisLabelPlacement {
@@ -640,31 +644,39 @@ struct CostHistoryChartMenuView: View {
 
     private static func dateFromDayKey(
         _ key: String,
+        provider: UsageProvider,
         calendar sourceCalendar: Calendar = .autoupdatingCurrent) -> Date?
     {
+        let bytes = Array(key.utf8)
+        let digitIndices = [0, 1, 2, 3, 5, 6, 8, 9]
+        guard bytes.count == 10,
+              bytes[4] == 45,
+              bytes[7] == 45,
+              digitIndices.allSatisfy({ (48...57).contains(bytes[$0]) })
+        else { return nil }
+
         let parts = key.split(separator: "-")
         guard parts.count == 3,
               let year = Int(parts[0]),
               let month = Int(parts[1]),
               let day = Int(parts[2]) else { return nil }
 
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = sourceCalendar.timeZone
-        var comps = DateComponents()
-        comps.calendar = calendar
-        comps.timeZone = calendar.timeZone
-        comps.year = year
-        comps.month = month
-        comps.day = day
-        comps.hour = 12
-        guard let date = comps.date else { return nil }
-        let resolved = calendar.dateComponents([.year, .month, .day], from: date)
-        guard resolved.year == year, resolved.month == month, resolved.day == day else { return nil }
-        return date
+        let displayCalendar = self.gregorianCalendar(timeZone: sourceCalendar.timeZone)
+        let bucketCalendar = self.bucketCalendar(provider: provider, displayCalendar: displayCalendar)
+        guard let date = bucketCalendar.date(from: DateComponents(year: year, month: month, day: day)) else {
+            return nil
+        }
+        guard bucketCalendar.dateComponents([.year, .month, .day], from: date) == DateComponents(
+            year: year,
+            month: month,
+            day: day)
+        else { return nil }
+        return displayCalendar.startOfDay(for: date)
     }
 
     private static func chartPointInput(
         for entry: DailyEntry,
+        provider: UsageProvider,
         metric: ChartMetric) -> (value: Double, date: Date)?
     {
         let value: Double? = switch metric {
@@ -674,14 +686,42 @@ struct CostHistoryChartMenuView: View {
             entry.costUSD.flatMap { $0 >= 0 ? $0 : nil }
         }
         guard let value else { return nil }
-        guard let date = self.dateFromDayKey(entry.date) else { return nil }
+        guard let date = self.dateFromDayKey(entry.date, provider: provider) else { return nil }
         return (value, date)
     }
 
-    private static func availableMetrics(provider _: UsageProvider, daily: [DailyEntry]) -> [ChartMetric] {
+    private static func availableMetrics(provider: UsageProvider, daily: [DailyEntry]) -> [ChartMetric] {
         ChartMetric.allCases.filter { metric in
-            daily.contains { self.chartPointInput(for: $0, metric: metric) != nil }
+            daily.contains { self.chartPointInput(for: $0, provider: provider, metric: metric) != nil }
         }
+    }
+
+    private static func detailLayout(provider: UsageProvider, daily: [DailyEntry]) -> DetailLayout {
+        let visibleEntries = daily.filter { entry in
+            ChartMetric.allCases.contains {
+                self.chartPointInput(for: entry, provider: provider, metric: $0) != nil
+            }
+        }
+        let breakdowns = visibleEntries.compactMap(\.modelBreakdowns)
+        let maxRows = breakdowns.map(\.count).max() ?? 0
+        let hasModeDetails = breakdowns.joined().contains(where: self.hasModeSubtitle)
+        return DetailLayout(
+            viewportRowCount: min(maxRows, self.maxVisibleDetailLines),
+            hasOverflow: maxRows > self.maxVisibleDetailLines,
+            rowHeight: hasModeDetails ? self.expandedDetailRowHeight : self.compactDetailRowHeight)
+    }
+
+    private static func gregorianCalendar(timeZone: TimeZone) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
+    }
+
+    private static func bucketCalendar(provider: UsageProvider, displayCalendar: Calendar) -> Calendar {
+        // Provider-specific by design: Mistral uses UTC day buckets; Codex alone defaults to exact local tokens.
+        guard provider == .mistral else { return displayCalendar }
+        // Mistral day keys are UTC buckets; map their boundary into the matching local display day.
+        return self.gregorianCalendar(timeZone: TimeZone(secondsFromGMT: 0) ?? .gmt)
     }
 
     private static func defaultMetric(provider: UsageProvider, daily: [DailyEntry]) -> ChartMetric {
@@ -900,13 +940,12 @@ struct CostHistoryChartMenuView: View {
 
     private func detailContent(selectedDateKey: String?, model: Model) -> DetailContent {
         guard let key = selectedDateKey,
-              let point = model.pointsByDateKey[key],
-              let date = Self.dateFromDayKey(key)
+              let point = model.pointsByDateKey[key]
         else {
             return DetailContent(primary: L("Hover a bar for details"), rows: [])
         }
 
-        let dayLabel = date.formatted(.dateTime.month(.abbreviated).day())
+        let dayLabel = point.date.formatted(.dateTime.month(.abbreviated).day())
         var parts: [String] = []
         if let cost = point.costUSD {
             parts.append(self.costString(cost))
@@ -1183,8 +1222,12 @@ extension CostHistoryChartMenuView {
             historyCoverageIsEstablished: historyCoverageIsEstablished)
     }
 
-    static func _dateFromDayKeyForTesting(_ key: String, calendar: Calendar) -> Date? {
-        self.dateFromDayKey(key, calendar: calendar)
+    static func _dateFromDayKeyForTesting(
+        _ key: String,
+        provider: UsageProvider,
+        calendar: Calendar) -> Date?
+    {
+        self.dateFromDayKey(key, provider: provider, calendar: calendar)
     }
 
     static func _axisDatesForTesting(provider: UsageProvider, daily: [DailyEntry]) -> [Date] {
@@ -1237,12 +1280,13 @@ extension CostHistoryChartMenuView {
 
     static func _detailViewportConfigurationForTesting(
         provider: UsageProvider,
-        daily: [DailyEntry]) -> (rowCount: Int, hasOverflow: Bool, rowHeight: CGFloat)
+        daily: [DailyEntry],
+        metric: ChartMetric? = nil) -> (rowCount: Int, hasOverflow: Bool, rowHeight: CGFloat)
     {
         let model = self.makeModel(
             provider: provider,
             daily: daily,
-            metric: self.defaultMetric(provider: provider, daily: daily))
+            metric: metric ?? self.defaultMetric(provider: provider, daily: daily))
         return (model.detailViewportRowCount, model.hasDetailOverflow, model.detailRowHeight)
     }
 }

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -63,6 +63,7 @@ struct CostHistoryChartMenuView: View {
     /// in the user's preferred currency while chart geometry stays in source values.
     private let costMultiplier: Double
     private let historyDays: Int
+    private let historyCoverageIsEstablished: Bool
     private let windowLabel: String?
     private let projects: [CostUsageProjectBreakdown]
     private let sessions: [CostUsageSessionBreakdown]
@@ -77,6 +78,7 @@ struct CostHistoryChartMenuView: View {
         currencyCode: String = "USD",
         costMultiplier: Double = 1,
         historyDays: Int = 30,
+        historyCoverageIsEstablished: Bool = true,
         windowLabel: String? = nil,
         projects: [CostUsageProjectBreakdown] = [],
         sessions: [CostUsageSessionBreakdown] = [],
@@ -88,6 +90,7 @@ struct CostHistoryChartMenuView: View {
         self.currencyCode = currencyCode
         self.costMultiplier = costMultiplier
         self.historyDays = max(1, min(365, historyDays))
+        self.historyCoverageIsEstablished = historyCoverageIsEstablished
         self.windowLabel = windowLabel
         self.projects = projects
         self.sessions = sessions
@@ -101,6 +104,10 @@ struct CostHistoryChartMenuView: View {
             ? self.metric
             : Self.defaultMetric(provider: self.provider, daily: self.daily)
         let model = Self.makeModel(provider: self.provider, daily: self.daily, metric: activeMetric)
+        let showsHistoryRefreshing = Self.showsHistoryRefreshing(
+            provider: self.provider,
+            metric: activeMetric,
+            historyCoverageIsEstablished: self.historyCoverageIsEstablished)
         let selectedDateKey = self.selectedDateKey.flatMap { model.pointsByDateKey[$0] == nil ? nil : $0 }
             ?? Self.defaultSelectedDateKey(model: model)
         VStack(alignment: .leading, spacing: Self.outerSpacing) {
@@ -110,19 +117,27 @@ struct CostHistoryChartMenuView: View {
                     .foregroundStyle(.secondary)
                     .accessibilityLabel(L("No data available"))
             } else {
-                if availableMetrics.count > 1 {
+                if availableMetrics.count > 1 || showsHistoryRefreshing {
                     HStack {
-                        Spacer(minLength: 0)
-                        Picker(L("Display mode"), selection: self.$metric) {
-                            ForEach(availableMetrics, id: \.self) { metric in
-                                Text(metric.title).tag(metric)
-                            }
+                        if showsHistoryRefreshing {
+                            Text(L("Refreshing"))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .accessibilityLabel(L("Refreshing"))
                         }
-                        .labelsHidden()
-                        .pickerStyle(.segmented)
-                        .controlSize(.small)
-                        .frame(width: Self.metricPickerWidth)
-                        .accessibilityLabel(L("Display mode"))
+                        Spacer(minLength: 0)
+                        if availableMetrics.count > 1 {
+                            Picker(L("Display mode"), selection: self.$metric) {
+                                ForEach(availableMetrics, id: \.self) { metric in
+                                    Text(metric.title).tag(metric)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.segmented)
+                            .controlSize(.small)
+                            .frame(width: Self.metricPickerWidth)
+                            .accessibilityLabel(L("Display mode"))
+                        }
                     }
                     .frame(height: Self.metricPickerHeight)
                 }
@@ -622,21 +637,29 @@ struct CostHistoryChartMenuView: View {
         return Color(red: color.red, green: color.green, blue: color.blue)
     }
 
-    private static func dateFromDayKey(_ key: String) -> Date? {
+    private static func dateFromDayKey(
+        _ key: String,
+        calendar sourceCalendar: Calendar = .autoupdatingCurrent) -> Date?
+    {
         let parts = key.split(separator: "-")
         guard parts.count == 3,
               let year = Int(parts[0]),
               let month = Int(parts[1]),
               let day = Int(parts[2]) else { return nil }
 
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = sourceCalendar.timeZone
         var comps = DateComponents()
-        comps.calendar = Calendar.current
-        comps.timeZone = TimeZone.current
+        comps.calendar = calendar
+        comps.timeZone = calendar.timeZone
         comps.year = year
         comps.month = month
         comps.day = day
         comps.hour = 12
-        return comps.date
+        guard let date = comps.date else { return nil }
+        let resolved = calendar.dateComponents([.year, .month, .day], from: date)
+        guard resolved.year == year, resolved.month == month, resolved.day == day else { return nil }
+        return date
     }
 
     private static func chartPointInput(
@@ -669,6 +692,14 @@ struct CostHistoryChartMenuView: View {
             return .cost
         }
         return available.first ?? .cost
+    }
+
+    private static func showsHistoryRefreshing(
+        provider: UsageProvider,
+        metric: ChartMetric,
+        historyCoverageIsEstablished: Bool) -> Bool
+    {
+        provider == .codex && metric == .tokens && !historyCoverageIsEstablished
     }
 
     private static func peakPoint(model: Model) -> Point? {
@@ -999,6 +1030,7 @@ extension CostHistoryChartMenuView {
         let currencyCode: String
         let costMultiplierBitPattern: UInt64
         let historyDays: Int
+        let historyCoverageIsEstablished: Bool
         let windowLabel: String?
         let totalCostBitPattern: UInt64?
         let hasDailyEntries: Bool
@@ -1064,6 +1096,7 @@ extension CostHistoryChartMenuView {
             currencyCode: displayCurrencyCode ?? snapshot.currencyCode,
             costMultiplierBitPattern: displayCostMultiplier.bitPattern,
             historyDays: snapshot.historyDays,
+            historyCoverageIsEstablished: snapshot.historyCoverageIsEstablished,
             windowLabel: snapshot.historyLabel,
             totalCostBitPattern: snapshot.last30DaysCostUSD.map(\.bitPattern),
             hasDailyEntries: !snapshot.daily.isEmpty,
@@ -1134,6 +1167,21 @@ extension CostHistoryChartMenuView {
             provider: provider,
             daily: daily,
             metric: self.defaultMetric(provider: provider, daily: daily)))
+    }
+
+    static func _showsHistoryRefreshingForTesting(
+        provider: UsageProvider,
+        metric: ChartMetric,
+        historyCoverageIsEstablished: Bool) -> Bool
+    {
+        self.showsHistoryRefreshing(
+            provider: provider,
+            metric: metric,
+            historyCoverageIsEstablished: historyCoverageIsEstablished)
+    }
+
+    static func _dateFromDayKeyForTesting(_ key: String, calendar: Calendar) -> Date? {
+        self.dateFromDayKey(key, calendar: calendar)
     }
 
     static func _axisDatesForTesting(provider: UsageProvider, daily: [DailyEntry]) -> [Date] {

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -12,19 +12,33 @@ struct CostHistoryChartMenuView: View {
         case edges
     }
 
+    enum ChartMetric: CaseIterable, Hashable {
+        case tokens
+        case cost
+
+        var title: String {
+            switch self {
+            case .tokens: L("Token")
+            case .cost: L("Cost")
+            }
+        }
+    }
+
     private struct Point: Identifiable {
         let id: String
         let date: Date
-        let costUSD: Double
+        let value: Double
+        let costUSD: Double?
         let totalTokens: Int?
         let requestCount: Int?
 
-        init(date: Date, costUSD: Double, totalTokens: Int?, requestCount: Int?) {
+        init(date: Date, value: Double, costUSD: Double?, totalTokens: Int?, requestCount: Int?) {
             self.date = date
+            self.value = value
             self.costUSD = costUSD
             self.totalTokens = totalTokens
             self.requestCount = requestCount
-            self.id = "\(Int(date.timeIntervalSince1970))-\(costUSD)"
+            self.id = "\(Int(date.timeIntervalSince1970))"
         }
     }
 
@@ -53,6 +67,7 @@ struct CostHistoryChartMenuView: View {
     private let projects: [CostUsageProjectBreakdown]
     private let sessions: [CostUsageSessionBreakdown]
     private let width: CGFloat
+    @State private var metric: ChartMetric
     @State private var selectedDateKey: String?
 
     init(
@@ -77,41 +92,67 @@ struct CostHistoryChartMenuView: View {
         self.projects = projects
         self.sessions = sessions
         self.width = width
+        self._metric = State(initialValue: Self.defaultMetric(provider: provider, daily: daily))
     }
 
     var body: some View {
-        let model = Self.makeModel(provider: self.provider, daily: self.daily)
-        let selectedDateKey = self.selectedDateKey ?? Self.defaultSelectedDateKey(model: model)
+        let availableMetrics = Self.availableMetrics(provider: self.provider, daily: self.daily)
+        let activeMetric = availableMetrics.contains(self.metric)
+            ? self.metric
+            : Self.defaultMetric(provider: self.provider, daily: self.daily)
+        let model = Self.makeModel(provider: self.provider, daily: self.daily, metric: activeMetric)
+        let selectedDateKey = self.selectedDateKey.flatMap { model.pointsByDateKey[$0] == nil ? nil : $0 }
+            ?? Self.defaultSelectedDateKey(model: model)
         VStack(alignment: .leading, spacing: Self.outerSpacing) {
             if model.points.isEmpty {
-                Text(L("No cost history data."))
+                Text(L("No data available"))
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-                    .accessibilityLabel(L("No cost history data."))
+                    .accessibilityLabel(L("No data available"))
             } else {
+                if availableMetrics.count > 1 {
+                    HStack {
+                        Spacer(minLength: 0)
+                        Picker(L("Display mode"), selection: self.$metric) {
+                            ForEach(availableMetrics, id: \.self) { metric in
+                                Text(metric.title).tag(metric)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .controlSize(.small)
+                        .frame(width: Self.metricPickerWidth)
+                        .accessibilityLabel(L("Display mode"))
+                    }
+                    .frame(height: Self.metricPickerHeight)
+                }
+
                 Chart {
                     ForEach(model.points) { point in
                         BarMark(
                             x: .value(L("Day"), point.date, unit: .day),
-                            y: .value(L("Cost"), point.costUSD))
+                            y: .value(activeMetric.title, point.value))
                             .foregroundStyle(model.barColor)
                     }
                     if let peak = Self.peakPoint(model: model) {
-                        let capStart = max(peak.costUSD - Self.capHeight(maxValue: model.maxCostUSD), 0)
+                        let capStart = max(peak.value - Self.capHeight(maxValue: model.maxValue), 0)
                         BarMark(
                             x: .value(L("Day"), peak.date, unit: .day),
                             yStart: .value(L("Cap start"), capStart),
-                            yEnd: .value(L("Cap end"), peak.costUSD))
+                            yEnd: .value(L("Cap end"), peak.value))
                             .foregroundStyle(Color(nsColor: .systemYellow))
                     }
                 }
                 .chartYAxis {
-                    AxisMarks(position: .leading, values: Self.yAxisTickValues(maxCostUSD: model.maxCostUSD)) { value in
+                    AxisMarks(
+                        position: .leading,
+                        values: Self.yAxisTickValues(maxValue: model.maxValue, metric: activeMetric))
+                    { value in
                         AxisGridLine().foregroundStyle(Color.clear)
                         AxisTick().foregroundStyle(Color.clear)
                         AxisValueLabel(centered: false) {
                             if let raw = value.as(Double.self) {
-                                Text(Self.yAxisCostString(raw * self.costMultiplier, currencyCode: self.currencyCode))
+                                Text(self.yAxisString(raw, metric: activeMetric))
                                     .font(.caption2)
                                     .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                                     .padding(.leading, 4)
@@ -134,10 +175,14 @@ struct CostHistoryChartMenuView: View {
                 }
                 .chartLegend(.hidden)
                 .frame(height: Self.chartHeight)
-                .accessibilityLabel(L("Cost history chart"))
+                .accessibilityLabel(activeMetric == .tokens ? L("Token activity") : L("Cost history chart"))
                 .accessibilityValue(
                     model.points.isEmpty
                         ? L("No data")
+                        : activeMetric == .tokens
+                        ? String(
+                            format: L("%@ tokens"),
+                            UsageFormatter.tokenCountString(Int(model.points.reduce(0) { $0 + $1.value })))
                         : String(format: L("%d days of cost data"), model.points.count))
                 .chartOverlay { proxy in
                     GeometryReader { geo in
@@ -323,7 +368,7 @@ struct CostHistoryChartMenuView: View {
         let axisDates: [Date]
         let barColor: Color
         let peakKey: String?
-        let maxCostUSD: Double
+        let maxValue: Double
         let detailViewportRowCount: Int
         let hasDetailOverflow: Bool
         let detailRowHeight: CGFloat
@@ -339,6 +384,8 @@ struct CostHistoryChartMenuView: View {
     private static let detailSpacing: CGFloat = 6
     private static let detailHintHeight: CGFloat = 13
     private static let chartHeight: CGFloat = 130
+    private static let metricPickerHeight: CGFloat = 22
+    private static let metricPickerWidth: CGFloat = 132
     private static let outerSpacing: CGFloat = 10
     private static let projectRowHeight: CGFloat = 31
     private static let projectRowSpacing: CGFloat = 5
@@ -467,7 +514,21 @@ struct CostHistoryChartMenuView: View {
         return [0, maxCostUSD / 2, maxCostUSD]
     }
 
-    private static func makeModel(provider: UsageProvider, daily: [DailyEntry]) -> Model {
+    private static func yAxisTickValues(maxValue: Double, metric: ChartMetric) -> [Double] {
+        switch metric {
+        case .tokens:
+            guard maxValue > 0 else { return [] }
+            return maxValue < 2 ? [0, maxValue] : [0, maxValue / 2, maxValue]
+        case .cost:
+            return self.yAxisTickValues(maxCostUSD: maxValue)
+        }
+    }
+
+    private static func makeModel(
+        provider: UsageProvider,
+        daily: [DailyEntry],
+        metric: ChartMetric) -> Model
+    {
         let sorted = daily.sorted { lhs, rhs in lhs.date < rhs.date }
         var points: [Point] = []
         points.reserveCapacity(sorted.count)
@@ -481,16 +542,17 @@ struct CostHistoryChartMenuView: View {
         var dateKeys: [(key: String, date: Date)] = []
         dateKeys.reserveCapacity(sorted.count)
 
-        var peak: (key: String, costUSD: Double)?
-        var maxCostUSD: Double = 0
+        var peak: (key: String, value: Double)?
+        var maxValue: Double = 0
         var maxDetailRows = 0
         var hasModeDetails = false
         for entry in sorted {
-            guard let (costUSD, date) = self.chartPointInput(for: entry) else { continue }
+            guard let (value, date) = self.chartPointInput(for: entry, metric: metric) else { continue }
             let point = Point(
                 date: date,
-                costUSD: costUSD,
-                totalTokens: entry.totalTokens,
+                value: value,
+                costUSD: entry.costUSD.flatMap { $0 >= 0 ? $0 : nil },
+                totalTokens: entry.totalTokens.flatMap { $0 >= 0 ? $0 : nil },
                 requestCount: entry.requestCount)
             points.append(point)
             pointsByKey[entry.date] = point
@@ -500,13 +562,13 @@ struct CostHistoryChartMenuView: View {
             maxDetailRows = max(maxDetailRows, modelBreakdowns.count)
             hasModeDetails = hasModeDetails || modelBreakdowns.contains { Self.hasModeSubtitle($0) }
             if let cur = peak {
-                if costUSD > cur.costUSD {
-                    peak = (entry.date, costUSD)
+                if value > cur.value {
+                    peak = (entry.date, value)
                 }
             } else {
-                peak = (entry.date, costUSD)
+                peak = (entry.date, value)
             }
-            maxCostUSD = max(maxCostUSD, costUSD)
+            maxValue = max(maxValue, value)
         }
 
         let axisDates: [Date] = {
@@ -525,8 +587,8 @@ struct CostHistoryChartMenuView: View {
             dateKeys: dateKeys,
             axisDates: axisDates,
             barColor: barColor,
-            peakKey: maxCostUSD > 0 ? peak?.key : nil,
-            maxCostUSD: maxCostUSD,
+            peakKey: maxValue > 0 ? peak?.key : nil,
+            maxValue: maxValue,
             detailViewportRowCount: min(maxDetailRows, self.maxVisibleDetailLines),
             hasDetailOverflow: maxDetailRows > self.maxVisibleDetailLines,
             detailRowHeight: hasModeDetails ? self.expandedDetailRowHeight : self.compactDetailRowHeight)
@@ -577,10 +639,36 @@ struct CostHistoryChartMenuView: View {
         return comps.date
     }
 
-    private static func chartPointInput(for entry: DailyEntry) -> (costUSD: Double, date: Date)? {
-        guard let costUSD = entry.costUSD, costUSD >= 0 else { return nil }
+    private static func chartPointInput(
+        for entry: DailyEntry,
+        metric: ChartMetric) -> (value: Double, date: Date)?
+    {
+        let value: Double? = switch metric {
+        case .tokens:
+            entry.totalTokens.flatMap { $0 >= 0 ? Double($0) : nil }
+        case .cost:
+            entry.costUSD.flatMap { $0 >= 0 ? $0 : nil }
+        }
+        guard let value else { return nil }
         guard let date = self.dateFromDayKey(entry.date) else { return nil }
-        return (costUSD, date)
+        return (value, date)
+    }
+
+    private static func availableMetrics(provider _: UsageProvider, daily: [DailyEntry]) -> [ChartMetric] {
+        ChartMetric.allCases.filter { metric in
+            daily.contains { self.chartPointInput(for: $0, metric: metric) != nil }
+        }
+    }
+
+    private static func defaultMetric(provider: UsageProvider, daily: [DailyEntry]) -> ChartMetric {
+        let available = self.availableMetrics(provider: provider, daily: daily)
+        if provider == .codex, available.contains(.tokens) {
+            return .tokens
+        }
+        if available.contains(.cost) {
+            return .cost
+        }
+        return available.first ?? .cost
     }
 
     private static func peakPoint(model: Model) -> Point? {
@@ -785,8 +873,10 @@ struct CostHistoryChartMenuView: View {
         }
 
         let dayLabel = date.formatted(.dateTime.month(.abbreviated).day())
-        let cost = self.costString(point.costUSD)
-        var parts = [cost]
+        var parts: [String] = []
+        if let cost = point.costUSD {
+            parts.append(self.costString(cost))
+        }
         if let tokens = point.totalTokens {
             parts.append("\(UsageFormatter.tokenCountString(tokens)) tokens")
         }
@@ -885,6 +975,19 @@ struct CostHistoryChartMenuView: View {
         UsageFormatter.compactCurrencyString(value, currencyCode: currencyCode)
     }
 
+    private static func yAxisTokenString(_ value: Double) -> String {
+        UsageFormatter.tokenCountString(Int(value.rounded()))
+    }
+
+    private func yAxisString(_ value: Double, metric: ChartMetric) -> String {
+        switch metric {
+        case .tokens:
+            Self.yAxisTokenString(value)
+        case .cost:
+            Self.yAxisCostString(value * self.costMultiplier, currencyCode: self.currencyCode)
+        }
+    }
+
     private static func breakdownAccentOpacity(for index: Int) -> Double {
         let opacity = 0.75 - (Double(index) * 0.12)
         return max(0.3, opacity)
@@ -965,7 +1068,9 @@ extension CostHistoryChartMenuView {
             totalCostBitPattern: snapshot.last30DaysCostUSD.map(\.bitPattern),
             hasDailyEntries: !snapshot.daily.isEmpty,
             daily: snapshot.daily
-                .filter { self.chartPointInput(for: $0) != nil }
+                .filter { entry in
+                    self.availableMetrics(provider: provider, daily: [entry]).isEmpty == false
+                }
                 .sorted { $0.date < $1.date }
                 .map(self.visibleDailyFingerprint),
             projects: Array(projects.prefix(self.maxVisibleProjectRows)).map { project in
@@ -1025,18 +1130,27 @@ extension CostHistoryChartMenuView {
     }
 
     static func _defaultSelectedDateKeyForTesting(provider: UsageProvider, daily: [DailyEntry]) -> String? {
-        self.defaultSelectedDateKey(model: self.makeModel(provider: provider, daily: daily))
+        self.defaultSelectedDateKey(model: self.makeModel(
+            provider: provider,
+            daily: daily,
+            metric: self.defaultMetric(provider: provider, daily: daily)))
     }
 
     static func _axisDatesForTesting(provider: UsageProvider, daily: [DailyEntry]) -> [Date] {
-        self.makeModel(provider: provider, daily: daily).axisDates
+        self.makeModel(
+            provider: provider,
+            daily: daily,
+            metric: self.defaultMetric(provider: provider, daily: daily)).axisDates
     }
 
     static func _axisLabelPlacementForTesting(
         provider: UsageProvider,
         daily: [DailyEntry]) -> AxisLabelPlacement
     {
-        self.axisLabelPlacement(for: self.makeModel(provider: provider, daily: daily).axisDates)
+        self.axisLabelPlacement(for: self.makeModel(
+            provider: provider,
+            daily: daily,
+            metric: self.defaultMetric(provider: provider, daily: daily)).axisDates)
     }
 
     static func _yAxisTickValuesForTesting(maxCostUSD: Double) -> [Double] {
@@ -1047,11 +1161,37 @@ extension CostHistoryChartMenuView {
         self.yAxisCostString(value, currencyCode: currencyCode)
     }
 
+    static func _yAxisTokenStringForTesting(_ value: Double) -> String {
+        self.yAxisTokenString(value)
+    }
+
+    static func _availableMetricsForTesting(
+        provider: UsageProvider,
+        daily: [DailyEntry]) -> [ChartMetric]
+    {
+        self.availableMetrics(provider: provider, daily: daily)
+    }
+
+    static func _defaultMetricForTesting(provider: UsageProvider, daily: [DailyEntry]) -> ChartMetric {
+        self.defaultMetric(provider: provider, daily: daily)
+    }
+
+    static func _chartValuesForTesting(
+        provider: UsageProvider,
+        daily: [DailyEntry],
+        metric: ChartMetric) -> [Double]
+    {
+        self.makeModel(provider: provider, daily: daily, metric: metric).points.map(\.value)
+    }
+
     static func _detailViewportConfigurationForTesting(
         provider: UsageProvider,
         daily: [DailyEntry]) -> (rowCount: Int, hasOverflow: Bool, rowHeight: CGFloat)
     {
-        let model = self.makeModel(provider: provider, daily: daily)
+        let model = self.makeModel(
+            provider: provider,
+            daily: daily,
+            metric: self.defaultMetric(provider: provider, daily: daily))
         return (model.detailViewportRowCount, model.hasDetailOverflow, model.detailRowHeight)
     }
 }

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -437,6 +437,7 @@ extension StatusItemController {
             currencyCode: displayConversion.currencyCode,
             costMultiplier: displayConversion.multiplier,
             historyDays: tokenSnapshot.historyDays,
+            historyCoverageIsEstablished: tokenSnapshot.historyCoverageIsEstablished,
             windowLabel: tokenSnapshot.historyLabel,
             projects: provider == .codex ? tokenSnapshot.projects : [],
             sessions: provider == .codex ? tokenSnapshot.sessions : [],

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -6,6 +6,44 @@ import Testing
 @MainActor
 struct CostHistoryChartMenuViewTests {
     @Test
+    func `partial Codex token history is marked refreshing until coverage completes`() {
+        #expect(CostHistoryChartMenuView._showsHistoryRefreshingForTesting(
+            provider: .codex,
+            metric: .tokens,
+            historyCoverageIsEstablished: false))
+        #expect(!CostHistoryChartMenuView._showsHistoryRefreshingForTesting(
+            provider: .codex,
+            metric: .tokens,
+            historyCoverageIsEstablished: true))
+        #expect(!CostHistoryChartMenuView._showsHistoryRefreshingForTesting(
+            provider: .codex,
+            metric: .cost,
+            historyCoverageIsEstablished: false))
+        #expect(!CostHistoryChartMenuView._showsHistoryRefreshingForTesting(
+            provider: .claude,
+            metric: .tokens,
+            historyCoverageIsEstablished: false))
+    }
+
+    @Test
+    func `chart day keys remain on the injected Hong Kong local day`() throws {
+        let hongKong = try #require(TimeZone(identifier: "Asia/Hong_Kong"))
+        var sourceCalendar = Calendar(identifier: .buddhist)
+        sourceCalendar.timeZone = hongKong
+        let date = try #require(CostHistoryChartMenuView._dateFromDayKeyForTesting(
+            "2026-08-14",
+            calendar: sourceCalendar))
+
+        var gregorian = Calendar(identifier: .gregorian)
+        gregorian.timeZone = hongKong
+        #expect(gregorian.dateComponents([.year, .month, .day, .hour], from: date) == DateComponents(
+            year: 2026,
+            month: 8,
+            day: 14,
+            hour: 12))
+    }
+
+    @Test
     func `Codex daily chart defaults to tokens while other providers preserve cost`() {
         let daily = [
             Self.dailyEntry(date: "2026-08-12", totalTokens: 1_250_000, costUSD: 1.25),
@@ -375,6 +413,17 @@ struct CostHistoryChartMenuViewTests {
             provider: .codex)
 
         #expect(before != after)
+    }
+
+    @Test
+    @MainActor
+    func `render fingerprint changes when history coverage completes`() {
+        let partial = Self.makeSnapshot(historyCoverageIsEstablished: false)
+        let complete = Self.makeSnapshot(historyCoverageIsEstablished: true)
+
+        #expect(
+            CostHistoryChartMenuView.renderFingerprint(from: partial, provider: .codex)
+                != CostHistoryChartMenuView.renderFingerprint(from: complete, provider: .codex))
     }
 
     @Test
@@ -808,6 +857,7 @@ struct CostHistoryChartMenuViewTests {
         currencyCode: String = "USD",
         historyDays: Int = 30,
         historyLabel: String? = nil,
+        historyCoverageIsEstablished: Bool = true,
         daily: [CostUsageDailyReport.Entry]? = nil,
         projects: [CostUsageProjectBreakdown]? = nil,
         sessions: [CostUsageSessionBreakdown] = []) -> CostUsageTokenSnapshot
@@ -819,6 +869,7 @@ struct CostHistoryChartMenuViewTests {
             last30DaysCostUSD: totalCostUSD ?? dailyCost,
             currencyCode: currencyCode,
             historyDays: historyDays,
+            historyCoverageIsEstablished: historyCoverageIsEstablished,
             historyLabel: historyLabel,
             daily: daily ?? [
                 CostUsageDailyReport.Entry(

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -33,6 +33,7 @@ struct CostHistoryChartMenuViewTests {
         sourceCalendar.timeZone = hongKong
         let date = try #require(CostHistoryChartMenuView._dateFromDayKeyForTesting(
             "2026-08-14",
+            provider: .codex,
             calendar: sourceCalendar))
 
         var gregorian = Calendar(identifier: .gregorian)
@@ -41,7 +42,39 @@ struct CostHistoryChartMenuViewTests {
             year: 2026,
             month: 8,
             day: 14,
-            hour: 12))
+            hour: 0))
+    }
+
+    @Test
+    func `chart day keys reject noncanonical and impossible dates`() throws {
+        let hongKong = try #require(TimeZone(identifier: "Asia/Hong_Kong"))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = hongKong
+
+        #expect(CostHistoryChartMenuView._dateFromDayKeyForTesting(
+            "2026-8-14",
+            provider: .codex,
+            calendar: calendar) == nil)
+        #expect(CostHistoryChartMenuView._dateFromDayKeyForTesting(
+            "2026-02-30",
+            provider: .codex,
+            calendar: calendar) == nil)
+    }
+
+    @Test
+    func `Mistral UTC day keys map to the same local day as spend activity`() throws {
+        let losAngeles = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = losAngeles
+        let date = try #require(CostHistoryChartMenuView._dateFromDayKeyForTesting(
+            "2026-08-14",
+            provider: .mistral,
+            calendar: calendar))
+
+        #expect(calendar.dateComponents([.year, .month, .day], from: date) == DateComponents(
+            year: 2026,
+            month: 8,
+            day: 13))
     }
 
     @Test
@@ -84,6 +117,26 @@ struct CostHistoryChartMenuViewTests {
                 provider: .codex,
                 daily: daily,
                 metric: .cost) == [1.25])
+    }
+
+    @Test
+    func `token chart does not add cached input to the canonical total`() {
+        let daily = [
+            CostUsageDailyReport.Entry(
+                date: "2026-08-12",
+                inputTokens: 100,
+                outputTokens: 50,
+                cacheReadTokens: 80,
+                totalTokens: 150,
+                costUSD: 1.25,
+                modelsUsed: nil,
+                modelBreakdowns: nil),
+        ]
+
+        #expect(CostHistoryChartMenuView._chartValuesForTesting(
+            provider: .codex,
+            daily: daily,
+            metric: .tokens) == [150])
     }
 
     @Test
@@ -218,6 +271,54 @@ struct CostHistoryChartMenuViewTests {
         #expect(compact.rowHeight == 36)
         #expect(expanded.rowHeight == 44)
         #expect(compact.rowCount == expanded.rowCount)
+    }
+
+    @Test
+    func `metric switch reserves one stable detail layout`() {
+        let tokenOnly = CostUsageDailyReport.Entry(
+            date: "2026-06-07",
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            costUSD: nil,
+            modelsUsed: (0..<5).map { "token-model-\($0)" },
+            modelBreakdowns: (0..<5).map {
+                CostUsageDailyReport.ModelBreakdown(
+                    modelName: "token-model-\($0)",
+                    costUSD: nil,
+                    totalTokens: 30,
+                    standardCostUSD: 0.1)
+            })
+        let costOnly = CostUsageDailyReport.Entry(
+            date: "2026-06-08",
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: nil,
+            costUSD: 1,
+            modelsUsed: ["cost-model"],
+            modelBreakdowns: [
+                CostUsageDailyReport.ModelBreakdown(
+                    modelName: "cost-model",
+                    costUSD: 1,
+                    totalTokens: nil),
+            ])
+        let daily = [tokenOnly, costOnly]
+
+        let tokens = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
+            provider: .codex,
+            daily: daily,
+            metric: .tokens)
+        let cost = CostHistoryChartMenuView._detailViewportConfigurationForTesting(
+            provider: .codex,
+            daily: daily,
+            metric: .cost)
+
+        #expect(tokens.rowCount == cost.rowCount)
+        #expect(tokens.hasOverflow == cost.hasOverflow)
+        #expect(tokens.rowHeight == cost.rowHeight)
+        #expect(tokens.rowCount == 4)
+        #expect(tokens.hasOverflow)
+        #expect(tokens.rowHeight == 44)
     }
 
     @Test

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -6,6 +6,54 @@ import Testing
 @MainActor
 struct CostHistoryChartMenuViewTests {
     @Test
+    func `Codex daily chart defaults to tokens while other providers preserve cost`() {
+        let daily = [
+            Self.dailyEntry(date: "2026-08-12", totalTokens: 1_250_000, costUSD: 1.25),
+        ]
+
+        #expect(CostHistoryChartMenuView._defaultMetricForTesting(provider: .codex, daily: daily) == .tokens)
+        #expect(CostHistoryChartMenuView._defaultMetricForTesting(provider: .claude, daily: daily) == .cost)
+    }
+
+    @Test
+    func `Codex daily chart falls back to cost when token totals are unavailable`() {
+        let daily = [
+            Self.dailyEntry(date: "2026-08-12", totalTokens: nil, costUSD: 1.25),
+        ]
+
+        #expect(CostHistoryChartMenuView._availableMetricsForTesting(provider: .codex, daily: daily) == [.cost])
+        #expect(CostHistoryChartMenuView._defaultMetricForTesting(provider: .codex, daily: daily) == .cost)
+    }
+
+    @Test
+    func `token chart keeps exact daily totals even when a cost estimate is unavailable`() {
+        let daily = [
+            Self.dailyEntry(date: "2026-08-12", totalTokens: 1_250_000, costUSD: 1.25),
+            Self.dailyEntry(date: "2026-08-13", totalTokens: 2_500_000, costUSD: nil),
+        ]
+
+        #expect(
+            CostHistoryChartMenuView._availableMetricsForTesting(provider: .codex, daily: daily)
+                == [.tokens, .cost])
+        #expect(
+            CostHistoryChartMenuView._chartValuesForTesting(
+                provider: .codex,
+                daily: daily,
+                metric: .tokens) == [1_250_000, 2_500_000])
+        #expect(
+            CostHistoryChartMenuView._chartValuesForTesting(
+                provider: .codex,
+                daily: daily,
+                metric: .cost) == [1.25])
+    }
+
+    @Test
+    func `token axis uses compact token labels instead of currency`() {
+        #expect(CostHistoryChartMenuView._yAxisTokenStringForTesting(1_250_000) == "1.2M")
+        #expect(!CostHistoryChartMenuView._yAxisTokenStringForTesting(1_250_000).contains("$"))
+    }
+
+    @Test
     func `Codex chart explains that its token estimate is not a subscription bill`() {
         #expect(
             CostHistoryChartMenuView.estimateDisclaimer(provider: .codex)
@@ -470,16 +518,16 @@ struct CostHistoryChartMenuViewTests {
 
     @Test
     @MainActor
-    func `render fingerprint excludes invalid daily rows that the chart drops`() {
+    func `render fingerprint excludes rows without a valid token or cost metric`() {
         let invalidRows = [
-            Self.dailyEntry(date: "2026-06-07", costUSD: nil),
-            Self.dailyEntry(date: "2026-06-08", costUSD: -1),
-            Self.dailyEntry(date: "not-a-date", costUSD: 1),
+            Self.dailyEntry(date: "2026-06-07", totalTokens: nil, costUSD: nil),
+            Self.dailyEntry(date: "2026-06-08", totalTokens: -1, costUSD: -1),
+            Self.dailyEntry(date: "not-a-date", totalTokens: 150, costUSD: 1),
         ]
         let differentInvalidRows = [
-            Self.dailyEntry(date: "2026-06-09", costUSD: nil),
-            Self.dailyEntry(date: "2026-06-10", costUSD: -99),
-            Self.dailyEntry(date: "still-not-a-date", costUSD: 99),
+            Self.dailyEntry(date: "2026-06-09", totalTokens: nil, costUSD: nil),
+            Self.dailyEntry(date: "2026-06-10", totalTokens: -99, costUSD: -99),
+            Self.dailyEntry(date: "still-not-a-date", totalTokens: 999, costUSD: 99),
         ]
         let empty = Self.fingerprint(daily: [])
 
@@ -735,11 +783,19 @@ struct CostHistoryChartMenuViewTests {
     }
 
     private static func dailyEntry(date: String, costUSD: Double?) -> CostUsageDailyReport.Entry {
+        self.dailyEntry(date: date, totalTokens: 150, costUSD: costUSD)
+    }
+
+    private static func dailyEntry(
+        date: String,
+        totalTokens: Int?,
+        costUSD: Double?) -> CostUsageDailyReport.Entry
+    {
         CostUsageDailyReport.Entry(
             date: date,
             inputTokens: 100,
             outputTokens: 50,
-            totalTokens: 150,
+            totalTokens: totalTokens,
             costUSD: costUSD,
             modelsUsed: nil,
             modelBreakdowns: nil)

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -4,6 +4,7 @@ import Testing
 @testable import CodexBar
 
 @MainActor
+// swiftlint:disable:next type_body_length
 struct CostHistoryChartMenuViewTests {
     @Test
     func `partial Codex token history is marked refreshing until coverage completes`() {

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1713,7 +1713,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/CostHistoryChartMenuView.swift",
-            line: 958,
+            line: 1096,
             anchor: "let projects = provider == .codex ? snapshot.projects : []",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,
@@ -2466,7 +2466,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+HostedSubmenus.swift",
-            line: 441,
+            line: 442,
             anchor: "projects: provider == .codex ? tokenSnapshot.projects : [],",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1713,7 +1713,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/CostHistoryChartMenuView.swift",
-            line: 1096,
+            line: 1135,
             anchor: "let projects = provider == .codex ? snapshot.projects : []",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,


### PR DESCRIPTION
## Summary

- add a Tokens/Cost switch to the status-menu daily history chart
- default Codex to exact daily token totals while preserving Cost for Codex and other providers
- show a lightweight Refreshing label while local Codex history coverage is incomplete
- parse chart day keys with a Gregorian calendar in the current system time zone

## Behavior

This reuses the existing daily token snapshots and does not add any scanner, timer, network request, or background refresh. Token totals use the existing input + output accounting; cached input remains a subset and is not added again.

## Testing

- CostHistoryChartMenuViewTests
- StatusMenuCodexCostHistoryRefreshTests
- StatusMenuHostedSubmenuRefreshTests
- CostUsageCalendarTests
- 57 tests across these 4 suites pass
- SwiftFormat lint passes
- app localization catalog check passes

🤖 Generated with [OpenAI Codex](https://developers.openai.com/codex/)