### PR TITLE
Fix OpenCode Go token overlay fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - General settings: turn Low Power Mode into an Off/On/Automatic preference, with Automatic following the system Low Power Mode state (#2995). Thanks @elijahfriedman!
 
 ### Fixed
+- OpenCode Go: surface expired selected session tokens instead of silently replacing failed server usage with local quota estimates (#2993). Thanks @Niclassslua!
 - Claude spend: price bare first-party model IDs from their models.dev vendor catalog, preserve explicit routes, and leave ambiguous cross-vendor matches unpriced (#3002). Thanks @Yuxin-Qiao!
 - Menu: prevent the system menu highlight from painting behind provider detail cards on macOS 27 beta (#2998). Thanks @Tan1103!
 - Cursor: keep an API-validated usage result when the Keychain cache is temporarily unavailable, instead of treating it as a missing or replaced session (#3000). Thanks @hxy91819!

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -213,9 +213,12 @@ struct OpenCodeGoLocalUsageFetchStrategy: ProviderFetchStrategy {
             #if os(macOS)
             if let cached = cookie.cachedEntry {
                 _ = CookieHeaderCache.clearIfCurrent(provider: .opencodego, expected: cached)
+                return SnapshotResult(snapshot: snapshot, webUsageApplied: false, quotaIsAuthoritative: false)
             }
             #endif
-            return SnapshotResult(snapshot: snapshot, webUsageApplied: false, quotaIsAuthoritative: false)
+            // A manually configured credential is an explicit account selection. Do not hide its
+            // authentication failure behind an unrelated local estimate.
+            throw OpenCodeGoUsageError.invalidCredentials
         } catch is CancellationError {
             throw CancellationError()
         } catch let error as URLError where error.code == .cancelled {
@@ -359,6 +362,13 @@ struct OpenCodeGoUsageFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
         guard context.sourceMode == .auto else { return false }
+        // Manual cookies include selected token accounts. Their authentication failures must be
+        // surfaced instead of silently falling through to an account-agnostic local estimate.
+        guard context.settings?.opencodego?.cookieSource != .manual,
+              context.selectedTokenAccountID == nil
+        else {
+            return false
+        }
         return switch error {
         case OpenCodeGoSettingsError.missingCookie,
              OpenCodeGoSettingsError.invalidCookie,

--- a/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
@@ -146,6 +146,24 @@ struct OpenCodeGoProviderStrategyTests {
     }
 
     @Test
+    func `web strategy surfaces authentication failures for selected token accounts`() {
+        let strategy = OpenCodeGoUsageFetchStrategy()
+        let settings = ProviderSettingsSnapshot.make(opencodego: .init(
+            cookieSource: .manual,
+            manualCookieHeader: "auth=selected",
+            workspaceID: nil))
+        let manualContext = self.makeContext(settings: settings)
+        let selectedAccountContext = self.makeContext(selectedTokenAccountID: UUID())
+
+        #expect(!strategy.shouldFallback(on: OpenCodeGoSettingsError.invalidCookie, context: manualContext))
+        #expect(!strategy.shouldFallback(on: OpenCodeGoUsageError.invalidCredentials, context: manualContext))
+        #expect(!strategy.shouldFallback(on: OpenCodeGoSettingsError.missingCookie, context: selectedAccountContext))
+        #expect(!strategy.shouldFallback(
+            on: OpenCodeGoUsageError.invalidCredentials,
+            context: selectedAccountContext))
+    }
+
+    @Test
     func `web strategy waits for zen balance only on usage completeness reads`() {
         #expect(!OpenCodeGoUsageFetchStrategy.shouldWaitForZenBalance(
             context: self.makeContext(runtime: .app)))

--- a/Tests/CodexBarTests/OpenCodeGoWebOverlayTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoWebOverlayTests.swift
@@ -82,7 +82,8 @@ struct OpenCodeGoWebOverlayTests {
 
     private func makeContext(
         includeOptionalUsage: Bool = true,
-        settings: ProviderSettingsSnapshot? = nil) -> ProviderFetchContext
+        settings: ProviderSettingsSnapshot? = nil,
+        selectedTokenAccountID: UUID? = nil) -> ProviderFetchContext
     {
         ProviderFetchContext(
             runtime: .app,
@@ -96,7 +97,8 @@ struct OpenCodeGoWebOverlayTests {
             settings: settings,
             fetcher: UsageFetcher(environment: [:]),
             claudeFetcher: StubClaudeFetcher(),
-            browserDetection: BrowserDetection(cacheTTL: 0))
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            selectedTokenAccountID: selectedTokenAccountID)
     }
 
     private func makeManualCookieSettings() -> ProviderSettingsSnapshot {
@@ -195,6 +197,53 @@ struct OpenCodeGoWebOverlayTests {
         #expect(result.usage.opencodegoUsage?.daily.count == 1)
         #expect(result.usage.providerCost?.used == 42.5)
         #expect(result.usage.dataConfidence != .estimated)
+    }
+
+    @Test
+    func `selected token account credential reaches the authoritative overlay`() async throws {
+        let account = ProviderTokenAccount(
+            id: UUID(),
+            label: "Selected",
+            token: "auth=selected",
+            addedAt: 0,
+            lastUsed: nil)
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let contribution = try #require(descriptor.settingsSection.credentialContribution(
+            context: ProviderCredentialSettingsContext(config: nil, account: account)))
+        let settings = ProviderSettingsSnapshot(contributions: [contribution])
+        let observedCookies = Recorder<String>()
+        let strategy = OpenCodeGoLocalUsageFetchStrategy(
+            localSnapshotLoader: { _ in Self.localEstimate() },
+            webUsageOverlayFetcher: { _, cookieHeader in
+                observedCookies.append(cookieHeader)
+                return Self.webUsage()
+            })
+
+        let result = try await strategy.fetch(self.makeContext(
+            settings: settings,
+            selectedTokenAccountID: account.id))
+
+        #expect(settings.opencodego?.cookieSource == .manual)
+        #expect(observedCookies.values == ["auth=selected"])
+        #expect(result.sourceLabel == "local+web")
+        #expect(result.usage.tertiary?.usedPercent == 64)
+        #expect(result.usage.dataConfidence != .estimated)
+    }
+
+    @Test
+    func `manual token authentication failure is surfaced instead of returning local estimate`() async {
+        let strategy = OpenCodeGoLocalUsageFetchStrategy(
+            localSnapshotLoader: { _ in Self.localEstimate() },
+            webUsageOverlayFetcher: { _, _ in throw OpenCodeGoUsageError.invalidCredentials })
+
+        do {
+            _ = try await strategy.fetch(self.makeContext(settings: self.makeManualCookieSettings()))
+            Issue.record("Expected the invalid manual session to fail")
+        } catch OpenCodeGoUsageError.invalidCredentials {
+            // Expected: an explicit account credential must not degrade to account-agnostic local usage.
+        } catch {
+            Issue.record("Expected invalidCredentials, got \(error)")
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- keep selected OpenCode Go session-token accounts on the authoritative web path
- surface invalid or expired explicit session tokens instead of silently returning local quota estimates
- preserve estimated local fallback for ambient missing or stale cached browser cookies
- cover token-account credential routing, auth-error propagation, and the existing estimate behavior

Fixes #2993.

## Tests

- `swift test --filter OpenCodeGo` (108 macOS tests and 3 Linux tests passed)
- `make check`
- autoreview clean

No live provider probes or real Keychain reads were run.
