### PR TITLE
Fix Cursor refresh when Keychain cache is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.52.1 — Unreleased
 
+### Fixed
+- Cursor: keep a successfully validated refresh result when its session cache is temporarily unavailable, instead of reporting that the session changed.
+
 ## 0.52.0 — 2026-08-17
 
 ### Added

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -1189,6 +1189,18 @@ extension CookieHeaderCache {
         }
     }
 
+    enum ConditionalMutationResult: Equatable, Sendable {
+        case stored
+        case rejected
+        case storageUnavailable
+    }
+
+    private enum ConditionalObservationMatch {
+        case matches
+        case changed
+        case storageUnavailable
+    }
+
     /// Captures enough state to conditionally persist an asynchronous refresh after a transient
     /// Keychain read failure without mistaking an untouched legacy entry for a concurrent write.
     static func observeForConditionalMutation(
@@ -1256,40 +1268,98 @@ extension CookieHeaderCache {
         sourceLabel: String,
         now: Date = Date()) -> Bool
     {
+        self.storeIfObservationCurrentResult(
+            provider: provider,
+            scope: scope,
+            expected: expected,
+            cookieHeader: cookieHeader,
+            sourceLabel: sourceLabel,
+            now: now) == .stored
+    }
+
+    static func storeIfObservationCurrentResult(
+        provider: UsageProvider,
+        scope: Scope? = nil,
+        expected: ConditionalMutationObservation,
+        cookieHeader: String,
+        sourceLabel: String,
+        now: Date = Date()) -> ConditionalMutationResult
+    {
         let trimmed = cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let normalized = CookieHeaderNormalizer.normalize(trimmed), !normalized.isEmpty else { return false }
+        guard let normalized = CookieHeaderNormalizer.normalize(trimmed), !normalized.isEmpty else { return .rejected }
         let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
         return expected.coordinator.lock.withLock {
             let key = self.key(for: provider, scope: scope)
             let gateState = expected.coordinator.gates[key] ?? ConditionalMutationGateState()
             guard gateState.activeTokens.isEmpty,
                   gateState.generation == expected.gateGeneration
-            else { return false }
+            else { return .rejected }
             do {
                 return try self.withLegacyMutationLock {
-                    guard self.currentStateMatches(expected, provider: provider, scope: scope) else { return false }
-                    return self.storeLocked(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+                    switch self.currentObservationMatch(expected, provider: provider, scope: scope) {
+                    case .changed:
+                        return .rejected
+                    case .storageUnavailable:
+                        return .storageUnavailable
+                    case .matches:
+                        break
+                    }
+                    if self.storeLocked(
+                        entry: entry,
+                        provider: provider,
+                        scope: scope,
+                        sourceLabel: sourceLabel)
+                    {
+                        return .stored
+                    }
+                    if case .temporarilyUnavailable = KeychainCacheStore.load(key: key, as: Entry.self) {
+                        return .storageUnavailable
+                    }
+                    return .rejected
                 }
             } catch {
                 self.log.error("Cookie cache observed store lock failed: \(error)")
-                return false
+                return .rejected
             }
         }
     }
 
-    private static func currentStateMatches(
+    private static func currentObservationMatch(
         _ expected: ConditionalMutationObservation,
         provider: UsageProvider,
-        scope: Scope?) -> Bool
+        scope: Scope?) -> ConditionalObservationMatch
     {
+        let key = self.key(for: provider, scope: scope)
+        if case let .visible(visible) = self.resolveRefreshRead(key: key, persisted: nil) {
+            return self.optionalEntriesMatch(visible, expected.entry) ? .matches : .changed
+        }
         switch expected {
         case let .authoritative(entry, _, _):
-            return self.currentEntryMatches(entry, provider: provider, scope: scope)
+            switch KeychainCacheStore.load(key: key, as: Entry.self) {
+            case let .found(current):
+                return self.entriesMatch(current, entry) ? .matches : .changed
+            case .missing:
+                if scope == nil, let legacy = self.loadLegacyEntry(for: provider) {
+                    return self.entriesMatch(legacy, entry) ? .matches : .changed
+                }
+                return entry == nil ? .matches : .changed
+            case .temporarilyUnavailable:
+                return .storageUnavailable
+            case .invalid:
+                return .changed
+            }
         case let .keychainTemporarilyUnavailable(expectedLegacyEntry, _, _):
-            let key = self.key(for: provider, scope: scope)
-            guard case .missing = KeychainCacheStore.load(key: key, as: Entry.self) else { return false }
-            guard scope == nil else { return true }
-            return self.optionalEntriesMatch(self.loadLegacyEntry(for: provider), expectedLegacyEntry)
+            switch KeychainCacheStore.load(key: key, as: Entry.self) {
+            case .missing:
+                guard scope == nil else { return .matches }
+                return self.optionalEntriesMatch(self.loadLegacyEntry(for: provider), expectedLegacyEntry)
+                    ? .matches
+                    : .changed
+            case .temporarilyUnavailable:
+                return .storageUnavailable
+            case .found, .invalid:
+                return .changed
+            }
         }
     }
 

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -117,8 +117,8 @@ public enum KeychainCacheStore {
         case .allowed:
             break
         case .interactionRequired:
-            self.log.info("Keychain cache item is unusable by this executable (\(key.account)); treating as missing")
-            return .missing
+            self.log.info("Keychain cache item is unavailable without interaction (\(key.account))")
+            return .temporarilyUnavailable
         case .notFound:
             return .missing
         case let .failure(status):

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -1253,12 +1253,22 @@ public struct CursorStatusProbe: Sendable {
         value: Value,
         context: ResolvedSessionReconciliationContext<Value>) async throws -> Value
     {
-        let stored = CookieHeaderCache.storeIfObservationCurrent(
+        let mutation = CookieHeaderCache.storeIfObservationCurrentResult(
             provider: .cursor,
             expected: context.cacheObservation,
             cookieHeader: context.cookieHeader,
             sourceLabel: context.sourceLabel)
-        guard !stored else { return value }
+        switch mutation {
+        case .stored:
+            return value
+        case .storageUnavailable:
+            // The API already validated this session. Publishing its result is safe while the
+            // unchanged mutation generation prevents an interactive account switch from reaching here.
+            context.log("Cursor session cache is temporarily unavailable; using the validated result")
+            return value
+        case .rejected:
+            break
+        }
         guard let replacement = CookieHeaderCache.load(provider: .cursor) else {
             context.log("Cursor session from \(context.sourceLabel) lost cache ownership without a replacement")
             throw CursorStatusProbeError.networkError("Cursor session changed during refresh")

--- a/Tests/CodexBarTests/CursorImportedSessionScanningTests.swift
+++ b/Tests/CodexBarTests/CursorImportedSessionScanningTests.swift
@@ -346,6 +346,39 @@ struct CursorImportedSessionScanningTests {
     }
 
     @Test
+    func `resolved session keeps successful result while Keychain is temporarily unavailable`() async throws {
+        let probe = CursorStatusProbe(browserDetection: BrowserDetection(cacheTTL: 0))
+        let session = Self.makeSessionInfo(sourceLabel: "Background", cookieValue: "background")
+        let service = "cursor-keychain-unavailable-\(UUID().uuidString)"
+        let legacyBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            try await CookieHeaderCache.withLegacyBaseURLOverrideForTesting(legacyBase) {
+                KeychainCacheStore.setTestStoreForTesting(true)
+                defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+                let outcome = try await KeychainCacheStore.withLoadFailureStatusOverrideForTesting(
+                    errSecInteractionNotAllowed)
+                {
+                    let observation = CookieHeaderCache.observeForConditionalMutation(provider: .cursor)
+                    return try await probe.resolveImportedSession(
+                        session,
+                        perform: { cookieHeader, _ in cookieHeader },
+                        log: { _ in },
+                        cacheObservation: observation)
+                }
+
+                guard case let .succeeded(cookieHeader) = outcome else {
+                    Issue.record("Expected the successful result to remain usable")
+                    return
+                }
+                #expect(cookieHeader == session.cookieHeader)
+            }
+        }
+    }
+
+    @Test
     func `imported session scan continues after non auth failure until later success`() async {
         let probe = CursorStatusProbe(browserDetection: BrowserDetection(cacheTTL: 0))
         let expected = CursorStatusSnapshot(

--- a/Tests/CodexBarTests/KeychainCacheStoreTests.swift
+++ b/Tests/CodexBarTests/KeychainCacheStoreTests.swift
@@ -168,7 +168,7 @@ struct KeychainCacheStoreTests {
 
     #if os(macOS)
     @Test
-    func `unsafe cache ACL is unusable for credential planning`() {
+    func `unsafe cache ACL remains unavailable without interaction`() {
         let service = "cache-preflight-\(UUID().uuidString)"
         let key = KeychainCacheStore.Key(category: "test", identifier: UUID().uuidString)
         let observed = LockIsolated<(String, String?)?>(nil)
@@ -191,10 +191,10 @@ struct KeychainCacheStoreTests {
         #expect(observed.value?.0 == service)
         #expect(observed.value?.1 == key.account)
         switch result {
-        case .missing:
+        case .temporarilyUnavailable:
             break
-        case .found, .invalid, .temporarilyUnavailable:
-            Issue.record("Expected an unsafe cache item to behave as missing")
+        case .found, .invalid, .missing:
+            Issue.record("Expected an unsafe cache item to remain unavailable")
         }
     }
 


### PR DESCRIPTION
## Summary

- distinguish a temporarily unavailable Keychain cache from a missing or replaced Cursor session
- keep an already API-validated Cursor usage result when the cache cannot be read or updated without UI
- preserve the existing account-switch generation gate and retry behavior for genuine session replacements

## User-visible issue

Cursor refresh could fail with:

```
Cursor API error: Cursor session changed during refresh
```

This happened even though the Cursor session was still valid and the Cursor API request had succeeded. In the affected local environment, Cursor usage had worked previously, Keychain access was enabled, and the failure appeared after installing a differently signed/newer CodexBar build.

This is a remaining noninteractive Keychain path after #2408 rather than the already-fixed “Disable Keychain access” case.

## Root cause

When the existing cache item's ACL requires interaction, the noninteractive Keychain preflight returns `interactionRequired`. `KeychainCacheStore.load` previously mapped that state to `missing`.

Cursor session reconciliation then treated the cache as absent, attempted a conditional store, and could not re-read the item without UI. That storage failure was indistinguishable from a concurrent session replacement, so a successful API result was discarded and reported as `Cursor session changed during refresh`.

## Fix

`KeychainCacheStore.load` now reports preflight interaction requirements as `temporarilyUnavailable`.

Conditional cookie-cache mutation now returns a typed result:

- `stored`: publish the validated result normally
- `rejected`: retain the existing replacement/session-ownership retry behavior
- `storageUnavailable`: keep the result that the Cursor API already validated

Interactive account switching still invalidates older observations through the existing generation gate, so this does not weaken genuine session-change protection.

## Validation

Focused tests:

```text
swift test --filter CursorImportedSessionScanningTests          # 14 passed
swift test --filter CookieHeaderCacheConditionalMutationTests   # 11 passed
swift test --filter KeychainCacheStoreTests                     # 21 passed
make check                                                      # passed, 0 lint violations
```

The regression test failed before the implementation with `Cursor session changed during refresh` and passes after the fix.

Structured autoreview completed with no accepted/actionable findings.

Live verification used a freshly packaged and locally installed `CodexBar.app` (0.51.0, build 123) while the app process remained running. Four consecutive real Cursor provider probes all returned:

```text
cursor:ok:source=web,usage=yes
```

No `Cursor session changed during refresh` error recurred.

`make test` also reached an unrelated existing `CostUsagePricingTests` failure (four pricing expectations). The same four failures reproduce on the unmodified base commit; all Cursor/Keychain tests pass.
