### PR TITLE
Align Overview spend calendar with dashboard

### DIFF
--- a/Sources/CodexBar/StatusItemController+OverviewSpend.swift
+++ b/Sources/CodexBar/StatusItemController+OverviewSpend.swift
@@ -140,6 +140,7 @@ extension StatusItemController {
             inputs: inputs,
             requestedDays: self.settings.costUsageHistoryDays,
             now: now,
+            calendar: self.settings.costUsageBucketCalendar,
             preferredCurrencyCode: self.settings.preferredCurrencyCode)
     }
 }

--- a/Tests/CodexBarTests/StatusMenuOverviewSpendTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOverviewSpendTests.swift
@@ -5,6 +5,67 @@ import Testing
 
 extension StatusMenuTests {
     @Test
+    func `overview spend uses the configured dashboard bucket calendar`() throws {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.costUsageEnabled = true
+        settings.costUsageHistoryDays = 1
+        let now = Date(timeIntervalSince1970: 1_787_079_600)
+        let currentOffset = Calendar.current.timeZone.secondsFromGMT(for: now)
+        let bucketIdentifier = currentOffset == 14 * 60 * 60
+            ? "Etc/GMT+12"
+            : "Pacific/Kiritimati"
+        settings.costUsageBucketTimeZoneIdentifier = bucketIdentifier
+        let bucketCalendar = settings.costUsageBucketCalendar
+        let dayComponents = bucketCalendar.dateComponents([.year, .month, .day], from: now)
+        let year = try #require(dayComponents.year)
+        let month = try #require(dayComponents.month)
+        let dayOfMonth = try #require(dayComponents.day)
+        let day = String(format: "%04d-%02d-%02d", year, month, dayOfMonth)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(CostUsageTokenSnapshot(
+            sessionTokens: nil,
+            sessionCostUSD: nil,
+            last30DaysTokens: 100,
+            last30DaysCostUSD: 1,
+            historyDays: 1,
+            costProvenance: .listPriceEstimate,
+            daily: [
+                CostUsageDailyReport.Entry(
+                    date: day,
+                    inputTokens: 60,
+                    outputTokens: 40,
+                    totalTokens: 100,
+                    requestCount: 1,
+                    costUSD: 1,
+                    modelsUsed: ["test-model"],
+                    modelBreakdowns: nil),
+            ],
+            updatedAt: now), provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let model = controller.overviewSpendDashboardModel(providers: [.codex], now: now)
+        let group = try #require(model.groups.first)
+        let bucketStart = bucketCalendar.startOfDay(for: now)
+
+        #expect(bucketStart != Calendar.current.startOfDay(for: now))
+        #expect(group.chartDomain.lowerBound == bucketStart)
+        #expect(group.timeZone.identifier == bucketCalendar.timeZone.identifier)
+        #expect(group.totalCost == 1)
+        #expect(group.totalTokens == 100)
+        #expect(group.dailyPoints.map(\.day) == [bucketStart])
+    }
+
+    @Test
     func `overview accounts for all six selected providers while summing only available spend`() {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false


### PR DESCRIPTION
## Summary

- make the Overview menu use the configured spend bucket calendar
- align its boundary-day grouping with the full Spend dashboard
- add a deterministic timezone-boundary regression covering dollars, tokens, chart domain, and daily points

## Root cause

The full Spend dashboard passes `settings.costUsageBucketCalendar` into `SpendDashboardModel`, but the Overview menu omitted the calendar argument and silently fell back to `Calendar.current`. A user-selected spend timezone could therefore put boundary-day usage into a different day—and potentially a different 30-day total—in the menu versus the dashboard.

## Fix

Pass `settings.costUsageBucketCalendar` through the existing Overview model builder. No new calculation path is introduced; both surfaces continue using `SpendDashboardModel`.

## Test oracle

The regression selects a valid bucket timezone with a day boundary different from the process calendar, publishes a one-day `$1` / 100-token snapshot, and asserts that Overview:

- uses the configured timezone
- starts its chart on the configured day boundary
- retains the exact dollar and token totals
- places the daily point on that same configured day

## Validation

- changed-file SwiftFormat lint: pass
- Swift parser checks: pass
- `git diff --check`: pass
- independent adversarial review: ready; no production blocker
- local focused execution is indeterminate because the Command Line Tools environment fails earlier in existing `AdaptiveReplayKitTests` with `no such module 'Testing'`; hosted Xcode/macOS CI is authoritative

This is independent of #3063: that PR separates the six-card display scope from the all-enabled accounting scope; this PR aligns same-input calendar math between the menu and dashboard.
