### PR TITLE
Fix Codex RPC timeout classification

### DIFF
--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -831,6 +831,11 @@ enum RPCWireError: Error, LocalizedError {
     }
 }
 
+private enum RPCRequestRaceResult<Value: Sendable>: Sendable {
+    case value(Value)
+    case timedOut
+}
+
 /// RPC helper used on background tasks; safe because we confine it to the owning task.
 private final class CodexRPCClient: @unchecked Sendable {
     // Provider-specific by design: Codex RPC owns its dedicated subprocess log category.
@@ -1007,24 +1012,29 @@ private final class CodexRPCClient: @unchecked Sendable {
         method: String,
         body: @escaping @Sendable () async throws -> T) async throws -> T
     {
-        try await withThrowingTaskGroup(of: T.self) { group in
+        try await withThrowingTaskGroup(of: RPCRequestRaceResult<T>.self) { group in
             group.addTask {
-                try await body()
+                try await .value(body())
             }
-            group.addTask { [weak self] in
+            group.addTask {
                 try await Task.sleep(for: .seconds(seconds))
-                self?.terminateProcessForTimeout(method: method)
+                return .timedOut
+            }
+
+            guard let result = try await group.next() else {
+                group.cancelAll()
                 throw RPCWireError.timeout(method: method)
             }
-            do {
-                guard let result = try await group.next() else {
-                    throw RPCWireError.timeout(method: method)
-                }
-                group.cancelAll()
-                return result
-            } catch {
-                group.cancelAll()
-                throw error
+            group.cancelAll()
+
+            switch result {
+            case let .value(value):
+                return value
+            case .timedOut:
+                // Terminating the process closes stdout. Classify that expected EOF as a
+                // timeout by selecting the timer before requesting process termination.
+                self.terminateProcessForTimeout(method: method)
+                throw RPCWireError.timeout(method: method)
             }
         }
     }


### PR DESCRIPTION
## What changed

Classify a Codex app-server request as timed out before terminating the subprocess that owns stdout.

## Why

The previous timeout task terminated the process and then threw. Closing stdout could wake the request body first, causing the same timeout to escape as a misleading EOF/malformed-response error. Selecting the timer result before process termination makes the reported failure deterministic.

## Scope

- one production file
- no settings, UI, spend-model, or provider behavior changes
- extracted from #2759 so the runtime fix can be reviewed independently

## Verification

- `swift test --filter CodexUsageFetcherFallbackTests` — 13 tests passed, including the real spawned-process hung RPC cases
- `make check` — passed with zero SwiftFormat or SwiftLint violations

Supersedes the timeout portion of #2759.
