### PR TITLE
Stop re-merging the Codex plan-utilization history with itself on every refresh

### DIFF
--- a/Sources/CodexBar/PlanUtilizationHistoryStore.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryStore.swift
@@ -40,6 +40,12 @@ struct PlanUtilizationSeriesHistory: Codable, Equatable, Sendable {
     let windowMinutes: Int
     let entries: [PlanUtilizationHistoryEntry]
 
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case windowMinutes
+        case entries
+    }
+
     init(name: PlanUtilizationSeriesName, windowMinutes: Int, entries: [PlanUtilizationHistoryEntry]) {
         self.name = name
         self.windowMinutes = windowMinutes
@@ -54,6 +60,14 @@ struct PlanUtilizationSeriesHistory: Codable, Equatable, Sendable {
             let rhsReset = rhs.resetsAt?.timeIntervalSince1970 ?? Date.distantPast.timeIntervalSince1970
             return lhsReset < rhsReset
         }
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let name = try container.decode(PlanUtilizationSeriesName.self, forKey: .name)
+        let windowMinutes = try container.decode(Int.self, forKey: .windowMinutes)
+        let entries = try container.decode([PlanUtilizationHistoryEntry].self, forKey: .entries)
+        self.init(name: name, windowMinutes: windowMinutes, entries: entries)
     }
 
     var latestCapturedAt: Date? {

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -373,8 +373,10 @@ extension UsageStore {
             let canonicalWindowMinutes = sample.name.canonicalWindowMinutes(sample.windowMinutes)
             let key = PlanUtilizationSeriesKey(name: sample.name, windowMinutes: canonicalWindowMinutes)
             if let existingHistory = historiesByKey[key] {
-                guard let updatedEntries = self.updatedPlanUtilizationEntries(
-                    existingEntries: existingHistory.entries,
+                var updatedEntries = existingHistory.entries
+                self.assertPlanUtilizationEntriesSorted(updatedEntries)
+                guard self.updatedPlanUtilizationEntries(
+                    existingEntries: &updatedEntries,
                     entry: sample.entry)
                 else {
                     continue
@@ -411,28 +413,72 @@ extension UsageStore {
     }
 
     private nonisolated static func updatedPlanUtilizationEntries(
-        existingEntries: [PlanUtilizationHistoryEntry],
-        entry: PlanUtilizationHistoryEntry) -> [PlanUtilizationHistoryEntry]?
+        existingEntries: inout [PlanUtilizationHistoryEntry],
+        entry: PlanUtilizationHistoryEntry) -> Bool
     {
-        var entries = existingEntries
-        let insertionIndex = entries.firstIndex(where: { $0.capturedAt > entry.capturedAt }) ?? entries.endIndex
+        let insertionIndex = self.planUtilizationEntryInsertionIndex(
+            entries: existingEntries,
+            capturedAt: entry.capturedAt)
         let sampleHourBucket = self.planUtilizationHourBucket(for: entry.capturedAt)
         let sameHourRange = self.planUtilizationHourRange(
-            entries: entries,
+            entries: existingEntries,
             insertionIndex: insertionIndex,
             hourBucket: sampleHourBucket)
-        let existingHourEntries = Array(entries[sameHourRange])
+        let existingHourEntries = Array(existingEntries[sameHourRange])
         let canonicalHourEntries = self.canonicalPlanUtilizationHourEntries(
             existingHourEntries: existingHourEntries,
             incomingEntry: entry)
 
-        guard canonicalHourEntries != existingHourEntries else { return nil }
-        entries.replaceSubrange(sameHourRange, with: canonicalHourEntries)
+        guard canonicalHourEntries != existingHourEntries else { return false }
+        existingEntries.replaceSubrange(sameHourRange, with: canonicalHourEntries)
 
-        if entries.count > self.planUtilizationMaxSamples {
-            entries.removeFirst(entries.count - self.planUtilizationMaxSamples)
+        if existingEntries.count > self.planUtilizationMaxSamples {
+            existingEntries.removeFirst(existingEntries.count - self.planUtilizationMaxSamples)
         }
-        return entries
+        return true
+    }
+
+    /// The insertion search assumes `capturedAt` order. Checked once per merged series rather than per entry —
+    /// a per-entry check would reintroduce the O(n) scan this insertion path exists to remove.
+    private nonisolated static func assertPlanUtilizationEntriesSorted(
+        _ entries: [PlanUtilizationHistoryEntry])
+    {
+        #if DEBUG
+        assert(
+            zip(entries, entries.dropFirst()).allSatisfy { $0.capturedAt <= $1.capturedAt },
+            "plan-utilization entries must be sorted by capturedAt before insertion")
+        #endif
+    }
+
+    private nonisolated static func planUtilizationEntryInsertionIndex(
+        entries: [PlanUtilizationHistoryEntry],
+        capturedAt: Date) -> Int
+    {
+        guard let lastCapturedAt = entries.last?.capturedAt else {
+            return entries.endIndex
+        }
+        if lastCapturedAt <= capturedAt {
+            return entries.endIndex
+        }
+        return self.planUtilizationEntryUpperBound(entries: entries, capturedAt: capturedAt)
+    }
+
+    /// First index i such that entries[i].capturedAt > capturedAt (endIndex if none).
+    private nonisolated static func planUtilizationEntryUpperBound(
+        entries: [PlanUtilizationHistoryEntry],
+        capturedAt: Date) -> Int
+    {
+        var low = entries.startIndex
+        var high = entries.endIndex
+        while low < high {
+            let mid = low + ((high - low) / 2)
+            if entries[mid].capturedAt > capturedAt {
+                high = mid
+            } else {
+                low = mid + 1
+            }
+        }
+        return low
     }
 
     #if DEBUG
@@ -440,7 +486,18 @@ extension UsageStore {
         existingEntries: [PlanUtilizationHistoryEntry],
         entry: PlanUtilizationHistoryEntry) -> [PlanUtilizationHistoryEntry]?
     {
-        self.updatedPlanUtilizationEntries(existingEntries: existingEntries, entry: entry)
+        var entries = existingEntries
+        guard self.updatedPlanUtilizationEntries(existingEntries: &entries, entry: entry) else {
+            return nil
+        }
+        return entries
+    }
+
+    nonisolated static func _planUtilizationEntryUpperBoundForTesting(
+        entries: [PlanUtilizationHistoryEntry],
+        capturedAt: Date) -> Int
+    {
+        self.planUtilizationEntryUpperBound(entries: entries, capturedAt: capturedAt)
     }
 
     nonisolated static func _updatedPlanUtilizationHistoriesForTesting(
@@ -1202,6 +1259,7 @@ extension UsageStore {
         var historiesToMerge: [[PlanUtilizationSeriesHistory]] = []
         let scopedRawKeys = Array(providerBuckets.accounts.keys)
         var legacyRawKeysToRemove: [String] = []
+        var hasForeignHistoryToMerge = false
 
         for rawKey in scopedRawKeys {
             let owner = CodexHistoryOwnership.classifyPersistedKey(
@@ -1219,6 +1277,7 @@ extension UsageStore {
                 historiesToMerge.append(accountHistories)
                 if rawKey != canonicalKey {
                     legacyRawKeysToRemove.append(rawKey)
+                    hasForeignHistoryToMerge = true
                 }
             }
         }
@@ -1232,6 +1291,7 @@ extension UsageStore {
         {
             historiesToMerge.append(opaqueHistories)
             legacyRawKeysToRemove.append(recoverableOpaqueRawKey)
+            hasForeignHistoryToMerge = true
         }
 
         if shouldAdoptUnscopedHistory,
@@ -1245,9 +1305,14 @@ extension UsageStore {
         {
             historiesToMerge.append(providerBuckets.unscoped)
             providerBuckets.unscoped = []
+            hasForeignHistoryToMerge = true
         }
 
-        guard !historiesToMerge.isEmpty else { return canonicalKey }
+        // Canonical-only contribution is not a migration; re-merging it with itself is quadratic.
+        // Skipping also skips incidental re-canonicalization of already-canonical series (duplicate
+        // (name, windowMinutes) collapse and per-hour peak replay). Repairing legacy data belongs
+        // at load time, not on every refresh and menu open.
+        guard hasForeignHistoryToMerge else { return canonicalKey }
         for rawKey in legacyRawKeysToRemove {
             providerBuckets.accounts.removeValue(forKey: rawKey)
         }
@@ -1523,29 +1588,29 @@ extension UsageStore {
         provider _: UsageProvider,
         histories: [[PlanUtilizationSeriesHistory]]) -> [PlanUtilizationSeriesHistory]
     {
-        var mergedByKey: [PlanUtilizationSeriesKey: PlanUtilizationSeriesHistory] = [:]
+        var mergedEntriesByKey: [PlanUtilizationSeriesKey: [PlanUtilizationHistoryEntry]] = [:]
 
         for historyGroup in histories {
             for history in historyGroup {
                 let key = PlanUtilizationSeriesKey(name: history.name, windowMinutes: history.windowMinutes)
-                let existingEntries = mergedByKey[key]?.entries ?? []
-                var mergedEntries = existingEntries
+                var mergedEntries = mergedEntriesByKey[key] ?? []
+                self.assertPlanUtilizationEntriesSorted(mergedEntries)
                 for entry in history.entries.sorted(by: { $0.capturedAt < $1.capturedAt }) {
-                    if let updatedEntries = self.updatedPlanUtilizationEntries(
-                        existingEntries: mergedEntries,
+                    _ = self.updatedPlanUtilizationEntries(
+                        existingEntries: &mergedEntries,
                         entry: entry)
-                    {
-                        mergedEntries = updatedEntries
-                    }
                 }
-                mergedByKey[key] = PlanUtilizationSeriesHistory(
-                    name: history.name,
-                    windowMinutes: history.windowMinutes,
-                    entries: mergedEntries)
+                mergedEntriesByKey[key] = mergedEntries
             }
         }
 
-        return mergedByKey.values.sorted { lhs, rhs in
+        return mergedEntriesByKey.map { key, entries in
+            PlanUtilizationSeriesHistory(
+                name: key.name,
+                windowMinutes: key.windowMinutes,
+                entries: entries)
+        }
+        .sorted { lhs, rhs in
             if lhs.windowMinutes != rhs.windowMinutes {
                 return lhs.windowMinutes < rhs.windowMinutes
             }

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2736,7 +2736,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+PlanUtilization.swift",
-            line: 846,
+            line: 903,
             anchor: "if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -2744,7 +2744,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+PlanUtilization.swift",
-            line: 861,
+            line: 918,
             anchor: "guard let identity = snapshot.identity(for: .claude) else { return nil }",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 3,
@@ -2752,7 +2752,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+PlanUtilization.swift",
-            line: 888,
+            line: 945,
             anchor: "key.hasPrefix(\"\\(UsageProvider.claude.rawValue):\")",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -2760,7 +2760,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+PlanUtilization.swift",
-            line: 1318,
+            line: 1383,
             anchor: "if ![UsageProvider.codex, .claude, .antigravity].contains(provider) {",
             expectedProviderIDs: ["antigravity", "claude", "codex"],
             expectedReferenceCount: 3,

--- a/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
+++ b/Tests/CodexBarTests/SessionEquivalentForecastTests.swift
@@ -341,7 +341,7 @@ struct SessionEquivalentForecastTests {
     }
 
     @Test
-    func `rejects hostile dates percentages and unsorted history`() throws {
+    func `rejects hostile dates and percentages and normalizes unsorted history`() throws {
         let now = Date(timeIntervalSince1970: 1_900_000_000)
         let session = RateWindow(
             usedPercent: 20,
@@ -380,15 +380,18 @@ struct SessionEquivalentForecastTests {
         let encodedSession = try JSONEncoder().encode(fixture.histories[0])
         var sessionJSON = try #require(JSONSerialization.jsonObject(with: encodedSession) as? [String: Any])
         let entriesJSON = try #require(sessionJSON["entries"] as? [[String: Any]])
+        // Decoding sorts entries (PlanUtilizationSeriesHistory.init(from:)), so a reversed payload
+        // normalizes to the same series and yields the same estimate as the sorted fixture above.
         sessionJSON["entries"] = Array(entriesJSON.reversed())
         let shuffledData = try JSONSerialization.data(withJSONObject: sessionJSON)
         let shuffledSession = try JSONDecoder().decode(PlanUtilizationSeriesHistory.self, from: shuffledData)
-        #expect((shuffledSession.entries.first?.capturedAt ?? .distantPast)
-            > (shuffledSession.entries.last?.capturedAt ?? .distantFuture))
-        #expect(SessionEquivalentBurnEstimator.estimate(
+        #expect(shuffledSession == fixture.histories[0])
+        let shuffledEstimate = try #require(SessionEquivalentBurnEstimator.estimate(
             histories: [shuffledSession, fixture.histories[1]],
             currentSessionResetsAt: fixture.currentSessionReset,
-            now: fixture.currentSessionReset.addingTimeInterval(-3600)) == nil)
+            now: fixture.currentSessionReset.addingTimeInterval(-3600)))
+        #expect(shuffledEstimate.sampleCount == 3)
+        #expect(shuffledEstimate.medianWeeklyPercentPerWindow == 6)
 
         let huge = UsagePaceText.sessionEquivalentDetail(forecast: SessionEquivalentForecast(
             estimatedWindowsToExhaustWeekly: .greatestFiniteMagnitude,

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCodexMergeTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCodexMergeTests.swift
@@ -1,0 +1,220 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct UsageStorePlanUtilizationCodexMergeTests {
+    @MainActor
+    @Test
+    func `codex materialize leaves canonical-only history untouched`() throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let snapshot = UsageStorePlanUtilizationTests.makeSnapshot(provider: .codex, email: "alice@example.com")
+        let canonicalKey = try #require(
+            UsageStore._planUtilizationAccountKeyForTesting(
+                provider: .codex,
+                snapshot: snapshot))
+        let hourStart = Date(timeIntervalSince1970: 1_699_999_200)
+        let session = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: hourStart.addingTimeInterval(3600), usedPercent: 40),
+            planEntry(at: hourStart, usedPercent: 10),
+        ])
+        let weekly = planSeries(name: .weekly, windowMinutes: 10080, entries: [
+            planEntry(at: hourStart.addingTimeInterval(7200), usedPercent: 15),
+        ])
+        // Direct assignment keeps this unsorted; a self-merge would reorder by windowMinutes.
+        let originalHistories = [weekly, session]
+        let originalBuckets = PlanUtilizationHistoryBuckets(
+            preferredAccountKey: canonicalKey,
+            unscoped: [],
+            accounts: [
+                canonicalKey: originalHistories,
+            ])
+        store.planUtilizationHistory[.codex] = originalBuckets
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+
+        let revisionBefore = store.planUtilizationHistoryRevision
+        let history = store.planUtilizationHistory(for: .codex)
+        let buckets = try #require(store.planUtilizationHistory[.codex])
+
+        #expect(history == originalHistories)
+        #expect(buckets == originalBuckets)
+        #expect(buckets.accounts[canonicalKey] == originalHistories)
+        #expect(buckets.accounts.keys.sorted() == [canonicalKey])
+        #expect(buckets.unscoped.isEmpty)
+        #expect(store.planUtilizationHistoryRevision == revisionBefore)
+    }
+
+    @MainActor
+    @Test
+    func `codex materialize merge matches reference for overlapping hours out of order entries and distinct series`()
+        throws
+    {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let snapshot = UsageStorePlanUtilizationTests.makeSnapshot(provider: .codex, email: "alice@example.com")
+        let canonicalKey = try #require(
+            UsageStore._planUtilizationAccountKeyForTesting(
+                provider: .codex,
+                snapshot: snapshot))
+        let legacyEmailHash = UsageStore._codexLegacyPlanUtilizationEmailHashKeyForTesting(
+            normalizedEmail: "alice@example.com")
+        let hourStart = Date(timeIntervalSince1970: 1_699_999_200)
+
+        let canonicalSession = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: hourStart.addingTimeInterval(3 * 3600), usedPercent: 40),
+            planEntry(at: hourStart.addingTimeInterval(5 * 60), usedPercent: 10),
+        ])
+        let canonicalWeekly = planSeries(name: .weekly, windowMinutes: 10080, entries: [
+            planEntry(at: hourStart, usedPercent: 15),
+        ])
+        let legacySession = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: hourStart.addingTimeInterval(3600), usedPercent: 20),
+            planEntry(at: hourStart.addingTimeInterval(25 * 60), usedPercent: 35),
+        ])
+        let legacyWeekly = planSeries(name: .weekly, windowMinutes: 10080, entries: [
+            planEntry(at: hourStart.addingTimeInterval(3600), usedPercent: 25),
+        ])
+        let unscopedSession = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: hourStart.addingTimeInterval(2 * 3600), usedPercent: 30),
+        ])
+
+        store.planUtilizationHistory[.codex] = PlanUtilizationHistoryBuckets(
+            unscoped: [unscopedSession],
+            accounts: [
+                canonicalKey: [canonicalWeekly, canonicalSession],
+                legacyEmailHash: [legacySession, legacyWeekly],
+            ])
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+
+        let history = store.planUtilizationHistory(for: .codex)
+        let buckets = try #require(store.planUtilizationHistory[.codex])
+
+        let expectedSession = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: hourStart.addingTimeInterval(25 * 60), usedPercent: 35),
+            planEntry(at: hourStart.addingTimeInterval(3600), usedPercent: 20),
+            planEntry(at: hourStart.addingTimeInterval(2 * 3600), usedPercent: 30),
+            planEntry(at: hourStart.addingTimeInterval(3 * 3600), usedPercent: 40),
+        ])
+        let expectedWeekly = planSeries(name: .weekly, windowMinutes: 10080, entries: [
+            planEntry(at: hourStart, usedPercent: 15),
+            planEntry(at: hourStart.addingTimeInterval(3600), usedPercent: 25),
+        ])
+        let expectedHistories = [expectedSession, expectedWeekly]
+
+        #expect(history == expectedHistories)
+        #expect(buckets.accounts[canonicalKey] == expectedHistories)
+        #expect(buckets.accounts[legacyEmailHash] == nil)
+        #expect(buckets.unscoped.isEmpty)
+        #expect(findSeries(history, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [
+            35, 20, 30, 40,
+        ])
+        #expect(findSeries(history, name: .weekly, windowMinutes: 10080)?.entries.map(\.usedPercent) == [15, 25])
+    }
+
+    @MainActor
+    @Test
+    func `codex materialize merge matches reference when retention trimming is exercised`() throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let snapshot = UsageStorePlanUtilizationTests.makeSnapshot(provider: .codex, email: "alice@example.com")
+        let canonicalKey = try #require(
+            UsageStore._planUtilizationAccountKeyForTesting(
+                provider: .codex,
+                snapshot: snapshot))
+        let legacyEmailHash = UsageStore._codexLegacyPlanUtilizationEmailHashKeyForTesting(
+            normalizedEmail: "alice@example.com")
+        let hourStart = Date(timeIntervalSince1970: 1_699_999_200)
+        let maxSamples = UsageStore._planUtilizationMaxSamplesForTesting
+        let overflow = 12
+        let totalSessionEntries = maxSamples + overflow
+        let legacySessionEntries = (0..<totalSessionEntries).map { offset in
+            planEntry(
+                at: hourStart.addingTimeInterval(Double(offset) * 3600),
+                usedPercent: Double(offset % 100))
+        }
+        let weeklyEntries = [
+            planEntry(at: hourStart, usedPercent: 8),
+            planEntry(at: hourStart.addingTimeInterval(3600), usedPercent: 11),
+        ]
+
+        store.planUtilizationHistory[.codex] = PlanUtilizationHistoryBuckets(accounts: [
+            canonicalKey: [
+                planSeries(name: .weekly, windowMinutes: 10080, entries: weeklyEntries),
+            ],
+            legacyEmailHash: [
+                planSeries(name: .session, windowMinutes: 300, entries: legacySessionEntries),
+            ],
+        ])
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+
+        let history = store.planUtilizationHistory(for: .codex)
+        let buckets = try #require(store.planUtilizationHistory[.codex])
+        let expectedSessionEntries = Array(legacySessionEntries.dropFirst(overflow))
+        let expectedHistories = [
+            planSeries(name: .session, windowMinutes: 300, entries: expectedSessionEntries),
+            planSeries(name: .weekly, windowMinutes: 10080, entries: weeklyEntries),
+        ]
+
+        #expect(history == expectedHistories)
+        #expect(buckets.accounts[canonicalKey] == expectedHistories)
+        #expect(buckets.accounts[legacyEmailHash] == nil)
+        #expect(findSeries(history, name: .session, windowMinutes: 300)?.entries.count == maxSamples)
+        #expect(findSeries(history, name: .session, windowMinutes: 300)?.entries.first?.capturedAt
+            == expectedSessionEntries.first?.capturedAt)
+        #expect(findSeries(history, name: .session, windowMinutes: 300)?.entries.last
+            == expectedSessionEntries.last)
+        #expect(findSeries(history, name: .weekly, windowMinutes: 10080)?.entries == weeklyEntries)
+    }
+
+    @Test
+    func `upper bound is one past the last equal capturedAt`() {
+        let probe = Date(timeIntervalSince1970: 1_700_000_000)
+        let prefix = (0..<32).map { offset in
+            planEntry(at: probe.addingTimeInterval(Double(offset) - 32), usedPercent: Double(offset))
+        }
+        let equalRun = (0..<16).map { offset in
+            planEntry(at: probe, usedPercent: Double(offset))
+        }
+        let suffix = (1..<18).map { offset in
+            planEntry(at: probe.addingTimeInterval(Double(offset)), usedPercent: Double(offset))
+        }
+        let entries = prefix + equalRun + suffix
+
+        #expect(entries.count == 65)
+        #expect(UsageStore._planUtilizationEntryUpperBoundForTesting(entries: entries, capturedAt: probe) == 48)
+        #expect(UsageStore._planUtilizationEntryUpperBoundForTesting(
+            entries: entries,
+            capturedAt: probe.addingTimeInterval(17)) == 65)
+        #expect(UsageStore._planUtilizationEntryUpperBoundForTesting(entries: equalRun, capturedAt: probe) == 16)
+        #expect(UsageStore._planUtilizationEntryUpperBoundForTesting(
+            entries: entries,
+            capturedAt: probe.addingTimeInterval(-33)) == 0)
+    }
+
+    @Test
+    func `decoded series sorts out-of-order entries and round-trips unchanged`() throws {
+        let hourStart = Date(timeIntervalSince1970: 1_699_999_200)
+        let later = hourStart.addingTimeInterval(3600)
+        let earliest = hourStart.addingTimeInterval(-3600)
+        let ordered = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: earliest, usedPercent: 10, resetsAt: hourStart),
+            planEntry(at: hourStart, usedPercent: 20),
+            planEntry(at: later, usedPercent: 30, resetsAt: later.addingTimeInterval(3600)),
+        ])
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let encoded = try encoder.encode(ordered)
+        let roundTrip = try decoder.decode(PlanUtilizationSeriesHistory.self, from: encoded)
+        #expect(roundTrip == ordered)
+
+        var json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let entries = try #require(json["entries"] as? [[String: Any]])
+        json["entries"] = Array(entries.reversed())
+        let decodedShuffled = try decoder.decode(
+            PlanUtilizationSeriesHistory.self,
+            from: JSONSerialization.data(withJSONObject: json))
+        #expect(decodedShuffled == ordered)
+        #expect(decodedShuffled.entries.map(\.capturedAt) == [earliest, hourStart, later])
+    }
+}

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -119,6 +119,75 @@ struct UsageStorePlanUtilizationTests {
         #expect(updated.last == appended)
     }
 
+    @Test
+    func `equal capturedAt lands in the same hour range as a linear upper bound`() throws {
+        let hourStart = Date(timeIntervalSince1970: 1_699_999_200)
+        let equalCapturedAt = hourStart.addingTimeInterval(10 * 60)
+        let laterHour = hourStart.addingTimeInterval(3600)
+        let existing = [
+            planEntry(at: equalCapturedAt, usedPercent: 10),
+            planEntry(at: laterHour, usedPercent: 50),
+        ]
+        let incoming = planEntry(at: equalCapturedAt, usedPercent: 40)
+
+        let updated = try #require(
+            UsageStore._updatedPlanUtilizationEntriesForTesting(
+                existingEntries: existing,
+                entry: incoming))
+
+        #expect(updated == [
+            incoming,
+            planEntry(at: laterHour, usedPercent: 50),
+        ])
+    }
+
+    @Test
+    func `duplicate capturedAt in the same hour is a no-op`() {
+        let hourStart = Date(timeIntervalSince1970: 1_699_999_200)
+        let existing = [
+            planEntry(at: hourStart.addingTimeInterval(10 * 60), usedPercent: 22, resetsAt: hourStart),
+        ]
+
+        let updated = UsageStore._updatedPlanUtilizationEntriesForTesting(
+            existingEntries: existing,
+            entry: existing[0])
+
+        #expect(updated == nil)
+    }
+
+    @Test
+    func `hour bucket edges stay in separate ranges`() throws {
+        let hourStart = Date(timeIntervalSince1970: 1_699_999_200)
+        let nextHour = hourStart.addingTimeInterval(3600)
+        let justBeforeNextHour = hourStart.addingTimeInterval(3599)
+
+        let splitAcrossBoundary = try #require(
+            UsageStore._updatedPlanUtilizationEntriesForTesting(
+                existingEntries: [planEntry(at: hourStart, usedPercent: 10)],
+                entry: planEntry(at: nextHour, usedPercent: 20)))
+        #expect(splitAcrossBoundary == [
+            planEntry(at: hourStart, usedPercent: 10),
+            planEntry(at: nextHour, usedPercent: 20),
+        ])
+
+        let previousBucketFromExactEdge = try #require(
+            UsageStore._updatedPlanUtilizationEntriesForTesting(
+                existingEntries: [planEntry(at: nextHour, usedPercent: 10)],
+                entry: planEntry(at: justBeforeNextHour, usedPercent: 20)))
+        #expect(previousBucketFromExactEdge == [
+            planEntry(at: justBeforeNextHour, usedPercent: 20),
+            planEntry(at: nextHour, usedPercent: 10),
+        ])
+
+        let sameBucketBeforeEdge = try #require(
+            UsageStore._updatedPlanUtilizationEntriesForTesting(
+                existingEntries: [planEntry(at: hourStart, usedPercent: 10)],
+                entry: planEntry(at: justBeforeNextHour, usedPercent: 20)))
+        #expect(sameBucketBeforeEdge == [
+            planEntry(at: justBeforeNextHour, usedPercent: 20),
+        ])
+    }
+
     @MainActor
     @Test
     func `native chart shows visible series tabs only`() {


### PR DESCRIPTION
## Summary

`UsageStore.materializeCodexPlanUtilizationHistoryIfNeeded` exists to fold legacy, opaque and unscoped Codex plan-utilization buckets into the canonical account bucket. Its scoped loop also appended **the canonical bucket's own histories** to `historiesToMerge` — `matchesTargetContinuity` is true for `rawKey == canonicalKey` (`CodexHistoryOwnership.swift:58-61`), and only the *removal* of the old key was guarded by `if rawKey != canonicalKey`. So `guard !historiesToMerge.isEmpty` never fired once the canonical bucket had any history, and the migration merge ran on **every successful provider refresh and every menu open**, merging the history with itself.

That merge is quadratic: `updatedPlanUtilizationEntries` copied the whole entry array per entry, scanned it linearly for the insertion point, and allocated the same-hour slice. Measured with an optimized standalone reproduction over a real three-month-old history (session 1909 entries, weekly 2239): **20.6 ms of MainActor time per call**, scaling ~3.9× per doubling. `planUtilizationMaxSamples` is 17520 per series, so it keeps growing — at the retention cap this would be several hundred ms per series, on the main thread, while the menu is opening.

Reached from `UsageStore+Refresh.swift` (`applyProviderRefreshSuccess` → `recordPlanUtilizationHistorySample` → `MainActor.run` → `resolvePlanUtilizationAccountKey` → `resolveCodexPlanUtilizationAccountKey`) and from the synchronous `planUtilizationHistorySelection(for:)` used while building the menu. Codex-only; Claude short-circuits earlier.

### Changes

- **Only merge when a foreign source contributed.** A flag is set in the three branches that add non-canonical data (legacy scoped key, opaque recovery, unscoped adoption) and required by the guard, so the canonical-only case returns without merging or rewriting anything. Every path where a legacy/opaque/unscoped bucket does contribute is untouched: `legacyRawKeysToRemove` is only ever populated in branches that also set the flag (so no removal is skipped), and `providerBuckets.unscoped` is cleared only inside the branch that sets it.
- **Make the genuine migration near-linear.** `updatedPlanUtilizationEntries` mutates the array in place and finds the insertion point with a binary search for the same strict upper bound (plus a fast path for the common append); `mergedPlanUtilizationHistories` accumulates per series and constructs each history once.
- **Enforce the sortedness invariant the binary search relies on.** Every in-app producer went through `PlanUtilizationSeriesHistory`'s designated initializer, which sorts — except the synthesized `Codable` decoder, which assigned `entries` verbatim from JSON. An explicit `init(from:)` now routes decoding through that initializer, so a history file written by an older build (or edited by hand) cannot smuggle in an unsorted series. The JSON shape is unchanged.

The skipped self-merge was also an *incidental* normalizer — it re-ran per-hour peak canonicalization on read, which is not a fixpoint. Repairing legacy data belongs at load time, not on every refresh and menu open, so that is not reintroduced here; the visible effect is that at most one extra real observation per affected hour is kept. This is commented at the guard.

### Measured on real data

Against this machine's real `history/codex.json` (4160 entries: `session` 1909, `weekly` 2251), driving the real `UsageStore.planUtilizationHistory(for: .codex)` read path (`swift test` debug builds, same machine; an optimized standalone reproduction of the same algorithm measured 20.6 ms per call for current main):

| Path | current main | this PR |
|---|---|---|
| canonical-only (every refresh, every menu open) | 243–274 ms | **0.94–1.12 ms** |
| genuine legacy migration | 238–273 ms | **13.8–16.8 ms** |

The migration result is unchanged: the legacy bucket is absorbed, one account bucket remains, all 4160 entries survive. Full terminal transcripts are in a comment below.

### Tests

- Canonical-only history is returned untouched **and enqueues no persistence write** (`planUtilizationHistoryRevision` unchanged) — the property that actually matters for the menu path.
- A genuine foreign merge matches an explicit expected result across overlapping hours, out-of-order sources, distinct session/weekly series, and retention trimming.
- The binary search's upper-bound contract is pinned directly through the DEBUG shim over a 65-entry array containing a run of equal `capturedAt` (a lower bound would return a different index), plus the `endIndex`/`startIndex` edges.
- Decoding a series whose JSON `entries` are out of order yields a sorted series, and the shuffled payload produces the same forecast estimate as the sorted fixture.

The existing Codex-ownership migration suite (12 cases, all of which seed a foreign key) is unchanged and still green.

### Process

Implemented by grok-4.6 (xhigh) via implementation-loop; reviewed hunk by hunk plus an independent deep review that confirmed both equivalence claims by differential fuzzing (200k sorted cases, zero mismatches; and an exhaustive path enumeration showing the foreign-source paths are byte-identical) and found the decoder gap, fixed in one iterate round. The line-anchored `ProviderArchitectureGatekeeperTests` entries for the touched file were re-verified independently after every edit. Full `make check` and `make test` (77/77 sharded groups, zero failures) pass locally on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
