### PR TITLE
Fix Codex spend availability after completed scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.50.1 — Unreleased
 
+### Fixed
+- Usage & Spend: keep safely priced Codex totals visible after completed history scans when request-tier uncertainty leaves some days unpriced (#2948). Thanks @Atopoz for the report!
+
 ## 0.50.0 — 2026-08-15
 
 ### Added

--- a/Sources/CodexBar/SpendDashboardModel+ModelBreakdown.swift
+++ b/Sources/CodexBar/SpendDashboardModel+ModelBreakdown.swift
@@ -127,7 +127,9 @@ extension SpendDashboardModel {
             return self.validCost(entry.costUSD) != nil
         }
 
-        guard let entryCost = validCost(entry.costUSD) else { return false }
+        guard let entryCost = validCost(entry.costUSD) else {
+            return self.hasExplicitlyUnpriceableCodexCost(entry)
+        }
         var pricedCost = 0.0
         var sawPricedBreakdown = false
         for breakdown in entry.modelBreakdowns ?? [] {
@@ -151,6 +153,19 @@ extension SpendDashboardModel {
             }
         }
         return sawPricedBreakdown && Self.costsMatch(entryCost, pricedCost)
+    }
+
+    static func hasExplicitlyUnpriceableCodexCost(_ entry: CostUsageDailyReport.Entry) -> Bool {
+        guard entry.costUSD == nil,
+              let breakdowns = entry.modelBreakdowns,
+              !breakdowns.isEmpty
+        else { return false }
+
+        return breakdowns.allSatisfy { breakdown in
+            !breakdown.modelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && breakdown.costUSD == nil
+                && Self.nonnegative(breakdown.totalTokens) != nil
+        }
     }
 
     private static func hasCompleteModelCostCoverage(_ entry: CostUsageDailyReport.Entry) -> Bool {

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -402,6 +402,7 @@ struct SpendDashboardModel: Equatable, Sendable {
             }
             guard coverage.contains(day) else { continue }
             guard let cost = validCost(entry.costUSD) else {
+                // Provider-specific by design: only the Codex ledger carries explicit unpriceable model/day evidence.
                 guard input.snapshot.historyCoverageIsEstablished,
                       input.provider == .codex,
                       Self.hasExplicitlyUnpriceableCodexCost(entry)

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -301,13 +301,17 @@ struct SpendDashboardModel: Equatable, Sendable {
             : entries.isEmpty
             ? (coveredDayCount > 0 && hasCompleteTokenHistory ? 0 : nil)
             : Self.completeIntSum(entries.map { Self.nonnegative($0.entry.totalTokens) })
-        let hasCompleteCostHistory = Self.hasCompleteCostHistory(input, displayCalendar: calendar)
-        let costAggregateIsConsistent = input.snapshot.last30DaysCostUSD == nil || hasCompleteCostHistory
+        let hasConsistentCostHistory = Self.hasConsistentCostHistory(input, displayCalendar: calendar)
+        let costAggregateIsConsistent = input.snapshot.last30DaysCostUSD == nil || hasConsistentCostHistory
         let invalidCostHistory = hasInvalidCostHistory || !costAggregateIsConsistent
         let totalCost = invalidCostHistory
             ? nil
             : entries.isEmpty
-            ? (coveredDayCount > 0 && hasCompleteCostHistory ? 0 : nil)
+            ? (coveredDayCount > 0 && hasConsistentCostHistory ? 0 : nil)
+            : hasConsistentCostHistory
+            ? Self.safeCostSum(entries.compactMap {
+                Self.validCost($0.entry.costUSD).map { $0 * costMultiplier }
+            })
             : Self.completeCostSum(entries.map {
                 Self.validCost($0.entry.costUSD).map { $0 * costMultiplier }
             })
@@ -382,7 +386,9 @@ struct SpendDashboardModel: Equatable, Sendable {
         return abs(lhs - rhs) <= tolerance
     }
 
-    private static func hasCompleteCostHistory(
+    /// A completed Codex scan can carry an authoritative priced subtotal while exact request-tier
+    /// evidence leaves some model/day rows unpriceable. Those explicit gaps do not contradict the subtotal.
+    private static func hasConsistentCostHistory(
         _ input: ProviderInput,
         displayCalendar: Calendar) -> Bool
     {
@@ -395,7 +401,13 @@ struct SpendDashboardModel: Equatable, Sendable {
                 continue
             }
             guard coverage.contains(day) else { continue }
-            guard let cost = validCost(entry.costUSD) else { return false }
+            guard let cost = validCost(entry.costUSD) else {
+                guard input.snapshot.historyCoverageIsEstablished,
+                      input.provider == .codex,
+                      Self.hasExplicitlyUnpriceableCodexCost(entry)
+                else { return false }
+                continue
+            }
             dailyTotal += cost
             guard dailyTotal.isFinite else { return false }
         }

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2362,7 +2362,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SpendDashboardModel.swift",
-            line: 660,
+            line: 673,
             anchor: "guard provider == .mistral else { return displayCalendar }",
             expectedProviderIDs: ["mistral"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/SpendDashboardPartialCostTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardPartialCostTests.swift
@@ -1,0 +1,126 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct SpendDashboardPartialCostTests {
+    @Test
+    func `established Codex history retains priced spend beside an unresolved long context day`() throws {
+        let snapshot = Self.snapshot(
+            entries: [
+                Self.entry(day: "2026-07-15", cost: 3, tokens: 30, model: "gpt-5.4-mini"),
+                Self.entry(day: "2026-07-16", cost: nil, tokens: 400_000, model: "gpt-5.6-sol"),
+            ],
+            last30DaysTokens: 400_030,
+            last30DaysCostUSD: 3)
+        let group = try Self.group(snapshot)
+
+        #expect(snapshot.historyCoverageIsEstablished)
+        #expect(group.totalCost == 3)
+        #expect(group.totalTokens == 400_030)
+        #expect(group.modelHistoryCompleteness == .incomplete)
+        #expect(group.models.map(\.modelName) == ["gpt-5.4-mini", "gpt-5.6-sol"])
+        #expect(group.models.map(\.totalCost) == [3, nil])
+        #expect(group.dailyPoints.map(\.cost) == [3])
+    }
+
+    @Test
+    func `incomplete Codex history with an unresolved day keeps spend unavailable`() throws {
+        let snapshot = Self.snapshot(
+            entries: [
+                Self.entry(day: "2026-07-15", cost: 3, tokens: 30, model: "gpt-5.4-mini"),
+                Self.entry(day: "2026-07-16", cost: nil, tokens: 400_000, model: "gpt-5.6-sol"),
+            ],
+            historyCoverageIsEstablished: false,
+            last30DaysTokens: 400_030,
+            last30DaysCostUSD: 3)
+        let group = try Self.group(snapshot)
+
+        #expect(!snapshot.historyCoverageIsEstablished)
+        #expect(group.totalCost == nil)
+        #expect(group.coveredDayCount == 0)
+        #expect(group.dailyPoints.isEmpty)
+    }
+
+    @Test
+    func `established Codex rows without aggregate proof keep partial spend unavailable`() throws {
+        let snapshot = Self.snapshot(
+            entries: [
+                Self.entry(day: "2026-07-15", cost: 3, tokens: 30, model: "gpt-5.4-mini"),
+                Self.entry(day: "2026-07-16", cost: nil, tokens: 400_000, model: "gpt-5.6-sol"),
+            ],
+            last30DaysTokens: 400_030,
+            last30DaysCostUSD: nil)
+        let group = try Self.group(snapshot)
+
+        #expect(snapshot.historyCoverageIsEstablished)
+        #expect(group.totalCost == nil)
+        #expect(group.modelHistoryCompleteness == .incomplete)
+        #expect(group.dailyPoints.map(\.cost) == [3])
+    }
+
+    @Test
+    func `established fully priced Codex history remains complete`() throws {
+        let snapshot = Self.snapshot(
+            entries: [
+                Self.entry(day: "2026-07-15", cost: 3, tokens: 30, model: "gpt-5.4-mini"),
+                Self.entry(day: "2026-07-16", cost: 4, tokens: 40, model: "gpt-5.6-sol"),
+            ],
+            last30DaysTokens: 70,
+            last30DaysCostUSD: 7)
+        let group = try Self.group(snapshot)
+
+        #expect(group.totalCost == 7)
+        #expect(group.totalTokens == 70)
+        #expect(group.modelHistoryCompleteness == .complete)
+        #expect(group.dailyPoints.map(\.cost) == [3, 4])
+    }
+
+    private static func group(_ snapshot: CostUsageTokenSnapshot) throws -> SpendDashboardModel.CurrencyGroup {
+        try #require(SpendDashboardModel.build(
+            inputs: [.init(provider: .codex, displayName: "Codex", snapshot: snapshot)],
+            requestedDays: 30,
+            now: self.now,
+            calendar: self.calendar).groups.first)
+    }
+
+    private static func snapshot(
+        entries: [CostUsageDailyReport.Entry],
+        historyCoverageIsEstablished: Bool = true,
+        last30DaysTokens: Int?,
+        last30DaysCostUSD: Double?) -> CostUsageTokenSnapshot
+    {
+        CostUsageTokenSnapshot(
+            sessionTokens: nil,
+            sessionCostUSD: nil,
+            last30DaysTokens: last30DaysTokens,
+            last30DaysCostUSD: last30DaysCostUSD,
+            historyDays: 2,
+            historyCoverageIsEstablished: historyCoverageIsEstablished,
+            daily: entries,
+            updatedAt: self.now)
+    }
+
+    private static func entry(
+        day: String,
+        cost: Double?,
+        tokens: Int,
+        model: String) -> CostUsageDailyReport.Entry
+    {
+        CostUsageDailyReport.Entry(
+            date: day,
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: tokens,
+            costUSD: cost,
+            modelsUsed: nil,
+            modelBreakdowns: [.init(modelName: model, costUSD: cost, totalTokens: tokens)])
+    }
+
+    private static let now = Date(timeIntervalSince1970: 1_784_179_200)
+    private static var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+}


### PR DESCRIPTION
## Summary

- retain the scanner-authoritative priced Codex subtotal after a completed scan when other model/day rows carry explicit unpriceable evidence
- preserve fail-closed totals for incomplete scans, missing aggregate proof, malformed rows, and aggregate contradictions
- keep priced model rows visible as a partial breakdown and add focused regression coverage

Fixes #2948

## Tests

- `make check`
- `swift test --filter 'SpendDashboardPartialCostTests|CostUsageTokenSnapshotDaySelectionTests'`
- `make test` reached shard 27/72; an unrelated load-sensitive RPC timeout test exceeded its 5-second bound by 115 ms when rerun in isolation (`CodexUsageFetcherFallbackTests`)
