### PR TITLE
fix: disclose local OpenCode Go quota estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Widgets: opt-in display of Claude model-scoped weekly quotas (for example Fable) projected from the shared usage snapshot, off by default (#2645). Thanks @alfredjbclaw!
 
 ### Fixed
+- OpenCode Go: label local-only quota windows as estimates in the menu and CLI when Auto has no server-confirmed usage (#2982). Thanks @Newarr!
 - Claude: let Auto reuse a working CLI fallback when OAuth Keychain access is revoked by Claude Code token rotation, distinguish revoked access from missing credentials, and keep last-known quota history visible with its capture age when every live source fails (#2516). Thanks @axisrow and everyone who supplied forensics!
 - Menu: apply the cost summary display style to every provider's menu card, so Submenu only hides inline cost rows for z.ai and other providers (#2976). Thanks @ar0nbg!
 - Cost history: align x-axis date labels with their bars in status-menu charts (#2974). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -275,6 +275,11 @@ extension UsageMenuCardView.Model {
             return [L("Usage via Claude CLI (limited detail)")] + subscriptionNotes
         }
 
+        // Provider-specific by design: OpenCode Go local quota windows need an explicit authority warning.
+        if input.provider == .opencodego, input.snapshot?.dataConfidence == .estimated {
+            return [L("Quota estimated from local usage history")] + subscriptionNotes
+        }
+
         if let notes = self.apiProviderUsageNotes(input: input) {
             return notes + subscriptionNotes
         }

--- a/Sources/CodexBarCLI/CLIHelpers.swift
+++ b/Sources/CodexBarCLI/CLIHelpers.swift
@@ -111,8 +111,14 @@ extension CodexBarCLI {
     static func usageTextNotes(
         provider: UsageProvider,
         sourceMode: ProviderSourceMode,
-        resolvedSourceLabel: String) -> [String]
+        resolvedSourceLabel: String,
+        dataConfidence: UsageDataConfidence = .unknown) -> [String]
     {
+        // Provider-specific by design: OpenCode Go local quota windows need an explicit authority warning.
+        if provider == .opencodego, dataConfidence == .estimated {
+            return ["Quota estimated from local usage history"]
+        }
+
         // Provider-specific by design: Kilo automatic mode reports when its CLI fallback won strategy selection.
         guard provider == .kilo,
               sourceMode == .auto,

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -532,7 +532,8 @@ extension CodexBarCLI {
             let notes = Self.usageTextNotes(
                 provider: provider,
                 sourceMode: effectiveSourceMode,
-                resolvedSourceLabel: source) + (result.diagnostic.map { [$0] } ?? [])
+                resolvedSourceLabel: source,
+                dataConfidence: usage.dataConfidence) + (result.diagnostic.map { [$0] } ?? [])
 
             Self.appendSuccessRenderOutput(
                 UsageSuccessRenderInput(

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -161,6 +161,12 @@ struct OpenCodeGoLocalUsageFetchStrategy: ProviderFetchStrategy {
         let cachedEntry: CookieHeaderCache.Entry?
     }
 
+    private struct SnapshotResult {
+        let snapshot: OpenCodeGoUsageSnapshot
+        let webUsageApplied: Bool
+        let quotaIsAuthoritative: Bool
+    }
+
     init(
         localSnapshotLoader: @escaping LocalSnapshotLoader = { context in
             try OpenCodeGoLocalUsageReader().fetch(historyDays: context.costUsageHistoryDays)
@@ -176,22 +182,23 @@ struct OpenCodeGoLocalUsageFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let (snapshot, overlaid) = try await self.snapshot(context: context)
+        let result = try await self.snapshot(context: context)
+        let usage = result.snapshot.toUsageSnapshot()
         return self.makeResult(
-            usage: snapshot.toUsageSnapshot(),
-            sourceLabel: overlaid ? "local+web" : "local")
+            usage: result.quotaIsAuthoritative ? usage : usage.withDataConfidence(.estimated),
+            sourceLabel: result.webUsageApplied ? "local+web" : "local")
     }
 
     func shouldFallback(on error: Error, context _: ProviderFetchContext) -> Bool {
         error is OpenCodeGoLocalUsageError
     }
 
-    private func snapshot(context: ProviderFetchContext) async throws -> (OpenCodeGoUsageSnapshot, Bool) {
+    private func snapshot(context: ProviderFetchContext) async throws -> SnapshotResult {
         let snapshot = try self.localSnapshotLoader(context)
         guard context.settings?.opencodego?.cookieSource != .off,
               let cookie = Self.cachedOrManualCookie(context: context)
         else {
-            return (snapshot, false)
+            return SnapshotResult(snapshot: snapshot, webUsageApplied: false, quotaIsAuthoritative: false)
         }
 
         // The server knows the real billing-cycle anchors; the local monthly window is only an
@@ -208,20 +215,23 @@ struct OpenCodeGoLocalUsageFetchStrategy: ProviderFetchStrategy {
                 _ = CookieHeaderCache.clearIfCurrent(provider: .opencodego, expected: cached)
             }
             #endif
-            return (snapshot, false)
+            return SnapshotResult(snapshot: snapshot, webUsageApplied: false, quotaIsAuthoritative: false)
         } catch is CancellationError {
             throw CancellationError()
         } catch let error as URLError where error.code == .cancelled {
             throw CancellationError()
         } catch {
-            return (snapshot, false)
+            return SnapshotResult(snapshot: snapshot, webUsageApplied: false, quotaIsAuthoritative: false)
         }
         if let webSnapshot {
-            return (snapshot.applyingWebUsage(webSnapshot), true)
+            return SnapshotResult(
+                snapshot: snapshot.applyingWebUsage(webSnapshot),
+                webUsageApplied: true,
+                quotaIsAuthoritative: !webSnapshot.isBalanceOnly)
         }
 
         guard context.includeOptionalUsage else {
-            return (snapshot, false)
+            return SnapshotResult(snapshot: snapshot, webUsageApplied: false, quotaIsAuthoritative: false)
         }
         let workspaceOverride = context.settings?.opencodego?.workspaceID
             ?? context.env["CODEXBAR_OPENCODEGO_WORKSPACE_ID"]
@@ -243,7 +253,10 @@ struct OpenCodeGoLocalUsageFetchStrategy: ProviderFetchStrategy {
             timeout: OpenCodeGoUsageFetcher.optionalZenBalanceJoinTimeout(
                 since: zenBalanceStart,
                 waitForZenBalance: OpenCodeGoUsageFetchStrategy.shouldWaitForZenBalance(context: context)))
-        return (snapshot.withZenBalanceUSD(zenBalance), false)
+        return SnapshotResult(
+            snapshot: snapshot.withZenBalanceUSD(zenBalance),
+            webUsageApplied: false,
+            quotaIsAuthoritative: false)
     }
 
     static func liveWebUsageOverlay(

--- a/Tests/CodexBarTests/OpenCodeGoCLIAuthorityTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoCLIAuthorityTests.swift
@@ -1,0 +1,51 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBarCLI
+
+struct OpenCodeGoCLIAuthorityTests {
+    @Test
+    func `json identifies local quota windows as estimated`() throws {
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 45, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            tertiary: RateWindow(usedPercent: 0, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            identity: nil,
+            dataConfidence: .estimated)
+        let payload = ProviderPayload(
+            provider: .opencodego,
+            account: nil,
+            version: nil,
+            source: "local",
+            status: nil,
+            usage: snapshot,
+            credits: nil,
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: nil)
+
+        let data = try JSONEncoder().encode([payload])
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        let first = try #require(json.first)
+        let usage = try #require(first["usage"] as? [String: Any])
+
+        #expect(first["source"] as? String == "local")
+        #expect(usage["dataConfidence"] as? String == "estimated")
+    }
+
+    @Test
+    func `text output explains local quota estimates`() {
+        let notes = CodexBarCLI.usageTextNotes(
+            provider: .opencodego,
+            sourceMode: .auto,
+            resolvedSourceLabel: "local",
+            dataConfidence: .estimated)
+
+        #expect(notes == ["Quota estimated from local usage history"])
+        #expect(CodexBarCLI.usageTextNotes(
+            provider: .opencodego,
+            sourceMode: .auto,
+            resolvedSourceLabel: "local+web").isEmpty)
+    }
+}

--- a/Tests/CodexBarTests/OpenCodeGoMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoMenuCardModelTests.swift
@@ -5,6 +5,41 @@ import Testing
 
 struct OpenCodeGoMenuCardModelTests {
     @Test
+    func `local quota estimates are disclosed in the menu card`() throws {
+        let now = Date(timeIntervalSince1970: 10_368_000)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 45, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            tertiary: RateWindow(usedPercent: 0, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
+            updatedAt: now,
+            identity: nil,
+            dataConfidence: .estimated)
+        let metadata = try #require(ProviderDefaults.metadata[.opencodego])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .opencodego,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.usageNotes == [L("Quota estimated from local usage history")])
+    }
+
+    @Test
     func `monthly quota shows deficit and run out details`() throws {
         let now = Date(timeIntervalSince1970: 10_368_000) // 1970-05-01T00:00:00Z
         let reset = now.addingTimeInterval(6 * 24 * 3600)

--- a/Tests/CodexBarTests/OpenCodeGoWebOverlayTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoWebOverlayTests.swift
@@ -194,6 +194,7 @@ struct OpenCodeGoWebOverlayTests {
         #expect(result.usage.secondary?.usedPercent == 52)
         #expect(result.usage.opencodegoUsage?.daily.count == 1)
         #expect(result.usage.providerCost?.used == 42.5)
+        #expect(result.usage.dataConfidence != .estimated)
     }
 
     @Test
@@ -208,6 +209,23 @@ struct OpenCodeGoWebOverlayTests {
 
         #expect(result.sourceLabel == "local")
         #expect(result.usage.tertiary?.usedPercent == 100)
+        #expect(result.usage.dataConfidence == .estimated)
+    }
+
+    @Test
+    func `balance only web response keeps local quota marked estimated`() async throws {
+        let strategy = OpenCodeGoLocalUsageFetchStrategy(
+            localSnapshotLoader: { _ in Self.localEstimate() },
+            webUsageOverlayFetcher: { _, _ in
+                OpenCodeGoUsageSnapshot.zenBalanceOnly(balanceUSD: 42.5, updatedAt: Self.updatedAt)
+            })
+
+        let result = try await strategy.fetch(self.makeContext(settings: self.makeManualCookieSettings()))
+
+        #expect(result.sourceLabel == "local+web")
+        #expect(result.usage.tertiary?.usedPercent == 100)
+        #expect(result.usage.providerCost?.used == 42.5)
+        #expect(result.usage.dataConfidence == .estimated)
     }
 
     @Test
@@ -229,6 +247,7 @@ struct OpenCodeGoWebOverlayTests {
         #expect(webCalls.values.isEmpty)
         #expect(result.sourceLabel == "local")
         #expect(result.usage.tertiary?.usedPercent == 100)
+        #expect(result.usage.dataConfidence == .estimated)
     }
 
     @Test
@@ -254,6 +273,27 @@ struct OpenCodeGoWebOverlayTests {
     }
 
     #if os(macOS)
+    @Test
+    func `empty cookie cache marks local quota windows estimated`() async throws {
+        try await self.withEmptyCookieCache {
+            let webCalls = Recorder<String>()
+            let strategy = OpenCodeGoLocalUsageFetchStrategy(
+                localSnapshotLoader: { _ in Self.localEstimate() },
+                webUsageOverlayFetcher: { _, cookieHeader in
+                    webCalls.append(cookieHeader)
+                    return Self.webUsage()
+                })
+
+            let result = try await strategy.fetch(self.makeContext(includeOptionalUsage: false))
+
+            #expect(webCalls.values.isEmpty)
+            #expect(result.sourceLabel == "local")
+            #expect(result.usage.secondary?.usedPercent == 49.4)
+            #expect(result.usage.tertiary?.usedPercent == 100)
+            #expect(result.usage.dataConfidence == .estimated)
+        }
+    }
+
     @Test
     func `local strategy evicts cached cookie after authentication failure`() async throws {
         try await self.withCachedCookie {
@@ -299,8 +339,20 @@ struct OpenCodeGoWebOverlayTests {
 
             #expect(result.sourceLabel == "local+web")
             #expect(result.usage.tertiary?.usedPercent == 64)
+            #expect(result.usage.dataConfidence != .estimated)
             #expect(observedCookies.values == ["auth=cached-session"])
             #expect(CookieHeaderCache.load(provider: .opencodego)?.cookieHeader == "auth=cached-session")
+        }
+    }
+
+    private func withEmptyCookieCache<T>(_ operation: () async throws -> T) async rethrows -> T {
+        let service = "com.steipete.codexbar.tests.opencodego-overlay-empty.\(UUID().uuidString)"
+        return try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            try await KeychainCacheStore.withImplicitTestStoreForTesting {
+                CookieHeaderCache.resetDisplayCacheForTesting()
+                defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+                return try await operation()
+            }
         }
     }
 

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1835,13 +1835,13 @@ struct ProviderArchitectureGatekeeperTests {
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
             line: 269,
             anchor: "if input.provider == .mimo, input.snapshot != nil {",
-            expectedProviderIDs: ["claude", "mimo"],
-            expectedReferenceCount: 2,
-            expectedReferenceFingerprint: ["mimo@0", "claude@4"],
+            expectedProviderIDs: ["claude", "mimo", "opencodego"],
+            expectedReferenceCount: 3,
+            expectedReferenceFingerprint: ["mimo@0", "claude@4", "opencodego@10"],
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 473,
+            line: 478,
             anchor: "if input.provider == .factory, snapshot.tertiary != nil {",
             expectedProviderIDs: ["alibabatokenplan", "amp", "crof", "cursor", "doubao", "factory", "grok", "sub2api"],
             expectedReferenceCount: 12,
@@ -1862,7 +1862,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 634,
+            line: 639,
             anchor: "case .minimax:",
             expectedProviderIDs: ["codex", "minimax", "poe"],
             expectedReferenceCount: 3,
@@ -1870,7 +1870,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 838,
+            line: 843,
             anchor: "if input.provider == .codex, !input.showOptionalCreditsAndExtraUsage {",
             expectedProviderIDs: ["claude", "codex", "copilot"],
             expectedReferenceCount: 4,
@@ -1878,7 +1878,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 863,
+            line: 868,
             anchor: "let resetText = input.provider == .sub2api && namedWindow.window.resetsAt == nil",
             expectedProviderIDs: ["doubao", "sub2api"],
             expectedReferenceCount: 3,
@@ -1886,7 +1886,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 934,
+            line: 939,
             anchor: "if input.provider == .antigravity,",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,
@@ -1894,7 +1894,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 968,
+            line: 973,
             anchor: "if provider == .claude, window.windowMinutes != 10080 {",
             expectedProviderIDs: ["antigravity", "claude", "codex"],
             expectedReferenceCount: 4,
@@ -1902,7 +1902,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1000,
+            line: 1005,
             anchor: "guard input.provider == .antigravity else { return nil }",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -35,7 +35,8 @@ read_when:
 - The local monthly window is an estimate anchored at the earliest local row and can drift from the real billing
   cycle. When a cached or manual session cookie is available, the local strategy overlays the server-reported
   rolling/weekly/monthly percentages and reset countdowns (plus Zen balance) onto the local snapshot, keeping the
-  local daily cost history. This path never triggers a fresh browser import.
+  local daily cost history. This path never triggers a fresh browser import. When no authoritative overlay is
+  available, the menu and text CLI label the quota as estimated, and JSON includes `dataConfidence: "estimated"`.
 - OpenCode Go cost history chart: `opencode.ai` has no daily-granularity endpoint, so per-day cost/request buckets
   come from local `opencode-go` assistant costs in `opencode.db`, keyed by device-local calendar day. Successful web
   usage remains workspace-scoped and is never blended with device-wide local costs, so it does not show cost history.


### PR DESCRIPTION
## Summary

- Mark OpenCode Go local-only quota windows as estimated when Auto has no server-confirmed usage.
- Surface the estimate in the menu card and text CLI, and include `dataConfidence: "estimated"` in JSON.
- Preserve the privacy-first local strategy: no fresh browser import, and cached/manual-cookie quota overlays remain authoritative.
- Keep balance-only web enrichment distinct from authoritative quota confirmation.

Fixes #2982

## Verification

- `swift test --filter OpenCodeGo` (105 macOS tests and 3 Linux tests)
- `swift test --filter ProviderArchitectureGatekeeperTests` (38 tests)
- `make check`
- `make test` (881 selections across 74 shards; two unrelated groups recovered on the harness's built-in retry)
