### PR TITLE
fix(codex): fall back to JWT organization identity

### DIFF
--- a/Sources/CodexBar/CodexAccountPromotionPreparation.swift
+++ b/Sources/CodexBar/CodexAccountPromotionPreparation.swift
@@ -172,8 +172,11 @@ struct PreparedPromotionContextBuilder {
     }
 
     private func inspectAuthMaterial(homeURL: URL, rawData: Data) async -> PreparedAuthMaterial? {
-        guard let credentials = try? CodexOAuthCredentialsStore.parse(data: rawData),
-              let runtimeAccount = try? Self.runtimeAccount(from: rawData)
+        guard let credentials = try? CodexOAuthCredentialsStore.parse(data: rawData) else {
+            return nil
+        }
+        let identityCredentials = (try? CodexOAuthCredentialsStore.parseOAuthTokens(data: rawData)) ?? credentials
+        guard let runtimeAccount = try? Self.runtimeAccount(from: rawData, credentials: identityCredentials)
         else {
             return nil
         }
@@ -246,7 +249,10 @@ struct PreparedPromotionContextBuilder {
         }
     }
 
-    private static func runtimeAccount(from rawData: Data) throws -> CodexAuthBackedAccount {
+    private static func runtimeAccount(
+        from rawData: Data,
+        credentials: CodexOAuthCredentials) throws -> CodexAuthBackedAccount
+    {
         guard let json = try JSONSerialization.jsonObject(with: rawData) as? [String: Any] else {
             throw CodexOAuthCredentialsError.decodeFailed("Invalid JSON")
         }
@@ -263,12 +269,7 @@ struct PreparedPromotionContextBuilder {
             (payload?["email"] as? String) ?? (profileDict?["email"] as? String))
         let plan = Self.normalizedField(
             (authDict?["chatgpt_plan_type"] as? String) ?? (payload?["chatgpt_plan_type"] as? String))
-        let accountID = ManagedCodexAccount.normalizeProviderAccountID(
-            tokens.flatMap {
-                Self.nonEmptyString(in: $0, snakeCaseKey: "account_id", camelCaseKey: "accountId")
-            }
-                ?? (authDict?["chatgpt_account_id"] as? String)
-                ?? (payload?["chatgpt_account_id"] as? String))
+        let accountID = ManagedCodexAccount.normalizeProviderAccountID(credentials.resolvedAccountId)
         let identity = Self.normalizedIdentity(
             CodexIdentityResolver.resolve(accountId: accountID, email: email),
             email: email)

--- a/Sources/CodexBar/UsageStore+CodexResetCredits.swift
+++ b/Sources/CodexBar/UsageStore+CodexResetCredits.swift
@@ -93,7 +93,7 @@ extension UsageStore {
         // Supplemental inventory is strictly read-only. The main OAuth usage strategy owns token refreshes;
         // CLI/web winners with stale credentials simply skip this best-effort GET.
         guard !credentials.needsRefresh else { return nil }
-        return try await request(credentials.accessToken, credentials.accountId, env)
+        return try await request(credentials.accessToken, credentials.resolvedAccountId, env)
     }
 
     nonisolated static func _fetchCodexResetCreditsForTesting(

--- a/Sources/CodexBarCore/ManagedCodexAccountStore.swift
+++ b/Sources/CodexBarCore/ManagedCodexAccountStore.swift
@@ -97,12 +97,7 @@ public struct FileManagedCodexAccountStore: ManagedCodexAccountStoring, @uncheck
         else {
             return nil
         }
-        let payload = credentials.idToken.flatMap(UsageFetcher.parseJWT)
-        let authDict = payload?["https://api.openai.com/auth"] as? [String: Any]
-        let providerAccountID = credentials.accountId
-            ?? (authDict?["chatgpt_account_id"] as? String)
-            ?? (payload?["chatgpt_account_id"] as? String)
-        return ManagedCodexAccount.normalizeProviderAccountID(providerAccountID)
+        return ManagedCodexAccount.normalizeProviderAccountID(credentials.resolvedAccountId)
     }
 
     public static func defaultURL() -> URL {

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthAccountIdentity.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthAccountIdentity.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Resolves the account scope used by Codex OAuth requests without exposing JWT contents.
+extension CodexOAuthCredentials {
+    /// Returns the first nonblank account claim, falling back to the first nonblank organization ID.
+    public var resolvedAccountId: String? {
+        CodexOAuthAccountIdentityResolver.resolve(accountId: self.accountId, idToken: self.idToken)
+    }
+}
+
+enum CodexOAuthAccountIdentityResolver {
+    static func resolve(accountId: String?, idToken: String?) -> String? {
+        let payload = idToken.flatMap(Self.payload(from:))
+        let auth = payload?["https://api.openai.com/auth"] as? [String: Any]
+        let candidates = [
+            accountId,
+            auth?["chatgpt_account_id"] as? String,
+            payload?["chatgpt_account_id"] as? String,
+        ]
+        for candidate in candidates {
+            if let normalized = Self.normalized(candidate) {
+                return normalized
+            }
+        }
+
+        guard let organizations = payload?["organizations"] as? [[String: Any]] else { return nil }
+        for organization in organizations {
+            if let normalized = Self.normalized(organization["id"] as? String) {
+                return normalized
+            }
+        }
+        return nil
+    }
+
+    static func payload(from token: String) -> [String: Any]? {
+        let parts = token.split(separator: ".")
+        guard parts.count >= 2 else { return nil }
+        var padded = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while padded.count % 4 != 0 {
+            padded.append("=")
+        }
+        guard let data = Data(base64Encoded: padded) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
@@ -83,6 +83,11 @@ public enum CodexOAuthCredentialsStore {
         }
 
         let data = try Data(contentsOf: url)
+        return try self.parseOAuthTokens(data: data)
+    }
+
+    /// Parses the OAuth token container even when a legacy API key is also present.
+    public static func parseOAuthTokens(data: Data) throws -> CodexOAuthCredentials {
         guard let credentials = try self.tokenCredentials(data: data) else {
             throw CodexOAuthCredentialsError.missingTokens
         }

--- a/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceResolver.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceResolver.swift
@@ -44,7 +44,7 @@ public enum CodexOpenAIWorkspaceResolver {
         credentials: CodexOAuthCredentials,
         session transport: any ProviderHTTPTransport) async throws -> CodexOpenAIWorkspaceIdentity?
     {
-        guard let workspaceAccountID = normalizeWorkspaceAccountID(credentials.accountId) else {
+        guard let workspaceAccountID = normalizeWorkspaceAccountID(credentials.resolvedAccountId) else {
             return nil
         }
 
@@ -76,7 +76,7 @@ public enum CodexOpenAIWorkspaceResolver {
         request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("codex-cli", forHTTPHeaderField: "User-Agent")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        if let workspaceAccountID = normalizeWorkspaceAccountID(credentials.accountId) {
+        if let workspaceAccountID = normalizeWorkspaceAccountID(credentials.resolvedAccountId) {
             request.setValue(workspaceAccountID, forHTTPHeaderField: "ChatGPT-Account-Id")
         }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -330,7 +330,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
 
         let usage = try await CodexOAuthUsageFetcher.fetchUsage(
             accessToken: credentials.accessToken,
-            accountId: credentials.accountId,
+            accountId: credentials.resolvedAccountId,
             env: context.env)
         let resetCredits = try await Self.fetchResetCreditsIfRequested(
             context: context,
@@ -514,7 +514,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
     {
         guard context.includeCredits,
               CodexSpendControlsMonthlyUsageGate.shouldFetch(response: usage),
-              let accountId = self.firstNonEmptyAccountId(credentials.accountId, usage.accountId)
+              let accountId = self.firstNonEmptyAccountId(credentials.resolvedAccountId, usage.accountId)
         else { return result }
 
         do {
@@ -580,7 +580,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             fetcher: { credentials in
                 try await CodexOAuthUsageFetcher.fetchRateLimitResetCredits(
                     accessToken: credentials.accessToken,
-                    accountId: credentials.accountId,
+                    accountId: credentials.resolvedAccountId,
                     env: context.env)
             })
     }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -1247,7 +1247,8 @@ public struct UsageFetcher: Sendable {
         let accountId = Self.normalizedCodexAccountField(
             credentials.accountId
                 ?? (authDict?["chatgpt_account_id"] as? String)
-                ?? (payload?["chatgpt_account_id"] as? String))
+                ?? (payload?["chatgpt_account_id"] as? String)
+                ?? Self.firstOrganizationID(from: payload))
         let identity = CodexIdentityResolver.resolve(accountId: accountId, email: email)
 
         return CodexAuthBackedAccount(identity: identity, email: email, plan: plan)
@@ -1456,6 +1457,17 @@ public struct UsageFetcher: Sendable {
             return nil
         }
         return value
+    }
+
+    private static func firstOrganizationID(from payload: [String: Any]?) -> String? {
+        guard let organizations = payload?["organizations"] as? [[String: Any]] else { return nil }
+        return organizations.lazy
+            .compactMap { organization -> String? in
+                guard let id = organization["id"] as? String else { return nil }
+                let normalized = id.trimmingCharacters(in: .whitespacesAndNewlines)
+                return normalized.isEmpty ? nil : normalized
+            }
+            .first
     }
 
     public static func parseJWT(_ token: String) -> [String: Any]? {

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -1245,10 +1245,7 @@ public struct UsageFetcher: Sendable {
         let plan = Self.normalizedCodexAccountField(
             (authDict?["chatgpt_plan_type"] as? String) ?? (payload?["chatgpt_plan_type"] as? String))
         let accountId = Self.normalizedCodexAccountField(
-            credentials.accountId
-                ?? (authDict?["chatgpt_account_id"] as? String)
-                ?? (payload?["chatgpt_account_id"] as? String)
-                ?? Self.firstOrganizationID(from: payload))
+            credentials.resolvedAccountId)
         let identity = CodexIdentityResolver.resolve(accountId: accountId, email: email)
 
         return CodexAuthBackedAccount(identity: identity, email: email, plan: plan)
@@ -1459,31 +1456,8 @@ public struct UsageFetcher: Sendable {
         return value
     }
 
-    private static func firstOrganizationID(from payload: [String: Any]?) -> String? {
-        guard let organizations = payload?["organizations"] as? [[String: Any]] else { return nil }
-        return organizations.lazy
-            .compactMap { organization -> String? in
-                guard let id = organization["id"] as? String else { return nil }
-                let normalized = id.trimmingCharacters(in: .whitespacesAndNewlines)
-                return normalized.isEmpty ? nil : normalized
-            }
-            .first
-    }
-
     public static func parseJWT(_ token: String) -> [String: Any]? {
-        let parts = token.split(separator: ".")
-        guard parts.count >= 2 else { return nil }
-        let payloadPart = parts[1]
-
-        var padded = String(payloadPart)
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        while padded.count % 4 != 0 {
-            padded.append("=")
-        }
-        guard let data = Data(base64Encoded: padded) else { return nil }
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-        return json
+        CodexOAuthAccountIdentityResolver.payload(from: token)
     }
 }
 

--- a/Tests/CodexBarTests/CodexAccountPromotionPreparationTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionPreparationTests.swift
@@ -43,6 +43,40 @@ struct CodexAccountPromotionPreparationTests {
     }
 
     @Test
+    func `builder resolves organization only JWT identity for live auth`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionPreparationTests-organization-only",
+            workspaceIdentities: [
+                "org-alpha": CodexOpenAIWorkspaceIdentity(
+                    workspaceAccountID: "org-alpha",
+                    workspaceLabel: "Organization"),
+            ])
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "beta@example.com",
+            authAccountID: "acct-beta")
+        try container.persistAccounts([target])
+        _ = try container.writeLiveOAuthAuthFile(
+            email: "alpha@example.com",
+            organizationIDs: ["org-alpha"])
+
+        let builder = PreparedPromotionContextBuilder(
+            store: container.fileStore,
+            workspaceResolver: container.workspaceResolver,
+            snapshotLoader: SettingsStoreCodexAccountReconciliationSnapshotLoader(settingsStore: container.settings),
+            authMaterialReader: DefaultCodexAuthMaterialReader(),
+            baseEnvironment: container.baseEnvironment,
+            fileManager: .default)
+
+        let context = try await builder.build(targetID: target.id)
+
+        #expect(context.live.authIdentity?.identity == .providerAccount(id: "org-alpha"))
+        #expect(context.live.authIdentity?.workspaceLabel == "Organization")
+        #expect(context.live.authIdentity?.workspaceAccountID == "org-alpha")
+    }
+
+    @Test
     func `builder preserves target missing auth as degraded home state`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionPreparationTests-target-missing-auth")

--- a/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
@@ -184,14 +184,16 @@ final class CodexAccountPromotionTestContainer {
         email: String,
         plan: String = "Pro",
         accountID: String? = nil,
-        apiKey: String? = nil) throws -> Data
+        apiKey: String? = nil,
+        organizationIDs: [String] = []) throws -> Data
     {
         try self.writeOAuthAuthFile(
             homeURL: self.liveHomeURL,
             email: email,
             plan: plan,
             accountID: accountID,
-            apiKey: apiKey)
+            apiKey: apiKey,
+            organizationIDs: organizationIDs)
     }
 
     @discardableResult
@@ -303,14 +305,19 @@ final class CodexAccountPromotionTestContainer {
         email: String,
         plan: String,
         accountID: String?,
-        apiKey: String? = nil) throws -> Data
+        apiKey: String? = nil,
+        organizationIDs: [String] = []) throws -> Data
     {
         try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
 
         var tokens: [String: Any] = [
             "accessToken": "access-\(email)",
             "refreshToken": "refresh-\(email)",
-            "idToken": Self.fakeJWT(email: email, plan: plan, accountID: accountID),
+            "idToken": Self.fakeJWT(
+                email: email,
+                plan: plan,
+                accountID: accountID,
+                organizationIDs: organizationIDs),
         ]
         if let accountID {
             tokens["accountId"] = accountID
@@ -329,7 +336,12 @@ final class CodexAccountPromotionTestContainer {
         return data
     }
 
-    private static func fakeJWT(email: String, plan: String, accountID: String?) -> String {
+    private static func fakeJWT(
+        email: String,
+        plan: String,
+        accountID: String?,
+        organizationIDs: [String] = []) -> String
+    {
         let header = (try? JSONSerialization.data(withJSONObject: ["alg": "none"])) ?? Data()
         var authClaims: [String: Any] = [
             "chatgpt_plan_type": plan,
@@ -337,11 +349,15 @@ final class CodexAccountPromotionTestContainer {
         if let accountID {
             authClaims["chatgpt_account_id"] = accountID
         }
-        let payload = (try? JSONSerialization.data(withJSONObject: [
+        var payloadValues: [String: Any] = [
             "email": email,
             "chatgpt_plan_type": plan,
             "https://api.openai.com/auth": authClaims,
-        ])) ?? Data()
+        ]
+        if !organizationIDs.isEmpty {
+            payloadValues["organizations"] = organizationIDs.map { ["id": $0] }
+        }
+        let payload = (try? JSONSerialization.data(withJSONObject: payloadValues)) ?? Data()
 
         func base64URL(_ data: Data) -> String {
             data.base64EncodedString()

--- a/Tests/CodexBarTests/CodexJWTOrganizationFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexJWTOrganizationFallbackTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct CodexJWTOrganizationFallbackTests {
+    @Test
+    func `auth identity falls back to the first JWT organization`() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-jwt-organization-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let payload: [String: Any] = [
+            "email": "user@example.com",
+            "organizations": [["id": "  "], ["id": "org-from-jwt"]],
+        ]
+        let payloadData = try JSONSerialization.data(withJSONObject: payload)
+        let encodedPayload = payloadData
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        let idToken = ["test-header", encodedPayload, "test-signature"].joined(separator: ".")
+        let auth: [String: Any] = [
+            "tokens": [
+                "access_token": "access-token",
+                "refresh_token": "refresh-token",
+                "id_token": idToken,
+            ],
+        ]
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: auth)
+            .write(to: home.appendingPathComponent("auth.json"))
+
+        let account = UsageFetcher(environment: ["CODEX_HOME": home.path]).loadAuthBackedCodexAccount()
+        #expect(account.identity == .providerAccount(id: "org-from-jwt"))
+        #expect(account.email == "user@example.com")
+    }
+}

--- a/Tests/CodexBarTests/CodexJWTOrganizationFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexJWTOrganizationFallbackTests.swift
@@ -35,4 +35,29 @@ struct CodexJWTOrganizationFallbackTests {
         #expect(account.identity == .providerAccount(id: "org-from-jwt"))
         #expect(account.email == "user@example.com")
     }
+
+    @Test
+    func `blank direct account claims fall through to the first JWT organization`() throws {
+        let payload: [String: Any] = [
+            "https://api.openai.com/auth": ["chatgpt_account_id": "  "],
+            "chatgpt_account_id": "\n\t",
+            "organizations": [["id": "  "], ["id": "org-after-blank-claims"]],
+        ]
+        let payloadData = try JSONSerialization.data(withJSONObject: payload)
+        let encodedPayload = payloadData
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        let idToken = ["test-header", encodedPayload, "test-signature"].joined(separator: ".")
+
+        let credentials = CodexOAuthCredentials(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            idToken: idToken,
+            accountId: " \t",
+            lastRefresh: Date())
+
+        #expect(credentials.resolvedAccountId == "org-after-blank-claims")
+    }
 }

--- a/Tests/CodexBarTests/CodexOAuthAccountScopeTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthAccountScopeTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite(.serialized)
+struct CodexOAuthAccountScopeTests {
+    @Test
+    func `usage strategy sends the resolved JWT organization account header`() async throws {
+        let home = try Self.makeAuthHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-Id") == "org-from-request")
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: nil)
+            else {
+                throw URLError(.badURL)
+            }
+            let body = #"""
+            {"rate_limit":{"primary_window":{"used_percent":12,"reset_at":1786161204,
+            "limit_window_seconds":18000},"secondary_window":null}}
+            """#
+            return (Data(body.utf8), response)
+        }
+
+        let context = Self.context(env: ["CODEX_HOME": home.path])
+        let result = try await CodexAuthenticatedHTTPTransport.$overrideForTesting
+            .withValue(transport) {
+                try await CodexOAuthFetchStrategy().fetch(context)
+            }
+
+        #expect(result.usage.primary?.usedPercent == 12)
+        #expect(await transport.requests().count == 1)
+    }
+
+    @Test
+    func `all account scoped OAuth endpoints use the resolved organization account`() async throws {
+        let credentials = Self.credentials()
+        let transport = ProviderHTTPTransportStub { request in
+            let path = request.url?.path ?? ""
+            let header = request.value(forHTTPHeaderField: "ChatGPT-Account-Id")
+                ?? request.value(forHTTPHeaderField: "ChatGPT-Account-ID")
+            #expect(header == "org-from-request")
+            if path.contains("rate-limit-reset-credits") {
+                let body = #"{"credits":[],"available_count":0}"#
+                guard let url = request.url,
+                      let response = HTTPURLResponse(
+                          url: url,
+                          statusCode: 200,
+                          httpVersion: nil,
+                          headerFields: nil)
+                else {
+                    throw URLError(.badURL)
+                }
+                return (Data(body.utf8), response)
+            }
+            if path.contains("monthly-usage") {
+                let body = #"""
+                {"current_month_usage":1,"effective_monthly_limit":{"limit":10,
+                "enforcement_mode":"HARD_CAP","limit_mode":"amount_credits"}}
+                """#
+                guard let url = request.url,
+                      let response = HTTPURLResponse(
+                          url: url,
+                          statusCode: 200,
+                          httpVersion: nil,
+                          headerFields: nil)
+                else {
+                    throw URLError(.badURL)
+                }
+                return (Data(body.utf8), response)
+            }
+            let body = #"{"rate_limit":{"primary_window":null,"secondary_window":null}}"#
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: nil)
+            else {
+                throw URLError(.badURL)
+            }
+            return (Data(body.utf8), response)
+        }
+
+        _ = try await CodexOAuthUsageFetcher.fetchUsage(
+            accessToken: credentials.accessToken,
+            accountId: credentials.resolvedAccountId,
+            env: [:],
+            session: transport)
+        _ = try await CodexOAuthUsageFetcher.fetchRateLimitResetCredits(
+            accessToken: credentials.accessToken,
+            accountId: credentials.resolvedAccountId,
+            env: [:],
+            session: transport)
+        _ = try await CodexOAuthUsageFetcher.fetchSpendControlsMonthlyUsage(
+            accessToken: credentials.accessToken,
+            accountId: #require(credentials.resolvedAccountId),
+            env: [:],
+            session: transport)
+
+        #expect(await transport.requests().count == 3)
+    }
+
+    private static func credentials() -> CodexOAuthCredentials {
+        let data = Data(#"{"organizations":[{"id":"org-from-request"}]}"#.utf8)
+        let encoded = data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return CodexOAuthCredentials(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            idToken: ["header", encoded, "signature"].joined(separator: "."),
+            accountId: " \n",
+            lastRefresh: Date())
+    }
+
+    private static func makeAuthHome() throws -> URL {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-oauth-scope-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        let credentials = Self.credentials()
+        let auth: [String: Any] = [
+            "last_refresh": ISO8601DateFormatter().string(from: Date()),
+            "tokens": [
+                "access_token": credentials.accessToken,
+                "refresh_token": credentials.refreshToken,
+                "id_token": credentials.idToken as Any,
+                "account_id": " \n",
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: auth).write(to: home.appendingPathComponent("auth.json"))
+        return home
+    }
+
+    private static func context(env: [String: String]) -> ProviderFetchContext {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .oauth,
+            includeCredits: false,
+            webTimeout: 60,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: env,
+            settings: nil,
+            fetcher: UsageFetcher(environment: env),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+}

--- a/Tests/CodexBarTests/CodexOAuthAccountScopeTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthAccountScopeTests.swift
@@ -108,6 +108,33 @@ struct CodexOAuthAccountScopeTests {
         #expect(await transport.requests().count == 3)
     }
 
+    @Test
+    func `workspace lookup uses the resolved organization account`() async throws {
+        let credentials = Self.credentials()
+        let transport = ProviderHTTPTransportStub { request in
+            let header = request.value(forHTTPHeaderField: "ChatGPT-Account-Id")
+            #expect(header == "org-from-request")
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: nil)
+            else {
+                throw URLError(.badURL)
+            }
+            return (Data(#"{"items":[{"id":"org-from-request","name":"Workspace"}]}"#.utf8), response)
+        }
+
+        let identity = try await CodexOpenAIWorkspaceResolver.resolve(
+            credentials: credentials,
+            session: transport)
+
+        #expect(identity?.workspaceAccountID == "org-from-request")
+        #expect(identity?.workspaceLabel == "Workspace")
+        #expect(await transport.requests().count == 1)
+    }
+
     private static func credentials() -> CodexOAuthCredentials {
         let data = Data(#"{"organizations":[{"id":"org-from-request"}]}"#.utf8)
         let encoded = data.base64EncodedString()

--- a/Tests/CodexBarTests/CodexResetCreditOutcomeTests.swift
+++ b/Tests/CodexBarTests/CodexResetCreditOutcomeTests.swift
@@ -39,6 +39,25 @@ struct CodexResetCreditOutcomeTests {
     }
 
     @Test
+    func `supplemental inventory uses the resolved organization account`() async throws {
+        let recorder = ResetCreditRequestRecorder()
+        let now = Date()
+        let credentials = try Self.credentials(
+            lastRefresh: now,
+            idToken: Self.jwtPayload(["organizations": [["id": "org-from-jwt"]]]),
+            accountId: " \n")
+
+        _ = try await UsageStore._fetchCodexResetCreditsForTesting(
+            credentials: credentials,
+            request: { accessToken, accountID, environment in
+                await recorder.record(accessToken: accessToken, accountID: accountID, environment: environment)
+                return Self.resetSnapshot(id: "resolved", now: now)
+            })
+
+        #expect(await recorder.lastAccountID() == "org-from-jwt")
+    }
+
+    @Test
     func `embedded OAuth inventory prevents a duplicate supplemental GET`() async throws {
         let now = Date(timeIntervalSince1970: 1_781_726_400)
         let embedded = Self.resetSnapshot(id: "embedded", now: now)
@@ -211,13 +230,26 @@ struct CodexResetCreditOutcomeTests {
             updatedAt: now)
     }
 
-    private static func credentials(lastRefresh: Date?) -> CodexOAuthCredentials {
+    private static func credentials(
+        lastRefresh: Date?,
+        idToken: String? = nil,
+        accountId: String? = "account-123") -> CodexOAuthCredentials
+    {
         CodexOAuthCredentials(
             accessToken: "access",
             refreshToken: "refresh",
-            idToken: nil,
-            accountId: "account-123",
+            idToken: idToken,
+            accountId: accountId,
             lastRefresh: lastRefresh)
+    }
+
+    private static func jwtPayload(_ payload: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let encoded = data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return ["header", encoded, "signature"].joined(separator: ".")
     }
 
     private static func usage(from outcome: ProviderFetchOutcome) throws -> UsageSnapshot {

--- a/Tests/CodexBarTests/ManagedCodexAccountStoreTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountStoreTests.swift
@@ -276,6 +276,46 @@ func `FileManagedCodexAccountStore hydrates provider account I D from id token w
 }
 
 @Test
+func `FileManagedCodexAccountStore hydrates provider account I D from JWT organization`() throws {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let fileURL = root.appendingPathComponent("managed.json", isDirectory: false)
+    let home = root.appendingPathComponent("organization-only-home", isDirectory: true)
+    try writeOrganizationOnlyCodexAuthFile(
+        homeURL: home,
+        email: "user@example.com",
+        organizationID: "org-jwt-only")
+
+    let accountID = UUID()
+    let json = """
+    {
+      "accounts" : [
+        {
+          "createdAt" : 10,
+          "email" : "user@example.com",
+          "id" : "\(accountID.uuidString)",
+          "lastAuthenticatedAt" : null,
+          "managedHomePath" : "\(home.path)",
+          "updatedAt" : 20
+        }
+      ],
+      "version" : 1
+    }
+    """
+
+    try json.write(to: fileURL, atomically: true, encoding: .utf8)
+
+    let store = FileManagedCodexAccountStore(fileURL: fileURL)
+    let loaded = try store.loadAccounts()
+
+    #expect(loaded.version == FileManagedCodexAccountStore.currentVersion)
+    #expect(loaded.accounts.count == 1)
+    #expect(loaded.accounts.first?.providerAccountID == "org-jwt-only")
+    #expect(loaded.account(email: "user@example.com", providerAccountID: "org-jwt-only")?.id == accountID)
+}
+
+@Test
 func `FileManagedCodexAccountStore drops duplicate IDs on load`() throws {
     let tempDir = FileManager.default.temporaryDirectory
     let fileURL = tempDir.appendingPathComponent("codexbar-managed-codex-accounts-duplicate-id-test.json")
@@ -519,6 +559,38 @@ private func writeCodexAuthFile(
     }
     let data = try JSONSerialization.data(withJSONObject: ["tokens": tokens], options: [.sortedKeys])
     try data.write(to: homeURL.appendingPathComponent("auth.json"))
+}
+
+private func writeOrganizationOnlyCodexAuthFile(
+    homeURL: URL,
+    email: String,
+    organizationID: String) throws
+{
+    try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
+    let tokens: [String: Any] = [
+        "accessToken": "access-token",
+        "refreshToken": "refresh-token",
+        "idToken": organizationOnlyJWT(email: email, organizationID: organizationID),
+    ]
+    let data = try JSONSerialization.data(withJSONObject: ["tokens": tokens], options: [.sortedKeys])
+    try data.write(to: homeURL.appendingPathComponent("auth.json"))
+}
+
+private func organizationOnlyJWT(email: String, organizationID: String) -> String {
+    let header = (try? JSONSerialization.data(withJSONObject: ["alg": "none"])) ?? Data()
+    let payload = (try? JSONSerialization.data(withJSONObject: [
+        "email": email,
+        "organizations": [["id": organizationID]],
+    ])) ?? Data()
+
+    func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "=", with: "")
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+    }
+
+    return "\(base64URL(header)).\(base64URL(payload))."
 }
 
 private func fakeJWT(email: String, accountId: String) -> String {

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1503,7 +1503,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This tagged diagnostic payload encodes MiniMax details under the matching wire key."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/UsageFetcher.swift",
-            line: 1498,
+            line: 1472,
             anchor: "providerID: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1503,7 +1503,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This tagged diagnostic payload encodes MiniMax details under the matching wire key."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/UsageFetcher.swift",
-            line: 1486,
+            line: 1498,
             anchor: "providerID: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),


### PR DESCRIPTION
## Summary

- use the first non-empty `organizations[].id` in a Codex JWT when the direct account claims are absent
- normalize whitespace-only direct claims and organization IDs before selecting an account scope
- use the resolved account scope consistently for usage, reset-credit, and spend-controls OAuth requests
- use the resolved identity for workspace lookup as well as usage, reset-credit, and spend-controls requests
- use the resolved identity for managed-account promotion and legacy store hydration
- keep mixed `OPENAI_API_KEY` + OAuth files on their OAuth identity path during promotion
- add focused identity, workspace, and request-capture regression coverage

## User impact

Codex usage and credit requests retain the correct account scope for tokens whose organization identity is present only in the JWT organization list, including when direct account claims are blank.

## Validation

- `swift test --disable-sandbox --filter 'CodexAccountPromotionServiceTests|CodexAccountPromotionPreparationTests|ManagedCodexAccountStoreTests|CodexOAuthTests|CodexOAuthAccountScopeTests|ProviderArchitectureGatekeeperTests'` — 111 tests, 0 failures
- organization-only JWT promotion and managed-store hydration regressions pass, including mixed API key + OAuth preservation
- `make check` (portable build, tests, formatting, lint) — passed
- `git diff --check`

## Verification evidence

The request capture used a redacted local fixture with no live token or network.

- `usage` sent `ChatGPT-Account-Id: org-from-request`.
- `rate-limit-reset-credits` sent `ChatGPT-Account-ID: org-from-request`.
- `spend-controls/monthly-usage` sent `ChatGPT-Account-Id: org-from-request`.
- workspace lookup sent `ChatGPT-Account-Id: org-from-request` and matched the returned workspace.
- the macOS app's supplemental reset-credit request sent `org-from-jwt` when the direct account claim was whitespace-only and the JWT contained only `organizations[].id`.
- Whitespace-only direct account claims and nested claims fell through to the first nonblank JWT organization ID.
- a local organization-only JWT with `org-alpha` resolved both promotion workspace identity and managed-account provider identity to `org-alpha`.
- a mixed local auth fixture preserved the displaced OAuth account identity even when `OPENAI_API_KEY` was present beside the OAuth tokens.


## Environment audit (2026-08-16)

- The installed native Codex auth file is owner-only and its redacted ID-token shape contains both a namespaced account claim and an `organizations` array. The direct claim is present, so the organization-only fallback cannot be honestly exercised with this live token.
- Altering a signed live token to remove the direct claim would make a synthetic fixture, not real behavior proof; no network request was made and no credential value was recorded.
- The resolved organization-identity implementation and its request/promotion coverage are already carried forward into the owner-safe OAuth series in PR #2944; this branch has no separate code defect to patch without duplicating that series.
- The remaining blocker is explicit maintainer approval for the first-nonblank organization fallback semantics.


## CI and identity-proof follow-up (2026-08-16)

- Head remains `1ff428b573825295bdc94eb9b4fb830ee5609903`.
- CI run [31832911255](https://github.com/steipete/CodexBar/actions/runs/31832911255): changes, lint, Linux x64/arm64, Linux musl, and GitGuardian passed. The only failed job is the aggregate Draft gate; its log explicitly reports `MACOS_TESTS_DEFERRED=true` and `macOS Swift tests are required but deferred`. This is the repository's Draft policy, not a product/test failure.
- Environment audit: the installed native Codex ID-token shape has both a direct account claim and an `organizations` array. Because the direct claim is present, it cannot honestly prove the organization-only fallback with this real token; altering a signed token would make a synthetic fixture. No credential value was recorded and no request was sent for this audit.
- The identity resolver and propagation changes are already carried into canonical PR [#2944](https://github.com/steipete/CodexBar/pull/2944). The remaining decision is whether first nonblank JWT organization selection is an approved provider-auth contract.
