### PR TITLE
README: add an independent maintenance badge (StillShipping, maintained · 100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![AUR](https://img.shields.io/aur/version/codexbar-cli?style=flat-square&color=1793d1)](https://aur.archlinux.org/packages/codexbar-cli)
 [![License: MIT](https://img.shields.io/badge/license-MIT-6e5aff?style=flat-square)](LICENSE)
 [![Site](https://img.shields.io/badge/site-codexbar.app-16d3b4?style=flat-square)](https://codexbar.app)
+[![Maintenance: maintained](https://toolproof.kynth.studio/badge/stillshipping/steipete/CodexBar.svg?style=flat-square)](https://stillshipping.kynth.studio/tool/codexbar)
 
 <a href="https://codexbar.app"><img src="docs/social.png" alt="CodexBar — every AI coding limit in your menu bar. 69 providers." width="100%" /></a>
 


### PR DESCRIPTION
Adds one badge to the README row, in your `?style=flat-square` so it sits level with the other six:

[![Maintenance: maintained](https://toolproof.kynth.studio/badge/stillshipping/steipete/CodexBar.svg?style=flat-square)](https://stillshipping.kynth.studio/tool/codexbar)

**What it is.** StillShipping tracks 333 agent tools and recomputes one of three verdicts — maintained, stale, dead — every night from the GitHub API: commit recency and volume, release cadence, issue response time, and how many people have committed in the last 90 days. CodexBar reads `maintained` at freshness 100/100. Every verdict ships with the list of facts that produced it, so it can be argued with rather than just believed: https://stillshipping.kynth.studio/tool/codexbar

**Why it might be worth a slot.** A "last commit" badge says a commit happened. This says a third party looked at commits, releases, issue response and contributor count together and concluded the project is alive — which is the question someone actually has before installing a menu bar app that talks to their provider accounts. It is also not a claim you are making about yourself.

**Disclosure.** I maintain StillShipping, so I am proposing a badge that points at my own index. Judge it on whether it earns the row and close it without ceremony if it does not — a badge nobody wanted is worse than no badge.

**The things that usually decide a badge PR:**

- **Free, no account, no key.** GET only.
- **It updates itself.** Recomputed nightly. If CodexBar ever went quiet the badge would say `stale` and then `dead` without anyone editing the README — which is the only reason a maintenance badge is worth anything.
- **You cannot set the value and neither can I.** There is no `?message=` parameter and there will not be one.
- **No tracking.** The endpoint sets no cookie, reads no header it does not need to render an SVG, and keeps no per-reader log.
- **If you would rather not hotlink a domain you have not heard of** — a completely fair objection to any badge, and the reason most of them are shields — the same data is served in shields.io's endpoint schema, so shields renders the image and your readers never talk to my domain:

  ```
  [![maintenance](https://img.shields.io/endpoint?url=https%3A%2F%2Ftoolproof.kynth.studio%2Fapi%2Fv1%2Fbadge%2Fstillshipping%2Fsteipete%2FCodexBar&style=flat-square)](https://stillshipping.kynth.studio/tool/codexbar)
  ```

  Say the word and I will switch this PR to that form.

**One more reading you may or may not want.** `AGENTS.md` in this repo also scores 93/100 on RuleStack, which measures what is actually in an agent instruction file — headings, extractable commands, code blocks, section coverage: https://rulestack.kynth.studio/configs/steipete-codexbar-agents · I left that badge out to keep this to one line. Happy to swap it in instead.

**Context.** Both indexes sit under [Toolproof](https://toolproof.kynth.studio), a measurement layer for AI agent tooling published by Kynth Studios. Method: https://toolproof.kynth.studio/methodology · Everything as JSON, no key: https://toolproof.kynth.studio/api · Badge terms, and the two indexes that deliberately mint no badge because a badge there could only ever be used against its subject: https://toolproof.kynth.studio/badges

Every reading that exists for a repository, in one call:

```
curl https://toolproof.kynth.studio/api/v1/subjects/steipete/CodexBar
```

Thanks either way — and if the verdict itself looks wrong to you, I would much rather hear that than land the badge.
