### PR TITLE
Generate portable CLI release checksums

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -409,11 +409,7 @@ jobs:
           ASSET="CodexBarCLI-${SAFE_REF_NAME}-${{ matrix.asset-platform }}-${{ matrix.asset-arch }}.tar.gz"
           (cd "$OUT_DIR" && tar czf "$ASSET" \
             CodexBarCLI codexbar VERSION CodexBar_CodexBarCore.bundle)
-          if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum "$OUT_DIR/$ASSET" > "$OUT_DIR/$ASSET.sha256"
-          else
-            shasum -a 256 "$OUT_DIR/$ASSET" > "$OUT_DIR/$ASSET.sha256"
-          fi
+          Scripts/generate_release_checksum.sh "$OUT_DIR/$ASSET"
 
           echo "out_dir=$OUT_DIR" >> "$GITHUB_OUTPUT"
           echo "asset=$ASSET" >> "$GITHUB_OUTPUT"

--- a/Scripts/generate_release_checksum.sh
+++ b/Scripts/generate_release_checksum.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: $(basename "$0") <asset>" >&2
+  exit 2
+fi
+
+ASSET_PATH="$1"
+if [[ ! -f "$ASSET_PATH" ]]; then
+  echo "Release asset not found: $ASSET_PATH" >&2
+  exit 1
+fi
+
+OUT_DIR="$(cd "$(dirname "$ASSET_PATH")" && pwd)"
+ASSET="$(basename "$ASSET_PATH")"
+
+(
+  cd "$OUT_DIR"
+  if command -v sha256sum >/dev/null 2>&1; then
+    CHECKSUM=(sha256sum)
+  elif command -v shasum >/dev/null 2>&1; then
+    CHECKSUM=(shasum -a 256)
+  else
+    echo "sha256sum or shasum is required." >&2
+    exit 1
+  fi
+
+  "${CHECKSUM[@]}" "$ASSET" > "$ASSET.sha256"
+  read -r _ CHECKSUM_ASSET < "$ASSET.sha256"
+  if [[ "$CHECKSUM_ASSET" != "$ASSET" ]]; then
+    echo "Checksum file references an unexpected path: $CHECKSUM_ASSET" >&2
+    exit 1
+  fi
+  "${CHECKSUM[@]}" -c "$ASSET.sha256"
+)

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -57,6 +57,10 @@ check_release_dsym_paths() {
   "${ROOT_DIR}/Scripts/test_release_dsym_paths.sh"
 }
 
+check_release_checksum() {
+  "${ROOT_DIR}/Scripts/test_release_checksum.sh"
+}
+
 check_sparkle_signing_paths() {
   "${ROOT_DIR}/Scripts/test_sparkle_signing_paths.sh"
 }
@@ -116,6 +120,7 @@ run_portable_checks() {
   check_package_signing
   check_package_info_plist
   check_release_dsym_paths
+  check_release_checksum
   check_sparkle_signing_paths
   check_swift_test_sharding
   check_ci_path_gate

--- a/Scripts/test_release_checksum.sh
+++ b/Scripts/test_release_checksum.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-release-checksum.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+ASSET_NAME="CodexBarCLI-v0.0.0-linux-x86_64.tar.gz"
+ASSET_PATH="$TEMP_DIR/source/$ASSET_NAME"
+VERIFY_DIR="$TEMP_DIR/verify"
+mkdir -p "$(dirname "$ASSET_PATH")" "$VERIFY_DIR"
+printf '%s\n' "release checksum fixture" > "$ASSET_PATH"
+
+"$ROOT/Scripts/generate_release_checksum.sh" "$ASSET_PATH"
+
+CHECKSUM_PATH="$ASSET_PATH.sha256"
+read -r _ CHECKSUM_ASSET < "$CHECKSUM_PATH"
+[[ "$CHECKSUM_ASSET" == "$ASSET_NAME" ]]
+
+mv "$ASSET_PATH" "$CHECKSUM_PATH" "$VERIFY_DIR/"
+(
+  cd "$VERIFY_DIR"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$ASSET_NAME.sha256"
+  else
+    shasum -a 256 -c "$ASSET_NAME.sha256"
+  fi
+)
+
+echo "Release checksum tests passed."


### PR DESCRIPTION
## Summary

- generate CLI release checksum sidecars from inside the output directory so they record only the asset basename
- validate both the recorded filename and digest before uploading release assets
- add a portable regression test that moves the asset and sidecar to a different directory before running `-c`

Closes #2971

## Testing

- `./Scripts/test_release_checksum.sh` — passes
- `./Scripts/lint.sh lint-linux` — portable checks (including the new regression test), JavaScript formatting/linting, and TypeScript checks pass; the final SwiftLint invocation is blocked because the downloaded binary requires newer glibc/libstdc++ than the b2 host provides
- `make check` — blocked on Linux because the existing app-localization check requires macOS `plutil`
- `make test` — blocked before discovery because Swift is not installed on the b2 host

## Real release-workflow proof

- Workflow run: [Release CLI run 31934142399](https://github.com/shockbladenull/CodexBar/actions/runs/31934142399)
- Trigger: `workflow_dispatch` on `shockbladenull:agent/fix-cli-checksum-paths`
- Reviewed head: `9f7d27b230e4b7d7f650d6e1ce8a7424cfeb184e`
- Result: all six real `build-cli` matrix jobs passed: Linux glibc x86_64/aarch64, Linux musl x86_64/aarch64, and macOS x86_64/arm64.
- Every workflow `Package` step generated and validated its sidecar; both macOS package jobs also reported `: OK`.
- I downloaded all six workflow artifacts onto b2, a different host and path from the GitHub runner temporary directories. For every sidecar, I first asserted that its recorded filename exactly matched the archive basename, then ran `sha256sum -c` from the downloaded artifact directory. All six passed.
- Since this was a manual proof run rather than a release event, the publish-only and Homebrew-update jobs were skipped; no release or tap update was made.

```text
CodexBarCLI-v0.50.0-pr2973-proof-linux-aarch64.tar.gz: OK
CodexBarCLI-v0.50.0-pr2973-proof-linux-musl-aarch64.tar.gz: OK
CodexBarCLI-v0.50.0-pr2973-proof-linux-musl-x86_64.tar.gz: OK
CodexBarCLI-v0.50.0-pr2973-proof-linux-x86_64.tar.gz: OK
CodexBarCLI-v0.50.0-pr2973-proof-macos-arm64.tar.gz: OK
CodexBarCLI-v0.50.0-pr2973-proof-macos-x86_64.tar.gz: OK
Verified 6 portable checksum sidecars
```
