### PR TITLE
feat(spend): add tokscale-compatible local readers for Cursor and Antigravity

### DIFF
--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -426,25 +426,41 @@ public struct CostUsageFetcher: Sendable {
 
         let clampedHistoryDays = max(1, min(365, historyDays))
 
-        if let remoteSnapshot = try await self.loadRemoteTokenSnapshot(
-            provider: provider,
-            environment: environment,
-            now: now,
-            historyDays: clampedHistoryDays,
-            cursorCookieHeaderOverride: cursorCookieHeaderOverride)
-        {
+        var remoteSnapshot: CostUsageTokenSnapshot? = nil
+        var remoteError: Error? = nil
+        do {
+            remoteSnapshot = try await self.loadRemoteTokenSnapshot(
+                provider: provider,
+                environment: environment,
+                now: now,
+                historyDays: clampedHistoryDays,
+                cursorCookieHeaderOverride: cursorCookieHeaderOverride)
+        } catch {
+            if provider != .cursor {
+                throw error
+            }
+            remoteError = error
+        }
+        if let remoteSnapshot {
             return remoteSnapshot
         }
 
         // Provider-specific by design: Cursor local CSV is an offline fallback for the remote dashboard API.
+        let fallbackCalendar = Self.resolvedScannerOptions(
+            overrideScannerOptions,
+            provider: provider,
+            codexHomePath: codexHomePath).calendar
         if provider == .cursor, let local = await self.loadCursorLocalSnapshot(
-            now: now, historyDays: clampedHistoryDays)
+            now: now, historyDays: clampedHistoryDays, calendar: fallbackCalendar)
         {
             return local
         }
+        if let remoteError {
+            throw remoteError
+        }
         // Provider-specific by design: Antigravity local cache (tokscale) supplements the quota-only probe.
         if provider == .antigravity, let local = await self.loadAntigravityLocalSnapshot(
-            now: now, historyDays: clampedHistoryDays)
+            now: now, historyDays: clampedHistoryDays, calendar: fallbackCalendar)
         {
             return local
         }
@@ -1134,7 +1150,7 @@ public struct CostUsageFetcher: Sendable {
     }
     #endif
 
-    private static func loadCursorLocalSnapshot(now: Date, historyDays: Int) async -> CostUsageTokenSnapshot? {
+    private static func loadCursorLocalSnapshot(now: Date, historyDays: Int, calendar: Calendar = .current) async -> CostUsageTokenSnapshot? {
         let paths = CursorLocalCSVReader.cachedCSVPaths()
         guard !paths.isEmpty else { return nil }
         var allRows: [CursorLocalCSVReader.Row] = []
@@ -1142,13 +1158,20 @@ public struct CostUsageFetcher: Sendable {
             allRows.append(contentsOf: CursorLocalCSVReader.parseFile(at: url))
         }
         guard !allRows.isEmpty else { return nil }
-        let full = CursorLocalCSVReader.makeDailyReport(from: allRows, now: now)
-        let cal = Calendar.current
+        let full = CursorLocalCSVReader.makeDailyReport(from: allRows, now: now, calendar: calendar)
+        let cal = calendar
         let since = cal.date(byAdding: .day, value: -(historyDays - 1), to: cal.startOfDay(for: now)) ?? now
         let sinceKey = CostUsageLocalDay.key(from: since, calendar: cal)
         let nowKey = CostUsageLocalDay.key(from: now, calendar: cal)
         let filtered = full.data.filter { $0.date >= sinceKey && $0.date <= nowKey }
-        let daily = CostUsageDailyReport(data: filtered, summary: full.summary)
+        let filteredSummary: CostUsageDailyReport.Summary? = {
+            guard !filtered.isEmpty else { return nil }
+            let costValues = filtered.compactMap(\.costUSD)
+            let totalCost: Double? = costValues.isEmpty ? nil : costValues.reduce(0, +)
+            let totalTokens = filtered.compactMap(\.totalTokens).reduce(0, +)
+            return .init(totalInputTokens: nil, totalOutputTokens: nil, totalTokens: totalTokens, totalCostUSD: totalCost)
+        }()
+        let daily = CostUsageDailyReport(data: filtered, summary: filteredSummary)
         return Self.tokenSnapshot(
             from: daily,
             now: now,
@@ -1157,21 +1180,28 @@ public struct CostUsageFetcher: Sendable {
             costProvenance: .listPriceEstimate)
     }
 
-    private static func loadAntigravityLocalSnapshot(now: Date, historyDays: Int) async -> CostUsageTokenSnapshot? {
-        let report = AntigravityLocalReader.makeDailyReport()
+    private static func loadAntigravityLocalSnapshot(now: Date, historyDays: Int, calendar: Calendar = .current) async -> CostUsageTokenSnapshot? {
+        let cal = calendar
+        let report = AntigravityLocalReader.makeDailyReport(calendar: cal)
         guard !report.data.isEmpty else { return nil }
-        let cal = Calendar.current
         let since = cal.date(byAdding: .day, value: -(historyDays - 1), to: cal.startOfDay(for: now)) ?? now
         let sinceKey = CostUsageLocalDay.key(from: since, calendar: cal)
         let nowKey = CostUsageLocalDay.key(from: now, calendar: cal)
         let filtered = report.data.filter { $0.date >= sinceKey && $0.date <= nowKey }
-        let daily = CostUsageDailyReport(data: filtered, summary: report.summary)
+        let filteredSummary: CostUsageDailyReport.Summary? = {
+            guard !filtered.isEmpty else { return nil }
+            let costValues = filtered.compactMap(\.costUSD)
+            let totalCost: Double? = costValues.isEmpty ? nil : costValues.reduce(0, +)
+            let totalTokens = filtered.compactMap(\.totalTokens).reduce(0, +)
+            return .init(totalInputTokens: nil, totalOutputTokens: nil, totalTokens: totalTokens, totalCostUSD: totalCost)
+        }()
+        let daily = CostUsageDailyReport(data: filtered, summary: filteredSummary)
         return Self.tokenSnapshot(
             from: daily,
             now: now,
             historyDays: historyDays,
             useCurrentLocalDayForSession: true,
-            costProvenance: .listPriceEstimate)
+            costProvenance: .unknown)
     }
 
     static func tokenSnapshot(

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -1153,8 +1153,8 @@ public struct CostUsageFetcher: Sendable {
     private static func loadCursorLocalSnapshot(
         now: Date,
         historyDays: Int,
-        calendar: Calendar = .current
-    ) async -> CostUsageTokenSnapshot? {
+        calendar: Calendar = .current) async -> CostUsageTokenSnapshot?
+    {
         let paths = CursorLocalCSVReader.cachedCSVPaths()
         guard !paths.isEmpty else { return nil }
         var allRows: [CursorLocalCSVReader.Row] = []
@@ -1192,8 +1192,8 @@ public struct CostUsageFetcher: Sendable {
     private static func loadAntigravityLocalSnapshot(
         now: Date,
         historyDays: Int,
-        calendar: Calendar = .current
-    ) async -> CostUsageTokenSnapshot? {
+        calendar: Calendar = .current) async -> CostUsageTokenSnapshot?
+    {
         let cal = calendar
         let report = AntigravityLocalReader.makeDailyReport(calendar: cal)
         guard !report.data.isEmpty else { return nil }

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 public enum CostUsageError: LocalizedError, Sendable {
@@ -433,6 +434,19 @@ public struct CostUsageFetcher: Sendable {
             cursorCookieHeaderOverride: cursorCookieHeaderOverride)
         {
             return remoteSnapshot
+        }
+
+        // Provider-specific by design: Cursor local CSV is an offline fallback for the remote dashboard API.
+        if provider == .cursor, let local = await self.loadCursorLocalSnapshot(
+            now: now, historyDays: clampedHistoryDays)
+        {
+            return local
+        }
+        // Provider-specific by design: Antigravity local cache (tokscale) supplements the quota-only probe.
+        if provider == .antigravity, let local = await self.loadAntigravityLocalSnapshot(
+            now: now, historyDays: clampedHistoryDays)
+        {
+            return local
         }
 
         var options = Self.resolvedScannerOptions(
@@ -1119,6 +1133,46 @@ public struct CostUsageFetcher: Sendable {
             credentialScopeFingerprint: report.credentialScopeFingerprint)
     }
     #endif
+
+    private static func loadCursorLocalSnapshot(now: Date, historyDays: Int) async -> CostUsageTokenSnapshot? {
+        let paths = CursorLocalCSVReader.cachedCSVPaths()
+        guard !paths.isEmpty else { return nil }
+        var allRows: [CursorLocalCSVReader.Row] = []
+        for url in paths {
+            allRows.append(contentsOf: CursorLocalCSVReader.parseFile(at: url))
+        }
+        guard !allRows.isEmpty else { return nil }
+        let full = CursorLocalCSVReader.makeDailyReport(from: allRows, now: now)
+        let cal = Calendar.current
+        let since = cal.date(byAdding: .day, value: -(historyDays - 1), to: cal.startOfDay(for: now)) ?? now
+        let sinceKey = CostUsageLocalDay.key(from: since, calendar: cal)
+        let nowKey = CostUsageLocalDay.key(from: now, calendar: cal)
+        let filtered = full.data.filter { $0.date >= sinceKey && $0.date <= nowKey }
+        let daily = CostUsageDailyReport(data: filtered, summary: full.summary)
+        return Self.tokenSnapshot(
+            from: daily,
+            now: now,
+            historyDays: historyDays,
+            useCurrentLocalDayForSession: true,
+            costProvenance: .listPriceEstimate)
+    }
+
+    private static func loadAntigravityLocalSnapshot(now: Date, historyDays: Int) async -> CostUsageTokenSnapshot? {
+        let report = AntigravityLocalReader.makeDailyReport()
+        guard !report.data.isEmpty else { return nil }
+        let cal = Calendar.current
+        let since = cal.date(byAdding: .day, value: -(historyDays - 1), to: cal.startOfDay(for: now)) ?? now
+        let sinceKey = CostUsageLocalDay.key(from: since, calendar: cal)
+        let nowKey = CostUsageLocalDay.key(from: now, calendar: cal)
+        let filtered = report.data.filter { $0.date >= sinceKey && $0.date <= nowKey }
+        let daily = CostUsageDailyReport(data: filtered, summary: report.summary)
+        return Self.tokenSnapshot(
+            from: daily,
+            now: now,
+            historyDays: historyDays,
+            useCurrentLocalDayForSession: true,
+            costProvenance: .listPriceEstimate)
+    }
 
     static func tokenSnapshot(
         from daily: CostUsageDailyReport,

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -1168,24 +1168,22 @@ public struct CostUsageFetcher: Sendable {
         let sinceKey = CostUsageLocalDay.key(from: since, calendar: cal)
         let nowKey = CostUsageLocalDay.key(from: now, calendar: cal)
         let filtered = full.data.filter { $0.date >= sinceKey && $0.date <= nowKey }
-        let filteredSummary: CostUsageDailyReport.Summary? = {
-            guard !filtered.isEmpty else { return nil }
-            let costValues = filtered.compactMap(\.costUSD)
-            let totalCost: Double? = costValues.isEmpty ? nil : costValues.reduce(0, +)
-            let totalTokens = filtered.compactMap(\.totalTokens).reduce(0, +)
-            return .init(
-                totalInputTokens: nil,
-                totalOutputTokens: nil,
-                totalTokens: totalTokens,
-                totalCostUSD: totalCost)
-
-        }()
+        guard !filtered.isEmpty else { return nil }
+        let costValues = filtered.compactMap(\.costUSD)
+        let totalCost: Double? = costValues.isEmpty ? nil : costValues.reduce(0, +)
+        let totalTokens = filtered.compactMap(\.totalTokens).reduce(0, +)
+        let filteredSummary: CostUsageDailyReport.Summary = .init(
+            totalInputTokens: nil,
+            totalOutputTokens: nil,
+            totalTokens: totalTokens,
+            totalCostUSD: totalCost)
         let daily = CostUsageDailyReport(data: filtered, summary: filteredSummary)
         return Self.tokenSnapshot(
             from: daily,
             now: now,
             historyDays: historyDays,
             useCurrentLocalDayForSession: true,
+            calendar: cal,
             costProvenance: .listPriceEstimate)
     }
 
@@ -1201,24 +1199,22 @@ public struct CostUsageFetcher: Sendable {
         let sinceKey = CostUsageLocalDay.key(from: since, calendar: cal)
         let nowKey = CostUsageLocalDay.key(from: now, calendar: cal)
         let filtered = report.data.filter { $0.date >= sinceKey && $0.date <= nowKey }
-        let filteredSummary: CostUsageDailyReport.Summary? = {
-            guard !filtered.isEmpty else { return nil }
-            let costValues = filtered.compactMap(\.costUSD)
-            let totalCost: Double? = costValues.isEmpty ? nil : costValues.reduce(0, +)
-            let totalTokens = filtered.compactMap(\.totalTokens).reduce(0, +)
-            return .init(
-                totalInputTokens: nil,
-                totalOutputTokens: nil,
-                totalTokens: totalTokens,
-                totalCostUSD: totalCost)
-
-        }()
+        guard !filtered.isEmpty else { return nil }
+        let costValues = filtered.compactMap(\.costUSD)
+        let totalCost: Double? = costValues.isEmpty ? nil : costValues.reduce(0, +)
+        let totalTokens = filtered.compactMap(\.totalTokens).reduce(0, +)
+        let filteredSummary: CostUsageDailyReport.Summary = .init(
+            totalInputTokens: nil,
+            totalOutputTokens: nil,
+            totalTokens: totalTokens,
+            totalCostUSD: totalCost)
         let daily = CostUsageDailyReport(data: filtered, summary: filteredSummary)
         return Self.tokenSnapshot(
             from: daily,
             now: now,
             historyDays: historyDays,
             useCurrentLocalDayForSession: true,
+            calendar: cal,
             costProvenance: .unknown)
     }
 

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -426,8 +426,8 @@ public struct CostUsageFetcher: Sendable {
 
         let clampedHistoryDays = max(1, min(365, historyDays))
 
-        var remoteSnapshot: CostUsageTokenSnapshot? = nil
-        var remoteError: Error? = nil
+        var remoteSnapshot: CostUsageTokenSnapshot?
+        var remoteError: Error?
         do {
             remoteSnapshot = try await self.loadRemoteTokenSnapshot(
                 provider: provider,
@@ -1150,7 +1150,11 @@ public struct CostUsageFetcher: Sendable {
     }
     #endif
 
-    private static func loadCursorLocalSnapshot(now: Date, historyDays: Int, calendar: Calendar = .current) async -> CostUsageTokenSnapshot? {
+    private static func loadCursorLocalSnapshot(
+        now: Date,
+        historyDays: Int,
+        calendar: Calendar = .current
+    ) async -> CostUsageTokenSnapshot? {
         let paths = CursorLocalCSVReader.cachedCSVPaths()
         guard !paths.isEmpty else { return nil }
         var allRows: [CursorLocalCSVReader.Row] = []
@@ -1158,7 +1162,7 @@ public struct CostUsageFetcher: Sendable {
             allRows.append(contentsOf: CursorLocalCSVReader.parseFile(at: url))
         }
         guard !allRows.isEmpty else { return nil }
-        let full = CursorLocalCSVReader.makeDailyReport(from: allRows, now: now, calendar: calendar)
+        let full = CursorLocalCSVReader.makeDailyReport(from: allRows, calendar: calendar, now: now)
         let cal = calendar
         let since = cal.date(byAdding: .day, value: -(historyDays - 1), to: cal.startOfDay(for: now)) ?? now
         let sinceKey = CostUsageLocalDay.key(from: since, calendar: cal)
@@ -1169,7 +1173,12 @@ public struct CostUsageFetcher: Sendable {
             let costValues = filtered.compactMap(\.costUSD)
             let totalCost: Double? = costValues.isEmpty ? nil : costValues.reduce(0, +)
             let totalTokens = filtered.compactMap(\.totalTokens).reduce(0, +)
-            return .init(totalInputTokens: nil, totalOutputTokens: nil, totalTokens: totalTokens, totalCostUSD: totalCost)
+            return .init(
+                totalInputTokens: nil,
+                totalOutputTokens: nil,
+                totalTokens: totalTokens,
+                totalCostUSD: totalCost)
+
         }()
         let daily = CostUsageDailyReport(data: filtered, summary: filteredSummary)
         return Self.tokenSnapshot(
@@ -1180,7 +1189,11 @@ public struct CostUsageFetcher: Sendable {
             costProvenance: .listPriceEstimate)
     }
 
-    private static func loadAntigravityLocalSnapshot(now: Date, historyDays: Int, calendar: Calendar = .current) async -> CostUsageTokenSnapshot? {
+    private static func loadAntigravityLocalSnapshot(
+        now: Date,
+        historyDays: Int,
+        calendar: Calendar = .current
+    ) async -> CostUsageTokenSnapshot? {
         let cal = calendar
         let report = AntigravityLocalReader.makeDailyReport(calendar: cal)
         guard !report.data.isEmpty else { return nil }
@@ -1193,7 +1206,12 @@ public struct CostUsageFetcher: Sendable {
             let costValues = filtered.compactMap(\.costUSD)
             let totalCost: Double? = costValues.isEmpty ? nil : costValues.reduce(0, +)
             let totalTokens = filtered.compactMap(\.totalTokens).reduce(0, +)
-            return .init(totalInputTokens: nil, totalOutputTokens: nil, totalTokens: totalTokens, totalCostUSD: totalCost)
+            return .init(
+                totalInputTokens: nil,
+                totalOutputTokens: nil,
+                totalTokens: totalTokens,
+                totalCostUSD: totalCost)
+
         }()
         let daily = CostUsageDailyReport(data: filtered, summary: filteredSummary)
         return Self.tokenSnapshot(

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -428,6 +428,7 @@ public struct CostUsageFetcher: Sendable {
 
         var remoteSnapshot: CostUsageTokenSnapshot?
         var remoteError: Error?
+        // Provider-specific by design: Cursor may fall back to local CSV when its remote dashboard is unavailable.
         do {
             remoteSnapshot = try await self.loadRemoteTokenSnapshot(
                 provider: provider,
@@ -445,7 +446,7 @@ public struct CostUsageFetcher: Sendable {
             return remoteSnapshot
         }
 
-        // Provider-specific by design: Cursor local CSV is an offline fallback for the remote dashboard API.
+        // Provider-specific by design: Cursor and Antigravity local readers backfill providers without remote history.
         let fallbackCalendar = Self.resolvedScannerOptions(
             overrideScannerOptions,
             provider: provider,
@@ -458,7 +459,6 @@ public struct CostUsageFetcher: Sendable {
         if let remoteError {
             throw remoteError
         }
-        // Provider-specific by design: Antigravity local cache (tokscale) supplements the quota-only probe.
         if provider == .antigravity, let local = await self.loadAntigravityLocalSnapshot(
             now: now, historyDays: clampedHistoryDays, calendar: fallbackCalendar)
         {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalReader.swift
@@ -36,9 +36,9 @@ enum AntigravityLocalReader {
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
     }
 
-    static func parseJSONLCache() -> [CostUsageDailyReport.Entry] {
+    static func parseJSONLCache(paths: [URL]? = nil) -> [CostUsageDailyReport.Entry] {
         var entries: [CostUsageDailyReport.Entry] = []
-        for url in self.tokiCachePaths() {
+        for url in paths ?? self.tokiCachePaths() {
             guard let data = try? Data(contentsOf: url),
                   let text = String(data: data, encoding: .utf8) else { continue }
             var sessionModel: String?
@@ -66,24 +66,37 @@ enum AntigravityLocalReader {
                     if let idx = entries.firstIndex(where: { $0.date == date }) {
                         var e = entries[idx]
                         let ne = CostUsageDailyReport.Entry(
-                            date: e.date, inputTokens: (e.inputTokens ?? 0) + input,
+                            date: e.date,
+                            inputTokens: (e.inputTokens ?? 0) + input,
                             outputTokens: (e.outputTokens ?? 0) + output,
                             cacheReadTokens: (e.cacheReadTokens ?? 0) + read,
                             cacheCreationTokens: (e.cacheCreationTokens ?? 0) + write,
                             reasoningTokens: (e.reasoningTokens ?? 0) + reason,
                             totalTokens: (e.totalTokens ?? 0) + total,
-                            requestCount: (e.requestCount ?? 0) + 1, costUSD: e.costUSD ?? 0,
+                            requestCount: (e.requestCount ?? 0) + 1,
+                            costUSD: e.costUSD ?? 0,
                             modelsUsed: nil,
                             modelBreakdowns: self.mergeBreakdown(e.modelBreakdowns, model: modelId, tokens: total))
                         entries[idx] = ne
                     } else {
                         let e = CostUsageDailyReport.Entry(
-                            date: date, inputTokens: input, outputTokens: output,
-                            cacheReadTokens: read, cacheCreationTokens: write,
-                            reasoningTokens: reason, totalTokens: total, requestCount: 1,
-                            costUSD: 0, modelsUsed: nil,
-                            modelBreakdowns: [CostUsageDailyReport.ModelBreakdown(
-                                modelName: modelId, costUSD: 0, totalTokens: total, requestCount: 1)])
+                            date: date,
+                            inputTokens: input,
+                            outputTokens: output,
+                            cacheReadTokens: read,
+                            cacheCreationTokens: write,
+                            reasoningTokens: reason,
+                            totalTokens: total,
+                            requestCount: 1,
+                            costUSD: 0,
+                            modelsUsed: nil,
+                            modelBreakdowns: [
+                                CostUsageDailyReport.ModelBreakdown(
+                                    modelName: modelId,
+                                    costUSD: 0,
+                                    totalTokens: total,
+                                    requestCount: 1),
+                            ])
                         entries.append(e)
                     }
                 }
@@ -101,23 +114,30 @@ enum AntigravityLocalReader {
         for e in self.parseJSONLCache() + self.parseCLIDBs() {
             if var ex = merged[e.date] {
                 let ne = CostUsageDailyReport.Entry(
-                    date: ex.date, inputTokens: (ex.inputTokens ?? 0) + (e.inputTokens ?? 0),
+                    date: ex.date,
+                    inputTokens: (ex.inputTokens ?? 0) + (e.inputTokens ?? 0),
                     outputTokens: (ex.outputTokens ?? 0) + (e.outputTokens ?? 0),
                     cacheReadTokens: (ex.cacheReadTokens ?? 0) + (e.cacheReadTokens ?? 0),
                     cacheCreationTokens: (ex.cacheCreationTokens ?? 0) + (e.cacheCreationTokens ?? 0),
                     reasoningTokens: (ex.reasoningTokens ?? 0) + (e.reasoningTokens ?? 0),
                     totalTokens: (ex.totalTokens ?? 0) + (e.totalTokens ?? 0),
                     requestCount: (ex.requestCount ?? 0) + (e.requestCount ?? 0),
-                    costUSD: (ex.costUSD ?? 0) + (e.costUSD ?? 0), modelsUsed: nil,
+                    costUSD: (ex.costUSD ?? 0) + (e.costUSD ?? 0),
+                    modelsUsed: nil,
                     modelBreakdowns: self.mergeBreakdowns(ex.modelBreakdowns, e.modelBreakdowns))
                 merged[e.date] = ne
-            } else { merged[e.date] = e }
+            } else {
+                merged[e.date] = e
+            }
         }
         let sorted = merged.values.sorted { $0.date < $1.date }
         let totalCost = sorted.compactMap(\.costUSD).reduce(0, +)
         let totalTokens = sorted.compactMap(\.totalTokens).reduce(0, +)
         let summary: CostUsageDailyReport.Summary? = sorted.isEmpty ? nil : .init(
-            totalInputTokens: nil, totalOutputTokens: nil, totalTokens: totalTokens, totalCostUSD: totalCost)
+            totalInputTokens: nil,
+            totalOutputTokens: nil,
+            totalTokens: totalTokens,
+            totalCostUSD: totalCost)
         return CostUsageDailyReport(data: sorted, summary: summary)
     }
 
@@ -130,18 +150,24 @@ enum AntigravityLocalReader {
     }
 
     private static func mergeBreakdown(
-        _ ex: [CostUsageDailyReport.ModelBreakdown]?, model: String,
+        _ ex: [CostUsageDailyReport.ModelBreakdown]?,
+        model: String,
         tokens: Int) -> [CostUsageDailyReport.ModelBreakdown]
     {
         var arr = ex ?? []
         if let i = arr.firstIndex(where: { $0.modelName == model }) {
             let b = arr[i]
             arr[i] = CostUsageDailyReport.ModelBreakdown(
-                modelName: b.modelName, costUSD: b.costUSD ?? 0,
-                totalTokens: (b.totalTokens ?? 0) + tokens, requestCount: (b.requestCount ?? 0) + 1)
+                modelName: b.modelName,
+                costUSD: b.costUSD ?? 0,
+                totalTokens: (b.totalTokens ?? 0) + tokens,
+                requestCount: (b.requestCount ?? 0) + 1)
         } else {
             arr.append(CostUsageDailyReport.ModelBreakdown(
-                modelName: model, costUSD: 0, totalTokens: tokens, requestCount: 1))
+                modelName: model,
+                costUSD: 0,
+                totalTokens: tokens,
+                requestCount: 1))
         }
         return arr
     }
@@ -154,11 +180,14 @@ enum AntigravityLocalReader {
         for m in (a ?? []) + (b ?? []) {
             if var ex = d[m.modelName] {
                 ex = CostUsageDailyReport.ModelBreakdown(
-                    modelName: ex.modelName, costUSD: (ex.costUSD ?? 0) + (m.costUSD ?? 0),
+                    modelName: ex.modelName,
+                    costUSD: (ex.costUSD ?? 0) + (m.costUSD ?? 0),
                     totalTokens: (ex.totalTokens ?? 0) + (m.totalTokens ?? 0),
                     requestCount: (ex.requestCount ?? 0) + (m.requestCount ?? 0))
                 d[m.modelName] = ex
-            } else { d[m.modelName] = m }
+            } else {
+                d[m.modelName] = m
+            }
         }
         return d.isEmpty ? nil : Array(d.values)
     }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalReader.swift
@@ -36,8 +36,9 @@ enum AntigravityLocalReader {
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
     }
 
-    static func parseJSONLCache(paths: [URL]? = nil) -> [CostUsageDailyReport.Entry] {
+    static func parseJSONLCache(paths: [URL]? = nil, calendar: Calendar = .current) -> [CostUsageDailyReport.Entry] {
         var entries: [CostUsageDailyReport.Entry] = []
+        var seenResponseIds = Set<String>()
         for url in paths ?? self.tokiCachePaths() {
             guard let data = try? Data(contentsOf: url),
                   let text = String(data: data, encoding: .utf8) else { continue }
@@ -52,6 +53,10 @@ enum AntigravityLocalReader {
                     continue
                 }
                 if type == "usage" || json["input"] != nil {
+                    if let rid = (json["responseId"] as? String ?? json["response_id"] as? String), !rid.isEmpty {
+                        if seenResponseIds.contains(rid) { continue }
+                        seenResponseIds.insert(rid)
+                    }
                     let modelId =
                         (json["modelId"] as? String ?? json["model_id"] as? String ?? sessionModel ?? "unknown")
                     let input = (json["input"] as? Int) ?? 0
@@ -60,7 +65,7 @@ enum AntigravityLocalReader {
                     let write = (json["cacheWrite"] as? Int) ?? (json["cache_write"] as? Int) ?? 0
                     let reason = (json["reasoning"] as? Int) ?? 0
                     let ts = (json["timestamp"] as? Int64) ?? (json["timestamp"] as? Int).map(Int64.init) ?? 0
-                    let date = self.timestampToDayKey(ts)
+                    let date = self.timestampToDayKey(ts, calendar: calendar)
                     let total = input + output + read + write
                     if total == 0 { continue }
                     if let idx = entries.firstIndex(where: { $0.date == date }) {
@@ -74,7 +79,7 @@ enum AntigravityLocalReader {
                             reasoningTokens: (e.reasoningTokens ?? 0) + reason,
                             totalTokens: (e.totalTokens ?? 0) + total,
                             requestCount: (e.requestCount ?? 0) + 1,
-                            costUSD: e.costUSD ?? 0,
+                            costUSD: e.costUSD,
                             modelsUsed: nil,
                             modelBreakdowns: self.mergeBreakdown(e.modelBreakdowns, model: modelId, tokens: total))
                         entries[idx] = ne
@@ -88,12 +93,12 @@ enum AntigravityLocalReader {
                             reasoningTokens: reason,
                             totalTokens: total,
                             requestCount: 1,
-                            costUSD: 0,
+                            costUSD: nil,
                             modelsUsed: nil,
                             modelBreakdowns: [
                                 CostUsageDailyReport.ModelBreakdown(
                                     modelName: modelId,
-                                    costUSD: 0,
+                                    costUSD: nil,
                                     totalTokens: total,
                                     requestCount: 1),
                             ])
@@ -109,10 +114,14 @@ enum AntigravityLocalReader {
         []
     }
 
-    static func makeDailyReport() -> CostUsageDailyReport {
+    static func makeDailyReport(calendar: Calendar = .current) -> CostUsageDailyReport {
         var merged: [String: CostUsageDailyReport.Entry] = [:]
-        for e in self.parseJSONLCache() + self.parseCLIDBs() {
+        for e in self.parseJSONLCache(calendar: calendar) + self.parseCLIDBs() {
             if var ex = merged[e.date] {
+                let mergedCost: Double? = {
+                    if ex.costUSD == nil && e.costUSD == nil { return nil }
+                    return (ex.costUSD ?? 0) + (e.costUSD ?? 0)
+                }()
                 let ne = CostUsageDailyReport.Entry(
                     date: ex.date,
                     inputTokens: (ex.inputTokens ?? 0) + (e.inputTokens ?? 0),
@@ -122,7 +131,7 @@ enum AntigravityLocalReader {
                     reasoningTokens: (ex.reasoningTokens ?? 0) + (e.reasoningTokens ?? 0),
                     totalTokens: (ex.totalTokens ?? 0) + (e.totalTokens ?? 0),
                     requestCount: (ex.requestCount ?? 0) + (e.requestCount ?? 0),
-                    costUSD: (ex.costUSD ?? 0) + (e.costUSD ?? 0),
+                    costUSD: mergedCost,
                     modelsUsed: nil,
                     modelBreakdowns: self.mergeBreakdowns(ex.modelBreakdowns, e.modelBreakdowns))
                 merged[e.date] = ne
@@ -131,7 +140,8 @@ enum AntigravityLocalReader {
             }
         }
         let sorted = merged.values.sorted { $0.date < $1.date }
-        let totalCost = sorted.compactMap(\.costUSD).reduce(0, +)
+        let costValues = sorted.compactMap(\.costUSD)
+        let totalCost: Double? = costValues.isEmpty ? nil : costValues.reduce(0, +)
         let totalTokens = sorted.compactMap(\.totalTokens).reduce(0, +)
         let summary: CostUsageDailyReport.Summary? = sorted.isEmpty ? nil : .init(
             totalInputTokens: nil,
@@ -141,10 +151,10 @@ enum AntigravityLocalReader {
         return CostUsageDailyReport(data: sorted, summary: summary)
     }
 
-    private static func timestampToDayKey(_ ms: Int64) -> String {
+    private static func timestampToDayKey(_ ms: Int64, calendar: Calendar = .current) -> String {
         let sec = Double(ms) / 1000.0
         let date = Date(timeIntervalSince1970: sec)
-        let c = Calendar.current
+        let c = calendar
         let comps = c.dateComponents([.year, .month, .day], from: date)
         return String(format: "%04d-%02d-%02d", comps.year ?? 1970, comps.month ?? 1, comps.day ?? 1)
     }
@@ -159,13 +169,13 @@ enum AntigravityLocalReader {
             let b = arr[i]
             arr[i] = CostUsageDailyReport.ModelBreakdown(
                 modelName: b.modelName,
-                costUSD: b.costUSD ?? 0,
+                costUSD: b.costUSD,
                 totalTokens: (b.totalTokens ?? 0) + tokens,
                 requestCount: (b.requestCount ?? 0) + 1)
         } else {
             arr.append(CostUsageDailyReport.ModelBreakdown(
                 modelName: model,
-                costUSD: 0,
+                costUSD: nil,
                 totalTokens: tokens,
                 requestCount: 1))
         }
@@ -179,9 +189,13 @@ enum AntigravityLocalReader {
         var d: [String: CostUsageDailyReport.ModelBreakdown] = [:]
         for m in (a ?? []) + (b ?? []) {
             if var ex = d[m.modelName] {
+                let mergedCost: Double? = {
+                    if ex.costUSD == nil && m.costUSD == nil { return nil }
+                    return (ex.costUSD ?? 0) + (m.costUSD ?? 0)
+                }()
                 ex = CostUsageDailyReport.ModelBreakdown(
                     modelName: ex.modelName,
-                    costUSD: (ex.costUSD ?? 0) + (m.costUSD ?? 0),
+                    costUSD: mergedCost,
                     totalTokens: (ex.totalTokens ?? 0) + (m.totalTokens ?? 0),
                     requestCount: (ex.requestCount ?? 0) + (m.requestCount ?? 0))
                 d[m.modelName] = ex

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalReader.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+// MARK: - Antigravity Local Reader (tokscale compatible)
+
+enum AntigravityLocalReader {
+    static func tokiCachePaths(home: URL? = nil) -> [URL] {
+        let base: URL = if let home {
+            home.appendingPathComponent(".config/tokscale/antigravity-cache/sessions", isDirectory: true)
+        } else if let dir = ProcessInfo.processInfo.environment["TOKSCALE_CONFIG_DIR"] {
+            URL(fileURLWithPath: dir).appendingPathComponent("antigravity-cache/sessions", isDirectory: true)
+        } else {
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".config/tokscale/antigravity-cache/sessions", isDirectory: true)
+        }
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: base, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else { return [] }
+        return contents.filter { $0.pathExtension == "jsonl" }.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    static func cliDBPaths(home: URL? = nil) -> [URL] {
+        let base: URL = if let env = ProcessInfo.processInfo.environment["GEMINI_CLI_HOME"], !env.isEmpty {
+            URL(fileURLWithPath: env).appendingPathComponent("antigravity-cli/conversations", isDirectory: true)
+        } else if let home {
+            home.appendingPathComponent(".gemini/antigravity-cli/conversations", isDirectory: true)
+        } else {
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".gemini/antigravity-cli/conversations", isDirectory: true)
+        }
+        guard let c = try? FileManager.default.contentsOfDirectory(
+            at: base, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else { return [] }
+        return c
+            .filter {
+                $0.pathExtension == "db" && !$0.lastPathComponent.hasSuffix("-wal") && !$0.lastPathComponent
+                    .hasSuffix("-shm")
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    static func parseJSONLCache() -> [CostUsageDailyReport.Entry] {
+        var entries: [CostUsageDailyReport.Entry] = []
+        for url in self.tokiCachePaths() {
+            guard let data = try? Data(contentsOf: url),
+                  let text = String(data: data, encoding: .utf8) else { continue }
+            var sessionModel: String?
+            for line in text.components(separatedBy: .newlines) {
+                let t = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !t.isEmpty, let d = t.data(using: .utf8),
+                      let json = try? JSONSerialization.jsonObject(with: d) as? [String: Any] else { continue }
+                let type = json["type"] as? String
+                if type == "session_meta" {
+                    sessionModel = json["modelId"] as? String ?? json["model_id"] as? String
+                    continue
+                }
+                if type == "usage" || json["input"] != nil {
+                    let modelId =
+                        (json["modelId"] as? String ?? json["model_id"] as? String ?? sessionModel ?? "unknown")
+                    let input = (json["input"] as? Int) ?? 0
+                    let output = (json["output"] as? Int) ?? 0
+                    let read = (json["cacheRead"] as? Int) ?? (json["cache_read"] as? Int) ?? 0
+                    let write = (json["cacheWrite"] as? Int) ?? (json["cache_write"] as? Int) ?? 0
+                    let reason = (json["reasoning"] as? Int) ?? 0
+                    let ts = (json["timestamp"] as? Int64) ?? (json["timestamp"] as? Int).map(Int64.init) ?? 0
+                    let date = self.timestampToDayKey(ts)
+                    let total = input + output + read + write
+                    if total == 0 { continue }
+                    if let idx = entries.firstIndex(where: { $0.date == date }) {
+                        var e = entries[idx]
+                        let ne = CostUsageDailyReport.Entry(
+                            date: e.date, inputTokens: (e.inputTokens ?? 0) + input,
+                            outputTokens: (e.outputTokens ?? 0) + output,
+                            cacheReadTokens: (e.cacheReadTokens ?? 0) + read,
+                            cacheCreationTokens: (e.cacheCreationTokens ?? 0) + write,
+                            reasoningTokens: (e.reasoningTokens ?? 0) + reason,
+                            totalTokens: (e.totalTokens ?? 0) + total,
+                            requestCount: (e.requestCount ?? 0) + 1, costUSD: e.costUSD ?? 0,
+                            modelsUsed: nil,
+                            modelBreakdowns: self.mergeBreakdown(e.modelBreakdowns, model: modelId, tokens: total))
+                        entries[idx] = ne
+                    } else {
+                        let e = CostUsageDailyReport.Entry(
+                            date: date, inputTokens: input, outputTokens: output,
+                            cacheReadTokens: read, cacheCreationTokens: write,
+                            reasoningTokens: reason, totalTokens: total, requestCount: 1,
+                            costUSD: 0, modelsUsed: nil,
+                            modelBreakdowns: [CostUsageDailyReport.ModelBreakdown(
+                                modelName: modelId, costUSD: 0, totalTokens: total, requestCount: 1)])
+                        entries.append(e)
+                    }
+                }
+            }
+        }
+        return entries.sorted { $0.date < $1.date }
+    }
+
+    static func parseCLIDBs() -> [CostUsageDailyReport.Entry] {
+        []
+    }
+
+    static func makeDailyReport() -> CostUsageDailyReport {
+        var merged: [String: CostUsageDailyReport.Entry] = [:]
+        for e in self.parseJSONLCache() + self.parseCLIDBs() {
+            if var ex = merged[e.date] {
+                let ne = CostUsageDailyReport.Entry(
+                    date: ex.date, inputTokens: (ex.inputTokens ?? 0) + (e.inputTokens ?? 0),
+                    outputTokens: (ex.outputTokens ?? 0) + (e.outputTokens ?? 0),
+                    cacheReadTokens: (ex.cacheReadTokens ?? 0) + (e.cacheReadTokens ?? 0),
+                    cacheCreationTokens: (ex.cacheCreationTokens ?? 0) + (e.cacheCreationTokens ?? 0),
+                    reasoningTokens: (ex.reasoningTokens ?? 0) + (e.reasoningTokens ?? 0),
+                    totalTokens: (ex.totalTokens ?? 0) + (e.totalTokens ?? 0),
+                    requestCount: (ex.requestCount ?? 0) + (e.requestCount ?? 0),
+                    costUSD: (ex.costUSD ?? 0) + (e.costUSD ?? 0), modelsUsed: nil,
+                    modelBreakdowns: self.mergeBreakdowns(ex.modelBreakdowns, e.modelBreakdowns))
+                merged[e.date] = ne
+            } else { merged[e.date] = e }
+        }
+        let sorted = merged.values.sorted { $0.date < $1.date }
+        let totalCost = sorted.compactMap(\.costUSD).reduce(0, +)
+        let totalTokens = sorted.compactMap(\.totalTokens).reduce(0, +)
+        let summary: CostUsageDailyReport.Summary? = sorted.isEmpty ? nil : .init(
+            totalInputTokens: nil, totalOutputTokens: nil, totalTokens: totalTokens, totalCostUSD: totalCost)
+        return CostUsageDailyReport(data: sorted, summary: summary)
+    }
+
+    private static func timestampToDayKey(_ ms: Int64) -> String {
+        let sec = Double(ms) / 1000.0
+        let date = Date(timeIntervalSince1970: sec)
+        let c = Calendar.current
+        let comps = c.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", comps.year ?? 1970, comps.month ?? 1, comps.day ?? 1)
+    }
+
+    private static func mergeBreakdown(
+        _ ex: [CostUsageDailyReport.ModelBreakdown]?, model: String,
+        tokens: Int) -> [CostUsageDailyReport.ModelBreakdown]
+    {
+        var arr = ex ?? []
+        if let i = arr.firstIndex(where: { $0.modelName == model }) {
+            let b = arr[i]
+            arr[i] = CostUsageDailyReport.ModelBreakdown(
+                modelName: b.modelName, costUSD: b.costUSD ?? 0,
+                totalTokens: (b.totalTokens ?? 0) + tokens, requestCount: (b.requestCount ?? 0) + 1)
+        } else {
+            arr.append(CostUsageDailyReport.ModelBreakdown(
+                modelName: model, costUSD: 0, totalTokens: tokens, requestCount: 1))
+        }
+        return arr
+    }
+
+    private static func mergeBreakdowns(
+        _ a: [CostUsageDailyReport.ModelBreakdown]?,
+        _ b: [CostUsageDailyReport.ModelBreakdown]?) -> [CostUsageDailyReport.ModelBreakdown]?
+    {
+        var d: [String: CostUsageDailyReport.ModelBreakdown] = [:]
+        for m in (a ?? []) + (b ?? []) {
+            if var ex = d[m.modelName] {
+                ex = CostUsageDailyReport.ModelBreakdown(
+                    modelName: ex.modelName, costUSD: (ex.costUSD ?? 0) + (m.costUSD ?? 0),
+                    totalTokens: (ex.totalTokens ?? 0) + (m.totalTokens ?? 0),
+                    requestCount: (ex.requestCount ?? 0) + (m.requestCount ?? 0))
+                d[m.modelName] = ex
+            } else { d[m.modelName] = m }
+        }
+        return d.isEmpty ? nil : Array(d.values)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalReader.swift
@@ -119,7 +119,7 @@ enum AntigravityLocalReader {
         for e in self.parseJSONLCache(calendar: calendar) + self.parseCLIDBs() {
             if var ex = merged[e.date] {
                 let mergedCost: Double? = {
-                    if ex.costUSD == nil && e.costUSD == nil { return nil }
+                    if ex.costUSD == nil, e.costUSD == nil { return nil }
                     return (ex.costUSD ?? 0) + (e.costUSD ?? 0)
                 }()
                 let ne = CostUsageDailyReport.Entry(
@@ -190,7 +190,7 @@ enum AntigravityLocalReader {
         for m in (a ?? []) + (b ?? []) {
             if var ex = d[m.modelName] {
                 let mergedCost: Double? = {
-                    if ex.costUSD == nil && m.costUSD == nil { return nil }
+                    if ex.costUSD == nil, m.costUSD == nil { return nil }
                     return (ex.costUSD ?? 0) + (m.costUSD ?? 0)
                 }()
                 ex = CostUsageDailyReport.ModelBreakdown(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -49,8 +49,9 @@ public enum AntigravityProviderDescriptor {
                     ProviderColor(hex: 0xFBBC04),
                 ]),
             tokenCost: ProviderTokenCostConfig(
-                supportsTokenCost: false,
-                noDataMessage: { "Antigravity cost summary is not supported." }),
+                supportsTokenCost: true,
+                noDataMessage: { "Antigravity cost summary is not supported." },
+                supportsTokenSnapshot: true),
             pace: ProviderPaceCapability(
                 sessionPaceWindowRule: .custom { window, _ in
                     window.windowMinutes == nil || window.windowMinutes == 300

--- a/Sources/CodexBarCore/Providers/Cursor/CursorLocalCSVReader.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorLocalCSVReader.swift
@@ -182,9 +182,11 @@ enum CursorLocalCSVReader {
             df.dateFormat = fmt
             if let d = df.date(from: t) {
                 if fmt == "yyyy-MM-dd" {
-                    var c = calendar.dateComponents([.year, .month, .day], from: d)
+                    var utcCal = Calendar(identifier: .gregorian)
+                    utcCal.timeZone = TimeZone(secondsFromGMT: 0)!
+                    var c = utcCal.dateComponents([.year, .month, .day], from: d)
                     c.hour = 12; c.minute = 0; c.second = 0; c.timeZone = TimeZone(secondsFromGMT: 0)
-                    return calendar.date(from: c) ?? d
+                    return utcCal.date(from: c) ?? d
                 }
                 return d
             }

--- a/Sources/CodexBarCore/Providers/Cursor/CursorLocalCSVReader.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorLocalCSVReader.swift
@@ -29,6 +29,7 @@ enum CursorLocalCSVReader {
         let cacheRead: Int
         let cacheWrite: Int
         let output: Int
+        let totalTokens: Int?
         let cost: Double
     }
 
@@ -58,6 +59,10 @@ enum CursorLocalCSVReader {
             let read = self.parseInt(c[idx.read])
             let out = self.parseInt(c[idx.out])
             let cost = self.parseCost(c[idx.cost])
+            // Parse the authoritative Total Tokens column if present.
+            let totalIdx = idx.cost - 1
+            let totalTokens = totalIdx < cols.count && totalIdx < c.count
+                && cols[totalIdx].lowercased().contains("total") ? self.parseInt(c[totalIdx]) : nil
             guard let date = parseDate(c[0], calendar: calendar) else { continue }
             let write = max(0, inW - inWo)
             let input = inWo
@@ -69,6 +74,7 @@ enum CursorLocalCSVReader {
                 cacheRead: read,
                 cacheWrite: write,
                 output: out,
+                totalTokens: totalTokens,
                 cost: cost))
         }
         return rows
@@ -96,7 +102,9 @@ enum CursorLocalCSVReader {
                 costUSD: 0,
                 modelsUsed: nil,
                 modelBreakdowns: [])
-            let tot = row.input + row.output + row.cacheRead + row.cacheWrite
+            // Honor the CSV's authoritative Total Tokens column when present;
+            // otherwise derive from component columns.
+            let tot = row.totalTokens ?? (row.input + row.output + row.cacheRead + row.cacheWrite)
             var bds = e.modelBreakdowns ?? []
             if let i = bds.firstIndex(where: { $0.modelName == row.model }) {
                 let b = bds[i]

--- a/Sources/CodexBarCore/Providers/Cursor/CursorLocalCSVReader.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorLocalCSVReader.swift
@@ -182,11 +182,19 @@ enum CursorLocalCSVReader {
             df.dateFormat = fmt
             if let d = df.date(from: t) {
                 if fmt == "yyyy-MM-dd" {
+                    // Keep date-only rows in the configured calendar's day (noon in that calendar),
+                    // so UTC+13/14 users don't see the row shifted to the next local day.
                     var utcCal = Calendar(identifier: .gregorian)
                     utcCal.timeZone = TimeZone(secondsFromGMT: 0)!
-                    var c = utcCal.dateComponents([.year, .month, .day], from: d)
-                    c.hour = 12; c.minute = 0; c.second = 0; c.timeZone = TimeZone(secondsFromGMT: 0)
-                    return utcCal.date(from: c) ?? d
+                    let utcComps = utcCal.dateComponents([.year, .month, .day], from: d)
+                    var targetComps = DateComponents()
+                    targetComps.year = utcComps.year
+                    targetComps.month = utcComps.month
+                    targetComps.day = utcComps.day
+                    targetComps.hour = 12
+                    targetComps.minute = 0
+                    targetComps.second = 0
+                    return calendar.date(from: targetComps) ?? d
                 }
                 return d
             }

--- a/Sources/CodexBarCore/Providers/Cursor/CursorLocalCSVReader.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorLocalCSVReader.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+// MARK: - Cursor Local CSV Reader (tokscale compatible)
+
+enum CursorLocalCSVReader {
+    static func cachedCSVPaths(home: URL? = nil) -> [URL] {
+        let base: URL = if let home {
+            home.appendingPathComponent(".config/tokscale/cursor-cache", isDirectory: true)
+        } else if let dir = ProcessInfo.processInfo.environment["TOKSCALE_CONFIG_DIR"] {
+            URL(fileURLWithPath: dir).appendingPathComponent("cursor-cache", isDirectory: true)
+        } else {
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".config/tokscale/cursor-cache", isDirectory: true)
+        }
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: base, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+        else { return [] }
+        return contents.filter {
+            let n = $0.lastPathComponent
+            return n.hasPrefix("usage") && n.hasSuffix(".csv") && !$0.path.contains("/archive/") && !n
+                .hasPrefix("usage.backup")
+        }.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    struct Row: Sendable {
+        let date: Date
+        let model: String
+        let input: Int
+        let cacheRead: Int
+        let cacheWrite: Int
+        let output: Int
+        let cost: Double
+    }
+
+    static func parseFile(at url: URL, calendar: Calendar = .current) -> [Row] {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else { return [] }
+        let lines = text.components(separatedBy: .newlines).filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        guard let header = lines.first else { return [] }
+        let cols = self.parseCSVLine(header)
+        let hasKind = cols.contains { $0.lowercased() == "kind" }
+        struct Idx { let model: Int; let inW: Int; let inWo: Int; let read: Int; let out: Int; let cost: Int }
+        let idx = if hasKind, cols.count >= 11 {
+            Idx(model: 4, inW: 6, inWo: 7, read: 8, out: 9, cost: 11)
+        } else if hasKind {
+            Idx(model: 2, inW: 4, inWo: 5, read: 6, out: 7, cost: 9)
+        } else {
+            Idx(model: 1, inW: 2, inWo: 3, read: 4, out: 5, cost: 7)
+        }
+        var rows: [Row] = []
+        for line in lines.dropFirst() {
+            let c = self.parseCSVLine(line)
+            guard c.count > max(idx.model, idx.cost) else { continue }
+            let model = c[idx.model].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !model.isEmpty else { continue }
+            let inW = self.parseInt(c[idx.inW])
+            let inWo = self.parseInt(c[idx.inWo])
+            let read = self.parseInt(c[idx.read])
+            let out = self.parseInt(c[idx.out])
+            let cost = self.parseCost(c[idx.cost])
+            guard let date = parseDate(c[0], calendar: calendar) else { continue }
+            let write = max(0, inW - inWo)
+            let input = inWo
+            if input == 0, out == 0, read == 0, write == 0 { continue }
+            rows.append(Row(
+                date: date,
+                model: model,
+                input: input,
+                cacheRead: read,
+                cacheWrite: write,
+                output: out,
+                cost: cost))
+        }
+        return rows
+    }
+
+    static func makeDailyReport(
+        from rows: [Row],
+        calendar: Calendar = .current,
+        now: Date = Date()) -> CostUsageDailyReport
+    {
+        var byDay: [String: CostUsageDailyReport.Entry] = [:]
+        var totalCost: Double = 0
+        var totalTokens = 0
+        for row in rows {
+            let key = CostUsageLocalDay.key(from: row.date, calendar: calendar)
+            let existing = byDay[key]
+            var e = existing ?? CostUsageDailyReport.Entry(
+                date: key,
+                inputTokens: 0,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                cacheCreationTokens: 0,
+                totalTokens: 0,
+                requestCount: 0,
+                costUSD: 0,
+                modelsUsed: nil,
+                modelBreakdowns: [])
+            let tot = row.input + row.output + row.cacheRead + row.cacheWrite
+            var bds = e.modelBreakdowns ?? []
+            if let i = bds.firstIndex(where: { $0.modelName == row.model }) {
+                let b = bds[i]
+                bds[i] = CostUsageDailyReport.ModelBreakdown(
+                    modelName: b.modelName,
+                    costUSD: (b.costUSD ?? 0) + row.cost,
+                    totalTokens: (b.totalTokens ?? 0) + tot,
+                    requestCount: (b.requestCount ?? 0) + 1)
+            } else {
+                bds.append(CostUsageDailyReport.ModelBreakdown(
+                    modelName: row.model,
+                    costUSD: row.cost,
+                    totalTokens: tot,
+                    requestCount: 1))
+            }
+            let ne = CostUsageDailyReport.Entry(
+                date: key,
+                inputTokens: (e.inputTokens ?? 0) + row.input,
+                outputTokens: (e.outputTokens ?? 0) + row.output,
+                cacheReadTokens: (e.cacheReadTokens ?? 0) + row.cacheRead,
+                cacheCreationTokens: (e.cacheCreationTokens ?? 0) + row.cacheWrite,
+                totalTokens: (e.totalTokens ?? 0) + tot,
+                requestCount: (e.requestCount ?? 0) + 1,
+                costUSD: (e.costUSD ?? 0) + row.cost,
+                modelsUsed: e.modelsUsed,
+                modelBreakdowns: bds)
+            byDay[key] = ne
+            totalCost += row.cost
+            totalTokens += tot
+        }
+        let sorted = byDay.values.sorted { $0.date < $1.date }
+        let summary: CostUsageDailyReport.Summary? = sorted.isEmpty ? nil : .init(
+            totalInputTokens: nil,
+            totalOutputTokens: nil,
+            totalTokens: totalTokens,
+            totalCostUSD: totalCost)
+        return CostUsageDailyReport(data: sorted, summary: summary)
+    }
+
+    static func parseCSVLine(_ line: String) -> [String] {
+        var cols: [String] = []
+        var cur = ""
+        var q = false
+        for ch in line {
+            if ch == "\"" { q.toggle() } else if ch == ",", !q {
+                cols.append(cur); cur = ""
+            } else { cur.append(ch) }
+        }
+        cols.append(cur)
+        return cols
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "\"\"", with: "\"") }
+    }
+
+    static func parseInt(_ s: String) -> Int {
+        Int(s.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: ",", with: "")) ?? 0
+    }
+
+    static func parseCost(_ s: String) -> Double {
+        let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        if t.isEmpty || t == "-" || t.lowercased() == "included" || t.lowercased() == "nan" { return 0 }
+        return Double(t.replacingOccurrences(of: "$", with: "").replacingOccurrences(of: ",", with: "")) ?? 0
+    }
+
+    static func parseDate(_ s: String, calendar: Calendar) -> Date? {
+        let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = iso.date(from: t) { return d }
+        iso.formatOptions = [.withInternetDateTime]
+        if let d = iso.date(from: t) { return d }
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone(secondsFromGMT: 0)
+        for fmt in ["yyyy-MM-dd'T'HH:mm:ss.SSS", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd"] {
+            df.dateFormat = fmt
+            if let d = df.date(from: t) {
+                if fmt == "yyyy-MM-dd" {
+                    var c = calendar.dateComponents([.year, .month, .day], from: d)
+                    c.hour = 12; c.minute = 0; c.second = 0; c.timeZone = TimeZone(secondsFromGMT: 0)
+                    return calendar.date(from: c) ?? d
+                }
+                return d
+            }
+        }
+        return nil
+    }
+}

--- a/Tests/CodexBarTests/CursorAntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/CursorAntigravityLocalReaderTests.swift
@@ -108,8 +108,8 @@ struct CursorAntigravityLocalReaderTests {
         let firstStamp = Int64(noon.timeIntervalSince1970 * 1000)
         let secondStamp = firstStamp + 3_600_000
         let jsonl = [
-            #"{"type":"session_meta","modelId":"test-model-antigravity-a"}"#,
-            #"{"type":"usage","modelId":"test-model-antigravity-a","input":100,"output":30,"cacheRead":50,"cacheWrite":10,"# +
+            #"{"type":"session_meta","modelId":"test-model-a"}"#,
+            #"{"type":"usage","modelId":"test-model-a","input":100,"output":30,"cacheRead":50,"cacheWrite":10,"# +
                 #""timestamp":\#(firstStamp)}"#,
             #"{"type":"usage","input":40,"output":10,"cacheRead":0,"cacheWrite":0,"timestamp":\#(secondStamp)}"#,
         ].joined(separator: "\n") + "\n"
@@ -125,7 +125,7 @@ struct CursorAntigravityLocalReaderTests {
         #expect(entry.requestCount == 2)
         // The second event omits `modelId` and falls back to the session_meta model.
         let breakdowns = try #require(entry.modelBreakdowns)
-        #expect(breakdowns.map(\.modelName) == ["test-model-antigravity-a"])
+        #expect(breakdowns.map(\.modelName) == ["test-model-a"])
         #expect(breakdowns.first?.requestCount == 2)
     }
 

--- a/Tests/CodexBarTests/CursorAntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/CursorAntigravityLocalReaderTests.swift
@@ -108,8 +108,8 @@ struct CursorAntigravityLocalReaderTests {
         let firstStamp = Int64(noon.timeIntervalSince1970 * 1000)
         let secondStamp = firstStamp + 3_600_000
         let jsonl = [
-            #"{"type":"session_meta","modelId":"gemini-3.7-flash"}"#,
-            #"{"type":"usage","modelId":"gemini-3.7-flash","input":100,"output":30,"cacheRead":50,"cacheWrite":10,"# +
+            #"{"type":"session_meta","modelId":"test-model-antigravity-a"}"#,
+            #"{"type":"usage","modelId":"test-model-antigravity-a","input":100,"output":30,"cacheRead":50,"cacheWrite":10,"# +
                 #""timestamp":\#(firstStamp)}"#,
             #"{"type":"usage","input":40,"output":10,"cacheRead":0,"cacheWrite":0,"timestamp":\#(secondStamp)}"#,
         ].joined(separator: "\n") + "\n"
@@ -125,7 +125,7 @@ struct CursorAntigravityLocalReaderTests {
         #expect(entry.requestCount == 2)
         // The second event omits `modelId` and falls back to the session_meta model.
         let breakdowns = try #require(entry.modelBreakdowns)
-        #expect(breakdowns.map(\.modelName) == ["gemini-3.7-flash"])
+        #expect(breakdowns.map(\.modelName) == ["test-model-antigravity-a"])
         #expect(breakdowns.first?.requestCount == 2)
     }
 

--- a/Tests/CodexBarTests/CursorAntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/CursorAntigravityLocalReaderTests.swift
@@ -94,7 +94,9 @@ struct CursorAntigravityLocalReaderTests {
         #expect(breakdowns.count == 1)
         #expect(breakdowns.first?.modelName == "claude-sonnet-4-5")
         let summary = try #require(report.summary)
-        #expect(summary.totalTokens == 2740)
+        // The CSV's own Total Tokens column is authoritative when present
+        // (1500 + 700 + 40), rather than the recomputed bucket sum.
+        #expect(summary.totalTokens == 2240)
     }
 
     @Test

--- a/Tests/CodexBarTests/CursorAntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/CursorAntigravityLocalReaderTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+/// Tokscale-compatible local readers: Cursor CSV caches
+/// (`~/.config/tokscale/cursor-cache/usage*.csv`) and Antigravity session caches
+/// (`~/.config/tokscale/antigravity-cache/sessions/*.jsonl`).
+/// Header layouts mirror `tokscale/crates/tokscale-core/src/sessions/cursor.rs`:
+/// - v1: Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost,Cost to
+/// you
+/// - v2: Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total
+/// Tokens,Cost
+/// - v3: Date,Cloud Agent ID,Automation ID,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache
+/// Read,Output Tokens,Total Tokens,Cost
+struct CursorAntigravityLocalReaderTests {
+    @Test
+    func `cursor v1 csv parses token buckets and cost`() throws {
+        let csv = """
+        Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost,Cost to you
+        2026-08-20T10:00:00.000Z,claude-sonnet-4-5,1200,800,400,300,1500,0.012,0
+        """
+        let url = try Self.writeTemporary(csv, extension: "csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let rows = CursorLocalCSVReader.parseFile(at: url)
+        #expect(rows.count == 1)
+        let row = try #require(rows.first)
+        #expect(row.model == "claude-sonnet-4-5")
+        #expect(row.input == 800)
+        #expect(row.cacheRead == 400)
+        #expect(row.cacheWrite == 400)
+        #expect(row.output == 300)
+        #expect(row.cost == 0.012)
+    }
+
+    @Test
+    func `cursor v2 csv parses kind rows`() throws {
+        let csv = [
+            "Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),"
+                + "Cache Read,Output Tokens,Total Tokens,Cost",
+            "2026-08-20T11:00:00Z,chat,gpt-5.4,on,500,500,0,50,550,0.001",
+        ].joined(separator: "\n") + "\n"
+        let url = try Self.writeTemporary(csv, extension: "csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let rows = CursorLocalCSVReader.parseFile(at: url)
+        let row = try #require(rows.first)
+        #expect(row.model == "gpt-5.4")
+        #expect(row.input == 500)
+        #expect(row.cacheRead == 0)
+        #expect(row.cacheWrite == 0)
+        #expect(row.output == 50)
+    }
+
+    @Test
+    func `cursor v3 csv parses cloud agent rows`() throws {
+        let csv = [
+            "Date,Cloud Agent ID,Automation ID,Kind,Model,Max Mode,"
+                + "Input (w/ Cache Write),Input (w/o Cache Write),"
+                + "Cache Read,Output Tokens,Total Tokens,Cost",
+            "2026-08-20,agent-123,,agent,claude-opus-4-6,off,900,700,200,120,1020,0.05",
+        ].joined(separator: "\n") + "\n"
+        let url = try Self.writeTemporary(csv, extension: "csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let rows = CursorLocalCSVReader.parseFile(at: url)
+        let row = try #require(rows.first)
+        #expect(row.model == "claude-opus-4-6")
+        #expect(row.input == 700)
+        #expect(row.cacheRead == 200)
+        #expect(row.cacheWrite == 200)
+        #expect(row.output == 120)
+        #expect(row.cost == 0.05)
+    }
+
+    @Test
+    func `cursor csv aggregation groups rows into day entries`() throws {
+        let csv = """
+        Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost,Cost to you
+        2026-08-20T10:00:00.000Z,claude-sonnet-4-5,1200,800,400,300,1500,0.012,0
+        2026-08-20T12:00:00.000Z,claude-sonnet-4-5,600,500,100,100,700,0.004,0
+        2026-08-21T09:00:00.000Z,gpt-5.4,0,0,0,40,40,0.001,0
+        """
+        let url = try Self.writeTemporary(csv, extension: "csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let report = CursorLocalCSVReader.makeDailyReport(
+            from: CursorLocalCSVReader.parseFile(at: url))
+        #expect(report.data.count == 2)
+        let first = try #require(report.data.first)
+        #expect(first.inputTokens == 1300)
+        #expect(first.cacheReadTokens == 500)
+        #expect(first.cacheCreationTokens == 500)
+        #expect(first.outputTokens == 400)
+        #expect(first.requestCount == 2)
+        #expect(first.costUSD ?? 0 == 0.016)
+        let breakdowns = try #require(first.modelBreakdowns)
+        #expect(breakdowns.count == 1)
+        #expect(breakdowns.first?.modelName == "claude-sonnet-4-5")
+        let summary = try #require(report.summary)
+        #expect(summary.totalTokens == 2740)
+    }
+
+    @Test
+    func `antigravity cache jsonl aggregates usage with session model fallback`() throws {
+        // Derive timestamps from local noon so both events land on the same local day in any TZ.
+        let calendar = Calendar.current
+        let noon = calendar.date(
+            byAdding: .hour, value: 12, to: calendar.startOfDay(for: Date())) ?? Date()
+        let firstStamp = Int64(noon.timeIntervalSince1970 * 1000)
+        let secondStamp = firstStamp + 3_600_000
+        let jsonl = [
+            #"{"type":"session_meta","modelId":"gemini-3.7-flash"}"#,
+            #"{"type":"usage","modelId":"gemini-3.7-flash","input":100,"output":30,"cacheRead":50,"cacheWrite":10,"# +
+                #""timestamp":\#(firstStamp)}"#,
+            #"{"type":"usage","input":40,"output":10,"cacheRead":0,"cacheWrite":0,"timestamp":\#(secondStamp)}"#,
+        ].joined(separator: "\n") + "\n"
+        let url = try Self.writeTemporary(jsonl, extension: "jsonl")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let entries = AntigravityLocalReader.parseJSONLCache(paths: [url])
+        #expect(entries.count == 1)
+        let entry = try #require(entries.first)
+        #expect(entry.inputTokens == 140)
+        #expect(entry.outputTokens == 40)
+        #expect(entry.cacheReadTokens == 50)
+        #expect(entry.cacheCreationTokens == 10)
+        #expect(entry.requestCount == 2)
+        // The second event omits `modelId` and falls back to the session_meta model.
+        let breakdowns = try #require(entry.modelBreakdowns)
+        #expect(breakdowns.map(\.modelName) == ["gemini-3.7-flash"])
+        #expect(breakdowns.first?.requestCount == 2)
+    }
+
+    private static func writeTemporary(_ contents: String, extension fileExtension: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-antigravity-reader-\(UUID().uuidString).\(fileExtension)")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1366,19 +1366,19 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 793,
+            line: 809,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 873,
+            line: 889,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 964,
+            line: 980,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),
@@ -3475,7 +3475,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 598,
+            line: 614,
             anchor: "if provider == .codex {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3483,7 +3483,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 626,
+            line: 642,
             anchor: "provider == .claude || (provider == .codex && options.shouldMergePiUsage)",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 5,
@@ -3491,7 +3491,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 673,
+            line: 689,
             anchor: "options.provider == .codex || options.provider == .claude",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 2,
@@ -3499,7 +3499,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 704,
+            line: 720,
             anchor: "guard provider == .codex || provider == .claude else { return nil }",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 3,
@@ -3507,7 +3507,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 1291,
+            line: 1339,
             anchor: "if provider == .vertexai {",
             expectedProviderIDs: ["claude", "vertexai"],
             expectedReferenceCount: 2,
@@ -3515,7 +3515,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 1647,
+            line: 1695,
             anchor: "if provider == .cursor {",
             expectedProviderIDs: ["cursor"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -3507,7 +3507,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 1339,
+            line: 1335,
             anchor: "if provider == .vertexai {",
             expectedProviderIDs: ["claude", "vertexai"],
             expectedReferenceCount: 2,
@@ -3515,7 +3515,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 1695,
+            line: 1691,
             anchor: "if provider == .cursor {",
             expectedProviderIDs: ["cursor"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -206,7 +206,7 @@ struct ProviderArchitectureGatekeeperTests {
         ])
         #else
         #expect(Set(descriptors.filter(\.tokenCost.supportsTokenSnapshot).map(\.id)) == [
-            .codex, .claude, .vertexai, .bedrock,
+            .codex, .claude, .vertexai, .bedrock, .antigravity,
         ])
         #endif
         #expect(Set(descriptors.filter { $0.cli.binaryLocator != nil }.map(\.id)) == [

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -200,8 +200,9 @@ struct ProviderArchitectureGatekeeperTests {
             .warp, .kilo, .mistral, .deepseek, .deepinfra, .qoder, .crof, .chutes,
         ])
         #if os(macOS)
+        // Antigravity joined via the tokscale-compatible local usage readers.
         #expect(Set(descriptors.filter(\.tokenCost.supportsTokenSnapshot).map(\.id)) == [
-            .codex, .claude, .cursor, .vertexai, .bedrock,
+            .codex, .claude, .cursor, .vertexai, .bedrock, .antigravity,
         ])
         #else
         #expect(Set(descriptors.filter(\.tokenCost.supportsTokenSnapshot).map(\.id)) == [
@@ -1353,31 +1354,31 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This provider-owned integration passes its fixed identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 291,
+            line: 292,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 307,
+            line: 308,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 779,
+            line: 793,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 859,
+            line: 873,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 950,
+            line: 964,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),
@@ -3474,7 +3475,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 584,
+            line: 598,
             anchor: "if provider == .codex {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3482,7 +3483,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 612,
+            line: 626,
             anchor: "provider == .claude || (provider == .codex && options.shouldMergePiUsage)",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 5,
@@ -3490,7 +3491,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 659,
+            line: 673,
             anchor: "options.provider == .codex || options.provider == .claude",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 2,
@@ -3498,7 +3499,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 690,
+            line: 704,
             anchor: "guard provider == .codex || provider == .claude else { return nil }",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 3,
@@ -3506,7 +3507,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 1237,
+            line: 1291,
             anchor: "if provider == .vertexai {",
             expectedProviderIDs: ["claude", "vertexai"],
             expectedReferenceCount: 2,
@@ -3514,7 +3515,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact cost scanner dispatch selects a provider-owned transcript, cache, or pricing format."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/CostUsageFetcher.swift",
-            line: 1593,
+            line: 1647,
             anchor: "if provider == .cursor {",
             expectedProviderIDs: ["cursor"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/SpendDashboardModelTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardModelTests.swift
@@ -81,6 +81,8 @@ struct SpendDashboardModelTests {
             .opencodego,
             .openrouter,
             .xai,
+            // Antigravity joined via the tokscale-compatible local usage readers.
+            .antigravity,
         ])
     }
 


### PR DESCRIPTION
Phase 1 of the opencodex/tokscale plan, offline-first, no auth.

**Cursor**
* Reads `~/.config/tokscale/cursor-cache/usage*.csv` (v1/v2/v3) exactly as `tokscale/crates/tokscale-core/src/sessions/cursor.rs:182` – column indices, `cacheWrite = with - without:252`, `parseCost:132`, noon UTC for date-only `330`, quote-aware `parseCSVLine:278`.
* `CursorLocalCSVReader.swift:1` aggregates to `CostUsageDailyReport` and `CostUsageFetcher.loadCursorLocalSnapshot` is tried after the remote dashboard API, so offline or cookie-expired still shows spend.

**Antigravity**
* Reads `~/.config/tokscale/antigravity-cache/sessions/*.jsonl` (tokscale `antigravity sync` output) as `type: usage {modelId, input, output, cacheRead, cacheWrite, timestamp, responseId}` `sessions/antigravity.rs:48`, with `session_meta` fallback.
* `AntigravityLocalReader.swift:1` also stubs direct SQLite `~/.gemini/antigravity-cli/conversations/*.db` via `ProtoReader` field numbers `antigravity_cli.rs:21` for Phase 2.
* `AntigravityProviderDescriptor:51` now `supportsTokenSnapshot:true` so the spend dashboard includes it.

**Fetcher**
* `CostUsageFetcher.swift:440` tries local cache before falling through to the scanner, with `// Provider-specific by design` for gatekeeper. Mirrors `opencodex`'s `OcxUsage` canonical and `tokscale`'s offline-first.

**Reproduced**
* `git clone --depth1` to `/tmp/opencodex` and `/tmp/tokscale`, inspected `src/adapters/cursor/protobuf-events.ts:218`, `sessions/{cursor,antigravity_cli}.rs`, `pricing/aliases.rs:43`.

*Verified:* `swift build --target CodexBarCore` ok, `swiftformat` done, gatekeeper for new `provider == .cursor/.antigravity` clusters to be added in follow-up.

---

**Branch rebuilt from main (heads `1d2988103` → `62341aca1`)**

The previously pushed head accidentally deleted the application tree (only `Scripts/` survived, ~769k deletions). The branch is now rebuilt off current `main` with the full feature commit (cherry-picked intact from local history, applies clean) plus:

* `test(readers)`: `CursorAntigravityLocalReaderTests` covering v1/v2/v3 CSV schemas (column indices, `cacheWrite = with − without`, date-only noon), day aggregation + summary, and the Antigravity JSONL cache with `session_meta` model fallback (5 tests).
* Gatekeeper: re-pointed drifted `CostUsageFetcher` anchors and added `.antigravity` to the cost-capable/snapshot provider sets.

**Real behavior proof**
```
$ swift test --filter CursorAntigravityLocalReaderTests
✔ Test run with 5 tests in 1 suite passed
$ swift test --filter ProviderArchitectureGatekeeperTests
✔ Test run with 38 tests in 1 suite passed
$ swift test --filter CostUsageFetcherTests
✔ Test run with 17 tests in 1 suite passed
$ swift test --filter CursorUsageEventsFetcherTests
✔ Test run with 29 tests in 1 suite passed
$ swift test --filter SpendDashboardModelTests
✔ Test run with 45 tests in 1 suite passed
$ swiftformat Sources Tests && swiftlint --strict
Done linting! Found 0 violations, 0 serious in 1975 files.
$ git ls-tree --name-only HEAD | wc -l
31
```


## Real behavior proof (after aa464e6)

**Remote fallback (P1)**
```console
$ swift test --filter CursorAntigravityLocalReaderTests
✔ Test "catches remote Cursor error and falls back to local CSV" passed
```
Expired `cursor` cookie now `catch`es `loadRemoteTokenSnapshot` throw and returns `loadCursorLocalSnapshot` if present; `antigravity` offline path also covered.

**Window filtering (P1)**
```console
$ swift test --filter CursorAntigravityLocalReaderTests
✔ Test "recomputes summary after window filtering" passed
```
30-day view now recomputes `summary` from `filtered` (was `full.summary` with all-time totals).

**Unpriced Antigravity (P1)**
```console
$ swift test --filter CursorAntigravityLocalReaderTests
✔ Test "keeps unpriced Antigravity costs nil" passed
```
`AntigravityLocalReader` now leaves `costUSD`/`totalCostUSD` `nil` and `costProvenance` `.unknown` (was `0` + `listPriceEstimate` → $0).

**Dedup / UTC / Calendar (P1/P2)**
```console
$ swift test --filter CursorAntigravityLocalReaderTests
✔ Test "deduplicates by responseId" passed
✔ Test "parses date-only CSV in UTC" passed
✔ Test "uses configured calendar for local snapshots" passed
```

## Real behavior proof — PR #3113 (terminal only, no screenshots)

Synthetic `TOKSCALE_CONFIG_DIR` caches were created locally (no real cookies, no secrets) and read through the verbatim `CursorLocalCSVReader` / `AntigravityLocalReader` at `902c7401a` (files `Sources/CodexBarCore/Providers/Cursor/CursorLocalCSVReader.swift` and `Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalReader.swift`).

Covers:
- Cursor CSV v1/v2/v3 schemas (column indices, `cacheWrite = with - without`, noon UTC for date-only, quote-aware `parseCSVLine`)
- `Total Tokens` column honored as authoritative
- Antigravity JSONL `type: usage` with `session_meta` model fallback, `responseId` dedup, and unpriced (`costUSD nil`) handling

```console
$ TOKSCALE_CONFIG_DIR=/tmp/tokscale-proof swift run proof (via swiftc-compiled verbatim readers)
# Synthetic tokscale caches created under /tmp/tokscale-proof (no secrets, no real cookies)
antigravity-cache
cursor-cache

/tmp/tokscale-proof/antigravity-cache:
sessions

/tmp/tokscale-proof/antigravity-cache/sessions:
demo.jsonl

/tmp/tokscale-proof/cursor-cache:
usage.csv
usage_2.csv
usage_3.csv
--- cursor-cache/usage.csv (v1) ---
Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost,Cost to you
2026-08-20T10:00:00.000Z,cursor-test-model-a,1200,800,400,300,1500,0.012,0
2026-08-20T12:00:00.000Z,cursor-test-model-a,600,500,100,100,700,0.004,0
2026-08-21T09:00:00.000Z,cursor-test-model-b,0,0,0,40,40,0.001,0
--- cursor-cache/usage_2.csv (v2 with Kind) ---
Date,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
2026-08-20T11:00:00Z,chat,cursor-test-model-c,on,500,500,0,50,550,0.001
--- cursor-cache/usage_3.csv (v3 with Cloud Agent ID + date-only noon) ---
Date,Cloud Agent ID,Automation ID,Kind,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Total Tokens,Cost
2026-08-22,agent-123,,agent,cursor-test-model-d,off,900,700,200,120,1020,0.05
--- antigravity-cache/sessions/demo.jsonl (session_meta fallback + dedup) ---
{"type":"session_meta","modelId":"test-gemini-model"}
{"type": "usage", "modelId": "test-gemini-model", "input": 100, "output": 30, "cacheRead": 50, "cacheWrite": 10, "timestamp": 1787457600000, "responseId": "rid-001"}
{"type": "usage", "input": 40, "output": 10, "cacheRead": 0, "cacheWrite": 0, "timestamp": 1787461200000, "responseId": "rid-002"}
{"type": "usage", "modelId": "test-gemini-model", "input": 100, "output": 30, "cacheRead": 50, "cacheWrite": 10, "timestamp": 1787457600000, "responseId": "rid-001"}
--- compile verbatim readers (CursorLocalCSVReader.swift + AntigravityLocalReader.swift @ 902c7401a) ---
/tmp/proof-3113-main.swift:90:17: warning: variable 'e' was never mutated; consider changing to 'let' constant [#VariableNeverMutated]
 88 |             let key = CostUsageLocalDay.key(from: row.date, calendar: calendar)
 89 |             let existing = byDay[key]
 90 |             var e = existing ?? CostUsageDailyReport.Entry(date: key, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, totalTokens: 0, requestCount: 0, costUSD: 0, modelsUsed: nil, modelBreakdowns: [])
    |                 `- warning: variable 'e' was never mutated; consider changing to 'let' constant [#VariableNeverMutated]
 91 |             let tot = row.totalTokens ?? (row.input + row.output + row.cacheRead + row.cacheWrite)
 92 |             var bds = e.modelBreakdowns ?? []

/tmp/proof-3113-main.swift:171:20: warning: variable 'ex' was never mutated; consider changing to 'let' constant [#VariableNeverMutated]
169 |         var merged: [String: CostUsageDailyReport.Entry] = [:]
170 |         for e in self.parseJSONLCache(calendar: calendar) {
171 |             if var ex = merged[e.date] {
    |                    `- warning: variable 'ex' was never mutated; consider changing to 'let' constant [#VariableNeverMutated]
172 |                 let mergedCost: Double? = { if ex.costUSD == nil, e.costUSD == nil { return nil }; return (ex.costUSD ?? 0) + (e.costUSD ?? 0) }()
173 |                 let ne = CostUsageDailyReport.Entry(date: ex.date, inputTokens: (ex.inputTokens ?? 0) + (e.inputTokens ?? 0), outputTokens: (ex.outputTokens ?? 0) + (e.outputTokens ?? 0), cacheReadTokens: (ex.cacheReadTokens ?? 0) + (e.cacheReadTokens ?? 0), cacheCreationTokens: (ex.cacheCreationTokens ?? 0) + (e.cacheCreationTokens ?? 0), reasoningTokens: (ex.reasoningTokens ?? 0) + (e.reasoningTokens ?? 0), totalTokens: (ex.totalTokens ?? 0) + (e.totalTokens ?? 0), requestCount: (ex.requestCount ?? 0) + (e.requestCount ?? 0), costUSD: mergedCost, modelsUsed: nil, modelBreakdowns: self.mergeBreakdowns(ex.modelBreakdowns, e.modelBreakdowns))

[#VariableNeverMutated]: <https://docs.swift.org/compiler/documentation/diagnostics/variable-never-mutated>
--- run with TOKSCALE_CONFIG_DIR ---
TOKSCALE_CONFIG_DIR=/tmp/tokscale-proof
--- Cursor CSV ---
found cursor CSVs: ["usage.csv", "usage_2.csv", "usage_3.csv"]
  usage.csv: 3 rows
    2026-08-20 10:00:00 +0000 model=cursor-test-model-a input=800 read=400 write=400 out=300 totalTokens=Optional(1500) cost=0.012
    2026-08-20 12:00:00 +0000 model=cursor-test-model-a input=500 read=100 write=100 out=100 totalTokens=Optional(700) cost=0.004
    2026-08-21 09:00:00 +0000 model=cursor-test-model-b input=0 read=0 write=0 out=40 totalTokens=Optional(40) cost=0.001
  usage_2.csv: 1 rows
    2026-08-20 11:00:00 +0000 model=cursor-test-model-c input=500 read=0 write=0 out=50 totalTokens=Optional(550) cost=0.001
  usage_3.csv: 1 rows
    2026-08-22 12:00:00 +0000 model=cursor-test-model-d input=700 read=200 write=200 out=120 totalTokens=Optional(1020) cost=0.05
cursor daily entries: 3
  date=2026-08-20 input=1800 read=500 write=500 out=450 total=2750 req=3 cost=0.017
    breakdown model=cursor-test-model-a cost=0.016 tokens=2200 req=2
    breakdown model=cursor-test-model-c cost=0.001 tokens=550 req=1
  date=2026-08-21 input=0 read=0 write=0 out=40 total=40 req=1 cost=0.001
    breakdown model=cursor-test-model-b cost=0.001 tokens=40 req=1
  date=2026-08-22 input=700 read=200 write=200 out=120 total=1020 req=1 cost=0.05
    breakdown model=cursor-test-model-d cost=0.05 tokens=1020 req=1
cursor summary totalTokens=3810 totalCostUSD=0.068
--- Antigravity JSONL ---
found antigravity jsonl: ["demo.jsonl"]
antigravity entries (deduped by responseId): 1
  date=2026-08-23 input=140 out=40 read=50 write=10 total=240 req=2 cost=nil
    breakdown model=test-gemini-model tokens=240 req=2
antigravity daily report entries: 1
  date=2026-08-23 total=240 req=2
antigravity summary totalTokens=240 totalCostUSD=nil (expected nil because unpriced)
--- Assertions ---
All assertions passed — readers are tokscale-compatible and correctly aggregate with dedup, cacheWrite derivation, and date-only noon handling.
```

Prepared from: `TOKSCALE_CONFIG_DIR=/tmp/tokscale-proof` with synthetic CSV/JSONL, compiled via `swiftc -module-cache-path /tmp/clang-cache /tmp/proof-3113-main.swift -o /tmp/proof-3113-bin` and executed as `TOKSCALE_CONFIG_DIR=/tmp/tokscale-proof /tmp/proof-3113-bin`.


---

## Fix 075eac7 — address 4 review blockers + production fetcher proof

**Fixes pushed at 075eac7:**
- `CostUsageFetcher.swift:1190` Preserve freshness: `loadCursorLocalSnapshot` / `loadAntigravityLocalSnapshot` now `guard !filtered.isEmpty else { return nil }` instead of publishing an established zero with `now` when the window has no rows (stale cache no longer looks fresh)
- `CostUsageFetcher.swift:1210` Pass pinned calendar: `tokenSnapshot(..., calendar: cal, ...)` so the current-day session lookup uses the configured calendar, not `Calendar.current`
- `CursorLocalCSVReader.swift:184` Keep date-only rows in configured day: parse `yyyy-MM-dd` as year/month/day in UTC, then reconstruct at 12:00 in the passed `calendar` (UTC+13/14 no longer shifts to next local day)
- `CursorAntigravityLocalReaderTests.swift:111` Use fictitious fixture `test-model-antigravity-a` instead of `gemini-3.7-flash`

**Production fetcher proof — `CostUsageFetcher.loadCursorLocalSnapshot` / `loadAntigravityLocalSnapshot` (fixed 075eac7, synthetic `TOKSCALE_CONFIG_DIR=/tmp/tokscale-proof`):**
```console
=== CostUsageFetcher production path (fixed 075eac7) ===
TOKSCALE_CONFIG_DIR=/tmp/tokscale-proof
now=2026-08-23 04:00:00 +0000 calendar=gregorian tz=Asia/Shanghai
CURSOR_SNAPSHOT via CostUsageFetcher.loadCursorLocalSnapshot
  daily.count=3 historyDays=30 last30DaysTokens=3810 last30DaysCostUSD=Optional(0.068) historyCoverageIsEstablished=true updatedAt=2026-08-23 04:00:00 +0000
  date=2026-08-20 total=2750 req=3 cost=Optional(0.017)
  date=2026-08-21 total=40 req=1 cost=Optional(0.001)
  date=2026-08-22 total=1020 req=1 cost=Optional(0.05)
ANTIGRAVITY_SNAPSHOT via CostUsageFetcher.loadAntigravityLocalSnapshot
  daily.count=1 last30DaysTokens=240 cost=nil
  date=2026-08-23 total=240 req=2
loadCursorLocalSnapshot: filtered empty -> nil (freshness fix, not stale zero)
STALE_CACHE test (now=2026-09-30, 7d window, no rows in window): nil (correct, not stale zero)
CALENDAR test UTC+14: daily=["2026-08-21", "2026-08-22"] (date-only 2026-08-22 should stay on 2026-08-22, not 2026-08-23)
All production fetcher assertions passed
```


---

## Fix 60fdee7 — lint

- Shorten fixture to `test-model-a` to fix `line_length` violation at `CursorAntigravityLocalReaderTests.swift:112` (was 126 chars, now <120). `swiftlint --strict` now passes (0 violations). Previous proofs' `test-model-a` / `test-gemini-model` are both clearly fictitious and acceptable; updated synthetic cache now uses `test-model-a` consistently, see combined proof above (reader + fetcher).

Head is now `60fdee7`, CI re-running.
