### PR TITLE
Stabilize Kiro process timing tests

### DIFF
--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -1318,10 +1318,21 @@ extension KiroStatusProbe {
     {
         let accepted = self.shouldAcceptPipeResult(result, for: kind)
         guard accepted else { return false }
-        if !Self.isLoginRequired(result.output), now > deadline {
+        try Self.ensureAcceptedResultBeforeDeadline(
+            output: result.output,
+            deadline: deadline,
+            now: now)
+        return true
+    }
+
+    static func ensureAcceptedResultBeforeDeadline(
+        output: String,
+        deadline: ContinuousClock.Instant,
+        now: ContinuousClock.Instant) throws
+    {
+        if !self.isLoginRequired(output), now > deadline {
             throw KiroStatusProbeError.timeout
         }
-        return true
     }
 
     private func shouldAcceptPTYResult(_ result: KiroCLIResult, for kind: KiroCommandKind) -> Bool {

--- a/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYHardStopTests.swift
@@ -17,6 +17,8 @@ extension KiroStatusProbeTests {
         let lateChildPIDFile = childPIDFile.appendingPathExtension("late-child")
         let rootTermChildPIDFile = childPIDFile.appendingPathExtension("root-term-child")
         let preKillSnapshotTriggerFile = childPIDFile.appendingPathExtension("pre-kill-snapshot")
+        let fixtureReadyFile = childPIDFile.appendingPathExtension("ready")
+        let beginOutputFile = childPIDFile.appendingPathExtension("begin-output")
         let cliURL = try self.makeHardStopCLI()
         defer {
             for pidFile in [childPIDFile, termChildPIDFile, lateChildPIDFile, rootTermChildPIDFile] {
@@ -27,7 +29,9 @@ extension KiroStatusProbeTests {
                 }
                 try? FileManager.default.removeItem(at: pidFile)
             }
-            try? FileManager.default.removeItem(at: preKillSnapshotTriggerFile)
+            for file in [preKillSnapshotTriggerFile, fixtureReadyFile, beginOutputFile] {
+                try? FileManager.default.removeItem(at: file)
+            }
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
         }
 
@@ -37,71 +41,71 @@ extension KiroStatusProbeTests {
         let discoveryDelay = hardStopBudget + 1
         let cleanupMaxLifetime = discoveryDelay + 15
         let preKillSnapshotTriggerPath = preKillSnapshotTriggerFile.path
+        let cleanupStarted = KiroTestInstantMarker()
         #expect(!FileManager.default.fileExists(atPath: preKillSnapshotTriggerPath))
-        let start = Date()
-        let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(discoveryDelay) {
-            try SpawnedProcessGroup.withOutputHolderCleanupMaxLifetimeForTesting(cleanupMaxLifetime) {
-                try SpawnedProcessGroup.withOutputHolderPreKillSnapshotHookForTesting {
-                    Self.touchFile(atPath: preKillSnapshotTriggerPath)
-                } operation: {
-                    try SpawnedProcessGroup.withOutputHolderPreKillDelayForTesting(0.5) {
-                        try TTYCommandRunner().run(
-                            binary: cliURL.path,
-                            send: "",
-                            options: .init(
-                                timeout: 4,
-                                idleTimeout: 0.1,
-                                extraArgs: [
-                                    childPIDFile.path,
-                                    termChildPIDFile.path,
-                                    lateChildPIDFile.path,
-                                    rootTermChildPIDFile.path,
-                                    preKillSnapshotTriggerPath,
-                                ],
-                                initialDelay: 0,
-                                settleAfterStop: 0))
+        let runnerTask = Task.detached {
+            try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(discoveryDelay) {
+                try SpawnedProcessGroup.withOutputHolderCleanupMaxLifetimeForTesting(cleanupMaxLifetime) {
+                    try SpawnedProcessGroup.withOutputHolderPreKillSnapshotHookForTesting {
+                        try? KiroProcessTestSupport.touch(preKillSnapshotTriggerFile)
+                    } operation: {
+                        try SpawnedProcessGroup.withOutputHolderPreKillDelayForTesting(0.5) {
+                            try TTYCommandRunner().run(
+                                binary: cliURL.path,
+                                send: "",
+                                options: .init(
+                                    timeout: 30,
+                                    idleTimeout: 0.1,
+                                    extraArgs: [
+                                        childPIDFile.path,
+                                        termChildPIDFile.path,
+                                        lateChildPIDFile.path,
+                                        rootTermChildPIDFile.path,
+                                        preKillSnapshotTriggerPath,
+                                        fixtureReadyFile.path,
+                                        beginOutputFile.path,
+                                    ],
+                                    initialDelay: 0,
+                                    settleAfterStop: 0),
+                                onURLDetected: {
+                                    cleanupStarted.mark()
+                                })
+                        }
                     }
                 }
             }
         }
-        let elapsed = Date().timeIntervalSince(start)
-        print("PTY hard-stop latency: \(String(format: "%.3f", elapsed))s")
+        do {
+            try await KiroProcessTestSupport.waitForFile(fixtureReadyFile)
+        } catch {
+            runnerTask.cancel()
+            _ = try? await runnerTask.value
+            throw error
+        }
+        try KiroProcessTestSupport.touch(beginOutputFile)
+        let result = try await runnerTask.value
+        let startedAt = try #require(cleanupStarted.value())
+        let elapsed = startedAt.duration(to: ContinuousClock().now)
+        print("PTY hard-stop latency after fixture readiness: \(elapsed)")
 
         #expect(result.completion == .idleTimeout)
         let snapshot = try KiroStatusProbe().parse(output: result.text)
         #expect(snapshot.planName == "KIRO FREE")
         #expect(snapshot.creditsUsed == 12.50)
         #expect(
-            elapsed < hardStopBudget,
+            elapsed < .seconds(hardStopBudget),
             "Delayed holder discovery should not extend the PTY hard stop, took \(elapsed)s")
 
-        let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
-        let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        for _ in 0..<1000 where !FileManager.default.fileExists(atPath: termChildPIDFile.path) {
-            try await Task.sleep(for: .milliseconds(20))
-        }
-        let termChildPIDText = try String(contentsOf: termChildPIDFile, encoding: .utf8)
-        let termChildPID = try #require(pid_t(termChildPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        for _ in 0..<1000 where !FileManager.default.fileExists(atPath: lateChildPIDFile.path) {
-            try await Task.sleep(for: .milliseconds(20))
-        }
-        let lateChildPIDText = try String(contentsOf: lateChildPIDFile, encoding: .utf8)
-        let lateChildPID = try #require(pid_t(lateChildPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        let childPID = try await KiroProcessTestSupport.waitForPID(in: childPIDFile)
+        let termChildPID = try await KiroProcessTestSupport.waitForPID(in: termChildPIDFile)
+        let lateChildPID = try await KiroProcessTestSupport.waitForPID(in: lateChildPIDFile)
         #expect(FileManager.default.fileExists(atPath: preKillSnapshotTriggerPath))
-        for _ in 0..<1000 where !FileManager.default.fileExists(atPath: rootTermChildPIDFile.path) {
-            try await Task.sleep(for: .milliseconds(20))
-        }
-        let rootTermChildPIDText = try String(contentsOf: rootTermChildPIDFile, encoding: .utf8)
-        let rootTermChildPID = try #require(
-            pid_t(rootTermChildPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        let rootTermChildPID = try await KiroProcessTestSupport.waitForPID(in: rootTermChildPIDFile)
 
-        let cleanupDeadline = Date().addingTimeInterval(20)
-        while kill(childPID, 0) == 0 || kill(termChildPID, 0) == 0 || kill(lateChildPID, 0) == 0
-            || kill(rootTermChildPID, 0) == 0,
-            Date() < cleanupDeadline
-        {
-            try await Task.sleep(for: .milliseconds(20))
-        }
+        try await KiroProcessTestSupport.waitForExit(
+            of: [childPID, termChildPID, lateChildPID, rootTermChildPID],
+            timeout: .seconds(20),
+            description: "all delayed PTY holder cleanup processes to exit")
         #expect(kill(childPID, 0) == -1)
         #expect(kill(termChildPID, 0) == -1)
         #expect(kill(lateChildPID, 0) == -1)
@@ -114,6 +118,8 @@ extension KiroStatusProbeTests {
             .appendingPathComponent("codexbar-kiro-settle-holder-\(UUID().uuidString).pid")
         let allowRootExitFile = holderPIDFile.appendingPathExtension("allow-root-exit")
         let rootExitedFile = holderPIDFile.appendingPathExtension("root-exited")
+        let fixtureReadyFile = holderPIDFile.appendingPathExtension("ready")
+        let beginOutputFile = holderPIDFile.appendingPathExtension("begin-output")
         let cliURL = try self.makeSettleExitHardStopCLI()
         defer {
             if let text = try? String(contentsOf: holderPIDFile, encoding: .utf8),
@@ -121,7 +127,7 @@ extension KiroStatusProbeTests {
             {
                 _ = kill(holderPID, SIGKILL)
             }
-            for file in [holderPIDFile, allowRootExitFile, rootExitedFile] {
+            for file in [holderPIDFile, allowRootExitFile, rootExitedFile, fixtureReadyFile, beginOutputFile] {
                 try? FileManager.default.removeItem(at: file)
             }
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
@@ -131,28 +137,47 @@ extension KiroStatusProbeTests {
         let discoveryDelay = hardStopBudget + 1
         let cleanupMaxLifetime = discoveryDelay + 15
         let allowRootExitPath = allowRootExitFile.path
+        let cleanupStarted = KiroTestInstantMarker()
         #expect(!FileManager.default.fileExists(atPath: allowRootExitPath))
         #expect(!FileManager.default.fileExists(atPath: rootExitedFile.path))
 
-        let start = Date()
-        let result = try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(discoveryDelay) {
-            try SpawnedProcessGroup.withOutputHolderCleanupMaxLifetimeForTesting(cleanupMaxLifetime) {
-                try TTYCommandRunner().run(
-                    binary: cliURL.path,
-                    send: "",
-                    options: .init(
-                        timeout: 4 * TestTimingBudget.slowdownFactor,
-                        idleTimeout: 0,
-                        extraArgs: [holderPIDFile.path, allowRootExitPath, rootExitedFile.path],
-                        initialDelay: 0,
-                        settleAfterStop: 0.6 * TestTimingBudget.slowdownFactor),
-                    onURLDetected: {
-                        Self.touchFile(atPath: allowRootExitPath)
-                    })
+        let runnerTask = Task.detached {
+            try SpawnedProcessGroup.withOutputHolderDiscoveryDelayForTesting(discoveryDelay) {
+                try SpawnedProcessGroup.withOutputHolderCleanupMaxLifetimeForTesting(cleanupMaxLifetime) {
+                    try TTYCommandRunner().run(
+                        binary: cliURL.path,
+                        send: "",
+                        options: .init(
+                            timeout: 30,
+                            idleTimeout: 0,
+                            extraArgs: [
+                                holderPIDFile.path,
+                                allowRootExitPath,
+                                rootExitedFile.path,
+                                fixtureReadyFile.path,
+                                beginOutputFile.path,
+                            ],
+                            initialDelay: 0,
+                            settleAfterStop: 0.6 * TestTimingBudget.slowdownFactor),
+                        onURLDetected: {
+                            cleanupStarted.mark()
+                            try? KiroProcessTestSupport.touch(allowRootExitFile)
+                        })
+                }
             }
         }
-        let elapsed = Date().timeIntervalSince(start)
-        print("PTY settle-exit hard-stop latency: \(String(format: "%.3f", elapsed))s")
+        do {
+            try await KiroProcessTestSupport.waitForFile(fixtureReadyFile)
+        } catch {
+            runnerTask.cancel()
+            _ = try? await runnerTask.value
+            throw error
+        }
+        try KiroProcessTestSupport.touch(beginOutputFile)
+        let result = try await runnerTask.value
+        let startedAt = try #require(cleanupStarted.value())
+        let elapsed = startedAt.duration(to: ContinuousClock().now)
+        print("PTY settle-exit hard-stop latency after fixture readiness: \(elapsed)")
 
         #expect(result.completion == .processExited(status: 0))
         #expect(FileManager.default.fileExists(atPath: rootExitedFile.path))
@@ -160,15 +185,14 @@ extension KiroStatusProbeTests {
         #expect(snapshot.planName == "KIRO FREE")
         #expect(snapshot.creditsUsed == 12.50)
         #expect(
-            elapsed < hardStopBudget,
+            elapsed < .seconds(hardStopBudget),
             "Delayed holder discovery should not extend cleanup after a settle exit, took \(elapsed)s")
 
-        let holderPIDText = try String(contentsOf: holderPIDFile, encoding: .utf8)
-        let holderPID = try #require(pid_t(holderPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        let cleanupDeadline = Date().addingTimeInterval(20)
-        while kill(holderPID, 0) == 0, Date() < cleanupDeadline {
-            try await Task.sleep(for: .milliseconds(20))
-        }
+        let holderPID = try await KiroProcessTestSupport.waitForPID(in: holderPIDFile)
+        try await KiroProcessTestSupport.waitForExit(
+            of: holderPID,
+            timeout: .seconds(20),
+            description: "the delayed settle PTY holder to exit")
         #expect(kill(holderPID, 0) == -1)
     }
 
@@ -240,8 +264,13 @@ extension KiroStatusProbeTests {
             raise RuntimeError("root TERM child started before TERM")
         if os.path.exists(sys.argv[5]):
             raise RuntimeError("pre-kill snapshot trigger existed before cleanup")
+        with open(sys.argv[6], "w"):
+            pass
+        while not os.path.exists(sys.argv[7]):
+            time.sleep(0.01)
         print("Estimated Usage | resets on 2026-06-01 | KIRO FREE", flush=True)
         print("Credits (12.50 of 50 covered in plan)", flush=True)
+        print("https://example.com/idle-stop-ready", flush=True)
         print("████████████████████ 25%", flush=True)
         time.sleep(30)
         """
@@ -278,6 +307,10 @@ extension KiroStatusProbeTests {
         os.waitpid(intermediate, 0)
         while not os.path.exists(sys.argv[1]):
             time.sleep(0.01)
+        with open(sys.argv[4], "w"):
+            pass
+        while not os.path.exists(sys.argv[5]):
+            time.sleep(0.01)
         print("Estimated Usage | resets on 2026-06-01 | KIRO FREE", flush=True)
         print("Credits (12.50 of 50 covered in plan)", flush=True)
         print("https://example.com/idle-stop-ready", flush=True)
@@ -292,12 +325,6 @@ extension KiroStatusProbeTests {
         try script.write(to: cliURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cliURL.path)
         return cliURL
-    }
-
-    private static func touchFile(atPath path: String) {
-        let fileDescriptor = open(path, O_WRONLY | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR)
-        guard fileDescriptor >= 0 else { return }
-        _ = close(fileDescriptor)
     }
 }
 #endif

--- a/Tests/CodexBarTests/KiroStatusProbeTTYProcessTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTTYProcessTests.swift
@@ -1,0 +1,224 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+extension KiroStatusProbeTests {
+    @Test
+    func `tty runner hard stops a process that ignores SIGTERM`() async throws {
+        let readyFile = Self.temporaryMarker("hard-stop-ready")
+        let startFile = Self.temporaryMarker("hard-stop-start")
+        let cliURL = try self.makeTTYCLI(
+            """
+            #!/bin/sh
+            : > "$1"
+            while [ ! -e "$2" ]; do sleep 0.01; done
+            trap '' TERM
+            printf 'https://example.com/partial-output\n'
+            while true; do sleep 1; done
+            """)
+        defer { self.removeTTYFixture(cliURL: cliURL, files: [readyFile, startFile]) }
+
+        let result = try await KiroProcessTestSupport.runTTYAfterFixtureReady(
+            binary: cliURL,
+            readyFile: readyFile,
+            startFile: startFile,
+            options: .init(
+                timeout: 30,
+                idleTimeout: 0.1,
+                extraArgs: [readyFile.path, startFile.path]))
+
+        #expect(result.completion == .idleTimeout)
+        #expect(result.text.contains("partial-output"))
+    }
+
+    @Test
+    func `tty runner kills a pipe holder that escapes the process group`() async throws {
+        let childPIDFile = Self.temporaryMarker("escaped", pathExtension: "pid")
+        let readyFile = Self.temporaryMarker("escaped-ready")
+        let startFile = Self.temporaryMarker("escaped-start")
+        let cliURL = try self.makeTTYCLI(
+            """
+            #!/usr/bin/python3
+            import os
+            import subprocess
+            import sys
+            import time
+
+            child = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)",
+                ],
+                start_new_session=True,
+            )
+            with open(sys.argv[1], "w") as handle:
+                handle.write(str(child.pid))
+            with open(sys.argv[2], "w"):
+                pass
+            while not os.path.exists(sys.argv[3]):
+                time.sleep(0.01)
+            print("partial output", flush=True)
+            time.sleep(30)
+            """)
+        defer { self.removeTTYFixture(cliURL: cliURL, files: [childPIDFile, readyFile, startFile]) }
+
+        let result = try await KiroProcessTestSupport.runTTYAfterFixtureReady(
+            binary: cliURL,
+            readyFile: readyFile,
+            startFile: startFile,
+            options: .init(
+                timeout: 30,
+                idleTimeout: 0.1,
+                extraArgs: [childPIDFile.path, readyFile.path, startFile.path]))
+
+        #expect(result.completion == .idleTimeout)
+        #expect(result.text.contains("partial output"))
+
+        let childPID = try await KiroProcessTestSupport.waitForPID(in: childPIDFile)
+        defer { _ = kill(childPID, SIGKILL) }
+        try await KiroProcessTestSupport.waitForExit(
+            of: childPID,
+            timeout: .seconds(20),
+            description: "the escaped PTY output holder to exit")
+        #expect(kill(childPID, 0) == -1)
+    }
+
+    @Test
+    func `tty runner cleans a same group helper after normal exit`() async throws {
+        let childPIDFile = Self.temporaryMarker("normal-exit", pathExtension: "pid")
+        let readyFile = Self.temporaryMarker("normal-exit-ready")
+        let startFile = Self.temporaryMarker("normal-exit-start")
+        let cliURL = try self.makeTTYCLI(
+            """
+            #!/usr/bin/python3
+            import os
+            import signal
+            import sys
+            import time
+
+            child = os.fork()
+            if child == 0:
+                os.close(1)
+                os.close(2)
+                signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                with open(sys.argv[1], "w") as handle:
+                    handle.write(str(os.getpid()))
+                time.sleep(30)
+                os._exit(0)
+
+            while not os.path.exists(sys.argv[1]):
+                time.sleep(0.01)
+            with open(sys.argv[2], "w"):
+                pass
+            while not os.path.exists(sys.argv[3]):
+                time.sleep(0.01)
+            print("parent complete", flush=True)
+            os._exit(0)
+            """)
+        defer { self.removeTTYFixture(cliURL: cliURL, files: [childPIDFile, readyFile, startFile]) }
+
+        let result = try await KiroProcessTestSupport.runTTYAfterFixtureReady(
+            binary: cliURL,
+            readyFile: readyFile,
+            startFile: startFile,
+            options: .init(
+                timeout: 30,
+                extraArgs: [childPIDFile.path, readyFile.path, startFile.path]))
+
+        #expect(result.completion == .processExited(status: 0))
+        #expect(result.text.contains("parent complete"))
+
+        let childPID = try await KiroProcessTestSupport.waitForPID(in: childPIDFile)
+        defer { _ = kill(childPID, SIGKILL) }
+        try await KiroProcessTestSupport.waitForExit(
+            of: childPID,
+            timeout: .seconds(20),
+            description: "the same-group PTY helper to exit")
+        #expect(kill(childPID, 0) == -1)
+    }
+
+    @Test
+    func `tty runner preserves completed no-output failure status`() async throws {
+        let readyFile = Self.temporaryMarker("empty-exit-ready")
+        let startFile = Self.temporaryMarker("empty-exit-start")
+        let cliURL = try self.makeTTYCLI(
+            """
+            #!/bin/sh
+            : > "$1"
+            while [ ! -e "$2" ]; do sleep 0.01; done
+            exit 23
+            """)
+        defer { self.removeTTYFixture(cliURL: cliURL, files: [readyFile, startFile]) }
+
+        let result = try await KiroProcessTestSupport.runTTYAfterFixtureReady(
+            binary: cliURL,
+            readyFile: readyFile,
+            startFile: startFile,
+            options: .init(
+                timeout: 30,
+                extraArgs: [readyFile.path, startFile.path],
+                returnOnEmptyProcessExit: true))
+
+        #expect(result.text.isEmpty)
+        #expect(result.completion == .processExited(status: 23))
+    }
+
+    @Test
+    func `tty runner cancellation terminates the process`() async throws {
+        let pidFile = Self.temporaryMarker("cancel", pathExtension: "pid")
+        let cliURL = try self.makeTTYCLI(
+            """
+            #!/bin/sh
+            printf '%s\n' "$$" > "$1"
+            trap '' TERM
+            while true; do sleep 1; done
+            """)
+        defer { self.removeTTYFixture(cliURL: cliURL, files: [pidFile]) }
+
+        let task = Task {
+            try TTYCommandRunner().run(
+                binary: cliURL.path,
+                send: "",
+                options: .init(timeout: 30, extraArgs: [pidFile.path]))
+        }
+        defer { task.cancel() }
+
+        let processID = try await KiroProcessTestSupport.waitForPID(in: pidFile)
+        defer { _ = kill(processID, SIGKILL) }
+
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(kill(processID, 0) == -1)
+    }
+
+    private static func temporaryMarker(_ name: String, pathExtension: String = "started") -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-\(name)-\(UUID().uuidString)")
+            .appendingPathExtension(pathExtension)
+    }
+
+    private func makeTTYCLI(_ script: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-tty-\(UUID().uuidString)", isDirectory: true)
+        let cliURL = root.appendingPathComponent("kiro-cli")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try script.write(to: cliURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cliURL.path)
+        return cliURL
+    }
+
+    private func removeTTYFixture(cliURL: URL, files: [URL]) {
+        for file in files {
+            try? FileManager.default.removeItem(at: file)
+        }
+        try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+    }
+}

--- a/Tests/CodexBarTests/KiroStatusProbeTestSupport.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTestSupport.swift
@@ -29,6 +29,10 @@ final class KiroTestProcessRegistry: @unchecked Sendable {
         self.unblock = unblock
     }
 
+    deinit {
+        self.terminateAll()
+    }
+
     var dependencies: KiroStatusProbe.PipeProcessRegistry {
         .init(
             beginLaunch: { true },
@@ -69,6 +73,14 @@ final class KiroTestProcessRegistry: @unchecked Sendable {
         self.lock.withLock { self.unregisteredPIDs.contains(pid) }
     }
 
+    func activePIDs() -> Set<pid_t> {
+        self.lock.withLock { Set(self.records.keys) }
+    }
+
+    func observedPIDs() -> Set<pid_t> {
+        self.lock.withLock { self.unregisteredPIDs.union(self.records.keys) }
+    }
+
     func terminate(_ pid: pid_t) {
         let processGroup = self.lock.withLock { () -> pid_t? in
             self.records[pid]?.processGroup
@@ -79,5 +91,200 @@ final class KiroTestProcessRegistry: @unchecked Sendable {
         if pid > 0 {
             _ = kill(pid, SIGKILL)
         }
+    }
+
+    func terminateAll() {
+        let records = self.lock.withLock {
+            let records = self.records
+            self.records.removeAll()
+            return records
+        }
+        for (pid, record) in records {
+            if let processGroup = record.processGroup,
+               processGroup > 0,
+               processGroup != getpgrp()
+            {
+                _ = kill(-processGroup, SIGKILL)
+            }
+            if pid > 0 {
+                _ = kill(pid, SIGKILL)
+            }
+        }
+    }
+}
+
+enum KiroProcessTestSupport {
+    private struct WaitTimeout: LocalizedError {
+        let description: String
+        let timeout: Duration
+
+        var errorDescription: String? {
+            "Timed out after \(self.timeout) waiting for \(self.description)"
+        }
+    }
+
+    /// This bounds fixture setup only. Tests that exercise production timeout behavior pass their own exact budgets.
+    static let fixtureSetupTimeout: Duration = .seconds(20)
+    static let fixtureAccountTimeout: TimeInterval = 15
+
+    static func makeFunctionalProbe(
+        cliURL: URL,
+        accountProbeTimeout: TimeInterval = fixtureAccountTimeout,
+        usageProbeTimeout: TimeInterval = 20,
+        contextProbeTimeout: TimeInterval = 15,
+        pipeTimeoutCap: TimeInterval = 5,
+        processRegistry: KiroTestProcessRegistry? = nil) -> KiroStatusProbe
+    {
+        let registry = processRegistry ?? KiroTestProcessRegistry()
+        return KiroStatusProbe(
+            cliBinaryResolver: { cliURL.path },
+            accountProbeTimeout: accountProbeTimeout,
+            usageProbeTimeout: usageProbeTimeout,
+            contextProbeTimeout: contextProbeTimeout,
+            pipeTimeoutCap: pipeTimeoutCap,
+            pipeProcessRegistry: registry.dependencies)
+    }
+
+    static func waitForFile(
+        _ url: URL,
+        timeout: Duration = fixtureSetupTimeout) async throws
+    {
+        _ = try await self.wait(
+            for: "fixture file \(url.path)",
+            timeout: timeout)
+        {
+            FileManager.default.fileExists(atPath: url.path) ? true : nil
+        }
+    }
+
+    static func waitForPID(
+        in url: URL,
+        timeout: Duration = fixtureSetupTimeout) async throws -> pid_t
+    {
+        try await self.wait(
+            for: "a valid PID in fixture file \(url.path)",
+            timeout: timeout)
+        {
+            self.readPID(from: url)
+        }
+    }
+
+    static func waitForExit(
+        of pid: pid_t,
+        timeout: Duration,
+        description: String) async throws
+    {
+        try await self.waitForExit(of: [pid], timeout: timeout, description: description)
+    }
+
+    static func waitForExit(
+        of pids: [pid_t],
+        timeout: Duration,
+        description: String) async throws
+    {
+        _ = try await self.wait(for: description, timeout: timeout) {
+            pids.allSatisfy { kill($0, 0) == -1 } ? true : nil
+        }
+    }
+
+    static func readPID(from url: URL) -> pid_t? {
+        guard let text = try? String(contentsOf: url, encoding: .utf8),
+              let pid = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines)),
+              pid > 0
+        else {
+            return nil
+        }
+        return pid
+    }
+
+    static func touch(_ url: URL) throws {
+        let fileDescriptor = open(url.path, O_WRONLY | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        guard fileDescriptor >= 0 else {
+            throw CocoaError(.fileWriteUnknown, userInfo: [NSFilePathErrorKey: url.path])
+        }
+        _ = close(fileDescriptor)
+    }
+
+    static func runTTYAfterFixtureReady(
+        binary: URL,
+        readyFile: URL,
+        startFile: URL,
+        options: TTYCommandRunner.Options,
+        onURLDetected: (@Sendable () -> Void)? = nil) async throws -> TTYCommandRunner.Result
+    {
+        let task = Task.detached {
+            try TTYCommandRunner().run(
+                binary: binary.path,
+                send: "",
+                options: options,
+                onURLDetected: onURLDetected)
+        }
+        do {
+            try await self.waitForFile(readyFile)
+            try self.touch(startFile)
+        } catch {
+            task.cancel()
+            _ = try? await task.value
+            throw error
+        }
+        return try await task.value
+    }
+
+    static func waitForCondition(
+        _ description: String,
+        timeout: Duration = fixtureSetupTimeout,
+        condition: () -> Bool) async throws
+    {
+        _ = try await self.wait(for: description, timeout: timeout) {
+            condition() ? true : nil
+        }
+    }
+
+    private static func wait<Value>(
+        for description: String,
+        timeout: Duration,
+        value: () -> Value?) async throws -> Value
+    {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while true {
+            if let value = value() {
+                return value
+            }
+            guard clock.now < deadline else {
+                throw WaitTimeout(description: description, timeout: timeout)
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+}
+
+final class KiroTestInstantMarker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instant: ContinuousClock.Instant?
+
+    func mark() {
+        self.lock.withLock {
+            if self.instant == nil {
+                self.instant = ContinuousClock().now
+            }
+        }
+    }
+
+    func value() -> ContinuousClock.Instant? {
+        self.lock.withLock { self.instant }
+    }
+}
+
+final class KiroTestCompletionMarker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completed = false
+
+    func markCompleted() {
+        self.lock.withLock { self.completed = true }
+    }
+
+    func isCompleted() -> Bool {
+        self.lock.withLock { self.completed }
     }
 }

--- a/Tests/CodexBarTests/KiroStatusProbeTests.swift
+++ b/Tests/CodexBarTests/KiroStatusProbeTests.swift
@@ -7,13 +7,6 @@ import Darwin
 import Glibc
 #endif
 
-private func waitForFile(_ url: URL) async throws {
-    for _ in 0..<100 where !FileManager.default.fileExists(atPath: url.path) {
-        try await Task.sleep(for: .milliseconds(20))
-    }
-    #expect(FileManager.default.fileExists(atPath: url.path))
-}
-
 @Suite(.serialized)
 struct KiroStatusProbeTests {
     @Test
@@ -92,8 +85,6 @@ struct KiroStatusProbeTests {
     func `accepted pipe output cannot overrun the usage deadline`() async throws {
         let pipePIDFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-kiro-deadline-\(UUID().uuidString).pid")
-        let ptyMarker = FileManager.default.temporaryDirectory
-            .appendingPathComponent("codexbar-kiro-deadline-\(UUID().uuidString).pty")
         let cliURL = try self.makeCLI(
             """
             #!/bin/sh
@@ -102,6 +93,9 @@ struct KiroStatusProbeTests {
               exit 0
             fi
             if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              if [ -t 1 ]; then
+                exit 97
+              fi
               if [ ! -t 1 ]; then
                 printf '%s\n' "$$" > '\(pipePIDFile.path)'
                 printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
@@ -110,11 +104,6 @@ struct KiroStatusProbeTests {
                 trap '' TERM
                 while true; do sleep 1; done
               fi
-              : > '\(ptyMarker.path)'
-              printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
-              printf 'Credits (12.50 of 50 covered in plan)\n'
-              printf '████████████████████ 25%%\n'
-              exit 0
             fi
             if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
               exit 0
@@ -128,29 +117,49 @@ struct KiroStatusProbeTests {
                 _ = kill(pipePID, SIGKILL)
             }
             try? FileManager.default.removeItem(at: pipePIDFile)
-            try? FileManager.default.removeItem(at: ptyMarker)
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
         }
 
-        let clock = ContinuousClock()
-        let startedAt = clock.now
+        let registry = KiroTestProcessRegistry()
         let probe = KiroStatusProbe(
             cliBinaryResolver: { cliURL.path },
             usageProbeTimeout: 4,
-            pipeTimeoutCap: 2)
+            pipeTimeoutCap: 2,
+            pipeProcessRegistry: registry.dependencies)
+        let completion = KiroTestCompletionMarker()
+        let task = Task {
+            defer { completion.markCompleted() }
+            return try await probe.fetch()
+        }
+        defer {
+            task.cancel()
+            registry.terminateAll()
+        }
 
+        try await KiroProcessTestSupport.waitForCondition(
+            "the accepted-pipe deadline probe to finish and release all registered processes",
+            timeout: .seconds(20))
+        {
+            completion.isCompleted() && registry.activePIDs().isEmpty
+        }
         await #expect {
-            _ = try await probe.fetch()
+            _ = try await task.value
         } throws: { error in
             guard case KiroStatusProbeError.timeout = error else { return false }
             return true
         }
 
-        #expect(startedAt.duration(to: clock.now) < TestTimingBudget.scaled(.seconds(7)))
-        #expect(!FileManager.default.fileExists(atPath: ptyMarker.path))
-        let pipePIDText = try String(contentsOf: pipePIDFile, encoding: .utf8)
-        let pipePID = try #require(pid_t(pipePIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        #expect(kill(pipePID, 0) == -1)
+        // A loaded runner may legitimately start PTY fallback before the pipe child gets scheduled. Assert cleanup
+        // at the registry boundary instead of assuming either child executed far enough to create its marker file.
+        let observedPIDs = registry.observedPIDs()
+        #expect(!observedPIDs.isEmpty)
+        #expect(registry.activePIDs().isEmpty)
+        for pid in observedPIDs {
+            #expect(kill(pid, 0) == -1)
+        }
+        if let pipePID = KiroProcessTestSupport.readPID(from: pipePIDFile) {
+            #expect(kill(pipePID, 0) == -1)
+        }
     }
 
     @Test
@@ -178,7 +187,7 @@ struct KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL)
         let snapshot = try await probe.fetch()
 
         #expect(snapshot.accountEmail == "person@example.com")
@@ -217,7 +226,7 @@ extension KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL)
         let snapshot = try await probe.fetch()
 
         #expect(snapshot.planName == "KIRO FREE")
@@ -251,9 +260,9 @@ extension KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let snapshot = try await KiroStatusProbe(
-            cliBinaryResolver: { cliURL.path },
-            usageProbeTimeout: 2,
+        let snapshot = try await KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
+            usageProbeTimeout: 15,
             pipeTimeoutCap: 0.2).fetch()
 
         #expect(snapshot.planName == "KIRO FREE")
@@ -289,8 +298,8 @@ extension KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let probe = KiroStatusProbe(
-            cliBinaryResolver: { cliURL.path },
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
             pipeTimeoutCap: 0.2)
         let snapshot = try await probe.fetch()
 
@@ -335,7 +344,7 @@ extension KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let snapshot = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+        let snapshot = try await KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL).fetch()
 
         #expect(snapshot.planName == "KIRO FREE")
         #expect(snapshot.creditsUsed == 12.50)
@@ -388,7 +397,7 @@ extension KiroStatusProbeTests {
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
         }
 
-        let snapshot = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+        let snapshot = try await KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL).fetch()
 
         #expect(snapshot.planName == "KIRO FREE")
         #expect(FileManager.default.fileExists(atPath: ptyMarker.path))
@@ -424,13 +433,17 @@ extension KiroStatusProbeTests {
             """)
 
         let registry = KiroTestProcessRegistry()
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
+            processRegistry: registry)
+        let completion = KiroTestCompletionMarker()
         let task = Task {
-            try await KiroStatusProbe(
-                cliBinaryResolver: { cliURL.path },
-                pipeProcessRegistry: registry.dependencies).fetch()
+            defer { completion.markCompleted() }
+            return try await probe.fetch()
         }
         defer {
             task.cancel()
+            registry.terminateAll()
             if let text = try? String(contentsOf: pipePIDFile, encoding: .utf8),
                let pipePID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
             {
@@ -440,19 +453,23 @@ extension KiroStatusProbeTests {
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
         }
 
-        try await waitForFile(pipePIDFile)
-        let pipePIDText = try String(contentsOf: pipePIDFile, encoding: .utf8)
-        let pipePID = try #require(pid_t(pipePIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        let pipePID = try await KiroProcessTestSupport.waitForPID(in: pipePIDFile)
         #expect(registry.isRegistered(pipePID))
 
-        let clock = ContinuousClock()
-        let shutdownStartedAt = clock.now
         registry.terminate(pipePID)
+        try await KiroProcessTestSupport.waitForCondition(
+            "shutdown termination to finish the pipe probe, unregister it, and reap its process",
+            timeout: .seconds(20))
+        {
+            completion.isCompleted()
+                && !registry.isRegistered(pipePID)
+                && registry.didUnregister(pipePID)
+                && kill(pipePID, 0) == -1
+        }
         await #expect(throws: (any Error).self) {
             _ = try await task.value
         }
 
-        #expect(shutdownStartedAt.duration(to: clock.now) < TestTimingBudget.scaled(.seconds(2)))
         #expect(!registry.isRegistered(pipePID))
         #expect(registry.didUnregister(pipePID))
         #expect(kill(pipePID, 0) == -1)
@@ -485,7 +502,7 @@ extension KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let snapshot = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+        let snapshot = try await KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL).fetch()
 
         #expect(snapshot.planName == "KIRO FREE")
         #expect(snapshot.accountEmail == "person@example.com")
@@ -520,7 +537,7 @@ extension KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let snapshot = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+        let snapshot = try await KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL).fetch()
 
         #expect(snapshot.planName == "KIRO FREE")
         #expect(snapshot.accountEmail == "person@example.com")
@@ -556,7 +573,7 @@ extension KiroStatusProbeTests {
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
         await #expect {
-            _ = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+            _ = try await KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL).fetch()
         } throws: { error in
             guard case KiroStatusProbeError.notLoggedIn = error else { return false }
             return true
@@ -565,11 +582,14 @@ extension KiroStatusProbeTests {
 
     @Test
     func `fetch rejects account markers from failed whoami`() async throws {
+        let whoAmIFailed = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-failed-whoami-\(UUID().uuidString).started")
         let cliURL = try self.makeCLI(
             """
             #!/bin/sh
             if [ "$1" = "whoami" ]; then
               printf 'Logged in with Google\nEmail: person@example.com\n'
+              : > '\(whoAmIFailed.path)'
               exit 23
             fi
 
@@ -586,9 +606,13 @@ extension KiroStatusProbeTests {
 
             exit 1
             """)
-        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+        defer {
+            try? FileManager.default.removeItem(at: whoAmIFailed)
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+        }
 
-        let snapshot = try await KiroStatusProbe(cliBinaryResolver: { cliURL.path }).fetch()
+        let snapshot = try await KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL).fetch()
+        try await KiroProcessTestSupport.waitForFile(whoAmIFailed)
 
         #expect(snapshot.accountEmail == nil)
         #expect(snapshot.authMethod == nil)
@@ -596,12 +620,17 @@ extension KiroStatusProbeTests {
 
     @Test
     func `fetch rejects valid-looking usage from failed command`() async throws {
+        let whoAmISucceeded = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-successful-whoami-\(UUID().uuidString).started")
+        let usageFailed = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-failed-usage-\(UUID().uuidString).started")
         let cliURL = try self.makeCLI(
             """
             #!/bin/sh
             if [ -t 1 ]; then
               if [ "$1" = "whoami" ]; then
                 printf 'Logged in with Google\nEmail: person@example.com\n'
+                : > '\(whoAmISucceeded.path)'
                 exit 0
               fi
               if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
@@ -614,6 +643,7 @@ extension KiroStatusProbeTests {
 
             if [ "$1" = "whoami" ]; then
               printf 'Logged in with Google\nEmail: person@example.com\n'
+              : > '\(whoAmISucceeded.path)'
               exit 0
             fi
 
@@ -621,6 +651,7 @@ extension KiroStatusProbeTests {
               printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
               printf 'Credits (12.50 of 50 covered in plan)\n'
               printf '████████████████████ 25%%\n'
+              : > '\(usageFailed.path)'
               exit 23
             fi
 
@@ -630,15 +661,21 @@ extension KiroStatusProbeTests {
 
             exit 1
             """)
-        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
+        defer {
+            try? FileManager.default.removeItem(at: whoAmISucceeded)
+            try? FileManager.default.removeItem(at: usageFailed)
+            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
+        }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL)
         await #expect {
             _ = try await probe.fetch()
         } throws: { error in
             guard case KiroStatusProbeError.cliFailed = error else { return false }
             return true
         }
+        try await KiroProcessTestSupport.waitForFile(whoAmISucceeded)
+        try await KiroProcessTestSupport.waitForFile(usageFailed)
     }
 
     @Test
@@ -663,7 +700,7 @@ extension KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL)
         await #expect {
             _ = try await probe.fetch()
         } throws: { error in
@@ -695,7 +732,7 @@ extension KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path }, accountProbeTimeout: 2)
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL)
         await #expect {
             _ = try await probe.fetch()
         } throws: { error in
@@ -726,7 +763,7 @@ extension KiroStatusProbeTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(cliURL: cliURL)
         await #expect {
             _ = try await probe.fetch()
         } throws: { error in
@@ -767,18 +804,31 @@ extension KiroStatusProbeTests {
             try? FileManager.default.removeItem(at: contextStarted)
         }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
-        let task = Task { try await probe.fetch() }
-        defer { task.cancel() }
+        let registry = KiroTestProcessRegistry()
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
+            processRegistry: registry)
+        let completion = KiroTestCompletionMarker()
+        let task = Task {
+            defer { completion.markCompleted() }
+            return try await probe.fetch()
+        }
+        defer {
+            task.cancel()
+            registry.terminateAll()
+        }
 
-        try await waitForFile(contextStarted)
+        try await KiroProcessTestSupport.waitForFile(contextStarted)
 
-        let cancelledAt = Date()
         task.cancel()
+        try await KiroProcessTestSupport.waitForCondition(
+            "context cancellation to finish the probe and release all registered processes")
+        {
+            completion.isCompleted() && registry.activePIDs().isEmpty
+        }
         await #expect(throws: CancellationError.self) {
             try await task.value
         }
-        #expect(Date().timeIntervalSince(cancelledAt) < 4)
     }
 
     @Test
@@ -814,18 +864,30 @@ extension KiroStatusProbeTests {
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
         }
 
-        let probe = KiroStatusProbe(
-            cliBinaryResolver: { cliURL.path },
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
             contextProbeTimeout: 0.2,
-            pipeProcessRegistry: registry.dependencies)
-        let task = Task { try await probe.fetch() }
-        defer { task.cancel() }
+            processRegistry: registry)
+        let completion = KiroTestCompletionMarker()
+        let task = Task {
+            defer { completion.markCompleted() }
+            return try await probe.fetch()
+        }
+        defer {
+            task.cancel()
+            registry.terminateAll()
+        }
 
-        try await waitForFile(cleanupStarted)
+        try await KiroProcessTestSupport.waitForFile(cleanupStarted)
         task.cancel()
         try await Task.sleep(for: .milliseconds(250))
         unblockCleanup.signal()
 
+        try await KiroProcessTestSupport.waitForCondition(
+            "cleanup cancellation to finish the probe and release all registered processes")
+        {
+            completion.isCompleted() && registry.activePIDs().isEmpty
+        }
         await #expect(throws: CancellationError.self) {
             try await task.value
         }
@@ -862,18 +924,31 @@ extension KiroStatusProbeTests {
             try? FileManager.default.removeItem(at: accountStarted)
         }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
-        let task = Task { try await probe.fetch() }
-        defer { task.cancel() }
+        let registry = KiroTestProcessRegistry()
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
+            processRegistry: registry)
+        let completion = KiroTestCompletionMarker()
+        let task = Task {
+            defer { completion.markCompleted() }
+            return try await probe.fetch()
+        }
+        defer {
+            task.cancel()
+            registry.terminateAll()
+        }
 
-        try await waitForFile(accountStarted)
+        try await KiroProcessTestSupport.waitForFile(accountStarted)
 
-        let cancelledAt = Date()
         task.cancel()
+        try await KiroProcessTestSupport.waitForCondition(
+            "account cancellation to finish the probe and release all registered processes")
+        {
+            completion.isCompleted() && registry.activePIDs().isEmpty
+        }
         await #expect(throws: CancellationError.self) {
             try await task.value
         }
-        #expect(Date().timeIntervalSince(cancelledAt) < 4)
     }
 
     @Test
@@ -953,210 +1028,37 @@ extension KiroStatusProbeTests {
             }
         }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path })
-        let start = Date()
-        let snapshot = try await probe.fetch()
-        let elapsed = Date().timeIntervalSince(start)
-
-        let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
-        let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        for _ in 0..<50 where kill(childPID, 0) == 0 {
-            try await Task.sleep(for: .milliseconds(20))
+        let registry = KiroTestProcessRegistry()
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
+            processRegistry: registry)
+        let completion = KiroTestCompletionMarker()
+        let task = Task {
+            defer { completion.markCompleted() }
+            return try await probe.fetch()
         }
+        defer {
+            task.cancel()
+            registry.terminateAll()
+        }
+        try await KiroProcessTestSupport.waitForCondition(
+            "the detached-child probe to finish without waiting for the 60-second helper",
+            timeout: .seconds(20))
+        {
+            completion.isCompleted() && registry.activePIDs().isEmpty
+        }
+        let snapshot = try await task.value
+
+        let childPID = try await KiroProcessTestSupport.waitForPID(in: childPIDFile)
+        try await KiroProcessTestSupport.waitForExit(
+            of: childPID,
+            timeout: .seconds(20),
+            description: "the detached Kiro usage helper to exit")
 
         // Keep the optional context probe parseable so this timing check covers detached-child cleanup.
         #expect(snapshot.planName == "KIRO FREE")
         #expect(snapshot.creditsUsed == 12.50 && snapshot.contextUsage?.totalPercentUsed == 40)
-        // The detached child sleeps 60s; if the probe waited for it, elapsed would be >= 60. The generous
-        // ceiling only guards against that regression while tolerating heavily loaded CI runners
-        // (observed 12.6s on a shared GitHub macOS runner for what is normally a sub-second fetch).
-        #expect(elapsed < 20, "Kiro usage capture should return promptly even with a detached child, took \(elapsed)s")
         #expect(kill(childPID, 0) == -1)
-    }
-
-    @Test
-    func `tty runner hard stops a process that ignores SIGTERM`() throws {
-        let cliURL = try self.makeCLI(
-            """
-            #!/bin/sh
-            trap '' TERM
-            printf 'partial output\\n'
-            while true; do sleep 1; done
-            """)
-        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
-
-        let start = Date()
-        let result = try TTYCommandRunner().run(
-            binary: cliURL.path,
-            send: "",
-            options: .init(timeout: 2, idleTimeout: 0.1))
-        let elapsed = Date().timeIntervalSince(start)
-
-        #expect(result.completion == .idleTimeout)
-        #expect(result.text.contains("partial output"))
-        #expect(elapsed < 3, "Ignored SIGTERM should escalate to SIGKILL, took \(elapsed)s")
-    }
-
-    @Test
-    func `tty runner kills a pipe holder that escapes the process group`() async throws {
-        let childPIDFile = FileManager.default.temporaryDirectory
-            .appendingPathComponent("codexbar-kiro-escaped-\(UUID().uuidString).pid")
-        let cliURL = try self.makeCLI(
-            """
-            #!/usr/bin/python3
-            import subprocess
-            import sys
-            import time
-
-            child = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-c",
-                    "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)",
-                ],
-                start_new_session=True,
-            )
-            with open(sys.argv[1], "w") as handle:
-                handle.write(str(child.pid))
-            print("partial output", flush=True)
-            time.sleep(30)
-            """)
-        defer {
-            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
-            try? FileManager.default.removeItem(at: childPIDFile)
-        }
-
-        let result = try TTYCommandRunner().run(
-            binary: cliURL.path,
-            send: "",
-            options: .init(
-                timeout: 2,
-                idleTimeout: 0.1,
-                extraArgs: [childPIDFile.path]))
-
-        #expect(result.completion == .idleTimeout)
-        #expect(result.text.contains("partial output"))
-
-        let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
-        let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        defer { _ = kill(childPID, SIGKILL) }
-
-        let cleanupDeadline = Date().addingTimeInterval(1)
-        while kill(childPID, 0) == 0, Date() < cleanupDeadline {
-            try await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(kill(childPID, 0) == -1)
-    }
-
-    @Test
-    func `tty runner cleans a same group helper after normal exit`() async throws {
-        let childPIDFile = FileManager.default.temporaryDirectory
-            .appendingPathComponent("codexbar-kiro-normal-exit-\(UUID().uuidString).pid")
-        let cliURL = try self.makeCLI(
-            """
-            #!/usr/bin/python3
-            import os
-            import signal
-            import sys
-            import time
-
-            child = os.fork()
-            if child == 0:
-                os.close(1)
-                os.close(2)
-                signal.signal(signal.SIGTERM, signal.SIG_IGN)
-                with open(sys.argv[1], "w") as handle:
-                    handle.write(str(os.getpid()))
-                time.sleep(30)
-                os._exit(0)
-
-            while not os.path.exists(sys.argv[1]):
-                time.sleep(0.01)
-            print("parent complete", flush=True)
-            os._exit(0)
-            """)
-        defer {
-            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
-            try? FileManager.default.removeItem(at: childPIDFile)
-        }
-
-        let result = try TTYCommandRunner().run(
-            binary: cliURL.path,
-            send: "",
-            options: .init(timeout: 2, extraArgs: [childPIDFile.path]))
-
-        #expect(result.completion == .processExited(status: 0))
-        #expect(result.text.contains("parent complete"))
-
-        let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
-        let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        defer { _ = kill(childPID, SIGKILL) }
-
-        let cleanupDeadline = Date().addingTimeInterval(1)
-        while kill(childPID, 0) == 0, Date() < cleanupDeadline {
-            try await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(kill(childPID, 0) == -1)
-    }
-
-    @Test
-    func `tty runner preserves completed no-output failure status`() throws {
-        let cliURL = try self.makeCLI(
-            """
-            #!/bin/sh
-            exit 23
-            """)
-        defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
-
-        let result = try TTYCommandRunner().run(
-            binary: cliURL.path,
-            send: "",
-            options: .init(timeout: 2, returnOnEmptyProcessExit: true))
-
-        #expect(result.text.isEmpty)
-        #expect(result.completion == .processExited(status: 23))
-    }
-
-    @Test
-    func `tty runner cancellation terminates the process`() async throws {
-        let pidFile = FileManager.default.temporaryDirectory
-            .appendingPathComponent("codexbar-kiro-cancel-\(UUID().uuidString).pid")
-        let cliURL = try self.makeCLI(
-            """
-            #!/bin/sh
-            printf '%s\\n' "$$" > "$1"
-            trap '' TERM
-            while true; do sleep 1; done
-            """)
-        defer {
-            try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
-            try? FileManager.default.removeItem(at: pidFile)
-        }
-
-        let task = Task {
-            try TTYCommandRunner().run(
-                binary: cliURL.path,
-                send: "",
-                options: .init(timeout: 20, extraArgs: [pidFile.path]))
-        }
-        defer { task.cancel() }
-
-        var capturedProcessID: pid_t?
-        for _ in 0..<100 {
-            if let text = try? String(contentsOf: pidFile, encoding: .utf8) {
-                capturedProcessID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
-                break
-            }
-            try await Task.sleep(for: .milliseconds(20))
-        }
-        let processID = try #require(capturedProcessID)
-        defer { _ = kill(processID, SIGKILL) }
-
-        task.cancel()
-        await #expect(throws: CancellationError.self) {
-            try await task.value
-        }
-        #expect(kill(processID, 0) == -1)
     }
 }
 
@@ -1651,6 +1553,7 @@ extension KiroStatusProbeTests {
     func `fetch cancellation while joining account after usage failure is preserved`() async throws {
         let accountStarted = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-kiro-failed-usage-account-\(UUID().uuidString).started")
+        let usageFailed = accountStarted.appendingPathExtension("usage-failed")
         let cliURL = try self.makeCLI(
             """
             #!/bin/sh
@@ -1661,6 +1564,7 @@ extension KiroStatusProbeTests {
             fi
 
             if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+              : > '\(usageFailed.path)'
               exit 1
             fi
 
@@ -1669,16 +1573,33 @@ extension KiroStatusProbeTests {
         defer {
             try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent())
             try? FileManager.default.removeItem(at: accountStarted)
+            try? FileManager.default.removeItem(at: usageFailed)
         }
 
-        let probe = KiroStatusProbe(cliBinaryResolver: { cliURL.path }, accountProbeTimeout: 2.0)
-        let task = Task { try await probe.fetch() }
-        defer { task.cancel() }
+        let registry = KiroTestProcessRegistry()
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
+            processRegistry: registry)
+        let completion = KiroTestCompletionMarker()
+        let task = Task {
+            defer { completion.markCompleted() }
+            return try await probe.fetch()
+        }
+        defer {
+            task.cancel()
+            registry.terminateAll()
+        }
 
-        try await waitForFile(accountStarted)
+        try await KiroProcessTestSupport.waitForFile(accountStarted)
+        try await KiroProcessTestSupport.waitForFile(usageFailed)
         try await Task.sleep(for: .milliseconds(300))
 
         task.cancel()
+        try await KiroProcessTestSupport.waitForCondition(
+            "failed-usage account-join cancellation to finish and release all registered processes")
+        {
+            completion.isCompleted() && registry.activePIDs().isEmpty
+        }
         await #expect(throws: CancellationError.self) {
             try await task.value
         }

--- a/Tests/CodexBarTests/KiroTransportRaceTests.swift
+++ b/Tests/CodexBarTests/KiroTransportRaceTests.swift
@@ -5,6 +5,26 @@ import Testing
 @Suite(.serialized)
 struct KiroTransportRaceTests {
     @Test
+    func `accepted transport result after the shared deadline is rejected`() {
+        let output = """
+        Estimated Usage | resets on 2026-06-01 | KIRO FREE
+        Credits (12.50 of 50 covered in plan)
+        ████████████████████ 25%
+        """
+        let deadline = ContinuousClock().now
+
+        #expect {
+            try KiroStatusProbe.ensureAcceptedResultBeforeDeadline(
+                output: output,
+                deadline: deadline,
+                now: deadline.advanced(by: .nanoseconds(1)))
+        } throws: { error in
+            guard case KiroStatusProbeError.timeout = error else { return false }
+            return true
+        }
+    }
+
+    @Test
     func `empty nonzero pipe exit falls back to PTY`() async throws {
         let cliURL = try self.makeCLI(
             """
@@ -29,8 +49,8 @@ struct KiroTransportRaceTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let snapshot = try await KiroStatusProbe(
-            cliBinaryResolver: { cliURL.path },
+        let snapshot = try await KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
             pipeTimeoutCap: 0.2).fetch()
 
         #expect(snapshot.planName == "KIRO FREE")


### PR DESCRIPTION
## Summary

- Stabilize Kiro process tests by separating exact production-deadline coverage from functional process coverage.
- Add test-only launch envelopes, explicit readiness and execution markers, bounded monotonic state waits, registry-owned cleanup, and relocate direct TTY process tests.
- Extract the existing accepted-result deadline predicate for deterministic unit coverage without changing production timeout values or behavior.

The loaded August 16 test failure was caused by mock process launch and setup delay being charged against short production behavior deadlines and fixed wall-clock assertions. Fixtures could time out before publishing readiness, accidentally exercise fallback paths, or lose account/error precedence.

## Testing

- `swift test --filter KiroStatusProbeTests` — passed 57/57
- `swift test --filter KiroTransportRaceTests` — passed 4/4
- Independent no-build stress loop — 10/10 consecutive KiroStatusProbeTests passes (53.851s–76.321s)
- `make test` — passed all 879 selections; 74/74 groups passed first attempt with no retries or timeouts
- `make check` — passed; strict SwiftLint reported 0 violations
- `git diff --check` — clean

