### PR TITLE
Make Burn Down widget backgrounds removable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu bar layout: add a compact run-out forecast token that shows only the predicted duration (#2865). Thanks @gnattu!
 
 ### Fixed
+- Widgets: let macOS desktop styling remove the Burn Down widgets' gradient container background (#2367). Thanks @FrancisKa!
 - Grok: label the current weekly credit window near reset instead of falling back to the ambiguous “Credits” title (#2929). Thanks @byteofsam!
 - Codex: show Business accounts' monthly credit remaining in the provider switcher when no session or weekly rate-limit window is available, and keep quota indicators visible on the selected provider tab (#2926). Thanks @jey3dayo!
 - Gemini: offer the Antigravity provider migration when local OAuth recovery cannot use Gemini CLI and an `agy` or Antigravity installation is available (#2808). Thanks @axisrow!

--- a/Sources/CodexBarWidget/CodexBarWidgetBundle.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetBundle.swift
@@ -80,6 +80,10 @@ struct CodexBarCompactWidget: Widget {
     }
 }
 
+enum BurnDownWidgetBackgroundConfiguration {
+    static let isRemovable = true
+}
+
 struct CodexBarBurnDownWidget: Widget {
     private let kind = "CodexBarBurnDownWidget"
 
@@ -94,6 +98,7 @@ struct CodexBarBurnDownWidget: Widget {
         .configurationDisplayName("CodexBar Burn Down")
         .description("Remaining budget compared with an ideal steady burn rate.")
         .supportedFamilies([.systemMedium])
+        .containerBackgroundRemovable(BurnDownWidgetBackgroundConfiguration.isRemovable)
     }
 }
 
@@ -111,5 +116,6 @@ struct CodexBarCombinedBurnDownWidget: Widget {
         .configurationDisplayName("CodexBar Burn Down (Combined)")
         .description("Session and weekly burn-down charts in one tile.")
         .supportedFamilies([.systemMedium])
+        .containerBackgroundRemovable(BurnDownWidgetBackgroundConfiguration.isRemovable)
     }
 }

--- a/Tests/CodexBarTests/BurnDownWidgetConfigurationTests.swift
+++ b/Tests/CodexBarTests/BurnDownWidgetConfigurationTests.swift
@@ -1,0 +1,9 @@
+import Testing
+@testable import CodexBarWidget
+
+struct BurnDownWidgetConfigurationTests {
+    @Test
+    func `burn down widget background is removable by the system`() {
+        #expect(BurnDownWidgetBackgroundConfiguration.isRemovable)
+    }
+}


### PR DESCRIPTION
## Summary

- opt both Burn Down widget configurations into WidgetKit's removable container-background behavior
- keep the existing full-color gradient and default appearance unchanged
- cover the configuration policy with a focused state-level test

## How to remove the background

Set the macOS desktop widget style to Monochrome in System Settings → Desktop & Dock → Widgets (or use Automatic when macOS selects the monochrome style). The Burn Down views already declare their gradient with `containerBackground(for: .widget)`; this change lets WidgetKit remove that container for both the single-window and combined widgets when the system style requests it. There is no new in-widget toggle or AppIntent migration.

## Testing

- `swift build --target CodexBarWidget`
- focused widget provider suite: 49 tests passed
- `make check`
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make test` (861 selections across 72 groups, 0 failures)

Visual verification on a real macOS desktop remains pending. The repository normally uses a Parallels VM for that proof, but this change was intentionally scoped to state-level tests and build proof.

Fixes #2367
