### PR TITLE
Show spend dashboard row metrics as cost and tokens together

### DIFF
--- a/Sources/CodexBar/PreferencesSpendDashboardPane.swift
+++ b/Sources/CodexBar/PreferencesSpendDashboardPane.swift
@@ -35,6 +35,25 @@ func spendDashboardTokenMixValue(_ value: Int?) -> String {
     value.map(UsageFormatter.tokenCountString) ?? "—"
 }
 
+func spendDashboardMetricText(
+    cost: Double?,
+    tokens: Int?,
+    currencyCode: String) -> String
+{
+    let costText = cost.map { UsageFormatter.currencyString($0, currencyCode: currencyCode) }
+    let tokenText = tokens.map(UsageFormatter.tokenCountString)
+    switch (costText, tokenText) {
+    case let (cost?, tokens?):
+        return "\(cost) · \(L("%@ tokens", tokens))"
+    case let (cost?, nil):
+        return cost
+    case let (nil, tokens?):
+        return L("%@ tokens", tokens)
+    case (nil, nil):
+        return "—"
+    }
+}
+
 func spendDashboardCoverageChipText(_ coverage: CostUsageCoverageCounts) -> String {
     "\(L("Priced")) \(codexBarLocalizedInteger(coverage.priced)) · "
         + "\(L("Unpriced")) \(codexBarLocalizedInteger(coverage.unpriced)) · "
@@ -594,10 +613,14 @@ private struct SpendProviderPanel: View {
                         SpendProviderIcon(provider: row.provider, sourceKind: row.sourceKind)
                         Text(row.displayName).lineLimit(1)
                         Spacer()
-                        Text(row.totalCost.map {
-                            UsageFormatter.currencyString($0, currencyCode: self.group.currencyCode)
-                        } ?? L("Spend unavailable"))
-                            .foregroundStyle(row.totalCost == nil ? .secondary : .primary)
+                        Text(
+                            row.totalCost == nil && row.totalTokens == nil
+                                ? L("Spend unavailable")
+                                : spendDashboardMetricText(
+                                    cost: row.totalCost,
+                                    tokens: row.totalTokens,
+                                    currencyCode: self.group.currencyCode))
+                            .foregroundStyle(row.totalCost == nil && row.totalTokens == nil ? .secondary : .primary)
                             .monospacedDigit()
                     }
                     .padding(.vertical, 9)
@@ -653,9 +676,10 @@ private struct SpendModelPanel: View {
                                 Text(row.providerName).font(.caption).foregroundStyle(.secondary)
                             }
                             Spacer()
-                            Text(row.totalCost.map {
-                                UsageFormatter.currencyString($0, currencyCode: self.group.currencyCode)
-                            } ?? "—")
+                            Text(spendDashboardMetricText(
+                                cost: row.totalCost,
+                                tokens: row.totalTokens,
+                                currencyCode: self.group.currencyCode))
                                 .monospacedDigit()
                         }
                         .padding(.vertical, 9)
@@ -701,9 +725,10 @@ private struct SpendProjectPanel: View {
                             Text(row.providerName).font(.caption).foregroundStyle(.secondary)
                         }
                         Spacer()
-                        Text(row.totalCost.map {
-                            UsageFormatter.currencyString($0, currencyCode: self.group.currencyCode)
-                        } ?? "—")
+                        Text(spendDashboardMetricText(
+                            cost: row.totalCost,
+                            tokens: row.totalTokens,
+                            currencyCode: self.group.currencyCode))
                             .monospacedDigit()
                     }
                     .padding(.vertical, 9)
@@ -879,9 +904,10 @@ private struct SpendSessionPanel: View {
                                     .foregroundStyle(.secondary)
                             }
                             Spacer()
-                            Text(row.totalCost.map {
-                                UsageFormatter.currencyString($0, currencyCode: self.group.currencyCode)
-                            } ?? spendDashboardTokenMixValue(row.totalTokens))
+                            Text(spendDashboardMetricText(
+                                cost: row.totalCost,
+                                tokens: row.totalTokens,
+                                currencyCode: self.group.currencyCode))
                                 .monospacedDigit()
                         }
                         .padding(.vertical, 9)

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2193,7 +2193,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/PreferencesSpendDashboardPane.swift",
-            line: 280,
+            line: 299,
             anchor: "self.configuration.providerIDs.contains(UsageProvider.codex.rawValue)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2201,7 +2201,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/PreferencesSpendDashboardPane.swift",
-            line: 435,
+            line: 454,
             anchor: ".count { $0.provider == .codex }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 3,

--- a/Tests/CodexBarTests/SpendDashboardMetricTextTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardMetricTextTests.swift
@@ -1,0 +1,20 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct SpendDashboardMetricTextTests {
+    @Test
+    func `metric text shows cost and tokens together`() {
+        let text = spendDashboardMetricText(cost: 1.25, tokens: 953_000, currencyCode: "USD")
+        #expect(text.contains("$"))
+        #expect(text.contains("953"))
+    }
+
+    @Test
+    func `metric text falls back to cost or tokens alone`() {
+        #expect(spendDashboardMetricText(cost: 2, tokens: nil, currencyCode: "USD").contains("$"))
+        #expect(spendDashboardMetricText(cost: nil, tokens: 1200, currencyCode: "USD").contains("1"))
+        #expect(spendDashboardMetricText(cost: nil, tokens: nil, currencyCode: "USD") == "—")
+    }
+}


### PR DESCRIPTION
## Summary
- 模型/项目/订阅/会话行同时显示 `$` 与 token 数（`spendDashboardMetricText`）
- 修复只显示 `$` 的问题

## Test plan
- [x] `swift test --filter SpendDashboardMetricTextTests`
- [ ] `make check`


Made with [Cursor](https://cursor.com)