### PR TITLE
Localize Codex session cost estimates in Korean

### DIFF
--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "Loading animations" = "로딩 애니메이션";
 "Loading…" = "불러오는 중…";
 "Local" = "로컬";
+"Local session cost estimates" = "로컬 세션 비용 추정치";
 "Logging" = "로깅";
 "Login failed" = "로그인 실패";
 "Login shell PATH (startup capture)" = "로그인 셸 PATH(시작 시 캡처)";
@@ -1185,6 +1186,7 @@
 "Username" = "사용자 이름";
 "Uses username + password to login and obtain an Oasis-Token automatically." = "사용자 이름 + 비밀번호로 로그인하여 Oasis-Token을 자동으로 가져옵니다.";
 "Uses username + password to login and obtain an %@ automatically." = "사용자 이름 + 비밀번호로 로그인하여 %@을(를) 자동으로 가져옵니다.";
+"Uses this Mac's Codex sessions instead of the selected managed account's session history. Works with organization API keys and does not require OpenAI billing or administrator access. Uses locally cached or bundled model prices without making a network request. This provider-specific toggle does not enable cost summaries for other providers." = "선택한 관리 계정의 세션 기록 대신 이 Mac의 Codex 세션을 사용합니다.\n조직 API 키를 지원하며 OpenAI 결제 정보나 관리자 권한 없이 사용할 수 있습니다.\n네트워크 요청 없이 로컬에 캐시되었거나 앱에 포함된 모델 가격을 사용합니다.\n이 공급자 전용 설정은 다른 공급자의 비용 요약을 활성화하지 않습니다.";
 "Utilization End" = "사용률 종료";
 "Utilization Start" = "사용률 시작";
 "Verbosity" = "상세도";

--- a/Tests/CodexBarTests/CodexLocalSessionCostSettingsTests.swift
+++ b/Tests/CodexBarTests/CodexLocalSessionCostSettingsTests.swift
@@ -43,6 +43,23 @@ struct CodexLocalSessionCostSettingsTests {
     }
 
     @Test
+    func `codex local session cost setting is localized in Korean`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "CodexLocalSessionCostSettingsTests-korean-copy")
+        let context = fixture.settingsContext(provider: .codex)
+        let toggle = try #require(CodexProviderImplementation().settingsToggles(context: context)
+            .first(where: { $0.id == "codex-local-session-cost-ledger" }))
+        let expectedSubtitle = [
+            "선택한 관리 계정의 세션 기록 대신 이 Mac의 Codex 세션을 사용합니다.",
+            "조직 API 키를 지원하며 OpenAI 결제 정보나 관리자 권한 없이 사용할 수 있습니다.",
+            "네트워크 요청 없이 로컬에 캐시되었거나 앱에 포함된 모델 가격을 사용합니다.",
+            "이 공급자 전용 설정은 다른 공급자의 비용 요약을 활성화하지 않습니다.",
+        ].joined(separator: "\n")
+
+        #expect(L(toggle.title, language: "ko") == "로컬 세션 비용 추정치")
+        #expect(L(toggle.subtitle, language: "ko") == expectedSubtitle)
+    }
+
+    @Test
     func `codex local ledger ignores the managed account home`() throws {
         let fixture = try self.makeSettingsFixture(suite: "CodexLocalSessionCostSettingsTests-local-ledger")
         fixture.settings._test_activeManagedCodexRemoteHomePath = "/tmp/managed-codex-home"


### PR DESCRIPTION
## Summary

- Localize the Codex "Local session cost estimates" title and description in Korean.
- Add a regression test that resolves the actual provider toggle through the Korean localization bundle.

## Scope

- Korean only.
- No provider behavior or other locale changes.

## Validation

- `swift test --filter CodexLocalSessionCostSettingsTests`
- `make check`
- `make test` (891 selections, 75 groups)
- Fresh debug app bundle with Korean selected and Keychain access disabled
- Two independent visual QA passes

## Screenshot

![Korean localization for Local session cost estimates](https://raw.githubusercontent.com/Yoonkeee/CodexBar/pr-assets/3034/.github/pr-assets/3034/codex-korean-local-session-cost.jpeg)

## References

- Follow-up to #2172
- Related: #2174
