### PR TITLE
docs: add Stream Deck integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ CLI install:
 
 ## Status bar & terminal integration
 - [showy-quota](https://github.com/enieuwy/showy-quota) — always-on AI plan quota strips for SketchyBar, tmux, and Zellij (standalone WASM plugin), built on `codexbar serve` / the bundled CLI.
+- [AI Usage Limits](https://github.com/lenadweb/stream-deck-ai-limits) — Elgato Stream Deck integration for macOS: shows a selected CodexBar provider, account, and configurable quota or payload metrics on keys and Stream Deck+ dials, using local `codexbar serve`.
 
 ## Credits
 Inspired by [ccusage](https://github.com/ryoppippi/ccusage) (MIT), specifically the cost usage tracking.


### PR DESCRIPTION
This adds AI Usage Limits to the README’s integrations list.

It’s a macOS Stream Deck plugin that displays a selected CodexBar provider, account, and usage metrics on Stream Deck keys and Stream Deck+ dials, using the local `codexbar serve` API. CodexBar continues to handle provider configuration, authentication, and data refresh.

Docs-only change, happy to adjust the wording or placement if you’d prefer.