### PR TITLE
Show pace for OpenCode Go CLI usage windows

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -60,7 +60,11 @@ public enum OpenCodeGoProviderDescriptor {
                 noDataMessage: {
                     "No OpenCode Go local usage history found in ~/.local/share/opencode/opencode.db."
                 }),
-            pace: .calendarMonthResetWindow,
+            pace: ProviderPaceCapability(
+                resetWindowPace: .windowDuration(minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
+                inferredMonthlyDuration: .windowDuration(minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
+                primary: .session(maximumMinutes: 300),
+                secondary: .weekly),
             history: .alwaysTracked,
             presentation: ProviderUsagePresentation(
                 costPresenter: { snapshot in

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -1470,4 +1470,105 @@ struct CLISnapshotTests {
         #expect(!output.contains("Cost:"))
         #expect(!output.contains(" / 0.0"))
     }
+
+    @Test
+    func `renders opencode go session and weekly pace lines`() {
+        let now = Date()
+        let snap = UsageSnapshot(
+            primary: .init(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(2 * 60 * 60),
+                resetDescription: nil),
+            secondary: .init(
+                usedPercent: 23,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(5 * 24 * 3600),
+                resetDescription: nil),
+            tertiary: nil,
+            updatedAt: now)
+
+        let output = CLIRenderer.renderText(
+            provider: .opencodego,
+            snapshot: snap,
+            credits: nil,
+            context: RenderContext(
+                header: "OpenCode Go (web)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown),
+            now: now)
+
+        #expect(output.contains("5-hour: 80% left"))
+        // 2h remaining of a 5h window => 3h elapsed => 60% expected; opencode go is not codex so no headroom suffix.
+        #expect(output.contains("Pace: 40% in reserve | Expected 60% used | Lasts until reset"))
+        #expect(output.contains("Weekly: 77% left"))
+        // 5d remaining of a 7d window => 2d elapsed => 28.57% expected (29% displayed), delta -5.57 => -6 displayed.
+        #expect(output.contains("Pace: 6% in reserve | Expected 29% used | Lasts until reset"))
+        #expect(!output.contains("1.5× headroom"))
+    }
+
+    @Test
+    func `returns opencode go pace payload for primary and secondary`() throws {
+        let now = Date()
+        let snap = UsageSnapshot(
+            primary: .init(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(2 * 60 * 60),
+                resetDescription: nil),
+            secondary: .init(
+                usedPercent: 23,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(5 * 24 * 3600),
+                resetDescription: nil),
+            tertiary: nil,
+            updatedAt: now)
+
+        let pace = try #require(CLIRenderer.providerPacePayload(provider: .opencodego, snapshot: snap, now: now))
+        #expect(pace.primary != nil)
+        #expect(pace.primary?.stage == "farBehind")
+        #expect(pace.primary?.deltaPercent == -40)
+        #expect(pace.primary?.expectedUsedPercent == 60)
+        #expect(pace.primary?.summary == "40% in reserve | Expected 60% used | Lasts until reset")
+        #expect(pace.secondary != nil)
+        #expect(pace.secondary?.stage == "slightlyBehind")
+        #expect(pace.secondary?.deltaPercent == -6)
+        #expect(pace.secondary?.expectedUsedPercent == 29)
+        #expect(pace.secondary?.summary == "6% in reserve | Expected 29% used | Lasts until reset")
+    }
+
+    @Test
+    func `returns opencode go primary-only pace when weekly usage is missing`() throws {
+        let now = Date()
+        let snap = UsageSnapshot(
+            primary: .init(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(2 * 60 * 60),
+                resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: now)
+
+        let pace = try #require(CLIRenderer.providerPacePayload(provider: .opencodego, snapshot: snap, now: now))
+        #expect(pace.primary != nil)
+        #expect(pace.secondary == nil)
+    }
+
+    @Test
+    func `hides opencode go primary pace when window exceeds five hours`() {
+        let now = Date()
+        let snap = UsageSnapshot(
+            primary: .init(
+                usedPercent: 20,
+                windowMinutes: 400,
+                resetsAt: now.addingTimeInterval(2 * 60 * 60),
+                resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: now)
+
+        #expect(CLIRenderer.providerPacePayload(provider: .opencodego, snapshot: snap, now: now) == nil)
+    }
 }


### PR DESCRIPTION
## Summary

`codexbar usage --provider opencodego` now returns pace for both the **primary** (5-hour rolling) and **secondary** (weekly) usage windows — in the text output (`Pace: ...` lines) and in the JSON `pace` payload (`pace.primary` / `pace.secondary`).

Previously the CLI pace path covered only `.session` (codex/claude/ollama) and `.weekly` (codex/claude/opencode/ollama) allowlists, so OpenCode Go got no pace on either lane even though its snapshot already carries both windows with reset times. The GUI already showed pace for the OpenCode Go monthly (tertiary) lane; this change brings the CLI in line via the descriptor's pace capability.

Scope: CLI-facing pace lanes only. The existing OpenCode Go reset-window (GUI Monthly) pace rules are preserved unchanged. No payload schema, fetcher, or docs changes; the Monthly (tertiary) row in the CLI stays unchanged.

## Changes

- `Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift` — extend the descriptor's `pace` capability: keep the existing reset-window / inferred-monthly-duration rules (GUI Monthly pace unchanged) and add `primary: .session(maximumMinutes: 300)` and `secondary: .weekly` so the CLI returns pace for the 5-hour and weekly windows (+5/-1).
- `Tests/CodexBarTests/CLISnapshotTests.swift` — 4 new tests: text pace lines for 5-hour + weekly, JSON payload primary+secondary, primary-only when weekly usage is missing, and the >5h window guard (+101).

## Verification

- `swift test --filter CLISnapshotTests` → 52/52 pass (incl. the 4 new tests)
- `swift test --filter ProviderPaceCapabilityTests` → 4/4 pass
- `swift test --filter MenuBarPaceTextTests` → 2/2 pass
- `swift build` → exit 0; CLI `--help` smoke test shows the `opencodego` provider
- SwiftFormat + SwiftLint on the changed files → 0 violations
- Note: the full `make test` shard run can abort on pre-existing, environment-dependent Claude OAuth keychain test failures unrelated to this change; `make check` can report pre-existing violations in unrelated uncommitted work-in-progress files. Both are isolated and documented (not touched here).
