### PR TITLE
fix(spend): widen ownership and revision coverage

### DIFF
--- a/Sources/CodexBar/SpendDashboardController.swift
+++ b/Sources/CodexBar/SpendDashboardController.swift
@@ -686,6 +686,26 @@ enum SpendDashboardSource {
                 encoder.append(breakdown.priorityTokens)
             }
         }
+        encoder.append(snapshot.hourly.count)
+        for entry in snapshot.hourly {
+            encoder.append(entry.hour.timeIntervalSinceReferenceDate)
+            encoder.append(entry.totalTokens)
+            encoder.append(entry.costUSD)
+        }
+        encoder.append(snapshot.projects.count)
+        encoder.append(snapshot.sessions.count)
+        for project in snapshot.projects {
+            encoder.append(project.name)
+            encoder.append(project.path ?? "")
+            encoder.append(project.totalTokens)
+            encoder.append(project.totalCostUSD)
+            encoder.append(project.daily.count)
+        }
+        for session in snapshot.sessions {
+            encoder.append(session.sessionID)
+            encoder.append(session.totalTokens)
+            encoder.append(session.costUSD)
+        }
         return encoder.finalize()
     }
 
@@ -1540,7 +1560,12 @@ final class SpendDashboardController {
         lhs.costUsageEnabled == rhs.costUsageEnabled &&
             lhs.providerIDs == rhs.providerIDs &&
             lhs.codexAccountIdentities == rhs.codexAccountIdentities &&
-            lhs.sourceOwnershipFingerprints == rhs.sourceOwnershipFingerprints
+            lhs.sourceOwnershipFingerprints == rhs.sourceOwnershipFingerprints &&
+            lhs.bucketTimeZoneIdentifier == rhs.bucketTimeZoneIdentifier &&
+            lhs.openCodexUsageLogsEnabled == rhs.openCodexUsageLogsEnabled &&
+            lhs.hideNativeCodexCostWhenOpenCodexPresent == rhs.hideNativeCodexCostWhenOpenCodexPresent &&
+            lhs.hiddenSourceIDs == rhs.hiddenSourceIDs &&
+            lhs.preferredCurrencyCode == rhs.preferredCurrencyCode
     }
 
     private static func invalidatedSourceIDs(


### PR DESCRIPTION
Two coalesce/revision gaps kept the dashboard stale:

**1. `sameSourceOwnership:1536` too narrow**
Only compared `costUsageEnabled/providerIDs/codexAccountIdentities/sourceOwnershipFingerprints`. Changing `bucketTimeZoneIdentifier` / `openCodexUsageLogsEnabled` / `hideNativeCodexCostWhenOpenCodexPresent` / `hiddenSourceIDs` / `preferredCurrencyCode` during an in-flight `forceRefresh` (`#3041` path) was treated as same-owner, adopted `request.configuration` without a new `load`, leaving `daily/hourly/chartDomain` stale. Now compare the 5 display-affecting fields.

**2. `snapshotRevision:659` ignored `hourly/projects/sessions`**
Only hashed `daily[]`. An OpenCodex per-request-hour update or project/session addition didn't bump `sourceRevisions`, so `ForcedOutcome.incorporating:922` saw `!hasNewerSourceRevision` and discarded the `confirmedNonempty` input. Now hash `hourly` (hour+cost), `projects` (name/path/tokens/cost/dailyCount), `sessions` (id/tokens/cost).

Both fixes keep `#3041` coalesce behavior for true same-owner churn while ensuring display changes and hourly-only OpenCodex updates invalidate.

*Verified:* `swiftformat` + `swiftlint --strict` clean. Gatekeeper anchors: no new provider clusters, only widened predicate + revision.