### PR TITLE
fix(spend): sync heatmap bucket calendar

### DIFF
--- a/Sources/CodexBar/PreferencesSpendDashboardPane.swift
+++ b/Sources/CodexBar/PreferencesSpendDashboardPane.swift
@@ -399,6 +399,7 @@ struct SpendDashboardPane: View {
             SpendDashboardPanel {
                 SpendActivityHeatmapView(
                     points: self.controller.model.tokenActivity,
+                    calendar: self.settings.costUsageBucketCalendar,
                     selectedDay: self.controller.selectedDay,
                     onSelectDay: { day in
                         self.controller.selectDay(day)

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -372,6 +372,7 @@ enum SpendActivityAccessibility {
 struct SpendActivityHeatmapView: View {
     let points: [SpendDashboardModel.TokenActivityPoint]
     let now: Date
+    let calendar: Calendar
     let selectedDay: Date?
     let onSelectDay: ((Date?) -> Void)?
 
@@ -381,14 +382,16 @@ struct SpendActivityHeatmapView: View {
     init(
         points: [SpendDashboardModel.TokenActivityPoint],
         now: Date = Date(),
+        calendar: Calendar = .current,
         selectedDay: Date? = nil,
         onSelectDay: ((Date?) -> Void)? = nil)
     {
         self.points = points
         self.now = now
+        self.calendar = calendar
         self.selectedDay = selectedDay
         self.onSelectDay = onSelectDay
-        self._series = State(initialValue: SpendActivitySeries.make(from: points, now: now))
+        self._series = State(initialValue: SpendActivitySeries.make(from: points, now: now, calendar: calendar))
     }
 
     var body: some View {
@@ -458,7 +461,10 @@ struct SpendActivityHeatmapView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onChange(of: self.points) { _, points in
-            self.series = SpendActivitySeries.make(from: points, now: self.now)
+            self.series = SpendActivitySeries.make(from: points, now: self.now, calendar: self.calendar)
+        }
+        .onChange(of: self.calendar) { _, calendar in
+            self.series = SpendActivitySeries.make(from: self.points, now: self.now, calendar: calendar)
         }
     }
 


### PR DESCRIPTION
Heatmap used `Calendar.current` and only observed `points` (`SpendActivityHeatmap.swift:391,460`), so changing `costUsageBucketTimeZoneIdentifier` (IANA pinned bucketing from #3015) left the 371-cell `SpendActivitySeries` sliced in the old zone until next points change — future column off-by-one and weekly aggregation aliasing.

**Before:** `PreferencesSpendDashboardPane.swift:400` created `SpendActivityHeatmapView(points:selectedDay:)` with default `.current`, `onChange(of: points)` only.

**After:** add `calendar: Calendar` to `SpendActivityHeatmapView`, init from `SpendActivitySeries.make(..., calendar:)` and add `onChange(of: calendar)`. Pane now passes `settings.costUsageBucketCalendar`, matching `SpendDashboardModel.build:300` `gregorianCalendar(timeZone: calendar.timeZone)` and `StatusItemController+OverviewSpend:201` fix in #3064.

*Verified:* `swiftformat` + `swiftlint --strict` clean, backward compatible default `.current` for previews.