### PR TITLE
fix: prefer successful CLI install status

### DIFF
--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -88,6 +88,7 @@ extension AdvancedPane {
         ]
 
         var installed: [String] = []
+        var conflicts: [String] = []
         var failures: [String] = []
         for dest in destinations {
             let dir = (dest as NSString).deletingLastPathComponent
@@ -101,7 +102,7 @@ extension AdvancedPane {
                 if Self.isLink(atPath: dest, pointingTo: helperURL.path) {
                     installed.append("Installed: \(dir)")
                 } else {
-                    failures.append("Exists: \(dir)")
+                    conflicts.append("Exists: \(dir)")
                 }
                 continue
             }
@@ -114,7 +115,10 @@ extension AdvancedPane {
             }
         }
 
-        self.cliStatus = Self.cliInstallStatus(installed: installed, failures: failures)
+        self.cliStatus = Self.cliInstallStatus(
+            installed: installed,
+            conflicts: conflicts,
+            failures: failures)
     }
 
     private static func isLink(atPath path: String, pointingTo destination: String) -> Bool {
@@ -126,9 +130,12 @@ extension AdvancedPane {
         return resolved == destination
     }
 
-    static func cliInstallStatus(installed: [String], failures: [String]) -> String {
+    static func cliInstallStatus(installed: [String], conflicts: [String], failures: [String]) -> String {
         if installed.isEmpty == false {
-            return installed.joined(separator: " · ")
+            return (installed + conflicts).joined(separator: " · ")
+        }
+        if conflicts.isEmpty == false {
+            return (conflicts + failures).joined(separator: " · ")
         }
         if failures.isEmpty == false {
             return failures.joined(separator: " · ")

--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -87,35 +87,34 @@ extension AdvancedPane {
             "/opt/homebrew/bin/codexbar",
         ]
 
-        var results: [String] = []
+        var installed: [String] = []
+        var failures: [String] = []
         for dest in destinations {
             let dir = (dest as NSString).deletingLastPathComponent
             guard fm.fileExists(atPath: dir) else { continue }
             guard fm.isWritableFile(atPath: dir) else {
-                results.append("No write access: \(dir)")
+                failures.append("No write access: \(dir)")
                 continue
             }
 
             if fm.fileExists(atPath: dest) {
                 if Self.isLink(atPath: dest, pointingTo: helperURL.path) {
-                    results.append("Installed: \(dir)")
+                    installed.append("Installed: \(dir)")
                 } else {
-                    results.append("Exists: \(dir)")
+                    failures.append("Exists: \(dir)")
                 }
                 continue
             }
 
             do {
                 try fm.createSymbolicLink(atPath: dest, withDestinationPath: helperURL.path)
-                results.append("Installed: \(dir)")
+                installed.append("Installed: \(dir)")
             } catch {
-                results.append("Failed: \(dir)")
+                failures.append("Failed: \(dir)")
             }
         }
 
-        self.cliStatus = results.isEmpty
-            ? L("no_writable_bin_dirs")
-            : results.joined(separator: " · ")
+        self.cliStatus = Self.cliInstallStatus(installed: installed, failures: failures)
     }
 
     private static func isLink(atPath path: String, pointingTo destination: String) -> Bool {
@@ -125,5 +124,15 @@ extension AdvancedPane {
             .standardizedFileURL
             .path
         return resolved == destination
+    }
+
+    static func cliInstallStatus(installed: [String], failures: [String]) -> String {
+        if installed.isEmpty == false {
+            return installed.joined(separator: " · ")
+        }
+        if failures.isEmpty == false {
+            return failures.joined(separator: " · ")
+        }
+        return L("no_writable_bin_dirs")
     }
 }

--- a/Tests/CodexBarTests/PreferencesAdvancedPaneTests.swift
+++ b/Tests/CodexBarTests/PreferencesAdvancedPaneTests.swift
@@ -1,22 +1,45 @@
 import Testing
 @testable import CodexBar
 
+@MainActor
 struct PreferencesAdvancedPaneTests {
     @Test
     func `cli install status prefers successful installs over unrelated failures`() {
         let status = AdvancedPane.cliInstallStatus(
             installed: ["Installed: /opt/homebrew/bin"],
+            conflicts: [],
             failures: ["No write access: /usr/local/bin"])
 
         #expect(status == "Installed: /opt/homebrew/bin")
     }
 
     @Test
+    func `cli install status keeps conflicting executables visible alongside successful installs`() {
+        let status = AdvancedPane.cliInstallStatus(
+            installed: ["Installed: /opt/homebrew/bin"],
+            conflicts: ["Exists: /usr/local/bin"],
+            failures: ["No write access: /some/other/bin"])
+
+        #expect(status == "Installed: /opt/homebrew/bin · Exists: /usr/local/bin")
+    }
+
+    @Test
     func `cli install status falls back to failures when nothing installed`() {
         let status = AdvancedPane.cliInstallStatus(
             installed: [],
-            failures: ["Exists: /opt/homebrew/bin", "No write access: /usr/local/bin"])
+            conflicts: ["Exists: /opt/homebrew/bin"],
+            failures: ["No write access: /usr/local/bin"])
 
         #expect(status == "Exists: /opt/homebrew/bin · No write access: /usr/local/bin")
+    }
+
+    @Test
+    func `cli install status falls back to failures when there are no successes or conflicts`() {
+        let status = AdvancedPane.cliInstallStatus(
+            installed: [],
+            conflicts: [],
+            failures: ["Failed: /opt/homebrew/bin", "No write access: /usr/local/bin"])
+
+        #expect(status == "Failed: /opt/homebrew/bin · No write access: /usr/local/bin")
     }
 }

--- a/Tests/CodexBarTests/PreferencesAdvancedPaneTests.swift
+++ b/Tests/CodexBarTests/PreferencesAdvancedPaneTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import CodexBar
+
+struct PreferencesAdvancedPaneTests {
+    @Test
+    func `cli install status prefers successful installs over unrelated failures`() {
+        let status = AdvancedPane.cliInstallStatus(
+            installed: ["Installed: /opt/homebrew/bin"],
+            failures: ["No write access: /usr/local/bin"])
+
+        #expect(status == "Installed: /opt/homebrew/bin")
+    }
+
+    @Test
+    func `cli install status falls back to failures when nothing installed`() {
+        let status = AdvancedPane.cliInstallStatus(
+            installed: [],
+            failures: ["Exists: /opt/homebrew/bin", "No write access: /usr/local/bin"])
+
+        #expect(status == "Exists: /opt/homebrew/bin · No write access: /usr/local/bin")
+    }
+}


### PR DESCRIPTION
## Summary
- report successful CLI installation when at least one writable destination installs or already points at the bundled helper
- keep conflicting existing `codexbar` destinations visible alongside successful installs so PATH-shadowing problems are still actionable
- add focused status-aggregation tests covering success-only, success-plus-conflict, conflict-only, and failure-only cases

## Testing
- `swift test --filter PreferencesAdvancedPaneTests`
- `swift build --product CodexBar`

## Real behavior proof
Actual local app-level proof on commit `ca6b532d559a0f514ce16132308036dbba8f2ac4`:

1. Packaged and launched the local `CodexBar.app` from this branch.
2. Opened `CodexBar -> Settings… -> Advanced`.
3. Temporarily removed the pre-existing `/opt/homebrew/bin/codexbar` conflict so the live app could install into the writable Homebrew bin directory.
4. Clicked the real `Install CLI` button in the running app.
5. Observed the live Settings footer update to:

```text
Installed: /opt/homebrew/bin
```

Proof environment for that exact live click:

```text
/opt/homebrew/bin was writable and empty before the click
/usr/local/bin existed but was not writable by the current user
```

That means this was a real `installed + failure` environment. On current main, the flat aggregation would continue to show the unrelated failure together with the install result; on this PR head, the live footer correctly prioritizes the successful install and suppresses the unrelated `No write access: /usr/local/bin` failure.

After capturing the proof, `/opt/homebrew/bin/codexbar` was restored to its original `/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI` target.
