### PR TITLE
Reuse a signed-in agy for Antigravity quota refresh without the desktop app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Spend dashboard: silently refresh independent providers (Claude/Cursor) when their token publications update, bucket the activity heatmap with the configured IANA timezone, and stop coalescing display-affecting ownership and revision changes (#3106). Thanks @Yuxin-Qiao!
 - Spend: add tokscale-compatible local readers for Cursor and Antigravity local history (#3113). Thanks @Yuxin-Qiao!
 - Antigravity: map retired Flash wire IDs to their current tier, and count local conversations as an offline fallback when the desktop app is unavailable (#3119). Thanks @Yuxin-Qiao!
+- Antigravity: reuse a signed-in `agy` for menu-bar quota refreshes without the desktop app, and report CLI sign-in failures instead of asking users to launch an unavailable app (#3146).
 
 - Fixed single-quota menu-bar icons understating remaining usage: a provider's only meaningful quota now renders as one prominent meter instead of half an icon next to a reserved empty lane, including when it arrives in the secondary slot (#3154, #3155). Thanks @akshayprabhu200!
 - Grok: report period-only CLI-proxy responses as unknown usage instead of 0% when Grok Build has hit its free limit, keeping identity and reset metadata (#3157, #3159). Thanks @anupamchugh!

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -31,21 +31,25 @@ protocol AntigravityCLIProcessLaunching: Sendable {
 
 enum AntigravityCLIAuthenticationPrompt {
     static let evidence = Data("Select login method:".utf8)
-    private static let promptPattern = #"select\s+login\s+method\s*:?"#
+    private static let authenticationPatterns = [
+        #"select\s+login\s+method\s*:?"#,
+        #"you\s+are\s+not\s+logged\s+into\s+antigravity"#,
+        #"keyring\s*auth\s*:\s*timed\s+out\b"#,
+    ]
 
     static func contains(_ output: Data) -> Bool {
         // `agy` briefly prints "You are currently not signed in" before it
-        // auto-refreshes an existing login. The actual blocking state is the
-        // interactive login-method prompt. The exact prompt is a CLI-owned TUI
-        // string, so keep matching tolerant to casing and whitespace changes.
+        // auto-refreshes an existing login. Only a blocking login prompt, an
+        // explicit Antigravity logout, or exhausted keyring authentication
+        // establishes that the managed session cannot recover its credentials.
         if output.range(of: self.evidence) != nil {
             return true
         }
         let asciiBytes = output.map { $0 < 0x80 ? $0 : 0x20 }
         let text = String(bytes: asciiBytes, encoding: .utf8) ?? ""
-        return text.range(
-            of: self.promptPattern,
-            options: [.regularExpression, .caseInsensitive]) != nil
+        return self.authenticationPatterns.contains { pattern in
+            text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
+        }
     }
 }
 
@@ -1087,12 +1091,16 @@ final class AntigravitySpawnedPTYProcessHandle: AntigravityCLIProcessHandle, @un
                     retries = 0
                     continue
                 }
-                if written == 0 { break }
+                if written == 0 {
+                    break
+                }
 
                 let err = errno
                 if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {
                     retries += 1
-                    if retries > 200 { return }
+                    if retries > 200 {
+                        return
+                    }
                     usleep(5000)
                     continue
                 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -76,7 +76,9 @@ public enum AntigravityProviderDescriptor {
                 }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .cli, .oauth],
-                pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
+                pipeline: ProviderFetchPipeline(
+                    resolveStrategies: self.resolveStrategies,
+                    resolveFallbackError: self.resolveFallbackError)),
             cli: ProviderCLIConfig(
                 name: "antigravity",
                 versionDetector: nil))
@@ -204,6 +206,15 @@ public enum AntigravityProviderDescriptor {
             ?? FileManager.default.homeDirectoryForCurrentUser
         let fileURL = AntigravityOAuthCredentialsStore.defaultURL(home: homeURL)
         return FileManager.default.fileExists(atPath: fileURL.path)
+    }
+
+    static func resolveFallbackError(_ previous: Error?, _ current: Error) -> Error {
+        if (previous as? AntigravityStatusProbeError) == .authenticationRequired,
+           (current as? AntigravityStatusProbeError) == .notRunning
+        {
+            return previous ?? current
+        }
+        return current
     }
 }
 
@@ -553,10 +564,10 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         // CodexBar must not manage its lifecycle, idle timeout, or
         // `resetAfterFetch` teardown. Those apply only to processes CodexBar
         // itself spawns on the fallback path below.
-        // Long-lived hosts already keep a managed session warm. Restrict external
-        // process reuse to one-shot CLI calls so app/server lifecycle accounting
-        // stays entirely inside AntigravityCLISession.
-        if resetAfterFetch, let warmSnapshot = try await Self.tryWarmAgyFetch(
+        // Persistent hosts also need the external path: a user-owned, signed-in
+        // `agy` may have credentials a newly spawned managed session cannot read.
+        // Owned pids remain excluded, so their lifecycle accounting is unchanged.
+        if let warmSnapshot = try await Self.tryWarmAgyFetch(
             timeout: 2.0,
             expectedBinaryPath: binary,
             expectedAccountEmail: expectedAccountEmail,

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -306,19 +306,23 @@ extension ProviderFetchStrategy {
 
 public struct ProviderFetchPipeline: Sendable {
     public typealias RetrySleeper = @Sendable (TimeInterval) async throws -> Void
+    public typealias FallbackErrorResolver = @Sendable (Error?, Error) -> Error
 
     public let resolveStrategies: @Sendable (ProviderFetchContext) async -> [any ProviderFetchStrategy]
     private let retrySleeper: RetrySleeper
+    private let resolveFallbackError: FallbackErrorResolver
 
     public init(
         resolveStrategies: @escaping @Sendable (ProviderFetchContext) async -> [any ProviderFetchStrategy],
         retrySleeper: @escaping RetrySleeper = { seconds in
             guard seconds > 0 else { return }
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-        })
+        },
+        resolveFallbackError: @escaping FallbackErrorResolver = { _, error in error })
     {
         self.resolveStrategies = resolveStrategies
         self.retrySleeper = retrySleeper
+        self.resolveFallbackError = resolveFallbackError
     }
 
     public func fetch(context: ProviderFetchContext, provider: UsageProvider) async -> ProviderFetchOutcome {
@@ -361,7 +365,7 @@ public struct ProviderFetchPipeline: Sendable {
                     errorDescription: nil))
                 return ProviderFetchOutcome(result: .success(result), attempts: attempts)
             } catch {
-                lastAvailableError = error
+                lastAvailableError = self.resolveFallbackError(lastAvailableError, error)
                 attempts.append(ProviderFetchAttempt(
                     strategyID: strategy.id,
                     kind: strategy.kind,

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -646,6 +646,37 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
+    func `cli HTTPS stops when managed agy reports exhausted keyring authentication`() async {
+        let output = AntigravityCLIOutputSequence([
+            Data("You are currently not signed in.\nSigning in...".utf8),
+            Data("keyringAuth: timed out after 10s, skipping keyring auth".utf8),
+        ])
+        let portPolls = AntigravityCLICounter()
+
+        do {
+            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: Date().addingTimeInterval(2),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 0,
+                    listeningPorts: { _, _ in
+                        portPolls.increment()
+                        return []
+                    },
+                    drainOutput: { output.next() },
+                    fetchSnapshot: { _ in
+                        Issue.record("An unauthenticated helper must not fetch a snapshot")
+                        throw AntigravityStatusProbeError.notRunning
+                    }))
+            Issue.record("Expected authentication failure")
+        } catch AntigravityStatusProbeError.authenticationRequired {
+            #expect(portPolls.value == 1)
+        } catch {
+            Issue.record("Expected authenticationRequired, got \(error)")
+        }
+    }
+
+    @Test
     func `cli HTTPS rechecks signed out prompt after snapshot readiness`() async {
         let output = AntigravityCLIOutputSequence([
             Data(),
@@ -950,5 +981,84 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         func detectVersion() -> String? {
             nil
         }
+    }
+}
+
+extension AntigravityCLIHTTPSFetchStrategyTests {
+    @Test
+    func `missing IDE cannot replace actionable signed out CLI error`() async {
+        let pipeline = ProviderFetchPipeline(
+            resolveStrategies: { _ in
+                [
+                    AntigravityFallbackFixtureStrategy(
+                        id: "antigravity.cli-https",
+                        error: .authenticationRequired),
+                    AntigravityFallbackFixtureStrategy(
+                        id: "antigravity.ide-local",
+                        error: .notRunning),
+                ]
+            },
+            resolveFallbackError: AntigravityProviderDescriptor.resolveFallbackError)
+
+        let outcome = await pipeline.fetch(context: self.makeFetchContext(), provider: .antigravity)
+
+        #expect(outcome.attempts.map(\.strategyID) == ["antigravity.cli-https", "antigravity.ide-local"])
+        do {
+            _ = try outcome.result.get()
+            Issue.record("Expected the signed-out CLI failure")
+        } catch {
+            #expect((error as? AntigravityStatusProbeError) == .authenticationRequired)
+        }
+    }
+
+    @Test
+    func `signed out CLI still allows a usable IDE fallback`() async throws {
+        let pipeline = ProviderFetchPipeline(
+            resolveStrategies: { _ in
+                [
+                    AntigravityFallbackFixtureStrategy(
+                        id: "antigravity.cli-https",
+                        error: .authenticationRequired),
+                    AntigravityFallbackFixtureStrategy(id: "antigravity.ide-local", error: nil),
+                ]
+            },
+            resolveFallbackError: AntigravityProviderDescriptor.resolveFallbackError)
+
+        let outcome = await pipeline.fetch(context: self.makeFetchContext(), provider: .antigravity)
+
+        #expect(try outcome.result.get().sourceLabel == "ide")
+        #expect(outcome.attempts.count == 2)
+    }
+
+    @Test
+    func `specific later fallback error replaces signed out CLI error`() {
+        let result = AntigravityProviderDescriptor.resolveFallbackError(
+            AntigravityStatusProbeError.authenticationRequired,
+            AntigravityStatusProbeError.apiError("OAuth credentials expired"))
+
+        #expect((result as? AntigravityStatusProbeError) == .apiError("OAuth credentials expired"))
+    }
+}
+
+private struct AntigravityFallbackFixtureStrategy: ProviderFetchStrategy {
+    let id: String
+    let error: AntigravityStatusProbeError?
+    let kind: ProviderFetchKind = .localProbe
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        if let error {
+            throw error
+        }
+        return self.makeResult(
+            usage: UsageSnapshot(primary: nil, secondary: nil, updatedAt: Date()),
+            sourceLabel: "ide")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        true
     }
 }

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -418,7 +418,9 @@ private final class AntigravityManualSleeper: @unchecked Sendable {
 
     func waitForSleeps(_ expectedCount: Int) async {
         for _ in 0..<200 {
-            if self.pendingSleepCount >= expectedCount { return }
+            if self.pendingSleepCount >= expectedCount {
+                return
+            }
             try? await Task.sleep(nanoseconds: 1_000_000)
         }
         Issue.record("Timed out waiting for \(expectedCount) sleep continuation(s)")
@@ -703,7 +705,9 @@ struct AntigravityCLISessionTests {
                 let lines = output
                     .split(separator: "\n")
                     .map(String.init)
-                if lines.count >= 2, output.hasSuffix("\n") { break }
+                if lines.count >= 2, output.hasSuffix("\n") {
+                    break
+                }
             }
             Thread.sleep(forTimeInterval: 0.01)
         }
@@ -774,6 +778,18 @@ struct AntigravityCLISessionTests {
             Data("Select login method:".utf8)))
         #expect(!AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(
             Data("You are currently not signed in".utf8)))
+    }
+
+    @Test
+    func `authentication prompt matcher recognizes logged out and exhausted keyring states`() {
+        #expect(AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(
+            Data("You are not logged into Antigravity.".utf8)))
+        #expect(AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(
+            Data("keyringAuth: timed out after 10s, skipping keyring auth".utf8)))
+        #expect(AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(
+            Data("KEYRING auth : timed out after 10s".utf8)))
+        #expect(!AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(
+            Data("Welcome. You are currently not signed in.\nSigning in...".utf8)))
     }
 
     @Test
@@ -1454,7 +1470,9 @@ extension AntigravityCLISessionTests {
 
     private func waitForLaunches(_ launcher: FakeAntigravityProcessLauncher, count: Int) async -> Bool {
         for _ in 0..<200 {
-            if launcher.launchedBinarySnapshot().count >= count { return true }
+            if launcher.launchedBinarySnapshot().count >= count {
+                return true
+            }
             try? await Task.sleep(nanoseconds: 1_000_000)
         }
         return false
@@ -1463,7 +1481,9 @@ extension AntigravityCLISessionTests {
     private func waitUntilStopped(_ session: AntigravityCLISession) async {
         for _ in 0..<200 {
             let running = await session.isRunning
-            if !running { return }
+            if !running {
+                return
+            }
             await Task.yield()
         }
         Issue.record("Timed out waiting for Antigravity CLI session to stop")

--- a/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
+++ b/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
@@ -345,7 +345,7 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
-    func `long lived session skips external warm scan`() async throws {
+    func `long lived session reuses signed in external agy without spawning`() async throws {
         let spawnCallCount = AntigravityWarmLockedCounter()
         let strategy = AntigravityCLIHTTPSFetchStrategy()
 
@@ -354,21 +354,43 @@ struct AntigravityWarmAgyReuseTests {
             idleWindow: 60,
             resetAfterFetch: false,
             warmDependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
-                processInfos: { _ in
-                    Issue.record("long-lived hosts must use their managed session")
-                    return [Self.cliProcessInfo(pid: 6301)]
-                },
-                listeningPorts: { _, _ in [] },
-                fetchSnapshot: { _, _ in throw AntigravityStatusProbeError.notRunning }),
-            spawnFetch: { _, _, resetAfterFetch in
+                processInfos: { _ in [Self.cliProcessInfo(pid: 6301)] },
+                listeningPorts: { _, _ in [50080] },
+                fetchSnapshot: { _, _ in Self.usableSnapshot(email: "terminal@example.com") }),
+            spawnFetch: { _, _, _ in
                 spawnCallCount.increment()
+                Issue.record("persistent hosts must reuse an authenticated user-owned agy")
+                throw AntigravityStatusProbeError.notRunning
+            })
+
+        #expect(result.usage.identity?.accountEmail == "terminal@example.com")
+        #expect(spawnCallCount.value == 0)
+    }
+
+    @Test
+    func `long lived session falls back to managed agy when external account mismatches`() async throws {
+        let spawnCallCount = AntigravityWarmLockedCounter()
+        let strategy = AntigravityCLIHTTPSFetchStrategy()
+
+        let result = try await strategy.fetchUsingWarmSession(
+            binary: "/usr/local/bin/agy",
+            idleWindow: 60,
+            resetAfterFetch: false,
+            expectedAccountEmail: "selected@example.com",
+            warmDependencies: AntigravityCLIHTTPSFetchStrategy.WarmAgyDependencies(
+                processInfos: { _ in [Self.cliProcessInfo(pid: 6301)] },
+                listeningPorts: { _, _ in [50080] },
+                fetchSnapshot: { _, _ in Self.usableSnapshot(email: "other@example.com") }),
+            spawnFetch: { _, idleWindow, resetAfterFetch in
+                spawnCallCount.increment()
+                #expect(idleWindow == 60)
                 #expect(!resetAfterFetch)
                 return strategy.makeResult(
-                    usage: Self.usableUsage(email: "managed@example.com"),
+                    usage: Self.usableUsage(email: "selected@example.com"),
                     sourceLabel: AntigravityCLIHTTPSFetchStrategy.sourceLabel)
             })
 
-        #expect(result.usage.identity?.accountEmail == "managed@example.com")
+        #expect(result.usage.identity?.accountEmail == "selected@example.com")
         #expect(spawnCallCount.value == 1)
     }
 

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -18,7 +18,8 @@ signal and never enables or falls back to Antigravity automatically.
 To use the `agy` CLI source without keeping the desktop app open, install the CLI first
 (`brew install --cask antigravity-cli`; use `ANTIGRAVITY_CLI_PATH` when it is not on PATH), then
 run `agy` once and sign in. CodexBar keeps the signed-in `agy` local HTTPS server alive briefly
-after each refresh and stops it when idle.
+after each refresh and stops it when idle, or reuses a signed-in `agy` you already have running
+without taking ownership of that process.
 
 Antigravity supports four usage data sources:
 
@@ -159,10 +160,11 @@ The fallback can return quota without the account email or plan fields from `Get
 Differences from the desktop local probe:
 
 - The CLI HTTPS endpoint does **not** require `X-Codeium-Csrf-Token`.
-- Before a one-shot CLI invocation launches `agy`, CodexBar spends at most two seconds looking for an already-running,
-  same-user `agy` at the selected binary path and reuses its tokenless local HTTPS endpoint when it returns parseable
-  usage for the selected account. Long-lived app/server refreshes keep using CodexBar's managed session, and
-  CodexBar-owned pids are excluded from external reuse so probe/idle lifecycle accounting stays balanced.
+- Before launching `agy`, both menu-bar refreshes and one-shot CLI invocations spend at most two seconds looking for
+  an already-running, same-user `agy` at the selected binary path and reuse its tokenless local HTTPS endpoint when it
+  returns parseable usage for the selected account. CodexBar-owned pids are excluded from external reuse so managed
+  probe/idle lifecycle accounting stays balanced; if no eligible external server answers, CodexBar uses its managed
+  session as before.
 - Readiness is endpoint-based: CodexBar retries until one of the quota endpoints parses, because fresh `agy`
   processes can bind a port before the quota service is initialized.
 - App runtime uses a bounded warm session: `agy` is kept alive briefly after a refresh, then stopped on idle. CLI runtime


### PR DESCRIPTION
Fixes the quota-refresh half of #3146 (Add Account OAuth without the desktop app stays a separate follow-up, per the issue).

## Root cause
- `AntigravityProviderDescriptor.swift`: existing signed-in `agy` processes were reused only for one-shot CLI invocations — menu-bar refreshes spawned a separate, potentially unauthenticated `agy`.
- `AntigravityCLISession.swift` didn't recognize definitive logout/keyring-timeout messages.
- `ProviderFetchPlan.swift` let a later missing-IDE error replace the actual authentication failure, producing the misleading "Launch Antigravity" guidance.

## Fix
- Menu-bar refreshes reuse authenticated external `agy` processes, preserving same-user, executable-path, selected-account, and managed-process ownership checks.
- Logged-out/keyring-timeout states now produce actionable sign-in guidance.
- Antigravity error prioritization keeps auth guidance without blocking valid IDE, OAuth, or offline fallbacks.

## Verification
110 tests across five focused suites (Keychain access suppressed), `swiftformat`, `swiftlint --strict`, `make check`, independent review clean.
