### PR TITLE
fix(commandcode): Add support for individual-pro-v1 plan ($80/mo credits)

### DIFF
--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodePlanCatalog.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodePlanCatalog.swift
@@ -24,6 +24,7 @@ public enum CommandCodePlanCatalog {
         Plan(id: "individual-go", displayName: "Go", monthlyCreditsUSD: 10),
         Plan(id: "individual-goat", displayName: "GOAT", monthlyCreditsUSD: 70),
         Plan(id: "individual-pro", displayName: "Pro", monthlyCreditsUSD: 30),
+        Plan(id: "individual-pro-v1", displayName: "Pro", monthlyCreditsUSD: 80),
         Plan(id: "individual-max", displayName: "Max", monthlyCreditsUSD: 150),
         Plan(id: "individual-ultra", displayName: "Ultra", monthlyCreditsUSD: 300),
     ]

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -390,10 +390,34 @@ struct CommandCodeUsageFetcherTests {
     }
 
     @Test
+    func `active pro-v1 subscription resolves to the eighty dollar plan`() async throws {
+        let proV1JSON = Self.subscriptionJSON.replacingOccurrences(
+            of: #""planId":"individual-go""#,
+            with: #""planId":"individual-pro-v1""#)
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            let body = path.hasSuffix("/credits") ? Self.creditsJSON : proV1JSON
+            return try Self.response(request: request, statusCode: 200, body: body)
+        }
+
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+            cookieHeader: "session=valid",
+            session: transport)
+
+        let plan = try #require(snapshot.plan)
+        #expect(plan.id == "individual-pro-v1")
+        #expect(plan.monthlyCreditsUSD == 80)
+        #expect(snapshot.monthlyCreditsTotal == 80)
+        #expect(abs((snapshot.monthlyCreditsUsed ?? -1) - 71.2216) < 0.0001)
+        #expect(snapshot.subscriptionEnrichmentUnavailable == false)
+    }
+
+    @Test
     func `plan catalog covers known plans`() {
         #expect(CommandCodePlanCatalog.plan(forID: "individual-go")?.monthlyCreditsUSD == 10)
         #expect(CommandCodePlanCatalog.plan(forID: "individual-goat")?.monthlyCreditsUSD == 70)
         #expect(CommandCodePlanCatalog.plan(forID: "individual-pro")?.monthlyCreditsUSD == 30)
+        #expect(CommandCodePlanCatalog.plan(forID: "individual-pro-v1")?.monthlyCreditsUSD == 80)
         #expect(CommandCodePlanCatalog.plan(forID: "individual-max")?.monthlyCreditsUSD == 150)
         #expect(CommandCodePlanCatalog.plan(forID: "individual-ultra")?.monthlyCreditsUSD == 300)
         #expect(CommandCodePlanCatalog.plan(forID: "unknown") == nil)


### PR DESCRIPTION
## Summary

Command Code repriced the Pro tier ($20/mo → **$80 in credits**) and ships it as a new `planId`: `individual-pro-v1`. The legacy `individual-pro` ($15/mo → $30) remains for existing subscribers.

Accounts on the new tier hit the hard `unknownPlan` throw in `CommandCodeUsageFetcher.fetchUsage`, surfacing as:

> Unknown Command Code plan: individual-pro-v1. Add it to CommandCodePlanCatalog.

This adds `individual-pro-v1` → `$80` to `CommandCodePlanCatalog` (legacy `individual-pro` → `$30` kept), so usage renders as `Pro · $X of $80.00` with the monthly window derived from the catalog total.

Plan IDs verified against Command Code's live frontend bundle (2026-08-20, no auth needed):

- `assets/constants-B6rERLKd.js`: `$={"individual-go":{premium:0,opensource:10,total:10},...,"individual-pro":{premium:15,opensource:15,total:30},"individual-pro-v1":{premium:0,opensource:80,total:80},...}`
- `assets/subscriptions-page-DpSwthla.js`: plan list is exactly `individual-go`, `individual-goat`, `individual-pro`, `individual-pro-v1`, `individual-provider`, `individual-max`, `individual-ultra`, `teams-pro` — `individual-pro-v1` is the only ID missing from our catalog
- Docs confirm: https://commandcode.ai/docs/resources/pricing-limits — Pro $20/mo, $80 credits, 5-hour $16 / weekly $40

No other catalog entries drifted (`go=10`, `goat=70`, `max=150`, `ultra=300` all match).

## Testing

Commands run:

```
.build/lint-tools/bin/swiftformat Sources/CodexBarCore/Providers/CommandCode/CommandCodePlanCatalog.swift Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
# SwiftFormat completed in 0.1s. 0/2 files formatted.

DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer .build/lint-tools/bin/swiftlint --strict Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift Sources/CodexBarCore/Providers/CommandCode/CommandCodePlanCatalog.swift
# Done linting! Found 0 violations, 0 serious in 2 files.

DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CommandCodeUsageFetcherTests
```

Real output:

```
◇ Suite CommandCodeUsageFetcherTests started.
...
✔ Test "plan catalog covers known plans" passed after 0.003 seconds.
✔ Test "active pro-v1 subscription resolves to the eighty dollar plan" passed after 0.003 seconds.
✔ Test "successful unknown active subscription still fails explicitly" passed after 0.003 seconds.
...
✔ Suite CommandCodeUsageFetcherTests passed after 2.066 seconds.
✔ Test run with 24 tests in 1 suite passed after 2.066 seconds.
```

New regression test `active pro-v1 subscription resolves to the eighty dollar plan` feeds an active subscription payload with `planId: "individual-pro-v1"` through `fetchUsage` and asserts it resolves to an $80 plan (used = 80 − remaining) instead of throwing `unknownPlan`.

Live app verification (packaged locally via `Scripts/package_app.sh`, adhoc signing):

```
$ strings CodexBar.app/Contents/MacOS/CodexBar | grep individual-pro-v1
individual-pro-v1

$ open CodexBar.app   # PID stays up; Command Code card now shows "Pro · $X of $80.00"
```