### PR TITLE
style: make Quit CodexBar button a prominent accent-color rounded button

### DIFF
--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -211,7 +211,6 @@ struct GeneralPane: View {
                     .frame(maxWidth: .infinity, alignment: .trailing)
                     .padding(.top, 8)
             }
-
         }
         .formStyle(.grouped)
         .toggleStyle(.switch)

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -205,14 +205,13 @@ struct GeneralPane: View {
                 }
             } header: {
                 Text(L("section_keyboard_shortcut"))
+            } footer: {
+                Button(L("quit_app")) { NSApp.terminate(nil) }
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .padding(.top, 8)
             }
 
-            Section {
-                HStack {
-                    Spacer()
-                    Button(L("quit_app")) { NSApp.terminate(nil) }
-                }
-            }
         }
         .formStyle(.grouped)
         .toggleStyle(.switch)

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -540,6 +540,16 @@ struct PreferencesPaneSmokeTests {
     }
 
     @Test
+    func `english quit app label resolves without format placeholders`() {
+        CodexBarLocalizationOverride.$appLanguage.withValue("en") {
+            let label = L("quit_app")
+            #expect(label == "Quit CodexBar")
+            #expect(!label.contains("%@"))
+            #expect(!label.contains("%d"))
+        }
+    }
+
+    @Test
     func `german app language resolves localized labels`() {
         let settings = Self.makeSettingsStore(suite: "PreferencesPaneSmokeTests-language-de")
         settings.appLanguage = "de"


### PR DESCRIPTION
## Summary

- replace the plain "Quit CodexBar" button in Settings → General with a `.borderedProminent` rounded button using the system accent color
- move the button out of its own `Section` (which added an unwanted grey card background) into the `footer:` of the "Keyboard Shortcut" section so it scrolls with the rest of the form content with no background chrome
- align the button to the trailing edge of the form rows via `.frame(maxWidth: .infinity, alignment: .trailing)`

## Tests

- add `english quit app label resolves without format placeholders` to `PreferencesPaneSmokeTests` — verifies `L("quit_app")` resolves to `"Quit CodexBar"` in English and contains no format placeholders; mirrors the existing German/Italian/Japanese localization test pattern
- full `make test` suite green; two `AdaptiveRefreshTimerTests` timer-timeout failures are pre-existing flakes unrelated to this change

## Verification

- built and ran locally; Quit CodexBar button renders as a filled, rounded, accent-color button
- button scrolls with the rest of the General pane (not sticky)
- button is right-aligned with the trailing edge of the form rows, with no grey card background
- `make check` clean (0 lint violations, 0 format changes)

## Screenshot
<img width="868" height="615" alt="Screenshot 2026-08-16 at 9 06 10 PM" src="https://github.com/user-attachments/assets/672b6946-db90-4ccc-93e4-37f0826a8e58" />
