### PR TITLE
Add per-provider accent color override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.50.1 — Unreleased
 
 ### Added
+- Providers: add a per-provider accent color override with a hex field, a color well, and a reset to the shipped color; it applies to usage bars, charts, switcher tabs, widgets, and the `codexbar serve` dashboard, and syncs across Macs. Thanks @urda!
 - Usage bars: make workday tick marks configurable with hidden, subtle, and high-contrast appearances (#2904, #2950). Thanks @dstier-git!
 
 ### Fixed

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -638,7 +638,7 @@ struct CostHistoryChartMenuView: View {
     }
 
     private static func barColor(for provider: UsageProvider) -> Color {
-        let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+        let color = ProviderAccentPalette.color(for: provider)
         return Color(red: color.red, green: color.green, blue: color.blue)
     }
 

--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -87,7 +87,7 @@ extension UsageMenuCardView.Model {
     /// Provider branding color for the inline usage bars, matching the provider's switcher tab and
     /// detailed cost-history chart.
     static func inlineDashboardBarColor(for provider: UsageProvider) -> Color {
-        let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+        let color = ProviderAccentPalette.color(for: provider)
         return Color(red: color.red, green: color.green, blue: color.blue)
     }
 

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -462,7 +462,7 @@ extension UsageMenuCardView.Model {
             return Color(nsColor: .labelColor)
         }
 
-        let color = branding.color
+        let color = ProviderAccentPalette.color(for: provider)
         return Color(red: color.red, green: color.green, blue: color.blue)
     }
 

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -313,7 +313,7 @@ struct PlanUtilizationHistoryChartMenuView: View {
 
         let pointsByID = Dictionary(uniqueKeysWithValues: points.map { ($0.id, $0) })
         let pointsByIndex = Dictionary(uniqueKeysWithValues: points.map { ($0.index, $0) })
-        let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+        let color = ProviderAccentPalette.color(for: provider)
         let barColor = Color(red: color.red, green: color.green, blue: color.blue)
         let trackColor = MenuHighlightStyle.progressTrack(false)
 
@@ -328,7 +328,7 @@ struct PlanUtilizationHistoryChartMenuView: View {
     }
 
     private nonisolated static func emptyModel(provider: UsageProvider) -> Model {
-        let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+        let color = ProviderAccentPalette.color(for: provider)
         let barColor = Color(red: color.red, green: color.green, blue: color.blue)
         let trackColor = MenuHighlightStyle.progressTrack(false)
         return Model(

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -191,6 +191,8 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
                 self.supplementarySettingsContent
             }
 
+            ProviderAccentColorSettingsView(provider: self.provider, settings: self.store.settings)
+
             ProviderQuotaWarningSettingsView(provider: self.provider, settings: self.store.settings)
 
             if !self.settingsToggles.isEmpty {

--- a/Sources/CodexBar/PreferencesSpendDashboardPane.swift
+++ b/Sources/CodexBar/PreferencesSpendDashboardPane.swift
@@ -653,7 +653,7 @@ private struct SpendDailyChart: View {
     }
 
     private func providerColor(_ provider: UsageProvider) -> Color {
-        let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+        let color = ProviderAccentPalette.color(for: provider)
         return Color(red: color.red, green: color.green, blue: color.blue)
     }
 }

--- a/Sources/CodexBar/ProviderAccentColorSettingsView.swift
+++ b/Sources/CodexBar/ProviderAccentColorSettingsView.swift
@@ -1,0 +1,136 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+
+/// Per-provider accent color override.
+///
+/// The hex field is the source of truth and the color well writes into it, so a user can paste an
+/// exact brand hex or pick visually. Reset appears only when an override exists. Descriptors hold the
+/// shipped color as a compile-time constant, so a reset restores it and can never lose it.
+@MainActor
+struct ProviderAccentColorSettingsView: View {
+    private static let swatchSize: CGFloat = 18
+    private static let swatchCornerRadius: CGFloat = 4
+    private static let hexFieldWidth: CGFloat = 92
+
+    let provider: UsageProvider
+    @Bindable var settings: SettingsStore
+
+    @State private var hexText: String
+    @FocusState private var isHexFieldFocused: Bool
+
+    init(provider: UsageProvider, settings: SettingsStore) {
+        self.provider = provider
+        self.settings = settings
+        // Seed here rather than in onAppear, so the field always carries a value on first render.
+        self._hexText = State(initialValue: settings.accentColor(for: provider).hexString)
+    }
+
+    var body: some View {
+        Section {
+            HStack(spacing: 10) {
+                self.swatch
+
+                TextField(L("provider_accent_color_title"), text: self.$hexText)
+                    .labelsHidden()
+                    .textFieldStyle(.roundedBorder)
+                    .font(.body.monospaced())
+                    .frame(width: Self.hexFieldWidth)
+                    .focused(self.$isHexFieldFocused)
+                    .onSubmit { self.commitHexText() }
+                    .accessibilityLabel(L("provider_accent_color_hex_label"))
+
+                ColorPicker(
+                    L("provider_accent_color_title"),
+                    selection: self.colorBinding,
+                    supportsOpacity: false)
+                    .labelsHidden()
+
+                Spacer(minLength: 0)
+
+                if self.hasOverride {
+                    Button(L("provider_accent_color_reset")) { self.reset() }
+                        .controlSize(.small)
+                }
+            }
+            .listRowSeparator(.hidden)
+        } header: {
+            Text(L("provider_accent_color_title"))
+        } footer: {
+            SettingsSectionFooter(L("provider_accent_color_footer"))
+        }
+        .background(FocusResigningBackground())
+        .onAppear { self.syncHexText() }
+        .onChange(of: self.isHexFieldFocused) { _, isFocused in
+            if !isFocused {
+                self.commitHexText()
+            }
+        }
+        .onChange(of: self.settings.configRevision) { _, _ in
+            // An external config edit or an inbound sync can move the color while this pane is open.
+            // Never fight the user mid-edit.
+            guard !self.isHexFieldFocused else { return }
+            self.syncHexText()
+        }
+    }
+
+    private var swatch: some View {
+        RoundedRectangle(cornerRadius: Self.swatchCornerRadius, style: .continuous)
+            .fill(Self.swiftUIColor(self.resolvedColor))
+            .frame(width: Self.swatchSize, height: Self.swatchSize)
+            .overlay(
+                RoundedRectangle(cornerRadius: Self.swatchCornerRadius, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.15)))
+            .accessibilityHidden(true)
+    }
+
+    private var hasOverride: Bool {
+        self.settings.accentColorOverride(for: self.provider) != nil
+    }
+
+    private var resolvedColor: ProviderColor {
+        self.settings.accentColor(for: self.provider)
+    }
+
+    private var colorBinding: Binding<Color> {
+        Binding(
+            get: { Self.swiftUIColor(self.resolvedColor) },
+            set: { newValue in
+                guard let color = Self.providerColor(from: newValue) else { return }
+                self.settings.setAccentColorOverride(color, for: self.provider)
+                self.hexText = color.hexString
+            })
+    }
+
+    private func syncHexText() {
+        self.hexText = self.resolvedColor.hexString
+    }
+
+    /// Applies the typed value, or restores the displayed one when the text does not parse.
+    private func commitHexText() {
+        guard let color = ProviderColor(hexString: self.hexText) else {
+            self.syncHexText()
+            return
+        }
+        self.settings.setAccentColorOverride(color, for: self.provider)
+        self.hexText = color.hexString
+    }
+
+    private func reset() {
+        self.settings.setAccentColorOverride(nil, for: self.provider)
+        self.syncHexText()
+    }
+
+    private static func swiftUIColor(_ color: ProviderColor) -> Color {
+        Color(red: color.red, green: color.green, blue: color.blue)
+    }
+
+    /// The color well can hand back a wide-gamut color, so pin it to sRGB before storing the hex.
+    private static func providerColor(from color: Color) -> ProviderColor? {
+        guard let srgb = NSColor(color).usingColorSpace(.sRGB) else { return nil }
+        return ProviderColor(
+            red: Double(srgb.redComponent),
+            green: Double(srgb.greenComponent),
+            blue: Double(srgb.blueComponent))
+    }
+}

--- a/Sources/CodexBar/ProviderAccentPalette.swift
+++ b/Sources/CodexBar/ProviderAccentPalette.swift
@@ -1,0 +1,52 @@
+import CodexBarCore
+import Foundation
+
+/// Resolved provider accent colors for the running app.
+///
+/// The helpers that color menu cards, charts, and switcher tabs are static and only receive a
+/// provider, so the resolved map lives here instead of threading `SettingsStore` into each of them.
+/// Some of those helpers are `nonisolated`, so a lock guards the map instead of an actor.
+///
+/// `SettingsStore` refreshes the palette whenever the config changes, from any origin: a settings
+/// edit, an external edit to `~/.codexbar/config.json`, or an inbound iCloud sync.
+enum ProviderAccentPalette {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var overrides: [ProviderInstanceID: ProviderColor] = [:]
+
+    /// Refreshes the palette from the config and mirrors it to the App Group for the widget.
+    /// Returns true when the mirrored copy changed, so the caller can reload widget timelines.
+    ///
+    /// The mirror always runs, never only when the in-memory map moves. The in-memory map starts
+    /// empty at launch, so gating on it would leave a stale color in the App Group after someone
+    /// edits the config file while the app is closed.
+    @MainActor
+    @discardableResult
+    static func apply(config: CodexBarConfig) -> Bool {
+        let resolved = ProviderAccentColors.overrides(in: config)
+        self.lock.lock()
+        self.overrides = resolved
+        self.lock.unlock()
+        // A test process can open the real App Group suite on a developer's Mac, so a test config
+        // would otherwise overwrite the colors that developer actually uses.
+        guard !SettingsStore.isRunningTests else { return false }
+        return ProviderAccentColors.mirrorToSharedDefaults(resolved)
+    }
+
+    /// The user override for a provider, or nil when the provider keeps its shipped color.
+    static func override(for provider: UsageProvider) -> ProviderColor? {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.overrides[provider.instanceID]
+    }
+
+    /// The color to paint with: the user override when one exists, otherwise the shipped brand color.
+    static func color(for provider: UsageProvider) -> ProviderColor {
+        self.override(for: provider) ?? ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+    }
+
+    static func _test_reset() {
+        self.lock.lock()
+        self.overrides = [:]
+        self.lock.unlock()
+    }
+}

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -485,6 +485,10 @@
 "quota_depleted_title" = "نفاد الحصة واستعادتها";
 "quota_warning_notifications_subtitle" = "يحذر عندما يتجاوز الحصة المتبقية من الجلسة أو الحصة الأسبوعية العتبات المكونة.";
 "threshold_warnings_title" = "تحذيرات العتبة";
+"provider_accent_color_title" = "لون التمييز";
+"provider_accent_color_footer" = "يحدد لون أشرطة الاستخدام والرسوم البيانية وعلامة التبديل لهذا المزود.";
+"provider_accent_color_hex_label" = "قيمة اللون السداسية";
+"provider_accent_color_reset" = "استخدام الافتراضي";
 "quota_warnings_title" = "تحذيرات الحصص";
 "quota_warning_session" = "الجلسة";
 "quota_warning_session_capitalized" = "الجلسة";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -483,6 +483,10 @@
 "quota_depleted_title" = "Quota esgotada i restablerta";
 "quota_warning_notifications_subtitle" = "Avisa quan la quota restant de sessió o setmanal baixa per sota dels llindars configurats.";
 "threshold_warnings_title" = "Avisos de llindar";
+"provider_accent_color_title" = "Color d'accent";
+"provider_accent_color_footer" = "Estableix el color de les barres d'ús, els gràfics i la pestanya del selector d'aquest proveïdor.";
+"provider_accent_color_hex_label" = "Valor de color hexadecimal";
+"provider_accent_color_reset" = "Usa el valor predeterminat";
 "quota_warnings_title" = "Avisos de quota";
 "quota_warning_session" = "sessió";
 "quota_warning_session_capitalized" = "Sessió";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -498,6 +498,10 @@
 "quota_depleted_title" = "Kontingent erschöpft und wiederhergestellt";
 "quota_warning_notifications_subtitle" = "Warnt, wenn verbleibende Sitzungs- oder Wochenquote die konfigurierten Schwellenwerte unterschreitet.";
 "threshold_warnings_title" = "Schwellenwertwarnungen";
+"provider_accent_color_title" = "Akzentfarbe";
+"provider_accent_color_footer" = "Legt die Farbe der Nutzungsbalken, Diagramme und des Umschalter-Tabs dieses Anbieters fest.";
+"provider_accent_color_hex_label" = "Hexadezimaler Farbwert";
+"provider_accent_color_reset" = "Standard verwenden";
 "quota_warnings_title" = "Kontingentwarnungen";
 "quota_warning_session" = "Sitzung";
 "quota_warning_session_capitalized" = "Sitzung";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -462,6 +462,10 @@
 "quota_depleted_title" = "Quota depleted & restored";
 "quota_warning_notifications_subtitle" = "Warns when session or weekly quota remaining crosses configured thresholds.";
 "threshold_warnings_title" = "Threshold warnings";
+"provider_accent_color_title" = "Accent color";
+"provider_accent_color_footer" = "Sets the color of this provider's usage bars, charts, and switcher tab.";
+"provider_accent_color_hex_label" = "Hex color value";
+"provider_accent_color_reset" = "Use default";
 "quota_warnings_title" = "Quota warnings";
 "quota_warning_session" = "session";
 "quota_warning_session_capitalized" = "Session";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -501,6 +501,10 @@
 "quota_depleted_title" = "Cuota agotada y restaurada";
 "quota_warning_notifications_subtitle" = "Avisa cuando la cuota restante de sesión o semanal cruza los umbrales configurados.";
 "threshold_warnings_title" = "Avisos de umbral";
+"provider_accent_color_title" = "Color de acento";
+"provider_accent_color_footer" = "Establece el color de las barras de uso, los gráficos y la pestaña del selector de este proveedor.";
+"provider_accent_color_hex_label" = "Valor de color hexadecimal";
+"provider_accent_color_reset" = "Usar predeterminado";
 "quota_warnings_title" = "Avisos de cuota";
 "quota_warning_session" = "sesión";
 "quota_warning_session_capitalized" = "Sesión";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -485,6 +485,10 @@
 "quota_depleted_title" = "اتمام و بازیابی سهمیه";
 "quota_warning_notifications_subtitle" = "هشدار می دهد وقتی سهمیه نشست یا هفتگی باقی مانده از آستانه های پیکربندی شده عبور کند.";
 "threshold_warnings_title" = "هشدارهای آستانه";
+"provider_accent_color_title" = "رنگ تأکید";
+"provider_accent_color_footer" = "رنگ نوارهای مصرف، نمودارها و زبانه جابه‌جایی این ارائه‌دهنده را تعیین می‌کند.";
+"provider_accent_color_hex_label" = "مقدار رنگ هگزادسیمال";
+"provider_accent_color_reset" = "استفاده از پیش‌فرض";
 "quota_warnings_title" = "هشدارهای سهمیه";
 "quota_warning_session" = "جلسه";
 "quota_warning_session_capitalized" = "جلسه";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -500,6 +500,10 @@
 "quota_depleted_title" = "Quota épuisé et rétabli";
 "quota_warning_notifications_subtitle" = "Vous avertit lorsque le quota restant (session ou hebdomadaire) franchit les seuils configurés.";
 "threshold_warnings_title" = "Alertes de seuil";
+"provider_accent_color_title" = "Couleur d'accentuation";
+"provider_accent_color_footer" = "Définit la couleur des barres d'utilisation, des graphiques et de l'onglet du sélecteur de ce fournisseur.";
+"provider_accent_color_hex_label" = "Valeur de couleur hexadécimale";
+"provider_accent_color_reset" = "Utiliser la valeur par défaut";
 "quota_warnings_title" = "Alertes de quota";
 "quota_warning_session" = "session";
 "quota_warning_session_capitalized" = "Session";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -479,6 +479,10 @@
 "quota_depleted_title" = "Cota esgotada e restaurada";
 "quota_warning_notifications_subtitle" = "Avisa cando a cota restante de sesión ou semanal supera os limiares configurados.";
 "threshold_warnings_title" = "Avisos de limiar";
+"provider_accent_color_title" = "Cor de acento";
+"provider_accent_color_footer" = "Establece a cor das barras de uso, das gráficas e da lapela do selector deste provedor.";
+"provider_accent_color_hex_label" = "Valor de cor hexadecimal";
+"provider_accent_color_reset" = "Usar o predeterminado";
 "quota_warnings_title" = "Avisos de cota";
 "quota_warning_session" = "sesión";
 "quota_warning_session_capitalized" = "Sesión";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -487,6 +487,10 @@
 "quota_depleted_title" = "Kuota habis & tersedia kembali";
 "quota_warning_notifications_subtitle" = "Memperingatkan saat sisa kuota sesi atau mingguan melewati ambang batas yang dikonfigurasi.";
 "threshold_warnings_title" = "Peringatan ambang batas";
+"provider_accent_color_title" = "Warna aksen";
+"provider_accent_color_footer" = "Menetapkan warna bilah penggunaan, bagan, dan tab pengalih penyedia ini.";
+"provider_accent_color_hex_label" = "Nilai warna heksadesimal";
+"provider_accent_color_reset" = "Gunakan bawaan";
 "quota_warnings_title" = "Peringatan kuota";
 "quota_warning_session" = "sesi";
 "quota_warning_session_capitalized" = "Sesi";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -487,6 +487,10 @@
 "quota_depleted_title" = "Quota esaurita e ripristinata";
 "quota_warning_notifications_subtitle" = "Avvisa quando la quota residua di sessione o settimanale scende sotto le soglie configurate.";
 "threshold_warnings_title" = "Avvisi di soglia";
+"provider_accent_color_title" = "Colore accento";
+"provider_accent_color_footer" = "Imposta il colore delle barre di utilizzo, dei grafici e della scheda del selettore di questo provider.";
+"provider_accent_color_hex_label" = "Valore colore esadecimale";
+"provider_accent_color_reset" = "Usa predefinito";
 "quota_warnings_title" = "Avvisi quota";
 "quota_warning_session" = "sessione";
 "quota_warning_session_capitalized" = "Sessione";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -497,6 +497,10 @@
 "quota_depleted_title" = "クォータの枯渇と回復";
 "quota_warning_notifications_subtitle" = "セッションまたは週間クォータの残量が設定したしきい値を下回ったときに警告します。";
 "threshold_warnings_title" = "しきい値警告";
+"provider_accent_color_title" = "アクセントカラー";
+"provider_accent_color_footer" = "このプロバイダの使用量バー、グラフ、切り替えタブの色を設定します。";
+"provider_accent_color_hex_label" = "16 進カラー値";
+"provider_accent_color_reset" = "デフォルトを使用";
 "quota_warnings_title" = "クォータ警告";
 "quota_warning_session" = "セッション";
 "quota_warning_session_capitalized" = "セッション";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -495,6 +495,10 @@
 "quota_depleted_title" = "할당량 소진 및 복원";
 "quota_warning_notifications_subtitle" = "세션 또는 주간 할당량 잔여량이 설정된 임곗값을 넘으면 경고합니다.";
 "threshold_warnings_title" = "임곗값 경고";
+"provider_accent_color_title" = "강조 색상";
+"provider_accent_color_footer" = "이 제공자의 사용량 막대, 차트, 전환 탭 색상을 설정합니다.";
+"provider_accent_color_hex_label" = "16진수 색상 값";
+"provider_accent_color_reset" = "기본값 사용";
 "quota_warnings_title" = "할당량 경고";
 "quota_warning_session" = "세션";
 "quota_warning_session_capitalized" = "세션";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -500,6 +500,10 @@
 "quota_depleted_title" = "Quotum uitgeput en hersteld";
 "quota_warning_notifications_subtitle" = "Waarschuwt wanneer het resterende sessie- of wekelijkse quotum de geconfigureerde drempels overschrijdt.";
 "threshold_warnings_title" = "Drempelwaarschuwingen";
+"provider_accent_color_title" = "Accentkleur";
+"provider_accent_color_footer" = "Stelt de kleur in van de gebruiksbalken, grafieken en schakeltab van deze aanbieder.";
+"provider_accent_color_hex_label" = "Hexadecimale kleurwaarde";
+"provider_accent_color_reset" = "Standaard gebruiken";
 "quota_warnings_title" = "Quotumwaarschuwingen";
 "quota_warning_session" = "sessie";
 "quota_warning_session_capitalized" = "Sessie";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -487,6 +487,10 @@
 "quota_depleted_title" = "Wyczerpanie i przywrócenie limitu";
 "quota_warning_notifications_subtitle" = "Ostrzega, gdy pozostały limit sesji lub tygodnia przekroczy skonfigurowane progi.";
 "threshold_warnings_title" = "Ostrzeżenia progowe";
+"provider_accent_color_title" = "Kolor akcentu";
+"provider_accent_color_footer" = "Ustawia kolor pasków użycia, wykresów i karty przełącznika tego dostawcy.";
+"provider_accent_color_hex_label" = "Szesnastkowa wartość koloru";
+"provider_accent_color_reset" = "Użyj domyślnego";
 "quota_warnings_title" = "Ostrzeżenia limitu";
 "quota_warning_session" = "sesja";
 "quota_warning_session_capitalized" = "Sesja";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -497,6 +497,10 @@
 "quota_depleted_title" = "Cota esgotada e restaurada";
 "quota_warning_notifications_subtitle" = "Avisa quando a cota restante da sessão ou da semana fica abaixo dos limites configurados.";
 "threshold_warnings_title" = "Alertas de limite";
+"provider_accent_color_title" = "Cor de destaque";
+"provider_accent_color_footer" = "Define a cor das barras de uso, dos gráficos e da aba do seletor deste provedor.";
+"provider_accent_color_hex_label" = "Valor de cor hexadecimal";
+"provider_accent_color_reset" = "Usar padrão";
 "quota_warnings_title" = "Alertas de cota";
 "quota_warning_session" = "sessão";
 "quota_warning_session_capitalized" = "Sessão";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -501,6 +501,10 @@
 "quota_depleted_title" = "Исчерпание и восстановление квоты";
 "quota_warning_notifications_subtitle" = "Предупреждает, когда остаток сессионной или недельной квоты пересекает заданные пороги.";
 "threshold_warnings_title" = "Предупреждения о порогах";
+"provider_accent_color_title" = "Акцентный цвет";
+"provider_accent_color_footer" = "Задаёт цвет полос использования, графиков и вкладки переключателя этого провайдера.";
+"provider_accent_color_hex_label" = "Шестнадцатеричное значение цвета";
+"provider_accent_color_reset" = "Использовать по умолчанию";
 "quota_warnings_title" = "Предупреждения о квотах";
 "quota_warning_session" = "сеанс";
 "quota_warning_session_capitalized" = "Сеанс";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -500,6 +500,10 @@
 "quota_depleted_title" = "Kvoten tar slut och återställs";
 "quota_warning_notifications_subtitle" = "Varnar när återstående sessions- eller veckokvot passerar inställda trösklar.";
 "threshold_warnings_title" = "Tröskelvarningar";
+"provider_accent_color_title" = "Accentfärg";
+"provider_accent_color_footer" = "Anger färgen på användningsstaplarna, diagrammen och växlarfliken för den här leverantören.";
+"provider_accent_color_hex_label" = "Hexadecimalt färgvärde";
+"provider_accent_color_reset" = "Använd standard";
 "quota_warnings_title" = "Kvotvarningar";
 "quota_warning_session" = "session";
 "quota_warning_session_capitalized" = "Session";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -485,6 +485,10 @@
 "quota_depleted_title" = "โควต้าหมดและกลับมาใช้งานได้";
 "quota_warning_notifications_subtitle" = "เตือนเมื่อเซสชันหรือโควต้ารายสัปดาห์ที่เหลืออยู่ข้ามเกณฑ์ที่กําหนดค่าไว้";
 "threshold_warnings_title" = "คำเตือนตามเกณฑ์";
+"provider_accent_color_title" = "สีเน้น";
+"provider_accent_color_footer" = "กำหนดสีของแถบการใช้งาน แผนภูมิ และแท็บสลับของผู้ให้บริการนี้";
+"provider_accent_color_hex_label" = "ค่าสีฐานสิบหก";
+"provider_accent_color_reset" = "ใช้ค่าเริ่มต้น";
 "quota_warnings_title" = "คําเตือนโควต้า";
 "quota_warning_session" = "เซสชั่น";
 "quota_warning_session_capitalized" = "เซสชั่น";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -485,6 +485,10 @@
 "quota_depleted_title" = "Kota tükenmesi ve yenilenmesi";
 "quota_warning_notifications_subtitle" = "Oturum veya haftalık kalan kota yapılandırılan eşikleri geçtiğinde uyarır.";
 "threshold_warnings_title" = "Eşik uyarıları";
+"provider_accent_color_title" = "Vurgu rengi";
+"provider_accent_color_footer" = "Bu sağlayıcının kullanım çubuklarının, grafiklerinin ve geçiş sekmesinin rengini belirler.";
+"provider_accent_color_hex_label" = "Onaltılık renk değeri";
+"provider_accent_color_reset" = "Varsayılanı kullan";
 "quota_warnings_title" = "Kota uyarıları";
 "quota_warning_session" = "oturum";
 "quota_warning_session_capitalized" = "Oturum";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -500,6 +500,10 @@
 "quota_depleted_title" = "Вичерпання та відновлення квоти";
 "quota_warning_notifications_subtitle" = "Попереджає, коли залишок сеансу або тижневої квоти перевищує налаштовані порогові значення.";
 "threshold_warnings_title" = "Попередження про порогові значення";
+"provider_accent_color_title" = "Акцентний колір";
+"provider_accent_color_footer" = "Задає колір смуг використання, графіків і вкладки перемикача цього провайдера.";
+"provider_accent_color_hex_label" = "Шістнадцяткове значення кольору";
+"provider_accent_color_reset" = "Використовувати типовий";
 "quota_warnings_title" = "Попередження про квоту";
 "quota_warning_session" = "сесії";
 "quota_warning_session_capitalized" = "Сесія";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -496,6 +496,10 @@
 "quota_depleted_title" = "Hạn mức đã cạn & được khôi phục";
 "quota_warning_notifications_subtitle" = "Cảnh báo khi phiên hoặc Hạn mức còn lại hàng tuần vượt qua ngưỡng được định cấu hình.";
 "threshold_warnings_title" = "Cảnh báo ngưỡng";
+"provider_accent_color_title" = "Màu nhấn";
+"provider_accent_color_footer" = "Đặt màu cho thanh mức dùng, biểu đồ và thẻ chuyển đổi của nhà cung cấp này.";
+"provider_accent_color_hex_label" = "Giá trị màu thập lục phân";
+"provider_accent_color_reset" = "Dùng mặc định";
 "quota_warnings_title" = "Hạn mức cảnh báo";
 "quota_warning_session" = "phiên";
 "quota_warning_session_capitalized" = "Phiên";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -507,6 +507,10 @@
 "quota_depleted_title" = "配额耗尽与恢复";
 "quota_warning_notifications_subtitle" = "当会话或每周剩余配额低于设置的阈值时提醒。";
 "threshold_warnings_title" = "阈值预警";
+"provider_accent_color_title" = "强调色";
+"provider_accent_color_footer" = "设置该提供商的用量条、图表和切换标签的颜色。";
+"provider_accent_color_hex_label" = "十六进制颜色值";
+"provider_accent_color_reset" = "使用默认值";
 "quota_warnings_title" = "配额预警";
 "quota_warning_session" = "会话";
 "quota_warning_session_capitalized" = "会话";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -505,6 +505,10 @@
 "quota_depleted_title" = "配額用完與恢復";
 "quota_warning_notifications_subtitle" = "當工作階段或每週剩餘配額達到設定門檻時提醒。";
 "threshold_warnings_title" = "門檻提醒";
+"provider_accent_color_title" = "強調色";
+"provider_accent_color_footer" = "設定此供應商的用量列、圖表與切換標籤的顏色。";
+"provider_accent_color_hex_label" = "十六進位顏色值";
+"provider_accent_color_reset" = "使用預設值";
 "quota_warnings_title" = "配額提醒";
 "quota_warning_session" = "工作階段";
 "quota_warning_session_capitalized" = "工作階段";

--- a/Sources/CodexBar/SettingsStore+Config.swift
+++ b/Sources/CodexBar/SettingsStore+Config.swift
@@ -85,6 +85,27 @@ extension SettingsStore {
         self.configSnapshot.providerConfig(for: provider.instanceID)?.quotaWarnings ?? QuotaWarningConfig()
     }
 
+    /// The user accent override for a provider, or nil when the provider keeps its shipped color.
+    func accentColorOverride(for provider: UsageProvider) -> ProviderColor? {
+        guard let raw = self.configSnapshot.providerConfig(for: provider.instanceID)?.accentColor else { return nil }
+        return ProviderColor(hexString: raw)
+    }
+
+    /// The color a provider paints with: the user override when one exists, otherwise the shipped brand color.
+    func accentColor(for provider: UsageProvider) -> ProviderColor {
+        self.accentColorOverride(for: provider)
+            ?? ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+    }
+
+    /// Stores an accent override, or clears it when `color` is nil. Clearing restores the shipped color,
+    /// which descriptors hold as a compile-time constant and this never writes over.
+    func setAccentColorOverride(_ color: ProviderColor?, for provider: UsageProvider) {
+        guard self.accentColorOverride(for: provider) != color else { return }
+        self.updateProviderConfig(provider: provider, affectsBackgroundWork: false) { entry in
+            entry.accentColor = color?.hexString
+        }
+    }
+
     func resolvedQuotaWarningThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int] {
         self.quotaWarningConfig(for: provider).thresholds(
             for: window,

--- a/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
+++ b/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
@@ -61,8 +61,17 @@ extension SettingsStore {
         self.bumpConfigRevision(.local(reason: reason, affectsBackgroundWork: affectsBackgroundWork))
     }
 
-    func updateProviderConfig(provider: UsageProvider, mutate: (inout ProviderConfig) -> Void) {
-        self.updateConfig(reason: "provider-\(provider.rawValue)", affectsBackgroundWork: true) { config in
+    /// Pass `affectsBackgroundWork: false` for a purely cosmetic change, so open menus and status items
+    /// rebuild without triggering a provider refresh.
+    func updateProviderConfig(
+        provider: UsageProvider,
+        affectsBackgroundWork: Bool = true,
+        mutate: (inout ProviderConfig) -> Void)
+    {
+        self.updateConfig(
+            reason: "provider-\(provider.rawValue)",
+            affectsBackgroundWork: affectsBackgroundWork)
+        { config in
             if let index = config.providers.firstIndex(where: { $0.id == provider.instanceID }) {
                 var entry = config.providers[index]
                 mutate(&entry)

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -2,6 +2,9 @@ import AppKit
 import CodexBarCore
 import Observation
 import ServiceManagement
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
 
 enum RefreshFrequency: String, CaseIterable, Identifiable {
     case manual
@@ -936,12 +939,24 @@ extension SettingsStore {
             enablement[instanceID] = isEnabled
         }
         self.providerEnablement = enablement
+        // Every config path crosses this method, so the accent palette refreshes from a settings edit,
+        // an external edit to the config file, and an inbound iCloud sync alike.
+        if ProviderAccentPalette.apply(config: config) {
+            #if canImport(WidgetKit)
+            WidgetCenter.shared.reloadAllTimelines()
+            #endif
+        }
     }
 
     private static func providerConfigFingerprint(_ config: ProviderConfig) -> Data {
+        // This fingerprint gates provider refresh publication, so it must cover only fields a fetch
+        // depends on. A purely cosmetic field would otherwise discard an in-flight probe result, and
+        // a cosmetic edit schedules no replacement fetch.
+        var fetchRelevant = config
+        fetchRelevant.accentColor = nil
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
-        return (try? encoder.encode(config)) ?? Data()
+        return (try? encoder.encode(fetchRelevant)) ?? Data()
     }
 
     func providerEnablementRevision(for provider: UsageProvider) -> UInt64 {

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -654,6 +654,12 @@ final class ProviderSwitcherView: NSView {
                             remainingPercent: remaining,
                             selection: segment.selection)
                         self.quotaIndicators[key] = indicator
+                    } else {
+                        // The switcher view outlives a menu update, so refresh the color even when the
+                        // ratio holds. A new accent color must not wait for usage to move.
+                        indicator.fill.layer?.backgroundColor = Self.quotaIndicatorColor(
+                            for: segment.selection,
+                            remainingPercent: remaining).cgColor
                     }
                 } else {
                     self.addQuotaIndicator(to: button, selection: segment.selection, remainingPercent: remaining)
@@ -1156,7 +1162,7 @@ extension ProviderSwitcherView {
         switch selection {
         case let .provider(instanceID):
             guard let provider = instanceID.firstPartyProvider else { return NSColor.secondaryLabelColor }
-            let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+            let color = ProviderAccentPalette.color(for: provider)
             return NSColor(deviceRed: color.red, green: color.green, blue: color.blue, alpha: 1)
         case .overview:
             return NSColor.secondaryLabelColor

--- a/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
+++ b/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
@@ -160,12 +160,15 @@ enum DashboardSnapshotBuilder {
         let enabledProviders = Set(config.enabledProviders().compactMap(\.firstPartyProvider))
         let sortKey = config.orderedProviders().firstIndex { $0.rawValue == id }.map { $0 * 10 }
             ?? fallbackSortKey
+        let accentOverride = ProviderInstanceID(rawValue: id)
+            .flatMap { config.providerConfig(for: $0)?.accentColor }
+            .flatMap { ProviderColor(hexString: $0) }
         return ProviderPresentation(
             id: id,
             name: descriptor?.metadata.displayName ?? id,
             enabled: provider.map { enabledProviders.contains($0) } ?? true,
             display: DashboardDisplayPayload(
-                accentColor: self.hexColor(descriptor?.branding.color),
+                accentColor: self.hexColor(accentOverride ?? descriptor?.branding.color),
                 sortKey: sortKey,
                 priority: "normal"))
     }

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -187,6 +187,8 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var enterpriseHost: String?
     public var tokenAccounts: ProviderTokenAccountData?
     public var quotaWarnings: QuotaWarningConfig?
+    /// User override for the provider brand color, as `#RRGGBB`. Nil keeps the descriptor default.
+    public var accentColor: String?
     /// Arbitrary user-plugin values stay scoped to the provider instance. Secure values are redacted from config dumps.
     public var pluginSettings: [String: String]?
     public var pluginSecrets: [String: String]?
@@ -206,6 +208,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         enterpriseHost: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
         quotaWarnings: QuotaWarningConfig? = nil,
+        accentColor: String? = nil,
         pluginSettings: [String: String]? = nil,
         pluginSecrets: [String: String]? = nil)
     {
@@ -222,6 +225,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.enterpriseHost = enterpriseHost
         self.tokenAccounts = tokenAccounts
         self.quotaWarnings = quotaWarnings
+        self.accentColor = accentColor
         self.pluginSettings = pluginSettings
         self.pluginSecrets = pluginSecrets
         self.extensionValues = [:]

--- a/Sources/CodexBarCore/Config/ProviderConfigCoding.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigCoding.swift
@@ -15,6 +15,7 @@ extension ProviderConfig {
         case enterpriseHost
         case tokenAccounts
         case quotaWarnings
+        case accentColor
         case pluginSettings
         case pluginSecrets
     }
@@ -42,6 +43,7 @@ extension ProviderConfig {
         self.quotaWarnings = try container.decodeIfPresent(
             QuotaWarningConfig.self,
             forKey: .init(CodingKeys.quotaWarnings.rawValue))
+        self.accentColor = try container.decodeIfPresent(String.self, forKey: .init(CodingKeys.accentColor.rawValue))
         self.pluginSettings = try container.decodeIfPresent(
             [String: String].self,
             forKey: .init(CodingKeys.pluginSettings.rawValue))
@@ -71,6 +73,7 @@ extension ProviderConfig {
         try container.encodeIfPresent(self.enterpriseHost, forKey: .init(CodingKeys.enterpriseHost.rawValue))
         try container.encodeIfPresent(self.tokenAccounts, forKey: .init(CodingKeys.tokenAccounts.rawValue))
         try container.encodeIfPresent(self.quotaWarnings, forKey: .init(CodingKeys.quotaWarnings.rawValue))
+        try container.encodeIfPresent(self.accentColor, forKey: .init(CodingKeys.accentColor.rawValue))
         try container.encodeIfPresent(self.pluginSettings, forKey: .init(CodingKeys.pluginSettings.rawValue))
         try container.encodeIfPresent(self.pluginSecrets, forKey: .init(CodingKeys.pluginSecrets.rawValue))
         for (key, value) in self.extensionValues {

--- a/Sources/CodexBarCore/Providers/ProviderAccentColors.swift
+++ b/Sources/CodexBarCore/Providers/ProviderAccentColors.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// User overrides for the provider brand colors.
+///
+/// `~/.codexbar/config.json` is the source of truth, and it reaches the app and the `codexbar serve`
+/// dashboard directly. The sandboxed widget cannot read that file, so the app mirrors the resolved
+/// map into the App Group defaults for it.
+///
+/// Descriptor colors stay compile-time constants and are never written over. An override is therefore
+/// always removable, and removal restores the shipped color.
+public enum ProviderAccentColors {
+    static let defaultsKey = "providerAccentColors"
+
+    /// Resolving the App Group container is a sandbox round trip, and the widget colors every row from
+    /// this map, so the resolved suite is memoized. The suite itself still reflects later writes.
+    private static let defaultsLock = NSLock()
+    private nonisolated(unsafe) static var cachedDefaults: (bundleID: String?, suite: UserDefaults?)?
+
+    private static func defaults(bundleID: String?) -> UserDefaults? {
+        self.defaultsLock.lock()
+        defer { self.defaultsLock.unlock() }
+        if let cached = self.cachedDefaults, cached.bundleID == bundleID {
+            return cached.suite
+        }
+        let suite = AppGroupSupport.sharedDefaults(bundleID: bundleID)
+        self.cachedDefaults = (bundleID, suite)
+        return suite
+    }
+
+    /// Collects the overrides a config carries. Values that do not parse as `#RRGGBB` are dropped, so a
+    /// hand-edited config file degrades to the shipped color instead of failing to load.
+    public static func overrides(in config: CodexBarConfig) -> [ProviderInstanceID: ProviderColor] {
+        config.providers.reduce(into: [:]) { result, provider in
+            guard let raw = provider.accentColor,
+                  let color = ProviderColor(hexString: raw)
+            else { return }
+            result[provider.id] = color
+        }
+    }
+
+    /// Reads the overrides the app last mirrored into the App Group. Used by the widget extension.
+    public static func sharedOverrides(
+        bundleID: String? = Bundle.main.bundleIdentifier) -> [ProviderInstanceID: ProviderColor]
+    {
+        guard let defaults = self.defaults(bundleID: bundleID) else { return [:] }
+        return self.decode(defaults.dictionary(forKey: self.defaultsKey) as? [String: String] ?? [:])
+    }
+
+    /// Reads a single mirrored override. Returns nil when the provider keeps its shipped color.
+    public static func sharedOverride(
+        for instanceID: ProviderInstanceID,
+        bundleID: String? = Bundle.main.bundleIdentifier) -> ProviderColor?
+    {
+        guard let defaults = self.defaults(bundleID: bundleID),
+              let raw = (defaults.dictionary(forKey: self.defaultsKey) as? [String: String])?[instanceID.rawValue]
+        else { return nil }
+        return ProviderColor(hexString: raw)
+    }
+
+    /// Mirrors the overrides into the App Group. Returns true when the stored value changed, so the
+    /// caller can reload widget timelines only when a color actually moved.
+    @discardableResult
+    public static func mirrorToSharedDefaults(
+        _ overrides: [ProviderInstanceID: ProviderColor],
+        bundleID: String? = Bundle.main.bundleIdentifier) -> Bool
+    {
+        guard let defaults = self.defaults(bundleID: bundleID) else { return false }
+        let encoded = self.encode(overrides)
+        let existing = defaults.dictionary(forKey: self.defaultsKey) as? [String: String] ?? [:]
+        guard encoded != existing else { return false }
+        if encoded.isEmpty {
+            defaults.removeObject(forKey: self.defaultsKey)
+        } else {
+            defaults.set(encoded, forKey: self.defaultsKey)
+        }
+        return true
+    }
+
+    static func encode(_ overrides: [ProviderInstanceID: ProviderColor]) -> [String: String] {
+        overrides.reduce(into: [:]) { result, entry in
+            result[entry.key.rawValue] = entry.value.hexString
+        }
+    }
+
+    static func decode(_ raw: [String: String]) -> [ProviderInstanceID: ProviderColor] {
+        raw.reduce(into: [:]) { result, entry in
+            guard let instanceID = ProviderInstanceID(rawValue: entry.key),
+                  let color = ProviderColor(hexString: entry.value)
+            else { return }
+            result[instanceID] = color
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/ProviderBranding.swift
+++ b/Sources/CodexBarCore/Providers/ProviderBranding.swift
@@ -17,6 +17,28 @@ public struct ProviderColor: Sendable, Equatable {
         self.green = Double((hex >> 8) & 0xFF) / 255
         self.blue = Double(hex & 0xFF) / 255
     }
+
+    /// Parses a user-supplied `#RRGGBB` or `RRGGBB` string. Returns nil for anything else so callers
+    /// can fall back to the provider default instead of failing.
+    public init?(hexString: String) {
+        var text = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.hasPrefix("#") {
+            text.removeFirst()
+        }
+        guard text.count == 6,
+              text.allSatisfy(\.isHexDigit),
+              let value = UInt32(text, radix: 16)
+        else { return nil }
+        self.init(hex: value)
+    }
+
+    /// Canonical uppercase `#RRGGBB` form. Round-trips through `init?(hexString:)`.
+    public var hexString: String {
+        func channel(_ value: Double) -> Int {
+            Int((min(1, max(0, value)) * 255).rounded())
+        }
+        return String(format: "#%02X%02X%02X", channel(self.red), channel(self.green), channel(self.blue))
+    }
 }
 
 public struct ProviderBranding: Sendable {

--- a/Sources/CodexBarCore/Sync/SyncModels.swift
+++ b/Sources/CodexBarCore/Sync/SyncModels.swift
@@ -36,6 +36,10 @@ public struct ProviderIntentPayload: Codable, Sendable {
     public var claudeSwapShowSingleAccount: Bool?
     public var antigravityPrioritizeExhaustedQuotas: Bool?
     public var quotaWarnings: QuotaWarningConfig?
+    /// Three-state on purpose. Nil means the sending Mac never reported the field, which is what an
+    /// older client that predates accent colors sends. An empty string means the user cleared the
+    /// override. A hex string sets it. Without this, an older client would erase a newer Mac's color.
+    public var accentColor: String?
     public var kiloKnownOrganizations: [KiloOrganization]?
     public var kiloEnabledOrganizationIDs: [String]?
     public var deepseekProfileID: String?
@@ -53,6 +57,8 @@ public struct ProviderIntentPayload: Codable, Sendable {
         self.claudeSwapShowSingleAccount = config.claudeSwapShowSingleAccount
         self.antigravityPrioritizeExhaustedQuotas = config.antigravityPrioritizeExhaustedQuotas
         self.quotaWarnings = config.quotaWarnings
+        // Always report, so that clearing an override propagates as an empty string.
+        self.accentColor = config.accentColor ?? ""
         self.kiloKnownOrganizations = config.kiloKnownOrganizations
         self.kiloEnabledOrganizationIDs = config.kiloEnabledOrganizationIDs
         self.deepseekProfileID = config.deepseekProfileID
@@ -83,6 +89,10 @@ public struct ProviderIntentPayload: Codable, Sendable {
         result.claudeSwapShowSingleAccount = self.claudeSwapShowSingleAccount
         result.antigravityPrioritizeExhaustedQuotas = self.antigravityPrioritizeExhaustedQuotas
         result.quotaWarnings = self.quotaWarnings
+        // An older client omits the field entirely. Keep the local color rather than erase it.
+        if let accentColor = self.accentColor {
+            result.accentColor = accentColor.isEmpty ? nil : accentColor
+        }
         result.kiloKnownOrganizations = self.kiloKnownOrganizations
         result.kiloEnabledOrganizationIDs = self.kiloEnabledOrganizationIDs
         result.deepseekProfileID = self.deepseekProfileID

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -928,7 +928,10 @@ enum UsageHistoryChartMode {
 enum WidgetColors {
     static func color(for instanceID: ProviderInstanceID) -> Color {
         guard let provider = instanceID.firstPartyProvider else { return .secondary }
-        let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.widgetColor
+        // The widget cannot read ~/.codexbar/config.json, so it resolves the user override from the
+        // copy the app mirrors into the App Group.
+        let color = ProviderAccentColors.sharedOverride(for: instanceID)
+            ?? ProviderDescriptorRegistry.descriptor(for: provider).branding.widgetColor
         return Color(red: color.red, green: color.green, blue: color.blue)
     }
 }

--- a/Tests/CodexBarTests/ProviderAccentColorScreenshotRenderTests.swift
+++ b/Tests/CodexBarTests/ProviderAccentColorScreenshotRenderTests.swift
@@ -1,0 +1,117 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+import XCTest
+@testable import CodexBar
+
+/// Developer tool, skipped by default: renders the accent color settings row and the recolored
+/// usage bars to PNGs for documentation and pull requests.
+///
+/// The renders use an isolated settings store, so they never read the developer's own config and
+/// never write to the shared App Group.
+///
+/// Run with:
+///   CODEXBAR_ACCENT_SCREENSHOT_DIR=~/Downloads swift test --filter ProviderAccentColorScreenshotRenderTests
+@MainActor
+final class ProviderAccentColorScreenshotRenderTests: XCTestCase {
+    private static let rowWidth: CGFloat = 460
+    private static let barWidth: CGFloat = 320
+
+    /// A deliberately unmistakable override, so a reviewer can tell at a glance that it took effect.
+    private static let overrideHex = "#A56CC1"
+
+    func test_renderAccentColorSettingsScreenshots() throws {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_ACCENT_SCREENSHOT_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_ACCENT_SCREENSHOT_DIR to render accent color screenshots.")
+        }
+        let directory = URL(
+            fileURLWithPath: NSString(string: dir).expandingTildeInPath,
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let provider = UsageProvider.antigravity
+        let defaultSettings = Self.settings(accentColor: nil, provider: provider)
+        let overriddenSettings = Self.settings(accentColor: Self.overrideHex, provider: provider)
+
+        let renders: [(String, AnyView)] = [
+            ("accent-color-row-default", AnyView(Self.settingsRow(provider: provider, settings: defaultSettings))),
+            ("accent-color-row-override", AnyView(Self.settingsRow(provider: provider, settings: overriddenSettings))),
+            ("accent-color-bars-before-after", AnyView(Self.barComparison(provider: provider))),
+        ]
+
+        for (name, view) in renders {
+            let data = try XCTUnwrap(Self.pngData(for: view), "render failed for \(name)")
+            let url = directory.appendingPathComponent("\(name).png")
+            try data.write(to: url, options: .atomic)
+            print("Wrote \(url.path)")
+        }
+    }
+
+    private static func settings(accentColor: String?, provider: UsageProvider) -> SettingsStore {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: provider.instanceID, enabled: true, accentColor: accentColor),
+        ])
+        return testSettingsStore(
+            suiteName: "ProviderAccentColorScreenshotRenderTests",
+            config: config)
+    }
+
+    private static func settingsRow(provider: UsageProvider, settings: SettingsStore) -> some View {
+        Form {
+            ProviderAccentColorSettingsView(provider: provider, settings: settings)
+        }
+        .formStyle(.grouped)
+        .frame(width: self.rowWidth)
+    }
+
+    /// Two bars in the shipped color and the override, so the effect reads without app chrome.
+    private static func barComparison(provider: UsageProvider) -> some View {
+        let shipped = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+        let overridden = ProviderColor(hexString: self.overrideHex) ?? shipped
+        return VStack(alignment: .leading, spacing: 18) {
+            self.labeledBar(title: "Default", color: shipped)
+            self.labeledBar(title: "Override \(self.overrideHex)", color: overridden)
+        }
+        .padding(20)
+        .frame(width: self.barWidth + 40)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private static func labeledBar(title: String, color: ProviderColor) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            UsageProgressBar(
+                percent: 62,
+                tint: Color(red: color.red, green: color.green, blue: color.blue),
+                accessibilityLabel: title)
+                .frame(width: self.barWidth, height: 8)
+        }
+    }
+
+    /// Renders through an offscreen window. AppKit-backed controls such as the hex field and the
+    /// color well draw nothing without one, so a windowless render shows an empty row.
+    private static func pngData(for view: AnyView) -> Data? {
+        let hosting = NSHostingView(rootView: view)
+        hosting.appearance = NSAppearance(named: .darkAqua)
+        let size = hosting.fittingSize
+        guard size.width > 0, size.height > 0 else { return nil }
+        hosting.frame = CGRect(origin: .zero, size: size)
+
+        let window = NSWindow(
+            contentRect: CGRect(origin: .zero, size: size),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false)
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.contentView = hosting
+        window.layoutIfNeeded()
+        hosting.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+
+        guard let representation = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds) else { return nil }
+        hosting.cacheDisplay(in: hosting.bounds, to: representation)
+        return representation.representation(using: .png, properties: [:])
+    }
+}

--- a/Tests/CodexBarTests/ProviderAccentColorTests.swift
+++ b/Tests/CodexBarTests/ProviderAccentColorTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ProviderAccentColorTests {
+    @Test
+    func `hex string parses with and without the leading hash`() throws {
+        let withHash = try #require(ProviderColor(hexString: "#60BA7E"))
+        let withoutHash = try #require(ProviderColor(hexString: "60BA7E"))
+
+        #expect(withHash == withoutHash)
+        #expect(withHash == ProviderColor(hex: 0x60BA7E))
+    }
+
+    @Test
+    func `hex string tolerates lowercase and surrounding whitespace`() throws {
+        let color = try #require(ProviderColor(hexString: "  #60ba7e \n"))
+
+        #expect(color == ProviderColor(hex: 0x60BA7E))
+    }
+
+    @Test
+    func `malformed hex strings return nil instead of a color`() {
+        #expect(ProviderColor(hexString: "") == nil)
+        #expect(ProviderColor(hexString: "#FFF") == nil)
+        #expect(ProviderColor(hexString: "#60BA7EFF") == nil)
+        #expect(ProviderColor(hexString: "#60BA7Z") == nil)
+        #expect(ProviderColor(hexString: "not a color") == nil)
+        // Swift's integer parser accepts a sign, so a six-character signed value must still fail.
+        #expect(ProviderColor(hexString: "+60BA7") == nil)
+    }
+
+    @Test
+    func `hex string round trips through the canonical uppercase form`() throws {
+        let color = try #require(ProviderColor(hexString: "#60ba7e"))
+
+        #expect(color.hexString == "#60BA7E")
+        #expect(ProviderColor(hexString: color.hexString) == color)
+    }
+
+    @Test
+    func `hex string clamps components outside the unit range`() {
+        let color = ProviderColor(red: -1, green: 0.5, blue: 2)
+
+        #expect(color.hexString == "#0080FF")
+    }
+
+    @Test
+    func `accent color survives a config round trip`() throws {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .codex, enabled: true, accentColor: "#60BA7E"),
+        ])
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(CodexBarConfig.self, from: data)
+
+        #expect(decoded.providerConfig(for: .codex)?.accentColor == "#60BA7E")
+    }
+
+    @Test
+    func `a config without an accent color decodes as no override`() throws {
+        let json = #"{"version":1,"providers":[{"id":"codex","enabled":true}]}"#
+        let data = try #require(json.data(using: .utf8))
+
+        let decoded = try JSONDecoder().decode(CodexBarConfig.self, from: data)
+
+        #expect(decoded.providerConfig(for: .codex)?.accentColor == nil)
+        #expect(ProviderAccentColors.overrides(in: decoded).isEmpty)
+    }
+
+    @Test
+    func `overrides collect only the providers that carry a parsable color`() {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .codex, accentColor: "#60BA7E"),
+            ProviderConfig(id: .claude, accentColor: "nonsense"),
+            ProviderConfig(id: .antigravity),
+        ])
+
+        let overrides = ProviderAccentColors.overrides(in: config)
+
+        #expect(overrides.count == 1)
+        #expect(overrides[.codex] == ProviderColor(hex: 0x60BA7E))
+        #expect(overrides[.claude] == nil)
+        #expect(overrides[.antigravity] == nil)
+    }
+
+    @Test
+    func `the mirrored payload round trips through its string encoding`() {
+        let overrides: [ProviderInstanceID: ProviderColor] = [
+            .codex: ProviderColor(hex: 0x60BA7E),
+            .claude: ProviderColor(hex: 0xD97757),
+        ]
+
+        let encoded = ProviderAccentColors.encode(overrides)
+
+        #expect(encoded["codex"] == "#60BA7E")
+        #expect(encoded["claude"] == "#D97757")
+        #expect(ProviderAccentColors.decode(encoded) == overrides)
+    }
+
+    @Test
+    func `the mirrored payload drops unknown providers and bad colors`() {
+        let decoded = ProviderAccentColors.decode([
+            "codex": "#60BA7E",
+            "claude": "not-a-color",
+            "": "#FFFFFF",
+        ])
+
+        #expect(decoded == [.codex: ProviderColor(hex: 0x60BA7E)])
+    }
+
+    @Test
+    func `sync carries the accent override to another Mac`() throws {
+        let local = ProviderConfig(id: .codex, enabled: true, accentColor: "#60BA7E")
+
+        let payload = ProviderIntentPayload(config: local)
+        let applied = try payload.applying(
+            to: ProviderConfig(id: .codex),
+            secretFields: [:],
+            canEnable: { _, _ in true })
+
+        #expect(payload.accentColor == "#60BA7E")
+        #expect(applied.accentColor == "#60BA7E")
+    }
+
+    @Test
+    func `sync clears the accent override when the sending Mac cleared it`() throws {
+        let payload = ProviderIntentPayload(config: ProviderConfig(id: .codex, enabled: true))
+
+        let applied = try payload.applying(
+            to: ProviderConfig(id: .codex, accentColor: "#60BA7E"),
+            secretFields: [:],
+            canEnable: { _, _ in true })
+
+        // A Mac that knows the field reports an empty string, which means "the user cleared it".
+        #expect(payload.accentColor?.isEmpty == true)
+        #expect(applied.accentColor == nil)
+    }
+
+    @Test
+    func `a client that predates accent colors cannot erase an override`() throws {
+        // A payload from an older Mac carries no accentColor key at all.
+        let legacy = #"""
+        {"schemaVersion":1,"provider":"codex","enabled":true}
+        """#
+        let data = try #require(legacy.data(using: .utf8))
+        let payload = try JSONDecoder().decode(ProviderIntentPayload.self, from: data)
+
+        let applied = try payload.applying(
+            to: ProviderConfig(id: .codex, accentColor: "#60BA7E"),
+            secretFields: [:],
+            canEnable: { _, _ in true })
+
+        #expect(payload.accentColor == nil)
+        #expect(applied.accentColor == "#60BA7E")
+    }
+}

--- a/Tests/CodexBarTests/ProviderAccentRefreshRevisionTests.swift
+++ b/Tests/CodexBarTests/ProviderAccentRefreshRevisionTests.swift
@@ -1,0 +1,47 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+/// The provider config revision gates publication of an in-flight refresh result. A cosmetic edit
+/// must therefore leave it alone, because a cosmetic edit schedules no replacement fetch.
+@MainActor
+struct ProviderAccentRefreshRevisionTests {
+    @Test
+    func `changing the accent color leaves the provider refresh revision untouched`() {
+        let settings = testSettingsStore(suiteName: "ProviderAccentRefreshRevisionTests-accent")
+        let provider = UsageProvider.codex
+        let before = settings.providerConfigRevision(for: provider)
+
+        settings.setAccentColorOverride(ProviderColor(hex: 0xA56CC1), for: provider)
+
+        #expect(settings.accentColorOverride(for: provider) == ProviderColor(hex: 0xA56CC1))
+        #expect(settings.providerConfigRevision(for: provider) == before)
+    }
+
+    @Test
+    func `resetting the accent color leaves the provider refresh revision untouched`() {
+        let settings = testSettingsStore(suiteName: "ProviderAccentRefreshRevisionTests-reset")
+        let provider = UsageProvider.codex
+        settings.setAccentColorOverride(ProviderColor(hex: 0xA56CC1), for: provider)
+        let before = settings.providerConfigRevision(for: provider)
+
+        settings.setAccentColorOverride(nil, for: provider)
+
+        #expect(settings.accentColorOverride(for: provider) == nil)
+        #expect(settings.providerConfigRevision(for: provider) == before)
+    }
+
+    /// Control: a field a fetch actually depends on must still bump the revision, so the exclusion
+    /// above cannot silently widen.
+    @Test
+    func `changing a fetch relevant field still bumps the provider refresh revision`() {
+        let settings = testSettingsStore(suiteName: "ProviderAccentRefreshRevisionTests-control")
+        let provider = UsageProvider.codex
+        let before = settings.providerConfigRevision(for: provider)
+
+        settings.updateProviderConfig(provider: provider) { $0.region = "us-east-1" }
+
+        #expect(settings.providerConfigRevision(for: provider) > before)
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2281,7 +2281,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1054,
+            line: 1069,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,


### PR DESCRIPTION
## Summary

Each provider settings card gets an Accent color row. The row shows a swatch, a hex
field, and a color well. A Reset button appears only when an override exists.

Provider descriptors keep the shipped color as a compile-time constant. This feature
never writes over that constant, so a reset always restores the original color.

## What changes

The override applies to every surface that paints the provider brand color:

- Usage bars in the menu and the inline dashboard.
- Cost history and plan utilization charts.
- The provider switcher tab indicator.
- The widget.
- The `codexbar serve` web dashboard.

Out of scope: `burnDownWidgetColor`, `confettiPalette`, and all bar styling other than
color.

## Storage

`ProviderConfig.accentColor` holds the value as `#RRGGBB` in `~/.codexbar/config.json`.
That file reaches the app and the `codexbar serve` dashboard directly.

The widget runs in a sandbox and cannot read that file. The app therefore mirrors the
resolved map into the App Group defaults, and reloads widget timelines when a color
moves.

Overrides travel between Macs through `ProviderIntentPayload`, with the same semantics
as the other fields in that payload.

## Implementation notes

- A hex value that does not parse degrades to the shipped color. A hand-edited config
  file cannot break the load.
- The color well can return a wide-gamut color. The view pins the value to sRGB before
  it stores the hex.
- An accent change uses `affectsBackgroundWork: false`. Open menus and status items
  rebuild, but no provider refresh occurs.
- `updateQuotaIndicators()` now refreshes the indicator color outside the ratio guard.
  The switcher view outlives a menu update, so a new color must not wait for usage to
  move.

## Commands run

- `swift build`
- `swift test --filter ProviderAccentColorTests` (12 tests, all pass)
- `make check`
- `make test`

## Screenshots

The row on a provider card, with no override. The hex field shows the shipped color.

<img width="460" height="133" alt="accent-color-row-default" src="https://github.com/user-attachments/assets/616080af-d9bf-4812-adc2-607ed6821481" />

The same row with an override. Reset appears only in this state.

<img width="460" height="133" alt="accent-color-row-override" src="https://github.com/user-attachments/assets/f1da564d-4dd2-4926-a9c5-1e6f6e2ecb53" />

Usage bars in the shipped color and in the override.

<img width="360" height="112" alt="accent-color-bars-before-after" src="https://github.com/user-attachments/assets/f191428f-cb23-404d-a3a3-7a74f2d9e533" />

These are rendered components, not captures of the running Settings window.
`ProviderAccentColorScreenshotRenderTests` produces them, and it is skipped by default:

```
CODEXBAR_ACCENT_SCREENSHOT_DIR=~/Downloads swift test --filter ProviderAccentColorScreenshotRenderTests
```

## Notes for review

The 22 non-English catalogs carry machine-generated translations. They pass the token
and coverage checks, but a native speaker should review the wording.

`ProviderArchitectureGatekeeperTests` pins one allowlist entry by line number. This
branch adds lines to `SettingsStore.swift`, so that entry moves from 1048 to 1058. Only
the line number changes.
