### PR TITLE
Add compact runs-out menu token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Cost history: add a Tokens/Cost switch to daily status-menu charts, defaulting Codex to exact local token totals and marking incomplete local history as refreshing (#2930). Thanks @Carl723000!
+- Menu bar layout: add a compact run-out forecast token that shows only the predicted duration (#2865). Thanks @gnattu!
 
 ### Fixed
 - Grok: label the current weekly credit window near reset instead of falling back to the ambiguous “Credits” title (#2929). Thanks @byteofsam!

--- a/Sources/CodexBar/MenuBarLayout.swift
+++ b/Sources/CodexBar/MenuBarLayout.swift
@@ -20,6 +20,7 @@ enum MenuBarLayoutToken: Codable, Hashable, Sendable {
     case resetCountdown
     case resetAbsolute
     case runsOut
+    case runsOutCompact
     case balance
     case costToday
     case cost30d

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -43,6 +43,10 @@ struct MenuBarLayoutDragItem: Codable, Hashable, Transferable, Sendable {
     static let lineBreak = Self(content: .lineBreak, source: nil, sourceLayout: nil)
 }
 
+enum MenuBarLayoutPaletteTokens {
+    static let time: [MenuBarLayoutToken] = [.resetCountdown, .resetAbsolute, .runsOut, .runsOutCompact]
+}
+
 enum MenuBarLayoutEditorMutations {
     static func append(_ component: MenuBarLayoutToken, to layout: MenuBarLayout) -> MenuBarLayout {
         var lines = layout.lines
@@ -255,7 +259,7 @@ struct MenuBarLayoutEditor: View {
             MenuBarLayoutPaletteGroup(
                 id: "time",
                 title: L("menu_bar_layout_group_time"),
-                tokens: [.resetCountdown, .resetAbsolute, .runsOut],
+                tokens: MenuBarLayoutPaletteTokens.time,
                 includesLineBreak: false),
             MenuBarLayoutPaletteGroup(
                 id: "money",
@@ -781,7 +785,7 @@ struct MenuBarLayoutPreview: View {
             sessionPace: samplePace(session),
             weeklyPace: samplePace(weekly),
             automaticPace: samplePace(session),
-            runsOut: L("menu_bar_layout_sample_runs_out"),
+            runsOut: L("Runs out in %@", "1d 16h"),
             // Provider-specific by design: only OpenRouter previews the Balance palette token.
             balance: provider == .openrouter ? "$12.34" : nil,
             costToday: "$1.25",
@@ -898,6 +902,7 @@ extension MenuBarLayoutToken {
         case .resetCountdown: L("menu_bar_layout_token_resets_in")
         case .resetAbsolute: L("menu_bar_layout_token_reset_at")
         case .runsOut: L("menu_bar_layout_token_runs_out")
+        case .runsOutCompact: "\(L("menu_bar_layout_token_runs_out")) (compact)"
         case .balance: L("Balance")
         case .costToday: L("menu_bar_layout_token_cost_today")
         case .cost30d: L("menu_bar_layout_token_cost_30d")
@@ -923,7 +928,7 @@ extension MenuBarLayoutToken {
         case .usageBar: "chart.bar.fill"
         case .resetCountdown: "timer"
         case .resetAbsolute: "clock"
-        case .runsOut: "hourglass.bottomhalf.filled"
+        case .runsOut, .runsOutCompact: "hourglass.bottomhalf.filled"
         case .balance: "creditcard"
         case .costToday: "dollarsign.circle"
         case .cost30d: "calendar.badge.clock"

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -391,10 +391,12 @@ final class MenuBarLayoutRenderer {
                     ?? data.automatic?.resetDescription,
                 unavailableLabel: L("Reset time unavailable"),
                 attributes: style.attributes)
-        case .runsOut:
+        case .runsOut, .runsOutCompact:
+            let isCompact = item == .runsOutCompact
             return self.optionalTextToken(
-                data.runsOut,
+                isCompact ? data.runsOut.map(self.compactRunsOutText) : data.runsOut,
                 unavailableLabel: L("Run-out estimate unavailable"),
+                accessibilityText: isCompact ? data.runsOut : nil,
                 attributes: style.attributes)
         case .balance:
             return self.optionalTextToken(
@@ -420,6 +422,27 @@ final class MenuBarLayoutRenderer {
 
     private static func iconAccessibilityText(data: MenuBarLayoutRenderData) -> String {
         L("%@ icon", data.providerName ?? L("Provider"))
+    }
+
+    private static func compactRunsOutText(_ text: String) -> String {
+        let nowLabel = L("Runs out now")
+        if text.hasPrefix(nowLabel) {
+            return "now" + text.dropFirst(nowLabel.count)
+        }
+
+        let marker = "\u{F8FF}"
+        let localizedTemplate = L("Runs out in %@", marker)
+        guard let markerRange = localizedTemplate.range(of: marker) else { return text }
+
+        let prefix = localizedTemplate[..<markerRange.lowerBound]
+        let suffix = localizedTemplate[markerRange.upperBound...]
+        guard text.hasPrefix(prefix) else { return text }
+
+        let withoutPrefix = text.dropFirst(prefix.count)
+        guard !suffix.isEmpty,
+              let suffixRange = withoutPrefix.range(of: suffix)
+        else { return String(withoutPrefix) }
+        return String(withoutPrefix[..<suffixRange.lowerBound]) + String(withoutPrefix[suffixRange.upperBound...])
     }
 
     private static func offsetLeadingIcon(_ image: NSImage, adjustment: Int) -> NSImage {
@@ -478,14 +501,15 @@ final class MenuBarLayoutRenderer {
         _ value: String?,
         unavailableLabel: String,
         accessibilityPrefix: String? = nil,
+        accessibilityText: String? = nil,
         attributes: [NSAttributedString.Key: Any])
         -> (value: NSAttributedString, accessibilityText: String?)
     {
         guard let value, !value.isEmpty else {
             return self.textToken(self.missingValue, accessibilityText: unavailableLabel, attributes: attributes)
         }
-        let accessibilityText = accessibilityPrefix.map { "\($0) \(value)" } ?? value
-        return self.textToken(value, accessibilityText: accessibilityText, attributes: attributes)
+        let resolvedAccessibilityText = accessibilityText ?? accessibilityPrefix.map { "\($0) \(value)" } ?? value
+        return self.textToken(value, accessibilityText: resolvedAccessibilityText, attributes: attributes)
     }
 
     private static func textToken(

--- a/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
@@ -7,6 +7,12 @@ import UniformTypeIdentifiers
 
 struct MenuBarLayoutEditorTests {
     @Test
+    func `time palette lists the compact run out token with a clear label`() {
+        #expect(MenuBarLayoutPaletteTokens.time.contains(.runsOutCompact))
+        #expect(MenuBarLayoutToken.runsOutCompact.editorLabel(provider: .codex) == "Runs out (compact)")
+    }
+
+    @Test
     func `Notion secondary editor labels use monthly cadence`() {
         let percent = MenuBarLayoutToken.percent(window: .weekly)
         let pace = MenuBarLayoutToken.pace(window: .weekly)

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -26,7 +26,8 @@ struct MenuBarLayoutRendererTests {
             (.pace(window: .automatic), "0%"),
             (.usageBar, "▮▮▯"),
             (.resetCountdown, "in 2h"),
-            (.runsOut, "Runs out tomorrow"),
+            (.runsOut, "Runs out in 1d 16h"),
+            (.runsOutCompact, "1d 16h"),
             (.balance, "$12.34"),
             (.costToday, "$1.25"),
             (.cost30d, "$20.00"),
@@ -198,6 +199,7 @@ struct MenuBarLayoutRendererTests {
             .resetCountdown,
             .resetAbsolute,
             .runsOut,
+            .runsOutCompact,
             .balance,
             .costToday,
             .cost30d,
@@ -205,8 +207,21 @@ struct MenuBarLayoutRendererTests {
 
         let output = renderer.render(layout: layout, data: missingData, icon: nil, options: self.options())
 
-        #expect(output.attributedTitle.string.count(where: { $0 == "–" }) == 17)
+        #expect(output.attributedTitle.string.count(where: { $0 == "–" }) == 18)
         #expect(output.accessibilityLabel.contains("unavailable"))
+    }
+
+    @Test
+    func `compact run out token keeps the labeled forecast for accessibility`() {
+        let renderer = MenuBarLayoutRenderer()
+        let output = renderer.render(
+            layout: MenuBarLayout(lines: [[.runsOutCompact]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options())
+
+        #expect(output.attributedTitle.string == "1d 16h")
+        #expect(output.accessibilityLabel == "Runs out in 1d 16h")
     }
 
     @Test
@@ -573,7 +588,7 @@ struct MenuBarLayoutRendererTests {
             sessionPace: "-8%",
             weeklyPace: "+11%",
             automaticPace: "0%",
-            runsOut: "Runs out tomorrow",
+            runsOut: "Runs out in 1d 16h",
             balance: "$12.34",
             costToday: "$1.25",
             cost30d: "$20.00")

--- a/Tests/CodexBarTests/MenuBarLayoutTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutTests.swift
@@ -27,6 +27,7 @@ struct MenuBarLayoutTests {
                 .resetCountdown,
                 .resetAbsolute,
                 .runsOut,
+                .runsOutCompact,
                 .balance,
                 .costToday,
                 .cost30d,
@@ -39,6 +40,16 @@ struct MenuBarLayoutTests {
         let decoded = try JSONDecoder().decode(MenuBarLayout.self, from: data)
 
         #expect(decoded == layout)
+    }
+
+    @Test
+    func `run out token discriminators stay stable`() throws {
+        let labeled = try JSONEncoder().encode(MenuBarLayoutToken.runsOut)
+        let compact = try JSONEncoder().encode(MenuBarLayoutToken.runsOutCompact)
+
+        #expect(String(bytes: labeled, encoding: .utf8) == #"{"runsOut":{}}"#)
+        #expect(String(bytes: compact, encoding: .utf8) == #"{"runsOutCompact":{}}"#)
+        #expect(try JSONDecoder().decode(MenuBarLayoutToken.self, from: labeled) == .runsOut)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1753,7 +1753,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuBarLayout.swift",
-            line: 270,
+            line: 271,
             anchor: "ProviderDescriptorRegistry.descriptor(for: provider ?? .codex).presentation.primarySemanticWindow)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,
@@ -1761,7 +1761,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuBarLayoutEditor.swift",
-            line: 650,
+            line: 654,
             anchor: "let provider = self.provider ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -1769,7 +1769,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuBarLayoutEditor.swift",
-            line: 676,
+            line: 680,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,


### PR DESCRIPTION
## Summary

- add a separately persisted compact run-out forecast token
- reuse the labeled token's pace forecast and eligibility while showing only the duration
- list the compact option in the layout editor and preserve the full forecast for accessibility

## Testing

- `make check`
- `make test`
- focused menu-bar layout suite

Fixes #2865
