### PR TITLE
Treat period-only Grok usage as unknown

### DIFF
--- a/Sources/CodexBarCore/Providers/Grok/GrokCreditsProxyFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokCreditsProxyFetcher.swift
@@ -80,7 +80,7 @@ public enum GrokCreditsProxyFetcher {
 
         if resetsAt != nil {
             return GrokWebBillingSnapshot(
-                usedPercent: 0,
+                usedPercent: nil,
                 resetsAt: resetsAt,
                 subscriptionTier: subscriptionTier)
         }

--- a/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
@@ -96,7 +96,7 @@ struct GrokCreditsProxyFetcherTests {
     }
 
     @Test
-    func `treats a period without usage as zero percent`() throws {
+    func `treats a period without usage as unknown`() throws {
         let snapshot = try GrokCreditsProxyFetcher.parseSnapshot(
             Data(
                 """
@@ -109,7 +109,7 @@ struct GrokCreditsProxyFetcherTests {
                 """.utf8))
         let expectedReset = try Self.date("2026-08-13T00:00:00.123Z")
 
-        #expect(snapshot.usedPercent == 0)
+        #expect(snapshot.usedPercent == nil)
         #expect(snapshot.resetsAt == expectedReset)
         #expect(snapshot.subscriptionTier == nil)
     }
@@ -134,7 +134,7 @@ struct GrokCreditsProxyFetcherTests {
         let expectedReset = try Self.date("2026-08-23T18:42:45.537749+00:00")
 
         #expect(snapshot.subscriptionTier == "SuperGrok Heavy")
-        #expect(snapshot.usedPercent == 0)
+        #expect(snapshot.usedPercent == nil)
         #expect(snapshot.resetsAt == expectedReset)
     }
 
@@ -184,7 +184,7 @@ struct GrokCreditsProxyFetcherTests {
                 """.utf8))
         let expectedReset = try Self.date("2026-08-13T00:00:00Z")
 
-        #expect(snapshot.usedPercent == 0)
+        #expect(snapshot.usedPercent == nil)
         #expect(snapshot.subscriptionTier == "SuperGrok Heavy")
         #expect(snapshot.resetsAt == expectedReset)
     }
@@ -231,7 +231,7 @@ struct GrokCreditsProxyFetcherTests {
                 """.utf8))
         let expectedReset = try Self.date("2026-08-13T00:00:00Z")
 
-        #expect(snapshot.usedPercent == 0)
+        #expect(snapshot.usedPercent == nil)
         #expect(snapshot.resetsAt == expectedReset)
     }
 

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -55,7 +55,7 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
      `Accept: application/json`.
    - Reads `config.creditUsagePercent`, falling back to
      `onDemandUsed.val / onDemandCap.val * 100`. A parseable current period
-     without either value represents zero usage. The reset timestamp comes from
+     without either value represents unknown usage. The reset timestamp comes from
      `config.currentPeriod.end`, then `config.billingPeriodEnd`.
    - Plan name does not come from the credits payload. After a successful
      auth-file or SuperGrok OAuth web billing result (CLI-proxy) or the team


### PR DESCRIPTION
## Summary

- preserve Grok identity and reset metadata when the CLI proxy omits usage values
- represent period-only usage as unknown instead of inventing 0%
- align focused tests and Grok documentation with the unknown-usage contract

## Tests

- swift test --filter GrokCreditsProxyFetcherTests
- swift test --filter GrokWebBillingFetcherTests
- make check
- make test

Fixes #3157

### Real CLI-proxy behavior proof (redacted)

Captured from the same authenticated Grok CLI-proxy setup on macOS. Email, account, and organization identifiers are omitted.

Before, using released CodexBar 0.54.0:

```json
{
  "provider": "grok",
  "source": "grok-cli-proxy",
  "version": "1.0.5",
  "primary": {
    "resetsAt": "2026-08-29T00:00:00Z",
    "usedPercent": 0
  }
}
```

After, using PR head `d2b041e848712a53cebe2313a13ba5944be7d941`:

```json
{
  "provider": "grok",
  "source": "grok-cli-proxy",
  "version": "1.0.5",
  "primary": null
}
```

No fixture or mocked provider was used. Both commands queried the real authenticated CLI-proxy. The patched parser preserves the successful provider response without fabricating a 0% usage window when the response contains period/reset information but no usage value.
