### PR TITLE
Isolate profile-scoped Codex token cost snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 0.54.1 — Unreleased
 
+- Fixed Codex profile-home account switches briefly showing another profile's token counts, costs, usage chart, top model, and cost history while the selected profile loads (#3125).
 - Command Code: recognize the repriced Pro tier (`individual-pro-v1`, $80/mo in credits) instead of failing with an unknown-plan error (#3116). Thanks @sebastianmarines!
 - Alibaba: retry the Personal usage gateway's transient empty-Success responses instead of surfacing a parse error (#3128). Thanks @LeoLin990405!
-
 - Fixed the Codex CLI usage probe against Codex CLI 0.149.0: the removed `untrusted` approval value is replaced by `never` on both the app-server and isolated status launches, keeping the read-only sandbox (#3115, #3118). Thanks @kiranmagic7!
 
 - Added conditional tokens to the menu bar layout editor: named, reusable if/then/else rules (1–4 AND/OR clauses over Session/Weekly/Scoped/Auto thresholds) that swap or hide tokens based on live usage, downgrade-safe and localized across all 23 catalogs (#3076). Thanks @wdmitchelluk!

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -30,6 +30,13 @@ struct CodexAccountScopedRefreshGuard: Equatable {
 
 @MainActor
 extension UsageStore {
+    func accountScopedTokenSnapshot(for provider: UsageProvider) -> CostUsageTokenSnapshot? {
+        guard provider == .codex, !self.settings.codexLocalSessionCostLedgerEnabled else {
+            return self.tokenSnapshots[provider.instanceID]
+        }
+        return self.tokenSnapshotForCurrentProviderConfig(for: provider)?.snapshot
+    }
+
     func refreshCodexAccountScopedState(
         allowDisabled: Bool = false,
         phaseDidChange: (@MainActor (CodexAccountScopedRefreshPhase) -> Void)? = nil)
@@ -81,7 +88,8 @@ extension UsageStore {
         let accountChanged = previousGuard.map {
             !Self.codexScopedRefreshGuardsMatchAccount($0, currentGuard)
         } ?? false
-        guard forceInvalidation || accountChanged else { return false }
+        let tokenCostScopeChanged = self.invalidateCodexTokenSnapshotIfScopeChanged()
+        guard forceInvalidation || accountChanged || tokenCostScopeChanged else { return false }
 
         let preserveSessionQuotaTransitionState = !forceInvalidation &&
             Self.codexSessionQuotaOwnersMatch(previousGuard, currentGuard)
@@ -98,6 +106,24 @@ extension UsageStore {
         self.clearCodexOpenAIWebStateForAccountTransition(targetEmail: self.codexAccountEmailForOpenAIDashboard())
 
         self.persistWidgetSnapshot(reason: "codex-account-invalidate")
+        return true
+    }
+
+    private func invalidateCodexTokenSnapshotIfScopeChanged() -> Bool {
+        guard !self.settings.codexLocalSessionCostLedgerEnabled,
+              let publication = self.tokenSnapshotPublications[.codex],
+              publication.scopeSignature != self.tokenSnapshotScopeSignature(for: .codex)
+        else {
+            return false
+        }
+
+        self.clearTokenSnapshot(for: .codex)
+        self.tokenErrors[.codex] = nil
+        self.tokenFailureGates[.codex]?.reset()
+        self.lastTokenFetchAt.removeValue(forKey: .codex)
+        self.lastTokenFetchScope.removeValue(forKey: .codex)
+        self.cancelCodexCostCatchUp()
+        self.synchronizeSharedSpendDashboardAfterTokenPublication(for: .codex)
         return true
     }
 

--- a/Sources/CodexBar/UsageStore+TokenCost.swift
+++ b/Sources/CodexBar/UsageStore+TokenCost.swift
@@ -89,7 +89,7 @@ extension UsageStore {
     }
 
     func tokenSnapshot(for provider: UsageProvider) -> CostUsageTokenSnapshot? {
-        self.tokenSnapshots[provider.instanceID]
+        self.accountScopedTokenSnapshot(for: provider)
     }
 
     func tokenSnapshotForCurrentProviderConfig(

--- a/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
+++ b/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
@@ -96,6 +96,132 @@ struct CodexProfileHomeAccountTests {
 
     @Test
     @MainActor
+    func `profile home selection immediately hides the previous account cost dashboard`() throws {
+        let fixture = try Self.makeProfileHomeCostFixture(suite: "CodexProfileHomeAccountTests-cost-selection")
+        defer { fixture.cleanup() }
+
+        let profileASnapshot = Self.costSnapshot(cost: 12, tokens: 1200, model: "fictional-profile-a")
+        fixture.store._setTokenSnapshotForTesting(profileASnapshot, provider: .codex)
+        let originalModel = ProvidersPane(settings: fixture.settings, store: fixture.store)
+            ._test_menuCardModel(for: .codex)
+
+        #expect(originalModel.tokenUsage?.sessionLine.contains("$12") == true)
+        #expect(originalModel.inlineUsageDashboard?.points.isEmpty == false)
+        #expect(originalModel.inlineUsageDashboard?.detailLines.contains { $0.contains("fictional-profile-a") } == true)
+
+        fixture.settings.selectDisplayedCodexVisibleAccount(fixture.secondAccount)
+
+        let switchedModel = ProvidersPane(settings: fixture.settings, store: fixture.store)
+            ._test_menuCardModel(for: .codex)
+
+        #expect(fixture.store.tokenSnapshots[.codex] == profileASnapshot)
+        #expect(fixture.store.tokenSnapshotPublicationForCurrentProviderConfig(for: .codex) == nil)
+        #expect(fixture.store.tokenSnapshot(for: .codex) == nil)
+        #expect(switchedModel.email == "profile-b@example.com")
+        #expect(switchedModel.tokenUsage == nil)
+        #expect(switchedModel.inlineUsageDashboard == nil)
+    }
+
+    @Test
+    @MainActor
+    func `profile home transition clears only codex cost state and preserves unrelated providers`() throws {
+        let fixture = try Self.makeProfileHomeCostFixture(suite: "CodexProfileHomeAccountTests-cost-invalidation")
+        defer { fixture.cleanup() }
+
+        let codexSnapshot = Self.costSnapshot(cost: 12, tokens: 1200, model: "fictional-profile-a")
+        let claudeSnapshot = Self.costSnapshot(cost: 34, tokens: 3400, model: "fictional-claude")
+        fixture.store._setTokenSnapshotForTesting(codexSnapshot, provider: .codex)
+        fixture.store._setTokenSnapshotForTesting(claudeSnapshot, provider: .claude)
+        fixture.store.tokenErrors[.codex] = "Profile A scan failed"
+        fixture.store.lastTokenFetchAt[.codex] = Date()
+        fixture.store.lastTokenFetchScope[.codex] = fixture.store.tokenSnapshotScopeSignature(for: .codex)
+        fixture.store.lastCodexAccountScopedRefreshGuard = fixture.store
+            .currentCodexAccountScopedRefreshGuard(preferCurrentSnapshot: false)
+
+        fixture.settings.selectDisplayedCodexVisibleAccount(fixture.secondAccount)
+        let didInvalidate = fixture.store.prepareCodexAccountScopedRefreshIfNeeded()
+
+        #expect(didInvalidate)
+        #expect(fixture.store.tokenSnapshots[.codex] == nil)
+        #expect(fixture.store.tokenSnapshotPublications[.codex] == nil)
+        #expect(fixture.store.tokenError(for: .codex) == nil)
+        #expect(fixture.store.tokenLastAttemptAt(for: .codex) == nil)
+        #expect(fixture.store.lastTokenFetchScope[.codex] == nil)
+        #expect(fixture.store.tokenSnapshot(for: .claude) == claudeSnapshot)
+        #expect(fixture.store.tokenSnapshotForCurrentProviderConfig(for: .claude)?.snapshot == claudeSnapshot)
+    }
+
+    @Test
+    @MainActor
+    func `profile home cost dashboard stays empty during scan and then publishes selected profile`() async throws {
+        let fixture = try Self.makeProfileHomeCostFixture(suite: "CodexProfileHomeAccountTests-cost-scan")
+        defer { fixture.cleanup() }
+
+        let profileASnapshot = Self.costSnapshot(cost: 12, tokens: 1200, model: "fictional-profile-a")
+        let profileBSnapshot = Self.costSnapshot(cost: 34, tokens: 3400, model: "fictional-profile-b")
+        fixture.store._setTokenSnapshotForTesting(profileASnapshot, provider: .codex)
+        fixture.store.lastCodexAccountScopedRefreshGuard = fixture.store
+            .currentCodexAccountScopedRefreshGuard(preferCurrentSnapshot: false)
+        let gate = CodexProfileHomeCostScanGate()
+        fixture.store._test_tokenUsageSnapshotLoaderOverride = { provider, _, _, homePath, _ in
+            #expect(provider == .codex)
+            #expect(homePath == fixture.secondHome.path)
+            return await gate.load()
+        }
+
+        fixture.settings.selectDisplayedCodexVisibleAccount(fixture.secondAccount)
+        fixture.store.prepareCodexAccountScopedRefreshIfNeeded()
+        let refresh = Task { @MainActor in
+            await fixture.store.refreshTokenUsageNow(for: .codex, force: true)
+        }
+        await gate.waitUntilStarted()
+
+        let loadingModel = ProvidersPane(settings: fixture.settings, store: fixture.store)
+            ._test_menuCardModel(for: .codex)
+        #expect(fixture.store.isTokenRefreshInFlight(for: .codex))
+        #expect(loadingModel.tokenUsage == nil)
+        #expect(loadingModel.inlineUsageDashboard == nil)
+
+        await gate.complete(with: profileBSnapshot)
+        await refresh.value
+
+        let completedModel = ProvidersPane(settings: fixture.settings, store: fixture.store)
+            ._test_menuCardModel(for: .codex)
+        #expect(fixture.store.tokenSnapshot(for: .codex) == profileBSnapshot)
+        #expect(completedModel.tokenUsage?.sessionLine.contains("$34") == true)
+        #expect(completedModel.tokenUsage?.sessionLine.contains("$12") == false)
+        #expect(completedModel.inlineUsageDashboard?.points.map(\.value) == [34])
+        #expect(completedModel.inlineUsageDashboard?.detailLines
+            .contains { $0.contains("fictional-profile-b") } == true)
+        #expect(completedModel.inlineUsageDashboard?.detailLines
+            .contains { $0.contains("fictional-profile-a") } == false)
+    }
+
+    @Test
+    @MainActor
+    func `ambient codex ledger remains visible when profile home selection changes`() throws {
+        let fixture = try Self.makeProfileHomeCostFixture(
+            suite: "CodexProfileHomeAccountTests-ambient-ledger",
+            localLedgerEnabled: true)
+        defer { fixture.cleanup() }
+
+        let ambientSnapshot = Self.costSnapshot(cost: 56, tokens: 5600, model: "fictional-ambient")
+        fixture.store._setTokenSnapshotForTesting(ambientSnapshot, provider: .codex)
+        fixture.store.lastCodexAccountScopedRefreshGuard = fixture.store
+            .currentCodexAccountScopedRefreshGuard(preferCurrentSnapshot: false)
+
+        fixture.settings.selectDisplayedCodexVisibleAccount(fixture.secondAccount)
+        fixture.store.prepareCodexAccountScopedRefreshIfNeeded()
+
+        let model = ProvidersPane(settings: fixture.settings, store: fixture.store)
+            ._test_menuCardModel(for: .codex)
+        #expect(fixture.store.tokenSnapshot(for: .codex) == ambientSnapshot)
+        #expect(model.tokenUsage?.sessionLine.contains("$56") == true)
+        #expect(model.inlineUsageDashboard?.points.map(\.value) == [56])
+    }
+
+    @Test
+    @MainActor
     func `removed profile home falls back without routing stale path`() throws {
         let suite = "CodexProfileHomeAccountTests-stale-routing"
         let settings = try Self.makeSettings(suite: suite)
@@ -351,6 +477,92 @@ struct CodexProfileHomeAccountTests {
         #expect(settings.codexActiveSource == .managedAccount(id: managedAccount.id))
     }
 
+    @MainActor
+    private struct ProfileHomeCostFixture {
+        let settings: SettingsStore
+        let store: UsageStore
+        let root: URL
+        let secondHome: URL
+        let secondAccount: CodexVisibleAccount
+
+        func cleanup() {
+            self.store._test_tokenUsageSnapshotLoaderOverride = nil
+            self.settings._test_codexReconciliationEnvironment = nil
+            try? FileManager.default.removeItem(at: self.root)
+        }
+    }
+
+    @MainActor
+    private static func makeProfileHomeCostFixture(
+        suite: String,
+        localLedgerEnabled: Bool = false) throws -> ProfileHomeCostFixture
+    {
+        let settings = try Self.makeSettings(suite: suite)
+        settings.costUsageEnabled = true
+        settings.costSummaryDisplayStyle = .both
+        settings.codexLocalSessionCostLedgerEnabled = localLedgerEnabled
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let firstHome = root.appendingPathComponent("profile-a", isDirectory: true)
+        let secondHome = root.appendingPathComponent("profile-b", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: firstHome,
+            email: "profile-a@example.com",
+            plan: "pro",
+            accountID: "acct-profile-a")
+        try Self.writeCodexAuthFile(
+            homeURL: secondHome,
+            email: "profile-b@example.com",
+            plan: "pro",
+            accountID: "acct-profile-b")
+        let environment = [
+            "HOME": root.path,
+            "CODEX_HOME": root.appendingPathComponent("missing-live-home", isDirectory: true).path,
+        ]
+        settings._test_codexReconciliationEnvironment = environment
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = [firstHome.path, secondHome.path]
+            entry.codexActiveSource = .profileHome(path: firstHome.path)
+        }
+        let metadata = try #require(ProviderRegistry.shared.metadata[.codex])
+        settings.setProviderEnabled(provider: .codex, metadata: metadata, enabled: true)
+        let secondAccount = try #require(settings.codexVisibleAccounts.first {
+            $0.email == "profile-b@example.com"
+        })
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: environment),
+            browserDetection: BrowserDetection(homeDirectory: root.path, cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: environment)
+        return ProfileHomeCostFixture(
+            settings: settings,
+            store: store,
+            root: root,
+            secondHome: secondHome,
+            secondAccount: secondAccount)
+    }
+
+    private static func costSnapshot(cost: Double, tokens: Int, model: String) -> CostUsageTokenSnapshot {
+        CostUsageTokenSnapshot(
+            sessionTokens: tokens,
+            sessionCostUSD: cost,
+            last30DaysTokens: tokens,
+            last30DaysCostUSD: cost,
+            daily: [CostUsageDailyReport.Entry(
+                date: "2026-08-21",
+                inputTokens: tokens / 2,
+                outputTokens: tokens / 2,
+                totalTokens: tokens,
+                costUSD: cost,
+                modelsUsed: [model],
+                modelBreakdowns: [CostUsageDailyReport.ModelBreakdown(
+                    modelName: model,
+                    costUSD: cost,
+                    totalTokens: tokens)])],
+            updatedAt: Date())
+    }
+
     private static func writeCodexAuthFile(
         homeURL: URL,
         email: String,
@@ -392,5 +604,32 @@ struct CodexProfileHomeAccountTests {
         }
 
         return "\(base64URL(header)).\(base64URL(payload))."
+    }
+}
+
+private actor CodexProfileHomeCostScanGate {
+    private var started = false
+    private var startedContinuation: CheckedContinuation<Void, Never>?
+    private var snapshotContinuation: CheckedContinuation<CostUsageTokenSnapshot, Never>?
+
+    func load() async -> CostUsageTokenSnapshot {
+        self.started = true
+        self.startedContinuation?.resume()
+        self.startedContinuation = nil
+        return await withCheckedContinuation { continuation in
+            self.snapshotContinuation = continuation
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard !self.started else { return }
+        await withCheckedContinuation { continuation in
+            self.startedContinuation = continuation
+        }
+    }
+
+    func complete(with snapshot: CostUsageTokenSnapshot) {
+        self.snapshotContinuation?.resume(returning: snapshot)
+        self.snapshotContinuation = nil
     }
 }


### PR DESCRIPTION
Fixes #3125.

## Root cause
Codex account/profile transitions in `UsageStore+CodexAccountState.swift` invalidated identity, quota, and credits — but retained the previous profile's token-cost snapshot, and `UsageStore+TokenCost.swift` exposed that snapshot without validating its profile scope. Selecting profile B rendered B's identity above A's Today/30d costs, chart, and top model.

## Fix
- Validate Codex token snapshot ownership immediately on selection.
- On profile change, clear obsolete Codex costs, errors, refresh metadata, and catch-up state; the popup shows loading/unavailable until B's scan lands.
- Other providers untouched; the independent ambient ledger is preserved.

## Tests
Four regressions in `CodexProfileHomeAccountTests`: immediate stale-data suppression, provider isolation, replacement scans, ambient-ledger preservation.

## Verification
189 tests across six suites, `swiftformat`, `swiftlint --strict`, `make check`, plus independent review.
