### PR TITLE
Fix Grok weekly credit window label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.49.7 — Unreleased
 
 ### Fixed
+- Grok: label the current weekly credit window near reset instead of falling back to the ambiguous “Credits” title (#2929). Thanks @byteofsam!
 - Codex: show Business accounts' monthly credit remaining in the provider switcher when no session or weekly rate-limit window is available, and keep quota indicators visible on the selected provider tab (#2926). Thanks @jey3dayo!
 - Gemini: offer the Antigravity provider migration when local OAuth recovery cannot use Gemini CLI and an `agy` or Antigravity installation is available (#2808). Thanks @axisrow!
 - Provider status: omit status-page transport errors from menus until a real status fetch succeeds, while preserving the last successful status through later fetch failures (#2925). Thanks @tomarai85!

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -478,7 +478,7 @@ extension UsageMenuCardView.Model {
         } else if input.provider == .crof {
             CrofProviderDescriptor.primaryLabel(snapshot: snapshot)
         } else if input.provider == .grok {
-            GrokProviderDescriptor.primaryLabel(window: snapshot.primary, now: input.now) ?? input.metadata.sessionLabel
+            GrokProviderDescriptor.displayLabel(window: snapshot.primary, now: input.now) ?? input.metadata.sessionLabel
         } else if input.provider == .doubao {
             DoubaoProviderDescriptor.primaryLabel(window: snapshot.primary) ?? input.metadata.sessionLabel
         } else if input.provider == .sub2api {

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -682,7 +682,7 @@ struct MenuDescriptor {
                 sessionLabel: metadata.sessionLabel,
                 weeklyLabel: metadata.weeklyLabel)
         } else if provider == .grok {
-            GrokProviderDescriptor.primaryLabel(window: snapshot.primary) ?? metadata.sessionLabel
+            GrokProviderDescriptor.displayLabel(window: snapshot.primary) ?? metadata.sessionLabel
         } else if provider == .crof {
             CrofProviderDescriptor.primaryLabel(snapshot: snapshot)
         } else if provider == .doubao {

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -418,7 +418,7 @@ extension UsageStore {
                 return "Requests"
             }
             if provider == .grok,
-               let dyn = GrokProviderDescriptor.primaryLabel(window: snapshot.primary)
+               let dyn = GrokProviderDescriptor.displayLabel(window: snapshot.primary)
             {
                 return dyn
             }

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -61,7 +61,7 @@ public enum GrokProviderDescriptor {
             }),
             presentation: ProviderUsagePresentation(rateWindowLabeler: { metadata, snapshot, now in
                 ProviderRateWindowLabels(
-                    primary: Self.primaryLabel(window: snapshot.primary, now: now) ?? metadata.sessionLabel,
+                    primary: Self.displayLabel(window: snapshot.primary, now: now) ?? metadata.sessionLabel,
                     secondary: metadata.weeklyLabel,
                     tertiary: metadata.opusLabel ?? "Sonnet",
                     showsTertiary: metadata.supportsOpus)
@@ -101,6 +101,17 @@ public enum GrokProviderDescriptor {
     public static func primaryLabel(resetsAt: Date?, now: Date = .now) -> String? {
         guard let resetsAt else { return nil }
         return self.primaryLabel(duration: resetsAt.timeIntervalSince(now))
+    }
+
+    /// Grok's current untyped credits surface is the weekly credit pool (#2929). Keep explicit
+    /// durations authoritative, but do not lose the weekly label near the end of an untyped window.
+    public static func displayLabel(window: RateWindow?, now: Date = .now) -> String? {
+        guard let window else { return nil }
+        if let label = self.primaryLabel(window: window, now: now) {
+            return label
+        }
+        guard window.windowMinutes == nil, window.resetsAt != nil else { return nil }
+        return "Weekly"
     }
 
     private static func primaryLabel(duration seconds: TimeInterval) -> String? {

--- a/Tests/CodexBarTests/GrokMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/GrokMenuCardModelTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
+@MainActor
 struct GrokMenuCardModelTests {
     @Test
     func `weekly CLI quota shows projection and pace marker`() throws {
@@ -79,21 +80,69 @@ struct GrokMenuCardModelTests {
     }
 
     @Test
-    func `unclassified quota does not show weekly projection`() throws {
+    func `weekly web quota near reset keeps its label without projection`() throws {
         let now = Date(timeIntervalSince1970: 0)
         let model = try Self.model(
             now: now,
             window: RateWindow(
                 usedPercent: 50,
                 windowMinutes: nil,
-                resetsAt: now.addingTimeInterval(2 * 24 * 3600),
+                resetsAt: now.addingTimeInterval(2 * 3600),
                 resetDescription: nil))
 
         let metric = try #require(model.metrics.first { $0.id == "primary" })
-        #expect(metric.title == "Credits")
+        #expect(metric.title == "Weekly")
         #expect(metric.detailLeftText == nil)
         #expect(metric.detailRightText == nil)
         #expect(metric.pacePercent == nil)
+    }
+
+    @Test
+    func `weekly web quota near reset keeps its label in the detail menu`() throws {
+        let suite = "GrokMenuCardModelTests-detail-menu"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let now = Date()
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 50,
+                    windowMinutes: nil,
+                    resetsAt: now.addingTimeInterval(2 * 3600),
+                    resetDescription: nil),
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: now,
+                identity: nil),
+            provider: .grok)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .grok,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updateReady: false,
+            includeContextualActions: false)
+        let lines = descriptor.sections
+            .flatMap(\.entries)
+            .compactMap { entry -> String? in
+                guard case let .text(text, _) = entry else { return nil }
+                return text
+            }
+
+        #expect(lines.contains(where: { $0.hasPrefix("Weekly:") }))
+        #expect(!lines.contains(where: { $0.hasPrefix("Credits:") }))
     }
 
     private static func model(now: Date, window: RateWindow) throws -> UsageMenuCardView.Model {


### PR DESCRIPTION
## Summary

- keep Grok’s current untyped credit pool labeled as Weekly when it is close to reset
- preserve explicit weekly/monthly durations as authoritative and leave pace behavior unchanged
- apply the same title to the menu card, provider-detail menu, and widget

## Before

Near the end of the weekly credit window, the title fell back to the ambiguous Credits label.

![Before: Grok credits row without a window label](https://github.com/user-attachments/assets/b0feb0fa-67c2-4c27-9d34-2bc27bd960bf)

## After

The same untyped credit window remains labeled Weekly near reset. Explicit monthly windows still render as Monthly.

![After: Grok row labeled Weekly](https://github.com/user-attachments/assets/fa43c4d2-7abb-4de3-b23d-14f782020f3e)

## Verification

- `swift test --filter 'GrokMenuCardModelTests|ProviderArchitectureGatekeeperTests'`
- `make check`
- `make test` — 72/72 groups passed on the first attempt

Fixes #2929
