### PR TITLE
Fix Vertex AI quota matching without limit names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.50.1 — Unreleased
 
+### Fixed
+- Vertex AI: match Cloud Monitoring quota usage without a `limit_name` to its unambiguous same-metric, same-location limit, restoring quota percentages (#2958). Thanks @MachApple!
+
 ## 0.50.0 — 2026-08-15
 
 ### Added

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIUsageFetcher.swift
@@ -95,6 +95,24 @@ public enum VertexAIUsageFetcher {
             projectId: projectId,
             filter: limitFilter)
 
+        return try Self.makeQuotaUsageResponse(
+            usageSeries: usageSeries,
+            limitSeries: limitSeries)
+    }
+
+    static func parseQuotaUsage(usageData: Data, limitData: Data) throws -> VertexAIUsageResponse {
+        let decoder = JSONDecoder()
+        let usageResponse = try decoder.decode(MonitoringTimeSeriesResponse.self, from: usageData)
+        let limitResponse = try decoder.decode(MonitoringTimeSeriesResponse.self, from: limitData)
+        return try Self.makeQuotaUsageResponse(
+            usageSeries: usageResponse.timeSeries ?? [],
+            limitSeries: limitResponse.timeSeries ?? [])
+    }
+
+    private static func makeQuotaUsageResponse(
+        usageSeries: [MonitoringTimeSeries],
+        limitSeries: [MonitoringTimeSeries]) throws -> VertexAIUsageResponse
+    {
         let usageByKey = Self.aggregate(series: usageSeries)
         let limitByKey = Self.aggregate(series: limitSeries)
 
@@ -104,10 +122,15 @@ public enum VertexAIUsageFetcher {
 
         var maxPercent: Double?
         var matchedCount = 0
-        var matchedKeys: Set<QuotaKey> = []
-        for (key, limit) in limitByKey {
-            guard limit > 0, let usage = usageByKey[key] else { continue }
-            matchedKeys.insert(key)
+        var matchedUsageKeys: Set<QuotaKey> = []
+        var matchedLimitKeys: Set<QuotaKey> = []
+        for (usageKey, usage) in usageByKey {
+            guard let (limitKey, limit) = Self.matchingLimit(
+                for: usageKey,
+                in: limitByKey)
+            else { continue }
+            matchedUsageKeys.insert(usageKey)
+            matchedLimitKeys.insert(limitKey)
             matchedCount += 1
             let percent = (usage / limit) * 100.0
             maxPercent = max(maxPercent ?? percent, percent)
@@ -117,8 +140,8 @@ public enum VertexAIUsageFetcher {
             throw VertexAIFetchError.noData
         }
 
-        let unmatchedUsage = Set(usageByKey.keys).subtracting(matchedKeys).count
-        let unmatchedLimit = Set(limitByKey.keys).subtracting(matchedKeys).count
+        let unmatchedUsage = Set(usageByKey.keys).subtracting(matchedUsageKeys).count
+        let unmatchedLimit = Set(limitByKey.keys).subtracting(matchedLimitKeys).count
         Self.log.debug("Quota series preview", metadata: [
             "usageKeys": Self.previewKeys(usageByKey),
             "limitKeys": Self.previewKeys(limitByKey),
@@ -138,6 +161,24 @@ public enum VertexAIUsageFetcher {
             resetsAt: nil,
             resetDescription: nil,
             rawData: nil)
+    }
+
+    private static func matchingLimit(
+        for usageKey: QuotaKey,
+        in limitByKey: [QuotaKey: Double]) -> (key: QuotaKey, value: Double)?
+    {
+        if let exactLimit = limitByKey[usageKey], exactLimit > 0 {
+            return (usageKey, exactLimit)
+        }
+
+        guard usageKey.limitName.isEmpty else { return nil }
+        let candidates = limitByKey.filter { limitKey, limit in
+            limit > 0
+                && limitKey.quotaMetric == usageKey.quotaMetric
+                && limitKey.location == usageKey.location
+        }
+        guard candidates.count == 1, let candidate = candidates.first else { return nil }
+        return candidate
     }
 
     private struct MonitoringTimeSeriesResponse: Decodable {
@@ -276,8 +317,12 @@ public enum VertexAIUsageFetcher {
     }
 
     private static func pointValue(from point: MonitoringPoint) -> Double? {
-        if let doubleValue = point.value.doubleValue { return doubleValue }
-        if let int64Value = point.value.int64Value { return Double(int64Value) }
+        if let doubleValue = point.value.doubleValue {
+            return doubleValue
+        }
+        if let int64Value = point.value.int64Value {
+            return Double(int64Value)
+        }
         return nil
     }
 

--- a/Tests/CodexBarTests/Fixtures/Providers/VertexAI/ambiguous-regional-limits.json
+++ b/Tests/CodexBarTests/Fixtures/Providers/VertexAI/ambiguous-regional-limits.json
@@ -1,0 +1,52 @@
+{
+  "timeSeries": [
+    {
+      "metric": {
+        "type": "serviceruntime.googleapis.com/quota/limit",
+        "labels": {
+          "limit_name": "ReasoningEngineEntitiesPerProjectPerRegion",
+          "quota_metric": "aiplatform.googleapis.com/reasoning_engine_service_entities"
+        }
+      },
+      "resource": {
+        "type": "consumer_quota",
+        "labels": {
+          "location": "us-west1",
+          "project_id": "redacted-project",
+          "service": "aiplatform.googleapis.com"
+        }
+      },
+      "points": [
+        {
+          "value": {
+            "int64Value": "100"
+          }
+        }
+      ]
+    },
+    {
+      "metric": {
+        "type": "serviceruntime.googleapis.com/quota/limit",
+        "labels": {
+          "limit_name": "ReasoningEngineEntitiesAlternatePerProjectPerRegion",
+          "quota_metric": "aiplatform.googleapis.com/reasoning_engine_service_entities"
+        }
+      },
+      "resource": {
+        "type": "consumer_quota",
+        "labels": {
+          "location": "us-west1",
+          "project_id": "redacted-project",
+          "service": "aiplatform.googleapis.com"
+        }
+      },
+      "points": [
+        {
+          "value": {
+            "int64Value": "200"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/CodexBarTests/Fixtures/Providers/VertexAI/exact-named-limits.json
+++ b/Tests/CodexBarTests/Fixtures/Providers/VertexAI/exact-named-limits.json
@@ -1,0 +1,52 @@
+{
+  "timeSeries": [
+    {
+      "metric": {
+        "type": "serviceruntime.googleapis.com/quota/limit",
+        "labels": {
+          "limit_name": "GenerateContentRequestsPerMinutePerProjectPerBaseModel",
+          "quota_metric": "aiplatform.googleapis.com/generate_content_requests"
+        }
+      },
+      "resource": {
+        "type": "consumer_quota",
+        "labels": {
+          "location": "global",
+          "project_id": "redacted-project",
+          "service": "aiplatform.googleapis.com"
+        }
+      },
+      "points": [
+        {
+          "value": {
+            "int64Value": "100"
+          }
+        }
+      ]
+    },
+    {
+      "metric": {
+        "type": "serviceruntime.googleapis.com/quota/limit",
+        "labels": {
+          "limit_name": "GenerateContentRequestsPerMinutePerProject",
+          "quota_metric": "aiplatform.googleapis.com/generate_content_requests"
+        }
+      },
+      "resource": {
+        "type": "consumer_quota",
+        "labels": {
+          "location": "global",
+          "project_id": "redacted-project",
+          "service": "aiplatform.googleapis.com"
+        }
+      },
+      "points": [
+        {
+          "value": {
+            "int64Value": "50"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/CodexBarTests/Fixtures/Providers/VertexAI/exact-named-usage.json
+++ b/Tests/CodexBarTests/Fixtures/Providers/VertexAI/exact-named-usage.json
@@ -1,0 +1,28 @@
+{
+  "timeSeries": [
+    {
+      "metric": {
+        "type": "serviceruntime.googleapis.com/quota/allocation/usage",
+        "labels": {
+          "limit_name": "GenerateContentRequestsPerMinutePerProjectPerBaseModel",
+          "quota_metric": "aiplatform.googleapis.com/generate_content_requests"
+        }
+      },
+      "resource": {
+        "type": "consumer_quota",
+        "labels": {
+          "location": "global",
+          "project_id": "redacted-project",
+          "service": "aiplatform.googleapis.com"
+        }
+      },
+      "points": [
+        {
+          "value": {
+            "int64Value": "25"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/CodexBarTests/Fixtures/Providers/VertexAI/issue-2958-regional-and-global-limits.json
+++ b/Tests/CodexBarTests/Fixtures/Providers/VertexAI/issue-2958-regional-and-global-limits.json
@@ -1,0 +1,52 @@
+{
+  "timeSeries": [
+    {
+      "metric": {
+        "type": "serviceruntime.googleapis.com/quota/limit",
+        "labels": {
+          "limit_name": "ReasoningEngineEntitiesPerProjectPerRegion",
+          "quota_metric": "aiplatform.googleapis.com/reasoning_engine_service_entities"
+        }
+      },
+      "resource": {
+        "type": "consumer_quota",
+        "labels": {
+          "location": "us-west1",
+          "project_id": "redacted-project",
+          "service": "aiplatform.googleapis.com"
+        }
+      },
+      "points": [
+        {
+          "value": {
+            "int64Value": "100"
+          }
+        }
+      ]
+    },
+    {
+      "metric": {
+        "type": "serviceruntime.googleapis.com/quota/limit",
+        "labels": {
+          "limit_name": "ReasoningEngineEntitiesPerProject",
+          "quota_metric": "aiplatform.googleapis.com/reasoning_engine_service_entities"
+        }
+      },
+      "resource": {
+        "type": "consumer_quota",
+        "labels": {
+          "location": "global",
+          "project_id": "redacted-project",
+          "service": "aiplatform.googleapis.com"
+        }
+      },
+      "points": [
+        {
+          "value": {
+            "int64Value": "1000"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/CodexBarTests/Fixtures/Providers/VertexAI/issue-2958-usage-without-limit-name.json
+++ b/Tests/CodexBarTests/Fixtures/Providers/VertexAI/issue-2958-usage-without-limit-name.json
@@ -1,0 +1,27 @@
+{
+  "timeSeries": [
+    {
+      "metric": {
+        "type": "serviceruntime.googleapis.com/quota/allocation/usage",
+        "labels": {
+          "quota_metric": "aiplatform.googleapis.com/reasoning_engine_service_entities"
+        }
+      },
+      "resource": {
+        "type": "consumer_quota",
+        "labels": {
+          "location": "us-west1",
+          "project_id": "redacted-project",
+          "service": "aiplatform.googleapis.com"
+        }
+      },
+      "points": [
+        {
+          "value": {
+            "int64Value": "1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/CodexBarTests/VertexAIUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/VertexAIUsageFetcherTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct VertexAIUsageFetcherTests {
+    @Test
+    func `usage without limit name matches the regional named limit`() throws {
+        let response = try VertexAIUsageFetcher.parseQuotaUsage(
+            usageData: Self.fixture("issue-2958-usage-without-limit-name"),
+            limitData: Self.fixture("issue-2958-regional-and-global-limits"))
+
+        #expect(response.requestsUsedPercent == 1)
+    }
+
+    @Test
+    func `existing exact limit name match remains authoritative`() throws {
+        let response = try VertexAIUsageFetcher.parseQuotaUsage(
+            usageData: Self.fixture("exact-named-usage"),
+            limitData: Self.fixture("exact-named-limits"))
+
+        #expect(response.requestsUsedPercent == 25)
+    }
+
+    @Test
+    func `unnamed usage does not guess between limits in the same region`() throws {
+        #expect(throws: VertexAIFetchError.self) {
+            try VertexAIUsageFetcher.parseQuotaUsage(
+                usageData: Self.fixture("issue-2958-usage-without-limit-name"),
+                limitData: Self.fixture("ambiguous-regional-limits"))
+        }
+    }
+
+    private static func fixture(_ name: String) throws -> Data {
+        try Data(contentsOf: #require(Bundle.module.url(
+            forResource: name,
+            withExtension: "json",
+            subdirectory: "Fixtures/Providers/VertexAI")))
+    }
+}


### PR DESCRIPTION
## Summary

- pair Vertex AI usage without `limit_name` to a unique positive limit with the same quota metric and location
- preserve exact named-limit matching and reject ambiguous same-region fallbacks
- cover the reported regional payload shape and existing named payload shape with fixtures

## Testing

- `swift test --filter VertexAIUsageFetcherTests`
- `make check`
- `make test` (blocked locally by pre-existing `KiroTransportRaceTests` failures; the Vertex AI tests pass)
- autoreview: clean

Fixes #2958
