### PR TITLE
Add per-provider menu bar percent window picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.57.1 — Unreleased
 
 ### Added
+- Menu bar: choose Auto, Session, or Weekly percent windows in provider settings while preserving custom layout tokens and the global icon style (#3124). Thanks @J2TeamNNL!
 - Menu bar layouts: choose session or weekly reset countdowns and clocks, including conditional branches; preserve older layouts, schedule visible countdown changes, and avoid repeated VoiceOver wording (#3481, #3356). Thanks @vincent-peng!
 
 ### Fixed

--- a/Sources/CodexBar/MenuBarPercentWindowPreference.swift
+++ b/Sources/CodexBar/MenuBarPercentWindowPreference.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Which quota window the menu bar percent reads from, expressed as a single choice.
+///
+/// The menu bar renders from a `MenuBarLayout`, whose `%` tokens each carry their own
+/// `PercentWindow`. That is expressive but only reachable through the layout editor, so an account
+/// whose stored preference resolves to the weekly lane can end up showing a nearly-full weekly
+/// percent with no obvious way to switch to the session lane. This maps the common case — every
+/// percent in the layout reading the same window — onto one picker.
+///
+/// Only top-level percent tokens are considered. A conditional token carries its own then/else
+/// tokens, which stay under the layout editor's control: a layout whose percent lives inside a
+/// conditional reports no single preference, so the picker hides rather than silently rewriting
+/// half of it.
+enum MenuBarPercentWindowPreference: String, CaseIterable, Identifiable, Sendable {
+    case automatic
+    case session
+    case weekly
+
+    var id: String { self.rawValue }
+
+    var percentWindow: PercentWindow {
+        switch self {
+        case .automatic: .automatic
+        case .session: .session
+        case .weekly: .weekly
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .automatic: L("menu_bar_layout_token_auto")
+        case .session: L("menu_bar_layout_token_session")
+        case .weekly: L("menu_bar_layout_token_weekly")
+        }
+    }
+
+    /// The preference a layout expresses, or nil when its percent tokens mix windows — a
+    /// combination only the layout editor can describe, which the picker must not silently flatten.
+    static func current(in layout: MenuBarLayout) -> Self? {
+        let windows = Self.percentWindows(in: layout)
+        guard let first = windows.first, windows.allSatisfy({ $0 == first }) else { return nil }
+        return Self.allCases.first { $0.percentWindow == first }
+    }
+
+    /// True when the layout shows a percent at all. A layout built from icon-only or reset-time
+    /// tokens has nothing for this preference to act on.
+    static func hasPercentToken(in layout: MenuBarLayout) -> Bool {
+        !Self.percentWindows(in: layout).isEmpty
+    }
+
+    /// Layout with every percent token pointed at this preference's window; all other tokens,
+    /// including line breaks and separators, are left exactly as the user arranged them.
+    func applied(to layout: MenuBarLayout) -> MenuBarLayout {
+        MenuBarLayout(lines: layout.lines.map { line in
+            line.map { token in
+                if case .percent = token {
+                    return .percent(window: self.percentWindow)
+                }
+                return token
+            }
+        })
+    }
+
+    private static func percentWindows(in layout: MenuBarLayout) -> [PercentWindow] {
+        layout.lines.flatMap(\.self).compactMap { token in
+            guard case let .percent(window) = token else { return nil }
+            return window
+        }
+    }
+}

--- a/Sources/CodexBar/MenuBarPercentWindowPreference.swift
+++ b/Sources/CodexBar/MenuBarPercentWindowPreference.swift
@@ -1,0 +1,156 @@
+import CodexBarCore
+import Foundation
+
+/// Which quota window the menu bar percent reads from, expressed as a single choice.
+///
+/// The menu bar renders from a `MenuBarLayout`, whose `%` tokens each carry their own
+/// `PercentWindow`. That is expressive but only reachable through the layout editor, so an account
+/// whose stored preference resolves to the weekly lane can end up showing a nearly-full weekly
+/// percent with no obvious way to switch to the session lane. This maps the common case — every
+/// percent in the layout reading the same window — onto one picker.
+///
+/// Only top-level percent tokens are considered. A conditional token carries its own then/else
+/// tokens, which stay under the layout editor's control. The picker hides when no top-level percent
+/// exists; mixed layouts expose only their top-level percent choice.
+enum MenuBarPercentWindowPreference: String, CaseIterable, Identifiable, Sendable {
+    case automatic
+    case session
+    case weekly
+
+    var id: String {
+        self.rawValue
+    }
+
+    var percentWindow: PercentWindow {
+        switch self {
+        case .automatic: .automatic
+        case .session: .session
+        case .weekly: .weekly
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .automatic: L("menu_bar_layout_token_auto")
+        case .session: L("menu_bar_layout_token_session")
+        case .weekly: L("menu_bar_layout_token_weekly")
+        }
+    }
+
+    /// Windows this provider can actually render as a menu-bar percent, in picker order.
+    ///
+    /// Extra-rate and plan metrics (monthly plan, extra usage, tertiary, average) still resolve
+    /// through Automatic — they do not invent a session/weekly lane the snapshot cannot feed.
+    static func available(
+        metrics: ProviderMenuBarMetricCapabilities,
+        primarySemanticWindow: ProviderSemanticWindow = .session,
+        secondarySemanticWindow: ProviderSemanticWindow = .weekly) -> [Self]
+    {
+        var windows = Set<PercentWindow>()
+        for metric in metrics.supported {
+            windows.insert(Self.percentWindow(
+                for: metric,
+                primarySemanticWindow: primarySemanticWindow,
+                secondarySemanticWindow: secondarySemanticWindow))
+        }
+        return Self.allCases.filter { windows.contains($0.percentWindow) }
+    }
+
+    static func available(for provider: UsageProvider) -> [Self] {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
+        return Self.available(
+            metrics: descriptor.menuBarMetrics,
+            primarySemanticWindow: descriptor.presentation.primarySemanticWindow,
+            secondarySemanticWindow: descriptor.presentation.secondarySemanticWindow)
+    }
+
+    /// The simplified picker is a percent-layout control. Critters and Bars keep their global style,
+    /// and a single remaining option (or no session/weekly lane at all) is not worth a dead control.
+    static func isVisible(
+        iconStyle: MenuBarIconStyle,
+        layout: MenuBarLayout,
+        available: [Self]) -> Bool
+    {
+        iconStyle == .iconAndPercent
+            && self.hasPercentToken(in: layout)
+            && available.count > 1
+    }
+
+    static func isVisible(
+        iconStyle: MenuBarIconStyle,
+        layout: MenuBarLayout,
+        provider: UsageProvider) -> Bool
+    {
+        self.isVisible(
+            iconStyle: iconStyle,
+            layout: layout,
+            available: self.available(for: provider))
+    }
+
+    /// Writes the per-provider layout override without flipping `menuBarIconStyle`.
+    @MainActor
+    static func persist(
+        _ preference: Self,
+        appliedTo layout: MenuBarLayout,
+        for provider: UsageProvider,
+        settings: SettingsStore)
+    {
+        settings.setMenuBarLayout(preference.applied(to: layout), for: provider)
+    }
+
+    /// The preference a layout expresses, or nil when its percent tokens mix windows — a
+    /// combination only the layout editor can describe, which the picker must not silently flatten.
+    static func current(in layout: MenuBarLayout) -> Self? {
+        let windows = Self.percentWindows(in: layout)
+        guard let first = windows.first, windows.allSatisfy({ $0 == first }) else { return nil }
+        return Self.allCases.first { $0.percentWindow == first }
+    }
+
+    /// True when the layout shows a percent at all. A layout built from icon-only or reset-time
+    /// tokens has nothing for this preference to act on.
+    static func hasPercentToken(in layout: MenuBarLayout) -> Bool {
+        !self.percentWindows(in: layout).isEmpty
+    }
+
+    /// Layout with every percent token pointed at this preference's window; all other tokens,
+    /// including line breaks and separators, are left exactly as the user arranged them.
+    func applied(to layout: MenuBarLayout) -> MenuBarLayout {
+        MenuBarLayout(lines: layout.lines.map { line in
+            line.map { token in
+                if case .percent = token {
+                    return .percent(window: self.percentWindow)
+                }
+                return token
+            }
+        })
+    }
+
+    private static func percentWindows(in layout: MenuBarLayout) -> [PercentWindow] {
+        layout.lines.flatMap(\.self).compactMap { token in
+            guard case let .percent(window) = token else { return nil }
+            return window
+        }
+    }
+
+    /// Same mapping the layout migration uses: primary/secondary become the provider's semantic
+    /// session or weekly lane; every other metric, including monthly plan, stays on Automatic.
+    private static func percentWindow(
+        for metric: ProviderMenuBarMetric,
+        primarySemanticWindow: ProviderSemanticWindow,
+        secondarySemanticWindow: ProviderSemanticWindow) -> PercentWindow
+    {
+        switch metric {
+        case .primary: self.percentWindow(primarySemanticWindow)
+        case .secondary: self.percentWindow(secondarySemanticWindow)
+        case .automatic, .primaryAndSecondary, .tertiary, .extraUsage, .average, .monthlyPlan:
+            .automatic
+        }
+    }
+
+    private static func percentWindow(_ window: ProviderSemanticWindow) -> PercentWindow {
+        switch window {
+        case .session: .session
+        case .weekly: .weekly
+        }
+    }
+}

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -150,6 +150,10 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
                 }
             }
 
+            ProviderMenuBarPercentWindowSettingsView(
+                provider: self.provider,
+                settings: self.store.settings)
+
             if !self.menuBarSettingsPickers.isEmpty {
                 Section {
                     ForEach(self.menuBarSettingsPickers) { picker in

--- a/Sources/CodexBar/ProviderMenuBarPercentWindowSettingsView.swift
+++ b/Sources/CodexBar/ProviderMenuBarPercentWindowSettingsView.swift
@@ -1,0 +1,60 @@
+import CodexBarCore
+import SwiftUI
+
+/// Per-provider picker for the quota window behind the menu bar percent.
+///
+/// Writes a per-provider layout override so the choice survives whatever the global layout says,
+/// which is also how the layout editor's provider scope persists.
+@MainActor
+struct ProviderMenuBarPercentWindowSettingsView: View {
+    let provider: UsageProvider
+    @Bindable var settings: SettingsStore
+
+    var body: some View {
+        let layout = self.settings.menuBarLayoutResolution(for: self.provider).layout
+        let available = MenuBarPercentWindowPreference.available(for: self.provider)
+        if MenuBarPercentWindowPreference.isVisible(
+            iconStyle: self.settings.menuBarIconStyle,
+            layout: layout,
+            available: available)
+        {
+            let current = MenuBarPercentWindowPreference.current(in: layout)
+            let selection = current.flatMap { available.contains($0) ? $0 : nil }
+            Section {
+                Picker(L("menu_bar_metric_title"), selection: self.binding(layout: layout, current: selection)) {
+                    if selection == nil {
+                        // Mixed windows (e.g. Session · Weekly) are only describable in the layout
+                        // editor; surface that instead of pretending one option is selected.
+                        Text(L("menu_bar_layout_preset_custom"))
+                            .tag(MenuBarPercentWindowPreference?.none)
+                    }
+                    ForEach(available) { preference in
+                        Text(preference.label).tag(MenuBarPercentWindowPreference?.some(preference))
+                    }
+                }
+                .pickerStyle(.menu)
+                .listRowSeparator(.hidden)
+            } footer: {
+                SettingsSectionFooter(L("menu_bar_metric_subtitle"))
+            }
+            .background(FocusResigningBackground())
+        }
+    }
+
+    private func binding(
+        layout: MenuBarLayout,
+        current: MenuBarPercentWindowPreference?)
+        -> Binding<MenuBarPercentWindowPreference?>
+    {
+        Binding(
+            get: { current },
+            set: { preference in
+                guard let preference else { return }
+                MenuBarPercentWindowPreference.persist(
+                    preference,
+                    appliedTo: layout,
+                    for: self.provider,
+                    settings: self.settings)
+            })
+    }
+}

--- a/Sources/CodexBar/ProviderMenuBarPercentWindowSettingsView.swift
+++ b/Sources/CodexBar/ProviderMenuBarPercentWindowSettingsView.swift
@@ -1,0 +1,53 @@
+import CodexBarCore
+import SwiftUI
+
+/// Per-provider picker for the quota window behind the menu bar percent.
+///
+/// Writes a per-provider layout override so the choice survives whatever the global layout says,
+/// which is also how the layout editor's provider scope persists.
+@MainActor
+struct ProviderMenuBarPercentWindowSettingsView: View {
+    let provider: UsageProvider
+    @Bindable var settings: SettingsStore
+
+    var body: some View {
+        let layout = self.settings.menuBarLayoutResolution(for: self.provider).layout
+        if MenuBarPercentWindowPreference.hasPercentToken(in: layout) {
+            let current = MenuBarPercentWindowPreference.current(in: layout)
+            Section {
+                Picker(L("menu_bar_metric_title"), selection: self.binding(layout: layout, current: current)) {
+                    if current == nil {
+                        // Mixed windows (e.g. Session · Weekly) are only describable in the layout
+                        // editor; surface that instead of pretending one option is selected.
+                        Text(L("menu_bar_layout_preset_custom"))
+                            .tag(MenuBarPercentWindowPreference?.none)
+                    }
+                    ForEach(MenuBarPercentWindowPreference.allCases) { preference in
+                        Text(preference.label).tag(MenuBarPercentWindowPreference?.some(preference))
+                    }
+                }
+                .pickerStyle(.menu)
+                .listRowSeparator(.hidden)
+            } footer: {
+                SettingsSectionFooter(L("menu_bar_metric_subtitle"))
+            }
+            .background(FocusResigningBackground())
+        }
+    }
+
+    private func binding(
+        layout: MenuBarLayout,
+        current: MenuBarPercentWindowPreference?)
+        -> Binding<MenuBarPercentWindowPreference?>
+    {
+        Binding(
+            get: { current },
+            set: { preference in
+                guard let preference else { return }
+                MenuBarLayoutEditorPersistence.activate(
+                    preference.applied(to: layout),
+                    for: self.provider,
+                    settings: self.settings)
+            })
+    }
+}

--- a/Tests/CodexBarTests/MenuBarPercentWindowNativeProofTests.swift
+++ b/Tests/CodexBarTests/MenuBarPercentWindowNativeProofTests.swift
@@ -1,0 +1,109 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+final class MenuBarPercentWindowNativeProofTests: XCTestCase {
+    func test_providerPickerPersistence() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["CODEXBAR_PERCENT_POINTER_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_PERCENT_POINTER_DIR for native picker proof")
+        }
+        guard SettingsStore.isRunningTests,
+              environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1"
+        else { return XCTFail("Requires an isolated test host") }
+        let output = URL(fileURLWithPath: path, isDirectory: true)
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let defaults = InMemoryUserDefaults(values: ["debugDisableKeychainAccess": true])
+        let config = CodexBarConfigStore(fileURL: output.appendingPathComponent("config.json"))
+        try config.save(CodexBarConfig(providers: UsageProvider.allCases.map {
+            ProviderConfig(id: $0.instanceID, enabled: $0 == .codex || $0 == .claude)
+        }))
+        let settings = Self.settings(defaults: defaults, config: config)
+        defer { settings.configFileWatcher?.stop() }
+        settings.menuBarIconStyle = .iconAndPercent
+        settings.setMenuBarLayout(MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]]), for: nil)
+        let app = NSApplication.shared
+        guard app.delegate == nil else { return XCTFail("Requires a standalone test application") }
+        let previousPolicy = app.activationPolicy()
+        let previousApp = NSWorkspace.shared.frontmostApplication
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 620, height: 380),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        window.title = "CodexBar Synthetic Percent Picker Proof"
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: Form {
+            Text("Codex").font(.headline)
+            ProviderMenuBarPercentWindowSettingsView(provider: .codex, settings: settings)
+            Text("Claude").font(.headline)
+            ProviderMenuBarPercentWindowSettingsView(provider: .claude, settings: settings)
+        }.formStyle(.grouped).frame(width: 620, height: 380))
+        defer {
+            window.close()
+            _ = app.setActivationPolicy(previousPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApp?.activate()
+            }
+        }
+        _ = app.setActivationPolicy(.regular)
+        app.finishLaunching()
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        app.activate(ignoringOtherApps: true)
+        let deadline = Date().addingTimeInterval(600)
+        let done = output.appendingPathComponent("done").path
+        while !FileManager.default.fileExists(atPath: done), Date() < deadline {
+            let receipt = [
+                "pid": String(ProcessInfo.processInfo.processIdentifier),
+                "window": String(window.windowNumber),
+                "codex": MenuBarPercentWindowPreference.current(
+                    in: settings.menuBarLayoutResolution(for: .codex).layout)?.rawValue ?? "custom",
+                "claude": MenuBarPercentWindowPreference.current(
+                    in: settings.menuBarLayoutResolution(for: .claude).layout)?.rawValue ?? "custom",
+            ]
+            try JSONEncoder().encode(receipt).write(to: output.appendingPathComponent("state.json"), options: .atomic)
+            if let event = app.nextEvent(
+                matching: .any, until: Date().addingTimeInterval(0.02), inMode: .default, dequeue: true)
+            {
+                app.sendEvent(event)
+            }
+            _ = RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: done), "Native proof timed out")
+        XCTAssertEqual(MenuBarPercentWindowPreference.current(
+            in: settings.menuBarLayoutResolution(for: .codex).layout), .weekly)
+        XCTAssertEqual(MenuBarPercentWindowPreference.current(
+            in: settings.menuBarLayoutResolution(for: .claude).layout), .automatic)
+        let reloaded = Self.settings(defaults: defaults, config: config)
+        defer { reloaded.configFileWatcher?.stop() }
+        XCTAssertEqual(
+            reloaded.menuBarLayoutResolution(for: .codex).layout,
+            settings.menuBarLayoutResolution(for: .codex).layout)
+        XCTAssertEqual(reloaded.menuBarIconStyle, .iconAndPercent)
+    }
+
+    static func settings(defaults: UserDefaults, config: CodexBarConfigStore) -> SettingsStore {
+        SettingsStore(
+            userDefaults: defaults,
+            configStore: config,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore(),
+            performInitialProviderDetection: false)
+    }
+}

--- a/Tests/CodexBarTests/MenuBarPercentWindowPreferenceTests.swift
+++ b/Tests/CodexBarTests/MenuBarPercentWindowPreferenceTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct MenuBarPercentWindowPreferenceTests {
+    @Test
+    func `a uniform layout maps to a single preference`() {
+        #expect(MenuBarPercentWindowPreference.current(
+            in: MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]])) == .automatic)
+        #expect(MenuBarPercentWindowPreference.current(
+            in: MenuBarLayout(lines: [[.icon, .percent(window: .weekly)]])) == .weekly)
+        // Repeated percents that agree still map to one option.
+        #expect(MenuBarPercentWindowPreference.current(in: MenuBarLayout(lines: [
+            [.icon, .percent(window: .session)],
+            [.percent(window: .session)],
+        ])) == .session)
+    }
+
+    @Test
+    func `mixed or absent percents have no single preference`() {
+        // Session · Weekly is only describable in the layout editor.
+        #expect(MenuBarPercentWindowPreference.current(in: MenuBarLayout(lines: [[
+            .icon,
+            .percent(window: .session),
+            .separatorDot,
+            .percent(window: .weekly),
+        ]])) == nil)
+
+        let iconOnly = MenuBarLayout(lines: [[.icon]])
+        #expect(MenuBarPercentWindowPreference.current(in: iconOnly) == nil)
+        #expect(MenuBarPercentWindowPreference.hasPercentToken(in: iconOnly) == false)
+        #expect(MenuBarPercentWindowPreference.hasPercentToken(
+            in: MenuBarLayout(lines: [[.icon, .percent(window: .weekly)]])))
+    }
+
+    @Test
+    func `applying a preference rewrites only the percent tokens`() {
+        let layout = MenuBarLayout(lines: [
+            [.icon, .percent(window: .weekly), .separatorDot, .runsOut],
+            [.percent(window: .automatic), .costToday],
+        ])
+
+        let session = MenuBarPercentWindowPreference.session.applied(to: layout)
+
+        #expect(session.lines == [
+            [.icon, .percent(window: .session), .separatorDot, .runsOut],
+            [.percent(window: .session), .costToday],
+        ])
+        #expect(MenuBarPercentWindowPreference.current(in: session) == .session)
+    }
+
+    @Test
+    func `switching between preferences round-trips`() {
+        let original = MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]])
+
+        let weekly = MenuBarPercentWindowPreference.weekly.applied(to: original)
+        let backToAutomatic = MenuBarPercentWindowPreference.automatic.applied(to: weekly)
+
+        #expect(backToAutomatic == original)
+    }
+}

--- a/Tests/CodexBarTests/MenuBarPercentWindowPreferenceTests.swift
+++ b/Tests/CodexBarTests/MenuBarPercentWindowPreferenceTests.swift
@@ -1,0 +1,191 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct MenuBarPercentWindowPreferenceTests {
+    @Test
+    @MainActor
+    func `percent choice preserves explicit reset windows and conditional library through V3 reload`() {
+        let rule = MenuBarLayoutConditional(
+            clauses: [MenuBarConditionalClause(
+                combinator: nil,
+                predicate: MenuBarConditionalPredicate(metric: .weekly, comparison: .greaterThan, threshold: 80))],
+            thenToken: .windowResetCountdown(window: .session),
+            elseToken: .percent(window: .session))
+        let layout = MenuBarLayout(lines: [[
+            .icon, .percent(window: .automatic), .windowResetCountdown(window: .weekly),
+            .windowResetAbsolute(window: .session), .conditional(id: rule.id), .lanePercent(lane: .tertiary),
+        ]])
+        let other = MenuBarLayout(lines: [[.windowResetAbsolute(window: .weekly)]])
+        let defaults = InMemoryUserDefaults()
+        let config = testConfigStore(suiteName: "percent-reset-integration-\(UUID().uuidString)")
+        let settings = MenuBarPercentWindowNativeProofTests.settings(defaults: defaults, config: config)
+        defer { settings.configFileWatcher?.stop() }
+        settings.menuBarIconStyle = .iconAndPercent
+        settings.menuBarLayoutConditionals = [rule]
+        settings.setMenuBarLayout(layout, for: .codex)
+        settings.setMenuBarLayout(other, for: .claude)
+
+        MenuBarPercentWindowPreference.persist(.weekly, appliedTo: layout, for: .codex, settings: settings)
+        let expected = MenuBarLayout(lines: [[
+            .icon, .percent(window: .weekly), .windowResetCountdown(window: .weekly),
+            .windowResetAbsolute(window: .session), .conditional(id: rule.id), .lanePercent(lane: .tertiary),
+        ]])
+        #expect(settings.menuBarLayoutResolution(for: .codex).layout == expected)
+        let reloaded = MenuBarPercentWindowNativeProofTests.settings(defaults: defaults, config: config)
+        defer { reloaded.configFileWatcher?.stop() }
+        #expect(reloaded.menuBarLayoutResolution(for: .codex).layout == expected)
+        #expect(reloaded.menuBarLayoutResolution(for: .claude).layout == other)
+        #expect(reloaded.menuBarLayoutConditionals == [rule])
+        #expect(reloaded.menuBarIconStyle == .iconAndPercent)
+        #expect(defaults.data(forKey: MenuBarLayoutUserDefaultsKey.overridesCurrent) != nil)
+        #expect(!MenuBarPercentWindowPreference.isVisible(
+            iconStyle: .iconAndPercent,
+            layout: MenuBarLayout(lines: [[.conditional(id: rule.id)]]),
+            provider: .codex))
+    }
+
+    @Test
+    func `a uniform layout maps to a single preference`() {
+        #expect(MenuBarPercentWindowPreference.current(
+            in: MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]])) == .automatic)
+        #expect(MenuBarPercentWindowPreference.current(
+            in: MenuBarLayout(lines: [[.icon, .percent(window: .weekly)]])) == .weekly)
+        // Repeated percents that agree still map to one option.
+        #expect(MenuBarPercentWindowPreference.current(in: MenuBarLayout(lines: [
+            [.icon, .percent(window: .session)],
+            [.percent(window: .session)],
+        ])) == .session)
+    }
+
+    @Test
+    func `mixed or absent percents have no single preference`() {
+        // Session · Weekly is only describable in the layout editor.
+        #expect(MenuBarPercentWindowPreference.current(in: MenuBarLayout(lines: [[
+            .icon,
+            .percent(window: .session),
+            .separatorDot,
+            .percent(window: .weekly),
+        ]])) == nil)
+
+        let iconOnly = MenuBarLayout(lines: [[.icon]])
+        #expect(MenuBarPercentWindowPreference.current(in: iconOnly) == nil)
+        #expect(MenuBarPercentWindowPreference.hasPercentToken(in: iconOnly) == false)
+        #expect(MenuBarPercentWindowPreference.hasPercentToken(
+            in: MenuBarLayout(lines: [[.icon, .percent(window: .weekly)]])))
+    }
+
+    @Test
+    func `applying a preference rewrites only the percent tokens`() {
+        let layout = MenuBarLayout(lines: [
+            [.icon, .percent(window: .weekly), .separatorDot, .runsOut],
+            [.percent(window: .automatic), .costToday],
+        ])
+
+        let session = MenuBarPercentWindowPreference.session.applied(to: layout)
+
+        #expect(session.lines == [
+            [.icon, .percent(window: .session), .separatorDot, .runsOut],
+            [.percent(window: .session), .costToday],
+        ])
+        #expect(MenuBarPercentWindowPreference.current(in: session) == .session)
+    }
+
+    @Test
+    func `switching between preferences round-trips`() {
+        let original = MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]])
+
+        let weekly = MenuBarPercentWindowPreference.weekly.applied(to: original)
+        let backToAutomatic = MenuBarPercentWindowPreference.automatic.applied(to: weekly)
+
+        #expect(backToAutomatic == original)
+    }
+
+    @Test
+    func `picker stays hidden unless the global style is icon and percent`() {
+        let layout = MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]])
+        let options = MenuBarPercentWindowPreference.allCases
+
+        #expect(MenuBarPercentWindowPreference.isVisible(
+            iconStyle: .iconAndPercent,
+            layout: layout,
+            available: options))
+        #expect(MenuBarPercentWindowPreference.isVisible(
+            iconStyle: .critters,
+            layout: layout,
+            available: options) == false)
+        #expect(MenuBarPercentWindowPreference.isVisible(
+            iconStyle: .bars,
+            layout: layout,
+            available: options) == false)
+        #expect(MenuBarPercentWindowPreference.isVisible(
+            iconStyle: .iconAndPercent,
+            layout: MenuBarLayout(lines: [[.icon]]),
+            available: options) == false)
+    }
+
+    @Test
+    func `picker hides when session and weekly cannot apply`() {
+        let layout = MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]])
+        let automaticOnly = MenuBarPercentWindowPreference.available(
+            metrics: ProviderMenuBarMetricCapabilities(supported: [.automatic, .monthlyPlan]))
+
+        #expect(automaticOnly == [.automatic])
+        #expect(MenuBarPercentWindowPreference.isVisible(
+            iconStyle: .iconAndPercent,
+            layout: layout,
+            available: automaticOnly) == false)
+        #expect(MenuBarPercentWindowPreference.isVisible(
+            iconStyle: .iconAndPercent,
+            layout: layout,
+            available: [.automatic, .session]))
+    }
+
+    @Test
+    func `available options follow provider percent-window capabilities`() {
+        let mistralLike = ProviderMenuBarMetricCapabilities(supported: [.automatic, .monthlyPlan])
+        #expect(MenuBarPercentWindowPreference.available(metrics: mistralLike) == [.automatic])
+
+        let sessionOnlyPrimary = ProviderMenuBarMetricCapabilities(supported: [.automatic, .primary])
+        #expect(MenuBarPercentWindowPreference.available(metrics: sessionOnlyPrimary) == [.automatic, .session])
+
+        let weeklyPrimary = ProviderMenuBarMetricCapabilities(supported: [.automatic, .primary])
+        #expect(MenuBarPercentWindowPreference.available(
+            metrics: weeklyPrimary,
+            primarySemanticWindow: .weekly) == [.automatic, .weekly])
+
+        #expect(MenuBarPercentWindowPreference.available(
+            metrics: .standard) == [.automatic, .session, .weekly])
+        #expect(MenuBarPercentWindowPreference.available(for: .mistral) == [.automatic])
+        #expect(MenuBarPercentWindowPreference.available(for: .openrouter) == [.automatic, .session])
+        #expect(MenuBarPercentWindowPreference.available(for: .codex) == [.automatic, .session, .weekly])
+        #expect(MenuBarPercentWindowPreference.isVisible(
+            iconStyle: .iconAndPercent,
+            layout: MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]]),
+            provider: .mistral) == false)
+    }
+
+    @Test
+    @MainActor
+    func `persisting a provider window does not flip the global icon style`() {
+        let settings = testSettingsStore(
+            suiteName: "MenuBarPercentWindowPreferenceTests-preserve-style")
+        settings.menuBarIconStyle = .critters
+        let layout = MenuBarLayout(lines: [[.icon, .percent(window: .automatic)]])
+        settings.setMenuBarLayout(layout, for: .claude)
+
+        MenuBarPercentWindowPreference.persist(
+            .session,
+            appliedTo: layout,
+            for: .claude,
+            settings: settings)
+
+        #expect(settings.menuBarIconStyle == .critters)
+        #expect(MenuBarPercentWindowPreference.current(in: settings.menuBarLayout(for: .claude)) == .session)
+        #expect(settings.menuBarLayoutOverrides[.claude] == MenuBarLayout(lines: [[
+            .icon,
+            .percent(window: .session),
+        ]]))
+    }
+}

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -134,3 +134,7 @@ Runs out tokens remain hidden until 3% of their window has elapsed.
 See also: `docs/widgets.md`.
 
 Cost-history submenus keep tall histories in a scrollable viewport. Switching Token/Cost preserves the viewport; scrolling over the chart moves through the history without moving the native menu.
+
+### Provider percent window
+
+In Icon and Percent mode, provider settings expose an Auto, Session, or Weekly picker when the provider supports multiple quota windows. The choice updates top-level percent tokens in that provider’s layout. Conditional tokens and other providers’ layouts remain independent; use the layout editor for mixed percent windows.


### PR DESCRIPTION
Choose Auto, Session, or Weekly as the percent window in provider settings. Choices follow provider capabilities, and the picker appears only for applicable Icon and Percent layouts. It edits top-level percent tokens for that provider while preserving the global style, custom conditional tokens, and direct lane tokens.

Built on the landed reset-window support in #3481. Paired V3 tests verify explicit reset tokens, conditional libraries, and other providers’ overrides survive a percent change and reload.

Validation: focused picker/renderer tests, paired persistence tests, a full standalone suite, and independent review passed. Signed native pointer proof changed Codex to Weekly while Claude stayed Auto, then verified reconstruction. The final combined tree passes 122 focused tests and formatting/lint; its full suite and exact-head CI are the final landing gates.

Includes UI documentation and an Unreleased entry. Thanks @J2TeamNNL!

Synthetic proof captures:

![Synthetic provider percent pickers before changing Codex](https://github.com/user-attachments/assets/c7874da7-0312-4987-9acc-abd65e2cf8ce)

![Synthetic Codex Weekly selection with Claude remaining Auto](https://github.com/user-attachments/assets/fe4192b8-41c9-44b4-ac52-4bc4a9103695)
