### PR TITLE
Fix Codex Bedrock rate-limit guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu bar layout: add a compact run-out forecast token that shows only the predicted duration (#2865). Thanks @gnattu!
 
 ### Fixed
+- Codex: replace OpenAI login instructions with accurate rate-limit guidance when the CLI uses Amazon Bedrock or another custom backend without ChatGPT authentication (#2679). Thanks @italo-drm!
 - Grok: label the current weekly credit window near reset instead of falling back to the ambiguous “Credits” title (#2929). Thanks @byteofsam!
 - Codex: show Business accounts' monthly credit remaining in the provider switcher when no session or weekly rate-limit window is available, and keep quota indicators visible on the selected provider tab (#2926). Thanks @jey3dayo!
 - Gemini: offer the Antigravity provider migration when local OAuth recovery cannot use Gemini CLI and an `agy` or Antigravity installation is available (#2808). Thanks @axisrow!

--- a/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
@@ -109,6 +109,7 @@ struct CodexUIErrorMapper {
             || lower.contains("codex credits are still loading")
             || lower.contains("codex account changed; importing browser cookies")
             || lower.contains("codex cli is not signed in.")
+            || lower.contains("chatgpt rate limits are unavailable.")
             || lower.contains("codex session expired. sign in again.")
             || lower.contains("openai web refresh timed out. refresh openai cookies and try again.")
             || lower.contains(

--- a/Sources/CodexBarCore/Providers/Codex/CodexCLIBackendConfiguration.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexCLIBackendConfiguration.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+enum CodexCLIBackendRateLimitError: LocalizedError, Equatable, Sendable {
+    enum Backend: Equatable, Sendable {
+        case amazonBedrock
+        case customProvider
+    }
+
+    case chatGPTRateLimitsUnavailable(Backend)
+
+    var errorDescription: String? {
+        switch self {
+        case .chatGPTRateLimitsUnavailable(.amazonBedrock):
+            "Codex is configured for Amazon Bedrock; ChatGPT rate limits are unavailable. " +
+                "Disable the Codex usage card or use cost-based tracking."
+        case .chatGPTRateLimitsUnavailable(.customProvider):
+            "Codex is configured for a custom provider; ChatGPT rate limits are unavailable. " +
+                "Disable the Codex usage card or use cost-based tracking."
+        }
+    }
+
+    static func classify(
+        _ error: Error,
+        environment: [String: String],
+        fileManager: FileManager = .default) -> Self?
+    {
+        guard let contents = CodexCLIBackendConfiguration.loadContents(
+            environment: environment,
+            fileManager: fileManager)
+        else { return nil }
+        return self.classify(errorDescription: error.localizedDescription, configContents: contents)
+    }
+
+    static func classify(errorDescription: String, configContents: String) -> Self? {
+        let lower = errorDescription.lowercased()
+        guard lower.contains("codex account authentication required") ||
+            lower.contains("account authentication required to read rate limits") ||
+            lower.contains("requiresopenaiauth")
+        else { return nil }
+        guard let configuration = CodexCLIBackendConfiguration(contents: configContents),
+              !configuration.requiresOpenAIAuth
+        else { return nil }
+        return .chatGPTRateLimitsUnavailable(configuration.backend)
+    }
+}
+
+private struct CodexCLIBackendConfiguration {
+    private static let maximumConfigBytes = 256 * 1024
+    // Provider-specific by design: Codex CLI assigns fixed IDs to its ChatGPT-authenticated and Bedrock backends.
+    private static let openAIProviderIDs: Set<String> = ["openai", "chatgpt"]
+    private static let amazonBedrockProviderIDs: Set<String> = ["amazon-bedrock", "amazon-bedrock-runtime"]
+
+    struct ProviderSettings {
+        var name: String?
+        var requiresOpenAIAuth: Bool?
+    }
+
+    let requiresOpenAIAuth: Bool
+    let backend: CodexCLIBackendRateLimitError.Backend
+
+    init?(contents: String) {
+        var activeProviderID: String?
+        var currentProviderID: String?
+        var providerSettings: [String: ProviderSettings] = [:]
+
+        for rawLine in contents.components(separatedBy: .newlines) {
+            let line = Self.removingComment(from: rawLine)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+
+            if line.hasPrefix("[") {
+                currentProviderID = Self.modelProviderID(fromTableHeader: line)
+                continue
+            }
+
+            let parts = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { continue }
+            let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let value = String(parts[1])
+
+            if currentProviderID == nil, key == "model_provider" {
+                activeProviderID = Self.tomlString(value)
+                continue
+            }
+
+            guard let currentProviderID else { continue }
+            switch key {
+            case "name":
+                providerSettings[currentProviderID, default: ProviderSettings()].name = Self.tomlString(value)
+            case "requires_openai_auth":
+                providerSettings[currentProviderID, default: ProviderSettings()].requiresOpenAIAuth =
+                    Self.tomlBool(value)
+            default:
+                continue
+            }
+        }
+
+        guard let activeProviderID = activeProviderID?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !activeProviderID.isEmpty
+        else { return nil }
+
+        let normalizedID = activeProviderID.lowercased()
+        if Self.openAIProviderIDs.contains(normalizedID) {
+            self.requiresOpenAIAuth = true
+            self.backend = .customProvider
+            return
+        }
+
+        let settings = providerSettings[activeProviderID]
+            ?? providerSettings.first(where: { $0.key.caseInsensitiveCompare(activeProviderID) == .orderedSame })?.value
+        self.requiresOpenAIAuth = settings?.requiresOpenAIAuth ?? false
+        let normalizedName = settings?.name?.lowercased() ?? ""
+        // Provider-specific by design: Custom provider names can identify Bedrock under a user-defined provider ID.
+        self.backend = Self.amazonBedrockProviderIDs.contains(normalizedID) || normalizedName.contains("bedrock")
+            ? .amazonBedrock
+            : .customProvider
+    }
+
+    static func loadContents(
+        environment: [String: String],
+        fileManager: FileManager) -> String?
+    {
+        let codexHome = environment["CODEX_HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let root = if let codexHome, !codexHome.isEmpty {
+            URL(fileURLWithPath: codexHome, isDirectory: true)
+        } else {
+            fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".codex", isDirectory: true)
+        }
+        let configURL = root.appendingPathComponent("config.toml")
+        guard let handle = try? FileHandle(forReadingFrom: configURL) else { return nil }
+        defer { try? handle.close() }
+        guard let data = try? handle.read(upToCount: Self.maximumConfigBytes),
+              !data.isEmpty
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func modelProviderID(fromTableHeader line: String) -> String? {
+        guard line.hasPrefix("["), line.hasSuffix("]"), !line.hasPrefix("[[") else { return nil }
+        let header = line.dropFirst().dropLast().trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefix = "model_providers."
+        guard header.hasPrefix(prefix) else { return nil }
+        let rawID = String(header.dropFirst(prefix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawID.isEmpty else { return nil }
+        return Self.tomlString(rawID) ?? (rawID.contains(".") ? nil : rawID)
+    }
+
+    private static func removingComment(from line: String) -> String {
+        var quote: Character?
+        var escaped = false
+        for index in line.indices {
+            let character = line[index]
+            if let activeQuote = quote {
+                if activeQuote == "\"", character == "\\", !escaped {
+                    escaped = true
+                    continue
+                }
+                if character == activeQuote, !escaped {
+                    quote = nil
+                }
+                escaped = false
+                continue
+            }
+            if character == "\"" || character == "'" {
+                quote = character
+            } else if character == "#" {
+                return String(line[..<index])
+            }
+        }
+        return line
+    }
+
+    private static func tomlString(_ rawValue: String) -> String? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let quote = value.first, quote == "\"" || quote == "'" else { return nil }
+        if quote == "'" {
+            guard let end = value.dropFirst().firstIndex(of: "'") else { return nil }
+            return String(value[value.index(after: value.startIndex)..<end])
+        }
+
+        var escaped = false
+        var index = value.index(after: value.startIndex)
+        while index < value.endIndex {
+            let character = value[index]
+            if character == "\"", !escaped {
+                let token = String(value[...index])
+                return try? JSONDecoder().decode(String.self, from: Data(token.utf8))
+            }
+            if character == "\\" {
+                escaped.toggle()
+            } else {
+                escaped = false
+            }
+            index = value.index(after: index)
+        }
+        return nil
+    }
+
+    private static func tomlBool(_ rawValue: String) -> Bool? {
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case "true": true
+        case "false": false
+        default: nil
+        }
+    }
+}

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -1196,7 +1196,7 @@ public struct UsageFetcher: Sendable {
                     credits: credits,
                     identity: usage?.identity)
             }
-            throw error
+            throw CodexCLIBackendRateLimitError.classify(error, environment: self.environment) ?? error
         }
     }
 

--- a/Tests/CodexBarTests/CodexCLIBackendConfigurationTests.swift
+++ b/Tests/CodexBarTests/CodexCLIBackendConfigurationTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct CodexCLIBackendConfigurationTests {
+    private static let authenticationError =
+        "Codex connection failed: codex account authentication required to read rate limits"
+
+    @Test
+    func `amazon bedrock config produces rate limit guidance without login instruction`() throws {
+        let config = try Self.fixture(named: "codex-config-amazon-bedrock")
+
+        let error = try #require(CodexCLIBackendRateLimitError.classify(
+            errorDescription: Self.authenticationError,
+            configContents: config))
+        let message = try #require(CodexUIErrorMapper.userFacingMessage(error.localizedDescription))
+
+        #expect(error == .chatGPTRateLimitsUnavailable(.amazonBedrock))
+        #expect(
+            message ==
+                "Codex is configured for Amazon Bedrock; ChatGPT rate limits are unavailable. " +
+                "Disable the Codex usage card or use cost-based tracking.")
+        #expect(!message.contains("codex login"))
+        #expect(!message.contains("device-auth"))
+    }
+
+    @Test
+    func `normal openai config keeps authentication failure unchanged`() throws {
+        let config = try Self.fixture(named: "codex-config-openai")
+
+        let classified = CodexCLIBackendRateLimitError.classify(
+            errorDescription: Self.authenticationError,
+            configContents: config)
+
+        #expect(classified == nil)
+        #expect(
+            CodexUIErrorMapper.userFacingMessage(Self.authenticationError) ==
+                "Codex CLI is not signed in. Run `codex login --device-auth`, then refresh.")
+    }
+
+    private static func fixture(named name: String) throws -> String {
+        let url = try #require(Bundle.module.url(
+            forResource: name,
+            withExtension: "toml",
+            subdirectory: "Fixtures"))
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+}

--- a/Tests/CodexBarTests/Fixtures/codex-config-amazon-bedrock.toml
+++ b/Tests/CodexBarTests/Fixtures/codex-config-amazon-bedrock.toml
@@ -1,0 +1,6 @@
+# Codex 0.146 writes this provider ID for Amazon Bedrock authentication.
+model_provider = "amazon-bedrock"
+
+[model_providers.unused]
+name = "Unused fixture provider"
+requires_openai_auth = true

--- a/Tests/CodexBarTests/Fixtures/codex-config-openai.toml
+++ b/Tests/CodexBarTests/Fixtures/codex-config-openai.toml
@@ -1,0 +1,5 @@
+model_provider = "openai"
+
+[model_providers.unused]
+name = "Unused fixture provider"
+requires_openai_auth = false


### PR DESCRIPTION
## Summary

- detect the active Codex CLI `model_provider` and its `requires_openai_auth` setting from the selected `CODEX_HOME/config.toml`
- classify rate-limit authentication failures from Amazon Bedrock and custom non-ChatGPT backends as unavailable ChatGPT limits
- preserve the existing device-login guidance for normal OpenAI-backed Codex CLI installs

This is guidance-only: it does not add a Bedrock usage fetch path or change authentication behavior.

Fixes #2679

## Test proof

- `swift test --filter CodexCLIBackendConfigurationTests`
- `make check`
- `make test` — 861 selections across 72 groups, zero failures or retries
- autoreview clean: no accepted/actionable findings
