### PR TITLE
Fix empty SwiftUI Settings window

### DIFF
--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -406,6 +406,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator?
     private var cloudSyncCoordinator: CloudSyncCoordinator?
     private var settingsWindowController: SettingsWindowController?
+    private lazy var placeholderSettingsWindowGuard = PlaceholderSettingsWindowGuard(
+        isKnownSettingsWindow: { [weak self] window in
+            self?.settingsWindowController?.window === window
+        })
     private var hasInstalledLimitResetObservers = false
     #if DEBUG
     private var debugMemoryPressureObserver: NSObjectProtocol?
@@ -438,6 +442,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         self.configureAppIconForMacOSVersion()
+        // The SwiftUI `Settings` scene is an empty placeholder; macOS otherwise presents it at launch.
+        self.placeholderSettingsWindowGuard.start()
+    }
+
+    func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
+        // CodexBar lives in the menu bar and has no untitled document to open at launch or on reopen.
+        false
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Sources/CodexBar/PlaceholderSettingsWindowGuard.swift
+++ b/Sources/CodexBar/PlaceholderSettingsWindowGuard.swift
@@ -1,0 +1,91 @@
+import AppKit
+import CodexBarCore
+
+/// CodexBar's preferences live in ``SettingsWindowController``. The SwiftUI `Settings` scene is an empty
+/// placeholder that only carries the app-menu command group, and because it is the app's only scene macOS
+/// presents it during launch, showing an empty "CodexBar Settings" window (#3053).
+enum PlaceholderSettingsWindowDecision {
+    /// SwiftUI names the window of a `Settings` scene with this fragment (identifier and frame autosave name).
+    static let swiftUISettingsNameFragment = "com_apple_SwiftUI_Settings"
+
+    /// A window CodexBar never wants onscreen: SwiftUI's placeholder Settings window.
+    static func shouldClose(identifier: String?, frameAutosaveName: String, isKnownSettingsWindow: Bool) -> Bool {
+        guard !isKnownSettingsWindow, identifier != SettingsWindowIdentity.identifier else { return false }
+        if let identifier, identifier.contains(self.swiftUISettingsNameFragment) { return true }
+        return frameAutosaveName.contains(self.swiftUISettingsNameFragment)
+    }
+}
+
+/// Closes the empty SwiftUI `Settings` placeholder window whenever macOS presents it, so the AppKit
+/// Settings window stays CodexBar's only preferences surface.
+@MainActor
+final class PlaceholderSettingsWindowGuard {
+    typealias WindowsProvider = @MainActor () -> [NSWindow]
+    typealias WindowPredicate = @MainActor (NSWindow) -> Bool
+    typealias WindowAction = @MainActor (NSWindow) -> Void
+
+    private let windows: WindowsProvider
+    private let isKnownSettingsWindow: WindowPredicate
+    private let closeWindow: WindowAction
+    private let logger = CodexBarLog.logger(LogCategories.app)
+    private var isStarted = false
+
+    init(
+        windows: @escaping WindowsProvider = { NSApp?.windows ?? [] },
+        isKnownSettingsWindow: @escaping WindowPredicate = { _ in false },
+        closeWindow: @escaping WindowAction = { $0.close() })
+    {
+        self.windows = windows
+        self.isKnownSettingsWindow = isKnownSettingsWindow
+        self.closeWindow = closeWindow
+    }
+
+    /// Sweeps once and keeps sweeping as window state changes; SwiftUI presents the placeholder after
+    /// `applicationWillFinishLaunching`, and window restoration can bring it back later.
+    func start() {
+        guard !self.isStarted else { return }
+        self.isStarted = true
+        let center = NotificationCenter.default
+        for name in [
+            NSApplication.didFinishLaunchingNotification,
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didBecomeMainNotification,
+            NSWindow.didUpdateNotification,
+        ] {
+            center.addObserver(
+                self,
+                selector: #selector(self.windowStateDidChange(_:)),
+                name: name,
+                object: nil)
+        }
+        self.sweep()
+    }
+
+    @discardableResult
+    func sweep() -> Int {
+        var closedCount = 0
+        for window in self.windows() {
+            guard PlaceholderSettingsWindowDecision.shouldClose(
+                identifier: window.identifier?.rawValue,
+                frameAutosaveName: window.frameAutosaveName,
+                isKnownSettingsWindow: self.isKnownSettingsWindow(window))
+            else { continue }
+            self.closeWindow(window)
+            closedCount += 1
+        }
+        if closedCount > 0 {
+            self.logger.info(
+                "Closed placeholder SwiftUI Settings window",
+                metadata: ["count": "\(closedCount)"])
+        }
+        return closedCount
+    }
+
+    @objc private func windowStateDidChange(_: Notification) {
+        self.sweep()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}

--- a/Tests/CodexBarTests/AppDelegateTests.swift
+++ b/Tests/CodexBarTests/AppDelegateTests.swift
@@ -6,6 +6,14 @@ import Testing
 @MainActor
 struct AppDelegateTests {
     @Test
+    func `refuses the untitled window macOS would fill with the empty Settings scene`() {
+        _ = NSApplication.shared
+        let appDelegate = AppDelegate()
+
+        #expect(appDelegate.applicationShouldOpenUntitledFile(NSApplication.shared) == false)
+    }
+
+    @Test
     func `builds status controller after launch`() {
         let appDelegate = AppDelegate()
         var factoryCalls = 0

--- a/Tests/CodexBarTests/PlaceholderSettingsWindowGuardTests.swift
+++ b/Tests/CodexBarTests/PlaceholderSettingsWindowGuardTests.swift
@@ -1,0 +1,80 @@
+import AppKit
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct PlaceholderSettingsWindowGuardTests {
+    @Test
+    func `closes the empty SwiftUI Settings placeholder window`() {
+        _ = NSApplication.shared
+        let placeholder = self.makeWindow(
+            identifier: "com_apple_SwiftUI_Settings_window",
+            frameAutosaveName: "com_apple_SwiftUI_Settings_window")
+        var closed: [NSWindow] = []
+        let guardian = PlaceholderSettingsWindowGuard(
+            windows: { [placeholder] },
+            isKnownSettingsWindow: { _ in false },
+            closeWindow: { closed.append($0) })
+
+        #expect(guardian.sweep() == 1)
+        #expect(closed.count == 1)
+        #expect(closed.first === placeholder)
+    }
+
+    @Test
+    func `keeps the AppKit Settings window and unrelated windows onscreen`() {
+        _ = NSApplication.shared
+        let settingsWindow = self.makeWindow(identifier: SettingsWindowIdentity.identifier)
+        let updateWindow = self.makeWindow(identifier: "SUUpdateAlert")
+        var closed: [NSWindow] = []
+        let guardian = PlaceholderSettingsWindowGuard(
+            windows: { [settingsWindow, updateWindow] },
+            isKnownSettingsWindow: { $0 === settingsWindow },
+            closeWindow: { closed.append($0) })
+
+        #expect(guardian.sweep() == 0)
+        #expect(closed.isEmpty)
+    }
+
+    @Test
+    func `recognizes the placeholder by frame autosave name when the identifier is missing`() {
+        #expect(PlaceholderSettingsWindowDecision.shouldClose(
+            identifier: nil,
+            frameAutosaveName: "com_apple_SwiftUI_Settings_window",
+            isKnownSettingsWindow: false))
+    }
+
+    @Test
+    func `never closes the registered Settings window`() {
+        #expect(!PlaceholderSettingsWindowDecision.shouldClose(
+            identifier: "com_apple_SwiftUI_Settings_window",
+            frameAutosaveName: "com_apple_SwiftUI_Settings_window",
+            isKnownSettingsWindow: true))
+        #expect(!PlaceholderSettingsWindowDecision.shouldClose(
+            identifier: SettingsWindowIdentity.identifier,
+            frameAutosaveName: SettingsWindowIdentity.frameAutosaveName,
+            isKnownSettingsWindow: false))
+    }
+
+    @Test
+    func `leaves windows without SwiftUI Settings naming alone`() {
+        #expect(!PlaceholderSettingsWindowDecision.shouldClose(
+            identifier: nil,
+            frameAutosaveName: "",
+            isKnownSettingsWindow: false))
+    }
+
+    private func makeWindow(identifier: String, frameAutosaveName: String = "") -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: true)
+        window.identifier = NSUserInterfaceItemIdentifier(identifier)
+        if !frameAutosaveName.isEmpty {
+            window.setFrameAutosaveName(frameAutosaveName)
+        }
+        window.isReleasedWhenClosed = false
+        return window
+    }
+}


### PR DESCRIPTION
Resolves #3053

## Summary

Fixes the blank CodexBar Settings window that opens on every launch, including launch at login (#3053).

`CodexBarApp.body` declares exactly one scene: `Settings { EmptyView() }`. The real preferences UI moved
to the AppKit `SettingsWindowController` in #3029, and the hidden keepalive `WindowGroup` was removed in
#3003 — which shipped in 0.52.0, exactly where the reports start. With the keepalive gone, the empty
Settings scene is the app's *only* scene, so at launch macOS takes the "open untitled window" path and
SwiftUI fills it with that empty scene: a blank 900×450 "CodexBar Settings" window that has no sidebar
and no controls, because there is nothing in it to render.

## Changes

- `AppDelegate.applicationShouldOpenUntitledFile` returns `false`. A menu bar app has no untitled document
  to open at launch or on reopen, and this is what actually keeps the placeholder window from being created.
- New `PlaceholderSettingsWindowGuard` (started in `applicationWillFinishLaunching`) closes any window
  SwiftUI names `com_apple_SwiftUI_Settings*` — by identifier or frame autosave name — if the system ever
  brings one back through state restoration or a system-sent settings action. It never closes the AppKit
  Settings window: that one is excluded both by identifier (`com.steipete.codexbar.settings`) and by a live
  identity check against `SettingsWindowController.window`.

The SwiftUI `Settings` scene itself stays, so `CommandGroup(replacing: .appSettings)` keeps owning ⌘, and
the localized application-menu item — it just never gets presented.

## Validation

macOS 26.5, freshly packaged bundle, windows enumerated with `CGWindowListCopyWindowInfo`:

- **Before** (installed 0.53.0): a 900×450 window is present in the process window list right after launch —
  the placeholder, reproduced.
- **After**: no such window at any point across repeated launches. The guard never fires (no log entry),
  which confirms the untitled-file path was the trigger rather than window restoration.
- **Settings still works**: the application menu has exactly one `Settings...` item; clicking it opens the
  real 800×572 AppKit window with content (`AXGroup` + 3 `AXButton` + `AXStaticText`), ⌘, keeps it, and both
  menu bar status items are present.
- `swift test --filter "AppDelegateTests|PlaceholderSettingsWindowGuardTests"` — 7 tests, pass
- `make test` — 2 failures in `AdaptiveRefreshTimerTests` (`CancellationError` in the two "long idle timer"
  tests). These reproduce identically with this branch's changes stashed, so they are pre-existing timing
  flakiness on this machine, not from this change.
- `make check` — 0 violations, no reformatting

## Notes

No screenshots: the user-visible change is the absence of a window at launch, which the window-list
evidence above captures more precisely than a screenshot would.
