### PR TITLE
fix: align chart date labels with bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Widgets: opt-in display of Claude model-scoped weekly quotas (for example Fable) projected from the shared usage snapshot, off by default (#2645). Thanks @alfredjbclaw!
 
 ### Fixed
+- Cost history: align x-axis date labels with their bars in status-menu charts (#2974). Thanks @Yuxin-Qiao!
 - Codex: keep CLI-owned `auth.json` read-only during usage refresh, delegate stale native credentials to CLI recovery, and fail closed for stale external OAuth files (#2944). Thanks @Yuxin-Qiao!
 - Usage & Spend: keep safely priced Codex totals visible after completed history scans when request-tier uncertainty leaves some days unpriced (#2948). Thanks @Atopoz for the report!
 - Vertex AI: match Cloud Monitoring quota usage without a `limit_name` to its unambiguous same-metric, same-location limit, restoring quota percentages (#2958). Thanks @MachApple!

--- a/Sources/CodexBar/ChartAxisLabelLayout.swift
+++ b/Sources/CodexBar/ChartAxisLabelLayout.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+enum ChartAxisLabelLayout {
+    /// Keeps the label's horizontal center on the x-axis value shared with its bar.
+    static let barCenteredAnchor = UnitPoint.top
+
+    static func barCenterX(slotIndex: Int, slotCount: Int, chartWidth: CGFloat) -> CGFloat? {
+        guard slotCount > 0, (0..<slotCount).contains(slotIndex), chartWidth >= 0 else { return nil }
+        let slotWidth = chartWidth / CGFloat(slotCount)
+        return (CGFloat(slotIndex) + 0.5) * slotWidth
+    }
+
+    static func labelCenterX(tickX: CGFloat, labelWidth: CGFloat, anchor: UnitPoint) -> CGFloat {
+        tickX + (0.5 - anchor.x) * labelWidth
+    }
+}

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -7,12 +7,6 @@ import SwiftUI
 struct CostHistoryChartMenuView: View {
     typealias DailyEntry = CostUsageDailyReport.Entry
 
-    enum AxisLabelPlacement: Equatable {
-        case hidden
-        case centered
-        case edges
-    }
-
     enum ChartMetric: CaseIterable, Hashable {
         case tokens
         case cost
@@ -187,7 +181,7 @@ struct CostHistoryChartMenuView: View {
                         AxisGridLine().foregroundStyle(Color.clear)
                         AxisTick().foregroundStyle(Color.clear)
                         if let date = value.as(Date.self) {
-                            AxisValueLabel(anchor: Self.xAxisLabelAnchor(for: date, axisDates: model.axisDates)) {
+                            AxisValueLabel(anchor: ChartAxisLabelLayout.barCenteredAnchor) {
                                 Text(date, format: .dateTime.month(.abbreviated).day())
                                     .font(.caption2)
                                     .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
@@ -612,29 +606,6 @@ struct CostHistoryChartMenuView: View {
             detailViewportRowCount: detailLayout.viewportRowCount,
             hasDetailOverflow: detailLayout.hasOverflow,
             detailRowHeight: detailLayout.rowHeight)
-    }
-
-    private static func axisLabelPlacement(for dates: [Date]) -> AxisLabelPlacement {
-        switch dates.count {
-        case 0: .hidden
-        case 1: .centered
-        default: .edges
-        }
-    }
-
-    private static func xAxisLabelAnchor(for date: Date, axisDates: [Date]) -> UnitPoint {
-        switch self.axisLabelPlacement(for: axisDates) {
-        case .hidden, .centered:
-            .top
-        case .edges:
-            if let first = axisDates.first, Calendar.current.isDate(date, inSameDayAs: first) {
-                .topLeading
-            } else if let last = axisDates.last, Calendar.current.isDate(date, inSameDayAs: last) {
-                .topTrailing
-            } else {
-                .top
-            }
-        }
     }
 
     private static func barColor(for provider: UsageProvider) -> Color {
@@ -1235,16 +1206,6 @@ extension CostHistoryChartMenuView {
             provider: provider,
             daily: daily,
             metric: self.defaultMetric(provider: provider, daily: daily)).axisDates
-    }
-
-    static func _axisLabelPlacementForTesting(
-        provider: UsageProvider,
-        daily: [DailyEntry]) -> AxisLabelPlacement
-    {
-        self.axisLabelPlacement(for: self.makeModel(
-            provider: provider,
-            daily: daily,
-            metric: self.defaultMetric(provider: provider, daily: daily)).axisDates)
     }
 
     static func _yAxisTickValuesForTesting(maxCostUSD: Double) -> [Double] {

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -131,16 +131,13 @@ struct PlanUtilizationHistoryChartMenuView: View {
                         AxisMarks(values: model.axisIndexes) { value in
                             AxisGridLine().foregroundStyle(Color.clear)
                             AxisTick().foregroundStyle(Color.clear)
-                            AxisValueLabel {
+                            AxisValueLabel(anchor: ChartAxisLabelLayout.barCenteredAnchor) {
                                 if let raw = value.as(Double.self) {
                                     let index = Int(raw.rounded())
                                     if let point = model.pointsByIndex[index] {
-                                        let isTrailingFullChartLabel = index == model.points.last?.index
-                                            && model.points.count == Layout.maxPoints
                                         Self.axisLabel(
                                             for: point,
-                                            windowMinutes: effectiveSelectedSeries?.history.windowMinutes ?? 0,
-                                            isTrailingFullChartLabel: isTrailingFullChartLabel)
+                                            windowMinutes: effectiveSelectedSeries?.history.windowMinutes ?? 0)
                                     }
                                 }
                             }
@@ -606,23 +603,13 @@ struct PlanUtilizationHistoryChartMenuView: View {
         return deduplicated.map(Double.init)
     }
 
-    @ViewBuilder
     private static func axisLabel(
         for point: Point,
-        windowMinutes: Int,
-        isTrailingFullChartLabel: Bool) -> some View
+        windowMinutes: Int) -> some View
     {
-        let label = Text(point.date.formatted(self.axisFormat(windowMinutes: windowMinutes)))
+        Text(point.date.formatted(self.axisFormat(windowMinutes: windowMinutes)))
             .font(.caption2)
             .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-
-        if isTrailingFullChartLabel {
-            label
-                .frame(width: 48, alignment: .trailing)
-                .offset(x: -24)
-        } else {
-            label
-        }
     }
 
     private nonisolated static func axisFormat(windowMinutes: Int) -> Date.FormatStyle {

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -91,7 +91,7 @@ struct UsageBreakdownChartMenuView: View {
                         AxisGridLine().foregroundStyle(Color.clear)
                         AxisTick().foregroundStyle(Color.clear)
                         if let date = value.as(Date.self) {
-                            AxisValueLabel(anchor: Self.xAxisLabelAnchor(for: date, axisDates: model.axisDates)) {
+                            AxisValueLabel(anchor: ChartAxisLabelLayout.barCenteredAnchor) {
                                 Text(date, format: .dateTime.month(.abbreviated).day())
                                     .font(.caption2)
                                     .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
@@ -321,16 +321,6 @@ struct UsageBreakdownChartMenuView: View {
             return [firstDate]
         }
         return [firstDate, lastDate]
-    }
-
-    private static func xAxisLabelAnchor(for date: Date, axisDates: [Date]) -> UnitPoint {
-        if let first = axisDates.first, Calendar.current.isDate(date, inSameDayAs: first) {
-            return .topLeading
-        }
-        if let last = axisDates.last, Calendar.current.isDate(date, inSameDayAs: last) {
-            return .topTrailing
-        }
-        return .top
     }
 
     private static func dateFromDayKey(_ key: String) -> Date? {

--- a/Tests/CodexBarTests/ChartAxisLabelLayoutTests.swift
+++ b/Tests/CodexBarTests/ChartAxisLabelLayoutTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct ChartAxisLabelLayoutTests {
+    @Test
+    func `first date label center matches first bar center`() throws {
+        let barCenter = try #require(ChartAxisLabelLayout.barCenterX(
+            slotIndex: 0,
+            slotCount: 16,
+            chartWidth: 480))
+        let labelCenter = ChartAxisLabelLayout.labelCenterX(
+            tickX: barCenter,
+            labelWidth: 44,
+            anchor: ChartAxisLabelLayout.barCenteredAnchor)
+
+        #expect(abs(labelCenter - barCenter) < 0.0001)
+    }
+
+    @Test
+    func `last date label center matches last bar center`() throws {
+        let barCenter = try #require(ChartAxisLabelLayout.barCenterX(
+            slotIndex: 15,
+            slotCount: 16,
+            chartWidth: 480))
+        let labelCenter = ChartAxisLabelLayout.labelCenterX(
+            tickX: barCenter,
+            labelWidth: 64,
+            anchor: ChartAxisLabelLayout.barCenteredAnchor)
+
+        #expect(abs(labelCenter - barCenter) < 0.0001)
+    }
+}

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -349,10 +349,6 @@ struct CostHistoryChartMenuViewTests {
         #expect(cal.component(.day, from: dates[0]) == 21)
         #expect(cal.component(.month, from: dates[1]) == 6)
         #expect(cal.component(.day, from: dates[1]) == 17)
-        #expect(
-            CostHistoryChartMenuView._axisLabelPlacementForTesting(
-                provider: .codex,
-                daily: daily) == .edges)
     }
 
     @Test
@@ -370,10 +366,6 @@ struct CostHistoryChartMenuViewTests {
         ]
         let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
         #expect(dates.count == 1)
-        #expect(
-            CostHistoryChartMenuView._axisLabelPlacementForTesting(
-                provider: .codex,
-                daily: daily) == .centered)
     }
 
     @Test
@@ -391,10 +383,6 @@ struct CostHistoryChartMenuViewTests {
         ]
         let dates = CostHistoryChartMenuView._axisDatesForTesting(provider: .codex, daily: daily)
         #expect(dates.isEmpty)
-        #expect(
-            CostHistoryChartMenuView._axisLabelPlacementForTesting(
-                provider: .codex,
-                daily: daily) == .hidden)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1713,7 +1713,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/CostHistoryChartMenuView.swift",
-            line: 1135,
+            line: 1106,
             anchor: "let projects = provider == .codex ? snapshot.projects : []",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,


### PR DESCRIPTION
## Summary

- center status-menu x-axis date labels on the same tick positions as their bars
- apply the shared alignment convention to cost history, usage breakdown, and plan utilization charts
- add pure slot-geometry regression tests for the first and last labels
- document the fix in the 0.50.1 changelog

Fixes #2974.

## Root cause

The bars and axis marks already share the same x values, but the endpoint labels did not share the same horizontal anchor. Cost history and usage breakdown used `.topLeading` for the first date and `.topTrailing` for the last date, which placed a label edge at the bar's x coordinate. The label center therefore moved right by half the first label's width and left by half the last label's width. The plan-utilization chart had the same class of workaround as a fixed 24-point left offset on its trailing label.

This replaces those edge-specific adjustments with one centered anchor. Bar data, date domains, day-key conversion, and token/cost values are unchanged.

## Tests

- `swift test --filter 'ChartAxisLabelLayoutTests|CostHistoryChartMenuViewTests|PlanUtilizationHistoryChartMenuViewTests|UsageBreakdownChartMenuViewTests'` — 49 tests passed
- source-blind geometry contract — 2 edge-center checks passed with different localized-label widths
- structured autoreview — clean, no accepted/actionable findings
- `make check` — passed on the issue branch's original `origin/main`; after rebasing onto current `origin/main`, it reaches SwiftLint and fails on the upstream-only `UsageStoreWidgetSnapshotTests.swift` type-body length (897 > 800). This PR does not modify that file.
