### PR TITLE
feat: hide untouched Antigravity families on the dashboard

### DIFF
--- a/Sources/CodexBarCLI/CLIServeWebUI+HTML.swift
+++ b/Sources/CodexBarCLI/CLIServeWebUI+HTML.swift
@@ -852,6 +852,13 @@ extension CLIServeWebUI {
           return dot;
         }
 
+        function visibleWindows(windows) {
+          // The producer marks a window idle when its whole model family reports no usage, which
+          // the page cannot work out on its own: a zero percentage also stands for a lane the
+          // provider never reported. Script clients still receive every window on the snapshot.
+          return (windows || []).filter(w => w.idle !== true);
+        }
+
         function worstWindowLevel(windows) {
           const worst = Math.max(...(windows || []).map(w => finiteNumber(w.usedPercent)), -1);
           if (worst < 0) return null;
@@ -881,7 +888,7 @@ extension CLIServeWebUI {
           if (account.active) {
             head.append(pill("active", "active"));
           } else {
-            const level = worstWindowLevel(account.windows);
+            const level = worstWindowLevel(visibleWindows(account.windows));
             if (level) head.append(pill(level, level === "ok" ? "ok" : level === "warning" ? "high" : "critical"));
           }
           card.append(head);
@@ -898,7 +905,7 @@ extension CLIServeWebUI {
           }
 
           const windows = node("div", "windows");
-          for (const window of account.windows || []) windows.append(renderWindow(window));
+          for (const window of visibleWindows(account.windows)) windows.append(renderWindow(window));
           card.append(windows);
           return card;
         }
@@ -952,7 +959,7 @@ extension CLIServeWebUI {
           }
 
           const windows = node("div", "windows");
-          for (const window of provider.windows || []) windows.append(renderWindow(window));
+          for (const window of visibleWindows(provider.windows)) windows.append(renderWindow(window));
           card.append(windows);
           if (provider.accountsError) {
             card.append(node("p", "error-message", provider.accountsError));

--- a/Sources/CodexBarCLI/DashboardPayloads.swift
+++ b/Sources/CodexBarCLI/DashboardPayloads.swift
@@ -204,6 +204,28 @@ struct DashboardWindowPayload: Encodable {
     let usedPercent: Double
     let remainingPercent: Double
     let resetAt: Date?
+    /// Whether a display client should skip this window. The producer sets it when the window belongs
+    /// to a model family that reports no usage at all, which a client cannot work out on its own
+    /// because a zero `usedPercent` also stands for a lane whose usage the provider never reported.
+    /// Additive schema-v1 extension: the key appears only when it is `true`, so every payload that
+    /// carries no idle window is byte-identical to the previous shape.
+    let idle: Bool
+
+    init(
+        kind: String,
+        label: String,
+        usedPercent: Double,
+        remainingPercent: Double,
+        resetAt: Date?,
+        idle: Bool = false)
+    {
+        self.kind = kind
+        self.label = label
+        self.usedPercent = usedPercent
+        self.remainingPercent = remainingPercent
+        self.resetAt = resetAt
+        self.idle = idle
+    }
 
     private enum CodingKeys: String, CodingKey {
         case kind
@@ -211,6 +233,7 @@ struct DashboardWindowPayload: Encodable {
         case usedPercent
         case remainingPercent
         case resetAt
+        case idle
     }
 
     func encode(to encoder: Encoder) throws {
@@ -220,6 +243,9 @@ struct DashboardWindowPayload: Encodable {
         try container.encode(self.usedPercent, forKey: .usedPercent)
         try container.encode(self.remainingPercent, forKey: .remainingPercent)
         try container.encode(self.resetAt, forKey: .resetAt)
+        if self.idle {
+            try container.encode(true, forKey: .idle)
+        }
     }
 }
 

--- a/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
+++ b/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
@@ -320,14 +320,23 @@ enum DashboardSnapshotBuilder {
     }
 
     /// Display lanes for an Antigravity quota-summary snapshot, or `nil` when the snapshot has no
-    /// summary lanes and must keep the standard primary and secondary rows. Every family stays
-    /// visible: the dashboard is a detail surface, so only the duplicated representatives go away.
+    /// summary lanes and must keep the standard primary and secondary rows. Every family stays in the
+    /// payload, because a script client reads the same document and must not lose a window. The lanes of
+    /// a family that reports no usage carry `idle`, the same rule the menu card and the widget use to
+    /// hide that family, so the web UI can drop those rows without repeating the rule in JavaScript.
     private static func antigravityQuotaSummaryWindows(_ usage: UsageSnapshot) -> [DashboardWindowPayload]? {
         let extras = usage.extraRateWindows ?? []
         guard extras.contains(where: { AntigravityStatusSnapshot.isQuotaSummaryWindowID($0.id) }) else {
             return nil
         }
-        return extras.map { self.makeWindow(kind: $0.id, label: $0.title, window: $0.window) }
+        let idleWindowIDs = AntigravityQuotaFamilyVisibility.idleWindowIDs(in: usage)
+        return extras.map {
+            self.makeWindow(
+                kind: $0.id,
+                label: $0.title,
+                window: $0.window,
+                idle: idleWindowIDs.contains($0.id))
+        }
     }
 
     private struct RateWindowLabels {
@@ -355,7 +364,12 @@ enum DashboardSnapshotBuilder {
             tertiary: labels.tertiary)
     }
 
-    private static func makeWindow(kind: String, label: String, window: RateWindow) -> DashboardWindowPayload {
+    private static func makeWindow(
+        kind: String,
+        label: String,
+        window: RateWindow,
+        idle: Bool = false) -> DashboardWindowPayload
+    {
         let used = self.clampedPercent(window.usedPercent)
         let remaining = self.clampedPercent(100 - used)
         return DashboardWindowPayload(
@@ -363,7 +377,8 @@ enum DashboardSnapshotBuilder {
             label: label,
             usedPercent: used,
             remainingPercent: remaining,
-            resetAt: window.resetsAt)
+            resetAt: window.resetsAt,
+            idle: idle)
     }
 
     private static func clampedPercent(_ value: Double) -> Double {

--- a/Tests/CodexBarTests/CLIServeWebUITests.swift
+++ b/Tests/CodexBarTests/CLIServeWebUITests.swift
@@ -31,6 +31,18 @@ struct CLIServeWebUITests {
     }
 
     @Test
+    func `web ui skips windows the snapshot marks idle`() {
+        let html = self.html
+        // The producer decides which lanes are idle, so the page must not repeat any
+        // provider-specific rule. It filters on the generic flag and nothing else.
+        #expect(html.contains("function visibleWindows(windows)"))
+        #expect(html.contains("w.idle !== true"))
+        #expect(html.contains("for (const window of visibleWindows(provider.windows))"))
+        #expect(html.contains("for (const window of visibleWindows(account.windows))"))
+        #expect(html.contains("worstWindowLevel(visibleWindows(account.windows))"))
+    }
+
+    @Test
     func `web ui keeps ambient windows when no accounts are present`() {
         let html = self.html
         #expect(html.contains("Array.isArray(provider.accounts)"))

--- a/Tests/CodexBarTests/DashboardAntigravityWindowTests.swift
+++ b/Tests/CodexBarTests/DashboardAntigravityWindowTests.swift
@@ -5,11 +5,17 @@ import Testing
 
 /// The dashboard snapshot renders one Antigravity lane per quota bucket. The primary and secondary
 /// representatives are copies of two of those buckets, kept only so the icon and menu bar have
-/// standard slots to read, so the dashboard must not repeat them as rows of their own.
+/// standard slots to read, so the dashboard must not repeat them as rows of their own. Every family
+/// stays in the payload for script clients, and the lanes of a family that reports no usage carry
+/// `idle` so a display client can drop the same rows the menu card and the widget hide.
 struct DashboardAntigravityWindowTests {
     @Test
     func `dashboard renders one Antigravity lane per quota bucket`() throws {
-        let windows = try self.antigravityWindows(geminiSessionPercent: 3.9, geminiWeeklyPercent: 8.1)
+        let windows = try self.antigravityWindows(
+            geminiSessionPercent: 3.9,
+            geminiWeeklyPercent: 8.1,
+            thirdPartySessionPercent: 1.5,
+            thirdPartyWeeklyPercent: 2.5)
 
         #expect(windows.map { $0["label"] as? String } == [
             "Gemini 5-hour",
@@ -17,7 +23,9 @@ struct DashboardAntigravityWindowTests {
             "Claude/GPT 5-hour",
             "Claude/GPT weekly",
         ])
-        #expect(windows.map { $0["usedPercent"] as? Double } == [3.9, 8.1, 0, 0])
+        #expect(windows.map { $0["usedPercent"] as? Double } == [3.9, 8.1, 1.5, 2.5])
+        // The key is absent rather than false, so a payload with no idle window keeps its old shape.
+        #expect(windows.allSatisfy { $0["idle"] == nil })
     }
 
     @Test
@@ -27,6 +35,39 @@ struct DashboardAntigravityWindowTests {
 
         #expect(!labels.contains("Gemini Models"))
         #expect(!labels.contains("Claude and GPT"))
+    }
+
+    @Test
+    func `dashboard marks an Antigravity family that reports no usage as idle`() throws {
+        let windows = try self.antigravityWindows(geminiSessionPercent: 3.9, geminiWeeklyPercent: 8.1)
+
+        // Every lane still ships, so a script client loses nothing.
+        #expect(windows.map { $0["label"] as? String } == [
+            "Gemini 5-hour",
+            "Gemini weekly",
+            "Claude/GPT 5-hour",
+            "Claude/GPT weekly",
+        ])
+        #expect(windows.map { $0["idle"] as? Bool } == [nil, nil, true, true])
+    }
+
+    @Test
+    func `dashboard marks no Antigravity family idle when none reports usage`() throws {
+        let windows = try self.antigravityWindows(geminiSessionPercent: 0, geminiWeeklyPercent: 0)
+
+        #expect(windows.count == 4)
+        #expect(windows.allSatisfy { $0["idle"] == nil })
+    }
+
+    @Test
+    func `dashboard leaves an Antigravity family with unknown usage unmarked`() throws {
+        let windows = try self.antigravityWindows(
+            geminiSessionPercent: 3.9,
+            geminiWeeklyPercent: 8.1,
+            thirdPartyUsageKnown: false)
+
+        #expect(windows.count == 4)
+        #expect(windows.allSatisfy { $0["idle"] == nil })
     }
 
     @Test
@@ -50,7 +91,10 @@ struct DashboardAntigravityWindowTests {
     /// `secondary` set to the most-used lane of each family rather than to distinct windows.
     private func antigravityWindows(
         geminiSessionPercent: Double,
-        geminiWeeklyPercent: Double) throws -> [[String: Any]]
+        geminiWeeklyPercent: Double,
+        thirdPartySessionPercent: Double = 0,
+        thirdPartyWeeklyPercent: Double = 0,
+        thirdPartyUsageKnown: Bool = true) throws -> [[String: Any]]
     {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let geminiSession = RateWindow(
@@ -63,9 +107,13 @@ struct DashboardAntigravityWindowTests {
             windowMinutes: 7 * 24 * 60,
             resetsAt: now,
             resetDescription: nil)
-        let thirdPartySession = RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: now, resetDescription: nil)
+        let thirdPartySession = RateWindow(
+            usedPercent: thirdPartySessionPercent,
+            windowMinutes: 300,
+            resetsAt: now,
+            resetDescription: nil)
         let thirdPartyWeekly = RateWindow(
-            usedPercent: 0,
+            usedPercent: thirdPartyWeeklyPercent,
             windowMinutes: 7 * 24 * 60,
             resetsAt: now,
             resetDescription: nil)
@@ -84,12 +132,12 @@ struct DashboardAntigravityWindowTests {
                 id: "antigravity-quota-summary-3p-5h",
                 title: "Claude/GPT 5-hour",
                 window: thirdPartySession,
-                usageKnown: true),
+                usageKnown: thirdPartyUsageKnown),
             NamedRateWindow(
                 id: "antigravity-quota-summary-3p-weekly",
                 title: "Claude/GPT weekly",
                 window: thirdPartyWeekly,
-                usageKnown: true),
+                usageKnown: thirdPartyUsageKnown),
         ]
         let usage = UsageSnapshot(
             primary: geminiWeeklyPercent >= geminiSessionPercent ? geminiWeekly : geminiSession,

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -238,6 +238,9 @@ shared OAuth file can still be used as a fallback credential source.
   right after a weekly reset. Provider details is the diagnostic surface and always lists every family, the same
   principle it already applies to cost data. The filter is display-only: the snapshot, CLI output, and menu-bar
   ranking still see every window, and menu-bar selection ranks by highest used, so an untouched family never wins.
+- The dashboard-v1 payload keeps every family for its script clients and marks the lanes of an untouched family with
+  `idle` instead. The `codexbar serve` web UI skips those rows, so the web card matches the menu without repeating
+  the family rule in JavaScript. See `docs/dashboard-api.md`.
 
 ## Constraints
 - Internal protocol; fields may change.

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -254,7 +254,14 @@ while leaving the ambient Claude row intact.
 - `providers[].source`: Source used for the provider data.
 - `providers[].status`: Provider service status when available (`level`: `ok` | `warning` | `critical` | `unknown`).
 - `providers[].identity`: Account email and plan label, or `null`; the email local part is hidden only in redacted mode.
-- `providers[].windows`: Session, weekly, tertiary, or provider-specific rate windows.
+- `providers[].windows`: Session, weekly, tertiary, or provider-specific rate windows. Antigravity drops its
+  duplicated representative rows here and emits one row per quota bucket instead.
+- `providers[].windows[].idle`: `true` when a display client should skip the row, because the window belongs to a
+  model family that reports no usage. The key appears only when it is `true`, so a payload with no idle window keeps
+  its previous shape. This is an additive schema-v1 extension. A client that wants every window, such as a script or
+  an adapter, ignores the key and keeps the row. The built-in web UI drops these rows so the page matches the app
+  menu, which hides an untouched Antigravity model family. Only the producer can set this: a zero `usedPercent` also
+  stands for a lane whose usage the provider never reported, and the payload does not carry that distinction.
 - `providers[].credits`: Remaining credits or balance when available.
 - `providers[].cost`: Local cost data when available.
 - `providers[].display`: UI hints for ordering and coloring.


### PR DESCRIPTION
## Problem

Menu cards and widgets hide an Antigravity model family once no lane in it
reports known usage (#2875, landed as #2924). The `codexbar serve` web UI did
not, so a Gemini-only account still saw the Claude/GPT pair pinned at 0% that
the menu had already dropped: four lanes on the web card where the menu shows
two.

## Fix

`DashboardSnapshotBuilder` keeps every quota-summary window in the payload and
marks the lanes of an untouched family with a new `idle` flag, computed by the
shared `AntigravityQuotaFamilyVisibility` rule in `CodexBarCore`. The web UI
skips a marked row. The menu card, the widget, and the web card now follow one
rule, and that rule stays in Swift.

`idle` encodes only when it is `true`, so a payload with no idle window is
byte-identical to the previous shape. It is an additive schema-v1 extension,
the same shape `docs/dashboard-api.md` already documents for the claude-swap
`accounts` field.

### Why a flag and not a filter

An earlier revision of this branch filtered the rows out of the payload. Both
transports share one producer, so `codexbar dashboard` lost two windows under
`schemaVersion: 1`, and a script reading them would break with no version
signal. That is a real compatibility break, so the payload now stays complete.

### Why the page cannot decide on its own

A zero `usedPercent` also stands for a lane whose usage Antigravity never
reported. Swift tells the two apart through `NamedRateWindow.usageKnown`, which
`DashboardWindowPayload` does not carry. A JavaScript filter would hide the
unknown case that 5384f0a3 fixed, and it would put a second copy of the family
rule into a script that names no provider today.

## Behavior

| Case | `idle` on Gemini lanes | `idle` on Claude/GPT lanes | Web card rows |
| --- | --- | --- | --- |
| both used | absent | absent | 4 |
| Gemini used only | absent | `true` | 2 |
| Claude/GPT usage unknown | absent | absent | 4 |
| neither used | absent | absent | 4 |

| Surface | one family used | script impact |
| --- | --- | --- |
| Menu card, widget | the used one | n/a |
| `codexbar serve` web card | the used one | n/a |
| `codexbar dashboard`, `/dashboard/v1/snapshot` | every window, marked | none |
| `codexbar usage`, `/usage` | every window, unmarked | none |

## Proof

- Green: `swift test --filter "DashboardAntigravityWindowTests|DashboardSnapshotBuilderTests|CLIServeWebUITests"` — 32/32 tests.
- Green: `make test` — 76/76 groups, 902 selections, 0 retries.
- Green: `make check` — 0 violations in 1947 files.

New cases cover marking an untouched family, marking nothing when no family is
touched, leaving a family with unknown usage unmarked, omitting the key rather
than emitting `false`, and the web UI filtering on the flag alone.
