### PR TITLE
fix: route codex RPC diagnostics to the logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Vertex AI: match Cloud Monitoring quota usage without a `limit_name` to its unambiguous same-metric, same-location limit, restoring quota percentages (#2958). Thanks @MachApple!
+- Codex: stop printing ungated `[codex notify]` and `[codex stderr]` diagnostics from the CLI, routing them to the debug log instead (#2952).
 
 ## 0.50.0 — 2026-08-15
 

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -845,12 +845,6 @@ private final class CodexRPCClient: @unchecked Sendable {
     private let initializeTimeoutSeconds: TimeInterval
     private let requestTimeoutSeconds: TimeInterval
 
-    private static func debugWriteStderr(_ message: String) {
-        #if !os(Linux)
-        fputs(message, stderr)
-        #endif
-    }
-
     init(
         executable: String = "codex", // Provider-specific by design: this RPC client launches Codex app-server.
         arguments: [String] = ["-s", "read-only", "-a", "untrusted", "app-server"],
@@ -943,7 +937,7 @@ private final class CodexRPCClient: @unchecked Sendable {
             }
             guard let text = String(data: data, encoding: .utf8), !text.isEmpty else { return }
             for line in text.split(whereSeparator: \.isNewline) {
-                Self.debugWriteStderr("[codex stderr] \(line)\n")
+                Self.log.debug("Codex RPC child stderr", metadata: ["line": String(line)])
             }
         }
     }
@@ -992,7 +986,7 @@ private final class CodexRPCClient: @unchecked Sendable {
                 let message = try await self.readNextMessage()
 
                 if message["id"] == nil, let methodName = message["method"] as? String {
-                    Self.debugWriteStderr("[codex notify] \(methodName)\n")
+                    Self.log.debug("Codex RPC notification", metadata: ["method": methodName])
                     continue
                 }
 

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1503,7 +1503,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This tagged diagnostic payload encodes MiniMax details under the matching wire key."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/UsageFetcher.swift",
-            line: 1486,
+            line: 1480,
             anchor: "providerID: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),


### PR DESCRIPTION
## Summary

`CodexRPCClient` wrote two diagnostic lines straight to stderr on every Codex
probe. No environment variable and no runtime setting controlled the output.
The `codexbar` CLI therefore printed protocol noise on a normal run:

```
[codex notify] remoteControl/status/changed
```

This change deletes `debugWriteStderr` and sends both call sites to the logger
that `CodexRPCClient` already owns.

## Why the logger is enough

The CLI already defaults to log level `.error`, and it already sends logs to
stderr (`CLIEntry.swift:416-421`). The lines therefore disappear on a normal
run. They return under `--verbose` or `--log-level debug`. No new environment
variable is needed.

Three further gains:

- The `#if !os(Linux)` block goes away. That guard came from `d90dbcf55`, a
  Linux build fix, not a debug gate. Linux now receives the diagnostics that it
  silently dropped.
- In the menu bar app, the lines land in the unified log under the `codex.rpc`
  category, where a developer can find them.
- Child stderr now passes through `LogRedactor` (`CodexBarLog.swift:118`).
  `codex app-server` stderr is untrusted text, so redaction helps.

`.debug` matches the convention in this package. `CodexBarCore` has 150
`log.debug` call sites and zero calls to `.trace` or `.verbose`.

## Runtime proof

Account values are redacted below. Both runs use `2>&1`, so the capture
includes stderr.

Normal run, the diagnostic is gone:

```
$ swift build --product CodexBarCLI && .build/debug/CodexBarCLI usage 2>&1 | head -20
Build of product 'CodexBarCLI' complete! (2.14s)
Error: Claude OAuth credentials not found. Run `claude` to authenticate.
== Codex 0.147.0 (oauth) ==
Weekly: <redacted>
Pace: <redacted>
Resets in <redacted>
Credits: <redacted>
Limit Reset Credits: <redacted>
Account: <redacted>
Plan: <redacted>
```

No `[codex notify]` line appears. The `Error:` line confirms that stderr still
reaches the terminal, so the absence is the fix and not a lost stream.

Verbose run, the diagnostic returns as a structured log:

```
$ .build/debug/CodexBarCLI usage --verbose 2>&1 | grep -i "codex rpc notification"
2026-08-15T02:55:32-0700 debug com.steipete.codexbar.codex-rpc: method=remoteControl/status/changed [CodexBarCore] Codex RPC notification
```

The line now carries a timestamp, a level, and the `codex-rpc` category. The
method name moves into structured metadata.

## Note on the third file

`ProviderArchitectureGatekeeperTests.swift` holds a line-anchored suppression
list. Removing six lines from `UsageFetcher.swift` moved the anchor for
`providerID: .codex,` from line 1486 to line 1480. The patch updates that
number. The gate itself is unchanged.

## Commands run

- `swift build`
- `make check` (0 violations in 1880 files)
- `make test` (72 of 72 groups on first pass, 863 selections, no retries)

Fixes #2952
