### PR TITLE
fix(alibaba): resolve mainland Personal/Solo sec_token from the console shell

### DIFF
--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
@@ -540,6 +540,17 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         request.setValue(
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             forHTTPHeaderField: "Accept")
+        // The OneConsole shell only server-renders `window.ALIYUN_CONSOLE_CONFIG.SEC_TOKEN` for a
+        // genuine same-origin document navigation; a bare request receives a token-less shell, so the
+        // Personal `sec_token` can never be scraped. Send the browser-navigation headers so the shell
+        // includes it (mainland Personal/Solo rejects the API without it — fixes #2500/#2349/#2370).
+        if let origin = request.url.flatMap(\.host).map({ "https://\($0)/" }) {
+            request.setValue(origin, forHTTPHeaderField: "Referer")
+        }
+        request.setValue("same-origin", forHTTPHeaderField: "Sec-Fetch-Site")
+        request.setValue("navigate", forHTTPHeaderField: "Sec-Fetch-Mode")
+        request.setValue("document", forHTTPHeaderField: "Sec-Fetch-Dest")
+        request.setValue("zh-CN,zh;q=0.9,en;q=0.8", forHTTPHeaderField: "Accept-Language")
 
         if let (data, response) = try? await session.data(for: request),
            let httpResponse = response as? HTTPURLResponse,
@@ -1257,12 +1268,15 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         return names.isEmpty ? "none" : names.joined(separator: ",")
     }
 
-    private static func extractSECToken(from html: String) -> String? {
+    static func extractSECToken(from html: String) -> String? {
         let patterns = [
             #""secToken"\s*:\s*"([^"]+)""#,
             #""sec_token"\s*:\s*"([^"]+)""#,
             #"secToken['"]?\s*[:=]\s*['"]([^'"]+)['"]"#,
             #"sec_token['"]?\s*[:=]\s*['"]([^'"]+)['"]"#,
+            // Aliyun's OneConsole shell embeds it inside `window.ALIYUN_CONSOLE_CONFIG` with an
+            // upper-case, unquoted key: `SEC_TOKEN: "<token>"`. The lower-case patterns above miss it.
+            #"SEC_TOKEN['"]?\s*[:=]\s*['"]([^'"]+)['"]"#,
         ]
         for pattern in patterns {
             if let token = self.matchFirstGroup(pattern: pattern, in: html), !token.isEmpty {

--- a/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
@@ -1313,3 +1313,34 @@ final class AlibabaTokenPlanStubURLProtocol: URLProtocol {
 
     override func stopLoading() {}
 }
+
+struct AlibabaTokenPlanSECTokenScrapeTests {
+    @Test
+    func `extracts the OneConsole SEC_TOKEN embedded in the dashboard shell`() {
+        // The aliyun OneConsole shell embeds the token as an upper-case, unquoted key inside
+        // `window.ALIYUN_CONSOLE_CONFIG` — the shape the mainland Personal/Solo gateway requires.
+        let html = """
+        <script>
+          window.ALIYUN_CONSOLE_CONFIG = {
+            LANG: "zh",
+            SEC_TOKEN: "NwsiCAv9SDsHsNab4Jexample",
+            ACCOUNT_NAME: "someone"
+          };
+        </script>
+        """
+        #expect(AlibabaTokenPlanUsageFetcher.extractSECToken(from: html) == "NwsiCAv9SDsHsNab4Jexample")
+    }
+
+    @Test
+    func `still extracts the lower-case secToken and sec_token shapes`() {
+        #expect(
+            AlibabaTokenPlanUsageFetcher.extractSECToken(from: #"{"secToken":"abc123"}"#) == "abc123")
+        #expect(
+            AlibabaTokenPlanUsageFetcher.extractSECToken(from: #"var x = { sec_token: 'def456' };"#) == "def456")
+    }
+
+    @Test
+    func `returns nil when no token is present`() {
+        #expect(AlibabaTokenPlanUsageFetcher.extractSECToken(from: "<html><body>no token here</body></html>") == nil)
+    }
+}


### PR DESCRIPTION
## Problem

Mainland **Personal/Solo** Token Plan (`cn-personal`) always shows **"Alibaba Token Plan login required"**, even right after a fresh, valid aliyun login. The API isn't returning 401 — every call returns **HTTP 200** with a body of `successResponse: true, message: "BailianGateway.Login.NotLogined"`. The OneConsole gateway treats the request as unauthenticated because it lacks the browser's **`sec_token`**.

#2533 already appends `sec_token` to the Personal request *when present*, but for mainland Personal it was never resolvable — `secTokenSource=missing` on every fetch — so the card stayed broken.

## Root cause (two parts)

Diagnosed against a real `cn-personal` account:

1. **Token-less shell.** `resolveSECToken` scrapes `window.ALIYUN_CONSOLE_CONFIG.SEC_TOKEN` from the console shell, but the shell only *server-renders* `SEC_TOKEN` for a genuine same-origin document navigation. CodexBar's bare `GET` received a ~29 KB shell **without** the token (while the browser gets a ~34 KB shell **with** it). Adding the browser-navigation headers (`Referer`, `Sec-Fetch-Site/Mode/Dest`, `Accept-Language`) makes the server include it.
2. **Regex miss.** Even once present, the shell embeds it as an **upper-case, unquoted** key — `SEC_TOKEN: "…"` — but `extractSECToken` only matched the lower-case `secToken` / `sec_token` shapes, so it extracted nothing.

## Fix

- Send browser-navigation headers on the dashboard-shell fetch so the shell carries `SEC_TOKEN`.
- Add a `SEC_TOKEN` (upper-case) pattern to `extractSECToken`.

## Verification (real `cn-personal` account, end-to-end)

Before → after, from the live fetch log (no secrets):

```
before:  secTokenSource=missing   body: message=BailianGateway.Login.NotLogined   -> "login required"
after:   secTokenSource=resolved  body: message=Success  successResponse=true      -> card renders
         Resolved Alibaba Token Plan sec_token from dashboard HTML (htmlBytes=34102)
         General · 5 hours: 1 / 100 · 1% used · Resets in 1 hour
         General · Weekly: Unlimited
```

Isolation-tested by temporarily disabling the other `sec_token` sources: the dashboard-shell scrape alone (headers + regex) resolves the token and the gateway returns `Success`, so the fix is causal — not a warm-session coincidence.

## Tests

`AlibabaTokenPlanSECTokenScrapeTests` — upper-case shell format, the existing lower-case shapes (no regression), and the no-token case. Existing Alibaba Token Plan suites stay green (`swift test --filter AlibabaTokenPlan` → 53 tests pass); `swiftformat`/`swiftlint --strict` clean.

Refs #2500, #2349, #2370, #2533.
