### PR TITLE
Add OpenCodex provider route dispatcher for spend attribution

### DIFF
--- a/Sources/CodexBarCore/Vendored/OpenCodexUsage/OpenCodexRouteDispatcher.swift
+++ b/Sources/CodexBarCore/Vendored/OpenCodexUsage/OpenCodexRouteDispatcher.swift
@@ -7,8 +7,8 @@ public enum OpenCodexRouteTarget: Equatable, Sendable {
 }
 
 public enum OpenCodexRouteDispatcher {
-    // Provider-specific by design: OpenCodex provider prefixes map onto subscription rows or token-only spend.
     public static func route(provider: String) -> OpenCodexRouteTarget {
+        // Provider-specific by design: OpenCodex provider prefixes map onto subscription rows or token-only spend.
         switch provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case "openai":
             .subscription(.codex)

--- a/Sources/CodexBarCore/Vendored/OpenCodexUsage/OpenCodexRouteDispatcher.swift
+++ b/Sources/CodexBarCore/Vendored/OpenCodexUsage/OpenCodexRouteDispatcher.swift
@@ -7,6 +7,7 @@ public enum OpenCodexRouteTarget: Equatable, Sendable {
 }
 
 public enum OpenCodexRouteDispatcher {
+    // Provider-specific by design: OpenCodex provider prefixes map onto subscription rows or token-only spend.
     public static func route(provider: String) -> OpenCodexRouteTarget {
         switch provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case "openai":

--- a/Sources/CodexBarCore/Vendored/OpenCodexUsage/OpenCodexRouteDispatcher.swift
+++ b/Sources/CodexBarCore/Vendored/OpenCodexUsage/OpenCodexRouteDispatcher.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public enum OpenCodexRouteTarget: Equatable, Sendable {
+    case subscription(UsageProvider)
+    case tokenOnly
+    case unknown
+}
+
+public enum OpenCodexRouteDispatcher {
+    public static func route(provider: String) -> OpenCodexRouteTarget {
+        switch provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "openai":
+            .subscription(.codex)
+        case "opencode-go":
+            .subscription(.opencodego)
+        case "kimi-coding", "kimi-for-coding":
+            .subscription(.kimi)
+        case "deepseek":
+            .subscription(.deepseek)
+        case "opencode-free", "opencode":
+            .tokenOnly
+        default:
+            .unknown
+        }
+    }
+
+    public static func route(modelName: String) -> OpenCodexRouteTarget {
+        let trimmed = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let slash = trimmed.firstIndex(of: "/") else {
+            return .subscription(.codex)
+        }
+        let prefix = String(trimmed[..<slash])
+        guard !prefix.isEmpty else { return .unknown }
+        return self.route(provider: prefix)
+    }
+
+    public static func countsTowardCodexSubscription(modelName: String) -> Bool {
+        if case .subscription(.codex) = self.route(modelName: modelName) {
+            return true
+        }
+        return false
+    }
+}

--- a/Tests/CodexBarTests/OpenCodexRouteDispatcherTests.swift
+++ b/Tests/CodexBarTests/OpenCodexRouteDispatcherTests.swift
@@ -1,0 +1,33 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct OpenCodexRouteDispatcherTests {
+    @Test(arguments: [
+        ("openai", OpenCodexRouteTarget.subscription(.codex)),
+        ("opencode-go", OpenCodexRouteTarget.subscription(.opencodego)),
+        ("kimi-coding", OpenCodexRouteTarget.subscription(.kimi)),
+        ("deepseek", OpenCodexRouteTarget.subscription(.deepseek)),
+        ("opencode-free", OpenCodexRouteTarget.tokenOnly),
+        ("unknown-vendor", OpenCodexRouteTarget.unknown),
+    ])
+    func `provider routes to the expected subscription target`(
+        provider: String,
+        expected: OpenCodexRouteTarget)
+    {
+        #expect(OpenCodexRouteDispatcher.route(provider: provider) == expected)
+    }
+
+    @Test(arguments: [
+        ("gpt-5.6-sol", true),
+        ("openai/gpt-5.6-sol", true),
+        ("opencode-go/deepseek-v4-flash", false),
+        ("kimi-coding/k2p5", false),
+    ])
+    func `codex subscription attribution respects model route prefixes`(
+        modelName: String,
+        expected: Bool)
+    {
+        #expect(OpenCodexRouteDispatcher.countsTowardCodexSubscription(modelName: modelName) == expected)
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `OpenCodexRouteDispatcher` 路由表
- `openai→Codex`、`opencode-go→OpenCode Go`、`kimi-coding→Kimi`、`deepseek→DeepSeek`、`opencode-free→token only`

## Test plan
- [x] `swift test --filter OpenCodexRouteDispatcherTests`
- [ ] `make check`


Made with [Cursor](https://cursor.com)