### PR TITLE
Clarify five-hour quota wording in Simplified Chinese

### DIFF
--- a/Sources/CodexBar/Localization.swift
+++ b/Sources/CodexBar/Localization.swift
@@ -213,6 +213,24 @@ func L(_ key: String, language: String) -> String {
     return codexBarLocalizedString(key, bundle: bundle, resourceBundle: resourceBundle)
 }
 
+/// Uses an explicit duration for Simplified Chinese quota surfaces while preserving the generic
+/// `Session` translation for conversations and other non-quota UI.
+func localizedSessionQuotaLabel(_ label: String, windowMinutes: Int?) -> String {
+    let localizedLabel = L(label)
+    guard label == "Session",
+          localizedBundle().bundleURL.lastPathComponent.caseInsensitiveCompare("zh-Hans.lproj") == .orderedSame,
+          let windowMinutes
+    else { return localizedLabel }
+
+    if windowMinutes == 7 * 24 * 60 {
+        return L("Weekly")
+    }
+    guard (60...(12 * 60)).contains(windowMinutes), windowMinutes.isMultiple(of: 60) else {
+        return localizedLabel
+    }
+    return "\(codexBarLocalizedInteger(windowMinutes / 60)) \(L("Hour"))"
+}
+
 func codexBarLocalizedLocale() -> Locale {
     codexBarLocale(forLanguage: resolvedAppLanguage())
 }

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -559,7 +559,7 @@ extension UsageMenuCardView.Model {
             ? L("Monthly")
             : input.metadata.opusLabel.map(L) ?? L("Sonnet")
         return (
-            L(primaryLabel),
+            localizedSessionQuotaLabel(primaryLabel, windowMinutes: snapshot.primary?.windowMinutes),
             L(secondaryLabel),
             tertiaryLabel,
             input.metadata.supportsOpus)

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -223,7 +223,10 @@ struct PlanUtilizationHistoryChartMenuView: View {
             .map { history in
                 VisibleSeries(
                     selection: SeriesSelection(name: history.name, windowMinutes: history.windowMinutes),
-                    title: self.seriesTitle(name: history.name, metadata: metadata),
+                    title: self.seriesTitle(
+                        name: history.name,
+                        metadata: metadata,
+                        windowMinutes: history.windowMinutes),
                     history: history)
             }
     }
@@ -621,11 +624,12 @@ struct PlanUtilizationHistoryChartMenuView: View {
 
     private nonisolated static func seriesTitle(
         name: PlanUtilizationSeriesName,
-        metadata: ProviderMetadata?) -> String
+        metadata: ProviderMetadata?,
+        windowMinutes: Int) -> String
     {
         switch name {
         case .session:
-            L(metadata?.sessionLabel ?? "Session")
+            localizedSessionQuotaLabel(metadata?.sessionLabel ?? "Session", windowMinutes: windowMinutes)
         case .weekly:
             L(metadata?.weeklyLabel ?? "Weekly")
         case .monthly:
@@ -673,6 +677,7 @@ struct PlanUtilizationHistoryChartMenuView: View {
         let xDomain: ClosedRange<Double>?
         let selectedSeries: String?
         let visibleSeries: [String]
+        let visibleSeriesTitles: [String]
         let usedPercents: [Double]
         let pointDates: [String]
     }
@@ -696,6 +701,7 @@ struct PlanUtilizationHistoryChartMenuView: View {
             xDomain: model.xDomain,
             selectedSeries: selectedSeries?.id,
             visibleSeries: visibleSeries.map(\.id),
+            visibleSeriesTitles: visibleSeries.map(\.title),
             usedPercents: model.points.map(\.usedPercent),
             pointDates: model.points.map { point in
                 let formatter = DateFormatter()

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -6,7 +6,7 @@
 "Fast" = "高速";
 "iCloud Sync" = "iCloud Sync";
 "Projects" = "项目";
-"Session %@" = "会话 %@";
+"Session %@" = "5 小时 %@";
 "Std" = "标准";
 "Show all (%d)" = "显示全部（%d）";
 "Show less" = "收起";
@@ -332,7 +332,7 @@
 "Secondary (\\(metadata.weeklyLabel))" = "次要（\\(metadata.weeklyLabel)）";
 "Select a provider" = "选择一个提供商";
 "Select the IDE to monitor" = "选择要监控的 IDE";
-"Session" = "会话";
+"Session" = "5 小时";
 "Session quota notifications" = "会话配额通知";
 "Session tokens" = "会话令牌";
 "provider_section_connection" = "连接";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -6,7 +6,7 @@
 "Fast" = "高速";
 "iCloud Sync" = "iCloud Sync";
 "Projects" = "项目";
-"Session %@" = "5 小时 %@";
+"Session %@" = "会话 %@";
 "Std" = "标准";
 "Show all (%d)" = "显示全部（%d）";
 "Show less" = "收起";
@@ -332,7 +332,7 @@
 "Secondary (\\(metadata.weeklyLabel))" = "次要（\\(metadata.weeklyLabel)）";
 "Select a provider" = "选择一个提供商";
 "Select the IDE to monitor" = "选择要监控的 IDE";
-"Session" = "5 小时";
+"Session" = "会话";
 "Session quota notifications" = "会话配额通知";
 "Session tokens" = "会话令牌";
 "provider_section_connection" = "连接";

--- a/Tests/CodexBarTests/PopupLocalizationTests.swift
+++ b/Tests/CodexBarTests/PopupLocalizationTests.swift
@@ -8,6 +8,43 @@ import Testing
 @Suite(.serialized)
 struct PopupLocalizationTests {
     @Test
+    func `simplified Chinese identifies Claude session quota as five hours`() throws {
+        try CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hans") {
+            let now = Date(timeIntervalSince1970: 1_700_000_000)
+            let metadata = try #require(ProviderDefaults.metadata[.claude])
+            let snapshot = UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 10,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(3600),
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now)
+            let model = UsageMenuCardView.Model.make(.init(
+                provider: .claude,
+                metadata: metadata,
+                snapshot: snapshot,
+                credits: nil,
+                creditsError: nil,
+                dashboard: nil,
+                dashboardError: nil,
+                tokenSnapshot: nil,
+                tokenError: nil,
+                account: AccountInfo(email: nil, plan: nil),
+                isRefreshing: false,
+                lastError: nil,
+                usageBarsShowUsed: false,
+                resetTimeDisplayStyle: .countdown,
+                tokenCostUsageEnabled: false,
+                showOptionalCreditsAndExtraUsage: true,
+                hidePersonalInfo: false,
+                now: now))
+
+            #expect(model.metrics.first?.title == "5 小时")
+        }
+    }
+
+    @Test
     func `descriptor account labels use selected localization`() throws {
         try CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hant") {
             let suite = "PopupLocalizationTests-descriptor"

--- a/Tests/CodexBarTests/PopupLocalizationTests.swift
+++ b/Tests/CodexBarTests/PopupLocalizationTests.swift
@@ -8,39 +8,58 @@ import Testing
 @Suite(.serialized)
 struct PopupLocalizationTests {
     @Test
-    func `simplified Chinese identifies Claude session quota as five hours`() throws {
+    func `simplified Chinese derives session quota titles from their duration`() throws {
         try CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hans") {
+            for (windowMinutes, expectedTitle) in [(60, "1 小时"), (300, "5 小时"), (720, "12 小时")] {
+                let model = try Self.makeClaudeMenuCardModel(primaryWindowMinutes: windowMinutes)
+
+                #expect(model.metrics.first?.title == expectedTitle)
+            }
+        }
+    }
+
+    @Test
+    func `simplified Chinese labels a Claude weekly primary fallback accurately`() throws {
+        try CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hans") {
+            let model = try Self.makeClaudeMenuCardModel(primaryWindowMinutes: 7 * 24 * 60)
+
+            #expect(model.metrics.first?.title == "每周")
+        }
+    }
+
+    @Test
+    func `simplified Chinese history selector uses quota duration without changing conversations`() {
+        CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hans") {
             let now = Date(timeIntervalSince1970: 1_700_000_000)
-            let metadata = try #require(ProviderDefaults.metadata[.claude])
+            let histories = [
+                PlanUtilizationSeriesHistory(
+                    name: .session,
+                    windowMinutes: 300,
+                    entries: [PlanUtilizationHistoryEntry(capturedAt: now, usedPercent: 10, resetsAt: nil)]),
+                PlanUtilizationSeriesHistory(
+                    name: .weekly,
+                    windowMinutes: 7 * 24 * 60,
+                    entries: [PlanUtilizationHistoryEntry(capturedAt: now, usedPercent: 20, resetsAt: nil)]),
+            ]
             let snapshot = UsageSnapshot(
                 primary: RateWindow(
                     usedPercent: 10,
                     windowMinutes: 300,
-                    resetsAt: now.addingTimeInterval(3600),
+                    resetsAt: nil,
                     resetDescription: nil),
-                secondary: nil,
+                secondary: RateWindow(
+                    usedPercent: 20,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: nil,
+                    resetDescription: nil),
                 updatedAt: now)
-            let model = UsageMenuCardView.Model.make(.init(
+            let model = PlanUtilizationHistoryChartMenuView._modelSnapshotForTesting(
+                histories: histories,
                 provider: .claude,
-                metadata: metadata,
-                snapshot: snapshot,
-                credits: nil,
-                creditsError: nil,
-                dashboard: nil,
-                dashboardError: nil,
-                tokenSnapshot: nil,
-                tokenError: nil,
-                account: AccountInfo(email: nil, plan: nil),
-                isRefreshing: false,
-                lastError: nil,
-                usageBarsShowUsed: false,
-                resetTimeDisplayStyle: .countdown,
-                tokenCostUsageEnabled: false,
-                showOptionalCreditsAndExtraUsage: true,
-                hidePersonalInfo: false,
-                now: now))
+                snapshot: snapshot)
 
-            #expect(model.metrics.first?.title == "5 小时")
+            #expect(model.visibleSeriesTitles == ["5 小时", "每周"])
+            #expect(String(format: L("Session %@"), "abc123") == "会话 abc123")
         }
     }
 
@@ -230,5 +249,37 @@ struct PopupLocalizationTests {
             guard case let .text(text, _) = entry else { return nil }
             return text
         }
+    }
+
+    private static func makeClaudeMenuCardModel(primaryWindowMinutes: Int) throws -> UsageMenuCardView.Model {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: primaryWindowMinutes,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now)
+        return UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
     }
 }


### PR DESCRIPTION
## Summary

- derive Simplified Chinese quota titles from the actual `windowMinutes` when the semantic label is `Session`
- render 1–12 hour session windows as `%d 小时` and a 10,080-minute primary fallback as `每周`
- preserve the shared `Session` / `Session %@` translations as `会话`, so conversation rows remain accurate
- apply the duration-aware title to both the usage card and plan-utilization history selector
- add regression coverage for 60, 300, 720, and 10,080-minute windows plus the conversation label

## Why

`Session` is shared by quota and conversation surfaces, while semantic quota windows can span 1–12 hours. A literal global translation to `5 小时` therefore mislabels both non-five-hour quota windows and conversation rows.

This revision follows the duration-aware approach suggested in review: quota surfaces use the actual rate-window duration, while generic conversation text remains `会话`.

| Surface / window | Simplified Chinese result |
| --- | --- |
| 60-minute session quota | `1 小时` |
| 300-minute session quota | `5 小时` |
| 720-minute session quota | `12 小时` |
| 10,080-minute primary fallback | `每周` |
| Conversation `Session %@` | `会话 abc123` |

## Scope and risk

The duration override is limited to Simplified Chinese, the canonical `Session` semantic label, and known session or weekly durations. Provider-specific labels such as credits, requests, or balances keep their existing translations. No provider data, percentages, reset calculations, or English text change.

## Validation

- `make check` — passed
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter PopupLocalizationTests` — 8/8 passed
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter ClaudeOAuthUsageMappingTests` — 3/3 passed
- `make test` — passed all 902 selected test groups/selections; one combined group exceeded the 180-second group limit and the runner automatically recovered it by running all 12 constituent suites successfully in isolation
- `plutil -lint Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings` — passed
- `git diff --check` — passed

### After-fix terminal proof

```text
✔ Suite PopupLocalizationTests passed
✔ Test run with 8 tests in 1 suite passed

✔ Suite ClaudeOAuthUsageMappingTests passed
✔ Test run with 3 tests in 1 suite passed

Swift test timing summary:
- Selected selections: 902
- Recovered groups: 1
- Isolated selection retries: 12
- make test exit status: 0
```

Closes #3069.
