### PR TITLE
perf(spend): parallelize provider baselines in makeRequest

### DIFF
--- a/Sources/CodexBar/SpendDashboardController.swift
+++ b/Sources/CodexBar/SpendDashboardController.swift
@@ -234,11 +234,18 @@ enum SpendDashboardSource {
                 publication: captured.publication,
                 publicationRevision: captured.revision)
         }
-        for baseline in providerBaselines where mode.shouldRefresh(hasPublication: baseline.publication != nil) {
-            if UsageStore.tokenCostRequiresProviderSnapshot(baseline.provider) {
-                await store.refreshProvider(baseline.provider)
-            } else {
-                await store.refreshSpendDashboardTokenUsageNow(for: baseline.provider, force: true)
+        let baselinesToRefresh = providerBaselines.filter { mode.shouldRefresh(hasPublication: $0.publication != nil) }
+        if !baselinesToRefresh.isEmpty {
+            await withTaskGroup(of: Void.self) { group in
+                for baseline in baselinesToRefresh {
+                    group.addTask {
+                        if UsageStore.tokenCostRequiresProviderSnapshot(baseline.provider) {
+                            await store.refreshProvider(baseline.provider)
+                        } else {
+                            await store.refreshSpendDashboardTokenUsageNow(for: baseline.provider, force: true)
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Parallelize independent spend snapshot refreshes in `SpendDashboardSource.makeRequest:237`.

**Before:** `for baseline where shouldRefresh { await store.refreshProvider / refreshSpendDashboardTokenUsageNow }` serially awaited per provider. With 3 independent providers (Claude/Cursor/OpenCodex) each 400ms-3s (Cursor pagination), total 1.2-9s additive.

**After:** `withTaskGroup` concurrent, wall-time = slowest provider only. Cold `全部` first-paint from ~3-10s → ~2-3s (Codex scan still dominates).

**Scope:** single function, no new persistence, no behavior change beyond concurrency. `SpendDashboardSourceConcurrencyTests` covers same-scope ownership.

Fixes P0-4 from spend audit.

*Verified:* `swiftformat` + `swiftlint --strict` clean.