### PR TITLE
fix(spend): notify shared dashboard on independent token pubs

### DIFF
--- a/Sources/CodexBar/UsageStore+SpendDashboardPublication.swift
+++ b/Sources/CodexBar/UsageStore+SpendDashboardPublication.swift
@@ -62,8 +62,10 @@ extension UsageStore {
     }
 
     func synchronizeSharedSpendDashboardAfterTokenPublication(for provider: UsageProvider) {
-        // Provider-specific by design: regular Codex publication triggers the account-scoped spend producer.
-        guard provider == .codex, self.sharedSpendDashboardObservationStarted else { return }
+        guard self.sharedSpendDashboardObservationStarted else { return }
+        // Codex and independent spend-dashboard token publications both drive the shared dashboard.
+        let isIndependent = Self.usesSpendDashboardIndependentTokenSnapshot(provider)
+        guard provider == .codex || isIndependent else { return }
         self.applySharedSpendDashboardConfiguration(
             SpendDashboardSource.configuration(settings: self.settings, store: self))
     }

--- a/Sources/CodexBar/UsageStore+SpendDashboardTokenCost.swift
+++ b/Sources/CodexBar/UsageStore+SpendDashboardTokenCost.swift
@@ -178,6 +178,7 @@ extension UsageStore {
             publicationRevision: self.spendDashboardTokenSnapshotPublicationRevision(for: provider),
             providerConfigRevision: self.settings.providerConfigRevision(for: provider),
             scopeSignature: self.spendDashboardTokenSnapshotScopeSignature(for: provider))
+        self.synchronizeSharedSpendDashboardAfterTokenPublication(for: provider)
     }
 
     private func spendDashboardTokenRefreshPublicationIsCurrent(


### PR DESCRIPTION
Independent spend-dashboard providers (`usesSpendDashboardIndependentTokenSnapshot` — Claude/Cursor/OpenCodex/etc) published to `spendDashboardTokenPublications` but `publishSpendDashboardTokenSnapshotState:171` never called `synchronizeSharedSpendDashboardAfterTokenPublication`, and the sync itself gated on `provider == .codex` (`UsageStore+SpendDashboardPublication.swift:64`).

Result: background `refreshSpendDashboardTokenUsageNow` completions didn't update the shared `SpendDashboardController` publication, so the *Usage & Spend* pane and Overview spend stayed stale until next config change or pane re-open — the "won't auto refresh silently" symptom.

**Fix**
* `UsageStore+SpendDashboardPublication.swift:64` widen guard to `provider == .codex || isIndependent`
* `UsageStore+SpendDashboardTokenCost.swift:171` call `synchronizeSharedSpendDashboardAfterTokenPublication` after publishing

Background imports now drive the shared dashboard like the Codex path already did.

*Verified:* `swiftformat` + `swiftlint --strict` clean, `SpendDashboardPublicationTests` covers shared ownership.