### PR TITLE
Allow partial token coverage on spend dashboard model rows with cost

### DIFF
--- a/Sources/CodexBar/SpendDashboardModel+ModelBreakdown.swift
+++ b/Sources/CodexBar/SpendDashboardModel+ModelBreakdown.swift
@@ -258,6 +258,9 @@ extension SpendDashboardModel {
             }
             sawNamedBreakdown = true
             guard let tokens = Self.nonnegative(breakdown.totalTokens) else {
+                if breakdown.totalTokens != nil {
+                    return false
+                }
                 missingBreakdownTokens = true
                 continue
             }
@@ -270,7 +273,7 @@ extension SpendDashboardModel {
         guard sawNamedBreakdown else { return Self.hasProvenZeroTokens(entry) }
         guard let entryTokens = Self.nonnegative(entry.totalTokens) else { return sawBreakdownTokens }
         if missingBreakdownTokens {
-            return true
+            return totalTokens <= entryTokens
         }
         return entryTokens == totalTokens
     }

--- a/Sources/CodexBar/SpendDashboardModel+ModelBreakdown.swift
+++ b/Sources/CodexBar/SpendDashboardModel+ModelBreakdown.swift
@@ -249,6 +249,7 @@ extension SpendDashboardModel {
         var totalTokens = 0
         var sawNamedBreakdown = false
         var sawBreakdownTokens = false
+        var missingBreakdownTokens = false
         for breakdown in entry.modelBreakdowns ?? [] {
             let name = breakdown.modelName.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !name.isEmpty else {
@@ -256,7 +257,10 @@ extension SpendDashboardModel {
                 continue
             }
             sawNamedBreakdown = true
-            guard let tokens = Self.nonnegative(breakdown.totalTokens) else { continue }
+            guard let tokens = Self.nonnegative(breakdown.totalTokens) else {
+                missingBreakdownTokens = true
+                continue
+            }
             sawBreakdownTokens = true
             let addition = totalTokens.addingReportingOverflow(tokens)
             guard !addition.overflow else { return false }
@@ -265,6 +269,9 @@ extension SpendDashboardModel {
 
         guard sawNamedBreakdown else { return Self.hasProvenZeroTokens(entry) }
         guard let entryTokens = Self.nonnegative(entry.totalTokens) else { return sawBreakdownTokens }
-        return entryTokens == totalTokens || sawBreakdownTokens
+        if missingBreakdownTokens {
+            return true
+        }
+        return entryTokens == totalTokens
     }
 }

--- a/Sources/CodexBar/SpendDashboardModel+ModelBreakdown.swift
+++ b/Sources/CodexBar/SpendDashboardModel+ModelBreakdown.swift
@@ -248,6 +248,7 @@ extension SpendDashboardModel {
     private static func hasCompleteModelTokenCoverage(_ entry: CostUsageDailyReport.Entry) -> Bool {
         var totalTokens = 0
         var sawNamedBreakdown = false
+        var sawBreakdownTokens = false
         for breakdown in entry.modelBreakdowns ?? [] {
             let name = breakdown.modelName.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !name.isEmpty else {
@@ -255,14 +256,15 @@ extension SpendDashboardModel {
                 continue
             }
             sawNamedBreakdown = true
-            guard let tokens = Self.nonnegative(breakdown.totalTokens) else { return false }
+            guard let tokens = Self.nonnegative(breakdown.totalTokens) else { continue }
+            sawBreakdownTokens = true
             let addition = totalTokens.addingReportingOverflow(tokens)
             guard !addition.overflow else { return false }
             totalTokens = addition.partialValue
         }
 
         guard sawNamedBreakdown else { return Self.hasProvenZeroTokens(entry) }
-        guard let entryTokens = Self.nonnegative(entry.totalTokens) else { return false }
-        return entryTokens == totalTokens
+        guard let entryTokens = Self.nonnegative(entry.totalTokens) else { return sawBreakdownTokens }
+        return entryTokens == totalTokens || sawBreakdownTokens
     }
 }


### PR DESCRIPTION
## Summary
- 放宽 `hasCompleteModelTokenCoverage()` 判定
- 有 cost 但 token 为 nil 的模型行仍可显示

## Test plan
- [ ] `make check`


Made with [Cursor](https://cursor.com)