### PR TITLE
Fix Codex CLI approval policy

### DIFF
--- a/Sources/CodexBarCore/Providers/Codex/CodexStatusProbeIsolation.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexStatusProbeIsolation.swift
@@ -28,7 +28,7 @@ enum CodexStatusProbeIsolation {
             "-s",
             "read-only",
             "-a",
-            "untrusted",
+            "never",
             "-c",
             "history.persistence=\"none\"",
             "-c",

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -858,7 +858,7 @@ private final class CodexRPCClient: @unchecked Sendable {
 
     init(
         executable: String = "codex", // Provider-specific by design: this RPC client launches Codex app-server.
-        arguments: [String] = ["-s", "read-only", "-a", "untrusted", "app-server"],
+        arguments: [String] = ["-s", "read-only", "-a", "never", "app-server"],
         environment: [String: String] = ProcessInfo.processInfo.environment,
         initializeTimeoutSeconds: TimeInterval = 8.0,
         requestTimeoutSeconds: TimeInterval = 3.0,
@@ -1126,14 +1126,14 @@ public struct UsageFetcher: Sendable {
         self.initializeTimeoutSeconds = 8.0
         self.requestTimeoutSeconds = 3.0
         self.codexExecutableResolver = defaultCodexExecutableResolver
-        self.codexArguments = ["-s", "read-only", "-a", "untrusted", "app-server"]
+        self.codexArguments = ["-s", "read-only", "-a", "never", "app-server"]
     }
 
     init(
         environment: [String: String],
         initializeTimeoutSeconds: TimeInterval,
         requestTimeoutSeconds: TimeInterval,
-        codexArguments: [String] = ["-s", "read-only", "-a", "untrusted", "app-server"],
+        codexArguments: [String] = ["-s", "read-only", "-a", "never", "app-server"],
         codexExecutableResolver: @escaping CodexExecutableResolver = defaultCodexExecutableResolver)
     {
         self.environment = environment

--- a/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
@@ -106,7 +106,7 @@ struct CodexUsageFetcherFallbackTests {
     }
 
     @Test
-    func `CLI usage loads plan only RPC response as unavailable limits`() async throws {
+    func `CLI usage starts app server with current read-only noninteractive arguments`() async throws {
         let stubCLIPath = try self.makePlanOnlyStubCodexCLI()
         defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
 
@@ -367,6 +367,11 @@ struct CodexUsageFetcherFallbackTests {
         import sys
 
         args = sys.argv[1:]
+        expected_prefix = ["-s", "read-only", "-a", "never", "app-server"]
+        if args[:5] != expected_prefix:
+            sys.stderr.write(f"unexpected Codex arguments: {args!r}\\n")
+            sys.exit(64)
+
         if "app-server" in args:
             for line in sys.stdin:
                 if not line.strip():

--- a/Tests/CodexBarTests/TTYCommandRunnerTests.swift
+++ b/Tests/CodexBarTests/TTYCommandRunnerTests.swift
@@ -217,7 +217,7 @@ struct TTYCommandRunnerEnvTests {
         let stateHome = URL(fileURLWithPath: "/tmp/codexbar status \"state\"", isDirectory: true)
         let args = CodexStatusProbeIsolation.codexArguments(stateHome: stateHome)
 
-        #expect(args.starts(with: ["-s", "read-only", "-a", "untrusted"]))
+        #expect(args.starts(with: ["-s", "read-only", "-a", "never"]))
         #expect(args.contains("history.persistence=\"none\""))
         #expect(args.contains("experimental_thread_store={type=\"in_memory\",id=\"codexbar-status\"}"))
         #expect(args.contains("sqlite_home=\"/tmp/codexbar status \\\"state\\\"\""))

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -115,7 +115,7 @@ Example:
   - Login required or Cloudflare interstitial.
 
 ### Codex CLI RPC (automatic CLI source)
-- Launches local RPC server: `codex -s read-only -a untrusted app-server`.
+- Launches local RPC server: `codex -s read-only -a never app-server`.
 - JSON-RPC over stdin/stdout:
   - `initialize` (client name/version)
   - `account/read`


### PR DESCRIPTION
Fixes #3115.

Codex CLI 0.149.0 removed the `untrusted` approval-policy value, so both CodexBar launch paths exit during argument parsing before usage can be read.

This switches the app-server and isolated `/status` launches to `-a never` while retaining the `read-only` sandbox. The app-server regression stub now rejects any other default argument sequence, and the Codex provider documentation matches the runtime command.

Compatibility risk is limited to the approval-policy value: `never` is supported by local Codex CLI 0.145.0 and is listed as valid by the reporter's 0.149.0 error. Review focus: whether `never` is the preferred non-interactive policy for both launch paths.

Real behavior proof with account identity, quota values, and reset times redacted:

```console
$ codex --version
codex-cli 0.149.0
$ CODEX_CLI_PATH=<0.149.0 binary> ./.build/debug/CodexBarCLI usage --provider codex --source cli --format json --json-only
[
  {
    "provider": "codex",
    "source": "codex-cli",
    "error": null,
    "usage": {
      "present": true,
      "primaryWindowPresent": false,
      "secondaryWindowPresent": true,
      "updatedAtPresent": true
    }
  }
]
```

Tests:
- `swift test --filter 'TTYCommandRunnerEnvTests|CodexUsageFetcherFallbackTests'` (42 passed)
- `make check`
- `make test` reaches an unrelated existing failure: two `AdaptiveRefreshTimerTests` time out with `CancellationError`. I reproduced the same failures at the same lines on upstream `f74117aeb7a9`.
