### PR TITLE
Fix Claude web cookie refresh

### DIFF
--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -60,6 +60,9 @@ public enum BrowserCookieAccessGate {
     private static let log = CodexBarLog.logger(LogCategories.browserCookieGate)
     @TaskLocal private static var explicitRetryScope: ExplicitRetryScope?
     @TaskLocal private static var deniedBrowsersForTesting: [Browser]?
+    #if DEBUG
+    @TaskLocal private static var shouldAttemptOverrideForTesting: Bool?
+    #endif
 
     static let allowTestCookieAccessEnvironmentKey = "CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"
 
@@ -84,6 +87,11 @@ public enum BrowserCookieAccessGate {
     }
 
     public static func shouldAttempt(_ browser: Browser, now: Date = Date()) -> Bool {
+        #if DEBUG
+        if let shouldAttemptOverrideForTesting {
+            return shouldAttemptOverrideForTesting
+        }
+        #endif
         guard browser.usesKeychainForCookieDecryption else { return true }
         guard !KeychainAccessGate.isDisabled else { return false }
         guard ProviderInteractionContext.current == .userInitiated else {
@@ -166,6 +174,17 @@ public enum BrowserCookieAccessGate {
             try await operation()
         }
     }
+
+    #if DEBUG
+    static func withShouldAttemptOverrideForTesting<T>(
+        _ result: Bool?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$shouldAttemptOverrideForTesting.withValue(result) {
+            try operation()
+        }
+    }
+    #endif
 
     static func operationPreservingAccessContext<T: Sendable>(
         _ operation: @escaping @Sendable () throws -> T) -> @Sendable () throws -> T

--- a/Sources/CodexBarCore/BrowserCookieImportOrder.swift
+++ b/Sources/CodexBarCore/BrowserCookieImportOrder.swift
@@ -15,13 +15,17 @@ extension [Browser] {
     ///
     /// This is intentionally stricter than "app installed": it aims to avoid unnecessary Keychain prompts.
     public func cookieImportCandidates(using detection: BrowserDetection) -> [Browser] {
-        let candidates = self.filter { browser in
+        Array(self.lazyCookieImportCandidates(using: detection))
+    }
+
+    /// Lazily filters browser sources so callers can stop after the first successful cookie import.
+    func lazyCookieImportCandidates(using detection: BrowserDetection) -> some Sequence<Browser> {
+        self.lazy.filter { browser in
             if KeychainAccessGate.isDisabled, browser.usesKeychainForCookieDecryption {
                 return false
             }
-            return detection.isCookieSourceAvailable(browser)
+            return detection.isCookieSourceAvailable(browser) && BrowserCookieAccessGate.shouldAttempt(browser)
         }
-        return candidates.filter { BrowserCookieAccessGate.shouldAttempt($0) }
     }
 
     /// Filters a browser list to sources with usable profile data on disk.

--- a/Sources/CodexBarCore/KeychainAccessGate.swift
+++ b/Sources/CodexBarCore/KeychainAccessGate.swift
@@ -7,6 +7,9 @@ public enum KeychainAccessGate {
     private static let flagKey = "debugDisableKeychainAccess"
     static let disableAccessEnvironmentKey = "CODEXBAR_DISABLE_KEYCHAIN_ACCESS"
     @TaskLocal private static var taskOverrideValue: Bool?
+    #if DEBUG
+    @TaskLocal private static var storedOverrideForTesting: Bool?
+    #endif
     // All mutable gate state and mirror writes share this lock. Resolve the effective value with
     // `isDisabledLocked()` instead of recursively entering through the public getter.
     private static let stateLock = NSLock()
@@ -38,6 +41,9 @@ public enum KeychainAccessGate {
         if Self.forcesDisabledUnderTests { return true }
         #endif
         if self.processForceDisabledReason != nil { return true }
+        #if DEBUG
+        if let storedOverrideForTesting { return storedOverrideForTesting }
+        #endif
         if let overrideValue { return overrideValue }
         if UserDefaults.standard.bool(forKey: Self.flagKey) { return true }
         if let shared = AppGroupSupport.sharedDefaults(), shared.bool(forKey: Self.flagKey) { return true }
@@ -55,6 +61,9 @@ public enum KeychainAccessGate {
         if let taskOverrideValue { return taskOverrideValue }
         if self.isDisabledByEnvironment() { return true }
         if self.processForceDisabledReason != nil { return true }
+        #if DEBUG
+        if let storedOverrideForTesting { return storedOverrideForTesting }
+        #endif
         if let overrideValue { return overrideValue }
         if UserDefaults.standard.bool(forKey: Self.flagKey) { return true }
         if let shared = AppGroupSupport.sharedDefaults(), shared.bool(forKey: Self.flagKey) { return true }
@@ -115,8 +124,25 @@ public enum KeychainAccessGate {
         }
     }
 
+    #if DEBUG
+    static func withStoredOverrideForTesting<T>(
+        _ disabled: Bool?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$storedOverrideForTesting.withValue(disabled) {
+            try operation()
+        }
+    }
+    #endif
+
     static var currentOverrideForTesting: Bool? {
+        #if DEBUG
+        self.taskOverrideValue
+            ?? self.storedOverrideForTesting
+            ?? self.stateLock.withLock { self.overrideValue }
+        #else
         self.taskOverrideValue ?? self.stateLock.withLock { self.overrideValue }
+        #endif
     }
 
     #if DEBUG

--- a/Sources/CodexBarCore/KeychainAccessPreflight.swift
+++ b/Sources/CodexBarCore/KeychainAccessPreflight.swift
@@ -1,6 +1,7 @@
+import Foundation
+
 #if os(macOS)
 import Darwin
-import Foundation
 import LocalAuthentication
 import Security
 #endif
@@ -90,7 +91,32 @@ public enum KeychainAccessPreflight {
         case failure(Int)
     }
 
+    private struct GenericPasswordKey: Hashable {
+        let service: String
+        let account: String?
+    }
+
+    private final class GenericPasswordCheckMemo: @unchecked Sendable {
+        private let lock = NSLock()
+        private var outcomes: [GenericPasswordKey: Outcome] = [:]
+
+        func outcome(
+            for key: GenericPasswordKey,
+            check: () -> Outcome) -> Outcome
+        {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            if let outcome = self.outcomes[key] {
+                return outcome
+            }
+            let outcome = check()
+            self.outcomes[key] = outcome
+            return outcome
+        }
+    }
+
     private static let log = CodexBarLog.logger(LogCategories.keychainPreflight)
+    @TaskLocal private static var genericPasswordCheckMemo: GenericPasswordCheckMemo?
 
     #if DEBUG
     final class CheckGenericPasswordOverrideStore: @unchecked Sendable {
@@ -131,7 +157,27 @@ public enum KeychainAccessPreflight {
     }
     #endif
 
+    /// Reuses identical no-UI generic-password preflights within one synchronous operation.
+    /// The scope is deliberately short-lived because Keychain items and their ACLs can change.
+    public static func withMemoizedGenericPasswordChecks<T>(
+        _ operation: () throws -> T) rethrows -> T
+    {
+        try self.$genericPasswordCheckMemo.withValue(GenericPasswordCheckMemo()) {
+            try operation()
+        }
+    }
+
     public static func checkGenericPassword(service: String, account: String?) -> Outcome {
+        let key = GenericPasswordKey(service: service, account: account)
+        if let memo = self.genericPasswordCheckMemo {
+            return memo.outcome(for: key) {
+                self.checkGenericPasswordUncached(service: service, account: account)
+            }
+        }
+        return self.checkGenericPasswordUncached(service: service, account: account)
+    }
+
+    private static func checkGenericPasswordUncached(service: String, account: String?) -> Outcome {
         #if os(macOS)
         #if DEBUG
         if let override = self.taskCheckGenericPasswordOverrideStore {

--- a/Sources/CodexBarCore/KeychainCacheStore+ApplicationPaths.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore+ApplicationPaths.swift
@@ -1,6 +1,47 @@
 import Foundation
+#if os(macOS)
+import Security
+#endif
 
 extension KeychainCacheStore {
+    #if DEBUG
+    @TaskLocal static var bundledAdHocProcessOverrideForTesting: Bool?
+    #endif
+
+    /// Ad-hoc app rebuilds cannot satisfy legacy Keychain ACLs created by an earlier executable identity.
+    /// Keep cookie caches process-local for those builds; certificate-signed development and release apps
+    /// retain the persistent Keychain cache.
+    static var isBundledAdHocProcess: Bool {
+        #if DEBUG
+        if let override = self.bundledAdHocProcessOverrideForTesting {
+            return override
+        }
+        #endif
+        return self.detectedBundledAdHocProcess
+    }
+
+    private static let detectedBundledAdHocProcess: Bool = {
+        #if os(macOS)
+        guard let appBundle = Self.appBundleURL(containing: Bundle.main.bundleURL)
+            ?? Bundle.main.executableURL.flatMap(Self.appBundleURL(containing:))
+        else { return false }
+        return !Self.hasCodeSigningCertificate(at: appBundle)
+        #else
+        return false
+        #endif
+    }()
+
+    #if DEBUG
+    static func withBundledAdHocProcessForTesting<T>(
+        _ enabled: Bool,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$bundledAdHocProcessOverrideForTesting.withValue(enabled) {
+            try operation()
+        }
+    }
+    #endif
+
     static func trustedApplicationPathsForCacheAccess(
         bundleURL: URL = Bundle.main.bundleURL,
         executableURL: URL? = Bundle.main.executableURL,
@@ -47,5 +88,27 @@ extension KeychainCacheStore {
             current.deleteLastPathComponent()
         }
         return nil
+    }
+
+    static func hasCodeSigningCertificate(at bundleURL: URL) -> Bool {
+        #if os(macOS)
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(bundleURL as CFURL, SecCSFlags(), &staticCode) == errSecSuccess,
+              let staticCode
+        else { return false }
+
+        var information: CFDictionary?
+        guard SecCodeCopySigningInformation(
+            staticCode,
+            SecCSFlags(rawValue: kSecCSSigningInformation),
+            &information) == errSecSuccess,
+            let values = information as? [String: Any],
+            let certificates = values[kSecCodeInfoCertificates as String] as? [SecCertificate]
+        else { return false }
+        return !certificates.isEmpty
+        #else
+        _ = bundleURL
+        return false
+        #endif
     }
 }

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -513,12 +513,14 @@ public enum KeychainCacheStore {
         !KeychainAccessGate.isDisabled
     }
 
-    /// When the user disables Keychain access, keep an in-process cache so cookie/session
+    /// When persistent cookie-cache access is unavailable, keep an in-process cache so session
     /// reconciliation can still succeed without treating every refresh as a session change.
     /// Unit tests keep using the isolated test stores instead, unless a test explicitly opts in.
     private static func shouldUseDisabledAccessMemoryStore(for category: String) -> Bool {
         #if DEBUG
-        if self.disabledAccessMemoryStoreEnabledForTesting == true {
+        if self.disabledAccessMemoryStoreEnabledForTesting == true ||
+            self.bundledAdHocProcessOverrideForTesting == true
+        {
             return category == "cookie"
         }
         if KeychainTestSafety.isRunningUnderTests(
@@ -538,7 +540,7 @@ public enum KeychainCacheStore {
             return true
         }
         guard category == "cookie" else { return false }
-        return KeychainAccessGate.isExplicitlyDisabled
+        return KeychainAccessGate.isExplicitlyDisabled || self.isBundledAdHocProcess
     }
 
     /// True when the running executable has no `.app` bundle ancestor.
@@ -587,7 +589,7 @@ public enum KeychainCacheStore {
     }
     #endif
 
-    /// Drops the in-process fallback used while Keychain access is explicitly disabled.
+    /// Drops the in-process fallback used when persistent cookie-cache access is unavailable.
     static func clearDisabledAccessMemoryStore() {
         self.disabledAccessMemoryLock.lock()
         self.disabledAccessMemoryStore.removeAll()
@@ -599,7 +601,8 @@ public enum KeychainCacheStore {
 
     private static var prefersDisabledAccessMemoryStoreOverTestStore: Bool {
         #if DEBUG
-        self.disabledAccessMemoryStoreEnabledForTesting == true
+        self.disabledAccessMemoryStoreEnabledForTesting == true ||
+            self.bundledAdHocProcessOverrideForTesting == true
         #else
         false
         #endif
@@ -846,7 +849,7 @@ public enum KeychainCacheStore {
         defer { self.disabledAccessMemoryLock.unlock() }
         let memoryKey = TestStoreKey(service: self.serviceName, account: key.account)
         self.disabledAccessMemoryStore[memoryKey] = data
-        self.log.debug("Keychain cache stored in memory (Keychain access disabled)", metadata: [
+        self.log.debug("Cookie cache stored in process memory", metadata: [
             "account": key.account,
         ])
         return true

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -1,7 +1,16 @@
 import Foundation
+import SweetCookieKit
 
 public enum ClaudeProviderDescriptor {
     public static let descriptor: ProviderDescriptor = Self.makeDescriptor()
+    private static var browserCookieOrder: BrowserCookieImportOrder? {
+        #if os(macOS)
+        [.chrome] + Browser.defaultImportOrder.filter { $0 != .chrome }
+        #else
+        nil
+        #endif
+    }
+
     private static let ttyLaunch = ProviderTTYLaunchConfig(
         executableOverrideEnvironmentKey: "CLAUDE_CLI_PATH",
         bundledWatchdogHelperName: "CodexBarClaudeWatchdog",
@@ -123,7 +132,7 @@ public enum ClaudeProviderDescriptor {
                     probeLogOrder: 1,
                     notificationSimulationOrder: 1,
                     errorSimulationOrder: 1),
-                browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
+                browserCookieOrder: self.browserCookieOrder,
                 dashboardURL: "https://console.anthropic.com/settings/billing",
                 subscriptionDashboardURL: "https://claude.ai/settings/usage",
                 changelogURL: "https://github.com/anthropics/claude-code/releases",

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -37,11 +37,23 @@ enum ClaudeWebPrepaidCreditsRequest {
 enum ClaudeWebSessionKeyImport {
     #if DEBUG
     @TaskLocal static var overrideForTesting: ClaudeWebAPIFetcher.SessionKeyInfo?
+    @TaskLocal static var browserOverrideForTesting:
+        (@Sendable (Browser) throws -> ClaudeWebAPIFetcher.SessionKeyInfo?)?
     #endif
 
     static var currentOverride: ClaudeWebAPIFetcher.SessionKeyInfo? {
         #if DEBUG
         self.overrideForTesting
+        #else
+        nil
+        #endif
+    }
+
+    static var currentBrowserOverride:
+        (@Sendable (Browser) throws -> ClaudeWebAPIFetcher.SessionKeyInfo?)?
+    {
+        #if DEBUG
+        self.browserOverrideForTesting
         #else
         nil
         #endif
@@ -535,33 +547,42 @@ extension ClaudeWebAPIFetcher {
 
         let cookieDomains = ["claude.ai"]
 
-        // Filter to cookie-eligible browsers to avoid unnecessary keychain prompts
-        let installedBrowsers = Self.cookieImportOrder.cookieImportCandidates(using: browserDetection)
-        for browserSource in installedBrowsers {
-            do {
-                let query = BrowserCookieQuery(domains: cookieDomains)
-                let sources = try Self.cookieClient.codexBarRecords(
-                    matching: query,
-                    in: browserSource,
-                    logger: log)
-                for source in sources {
-                    if let sessionKey = findSessionKey(in: source.records.map { record in
-                        (name: record.name, value: record.value)
-                    }) {
-                        log("Found sessionKey in \(source.label)")
-                        return SessionKeyInfo(
-                            key: sessionKey,
-                            sourceLabel: source.label,
-                            cookieCount: source.records.count)
+        return try KeychainAccessPreflight.withMemoizedGenericPasswordChecks {
+            // Evaluate sources on demand so a successful preferred browser avoids later Keychain preflights.
+            let installedBrowsers = Self.cookieImportOrder.lazyCookieImportCandidates(using: browserDetection)
+            for browserSource in installedBrowsers {
+                do {
+                    if let override = ClaudeWebSessionKeyImport.currentBrowserOverride {
+                        if let sessionInfo = try override(browserSource) {
+                            log("Found sessionKey in \(sessionInfo.sourceLabel)")
+                            return sessionInfo
+                        }
+                        continue
                     }
+                    let query = BrowserCookieQuery(domains: cookieDomains)
+                    let sources = try Self.cookieClient.codexBarRecords(
+                        matching: query,
+                        in: browserSource,
+                        logger: log)
+                    for source in sources {
+                        if let sessionKey = findSessionKey(in: source.records.map { record in
+                            (name: record.name, value: record.value)
+                        }) {
+                            log("Found sessionKey in \(source.label)")
+                            return SessionKeyInfo(
+                                key: sessionKey,
+                                sourceLabel: source.label,
+                                cookieCount: source.records.count)
+                        }
+                    }
+                } catch {
+                    BrowserCookieAccessGate.recordIfNeeded(error)
+                    log("\(browserSource.displayName) cookie load failed: \(error.localizedDescription)")
                 }
-            } catch {
-                BrowserCookieAccessGate.recordIfNeeded(error)
-                log("\(browserSource.displayName) cookie load failed: \(error.localizedDescription)")
             }
-        }
 
-        throw FetchError.noSessionKeyFound
+            throw FetchError.noSessionKeyFound
+        }
     }
 
     private static func findSessionKey(in cookies: [(name: String, value: String)]) -> String? {

--- a/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
@@ -17,6 +17,15 @@ struct BrowserCookieOrderStatusStringTests {
     }
 
     @Test
+    func `claude cookie import prefers chrome without dropping fallback browsers`() throws {
+        let order = try #require(ProviderDefaults.metadata[.claude]?.browserCookieOrder)
+
+        #expect(order.first == .chrome)
+        #expect(order.count == Browser.defaultImportOrder.count)
+        #expect(Set(order) == Set(Browser.defaultImportOrder))
+    }
+
+    @Test
     func `cursor no session includes browser login hint`() {
         let order = ProviderDefaults.metadata[.cursor]?.browserCookieOrder ?? Browser.defaultImportOrder
         let message = CursorStatusProbeError.noSessionCookie.errorDescription ?? ""

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -164,6 +164,57 @@ struct BrowserDetectionTests {
     }
 
     @Test
+    func `lazy cookie candidates stop before probing later browsers`() throws {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let chromeCookies = temp
+            .appendingPathComponent("Library/Application Support/Google/Chrome/Default/Network/Cookies")
+        try FileManager.default.createDirectory(
+            at: chromeCookies.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: chromeCookies.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let edgeProbeCount = OSAllocatedUnfairLock(initialState: 0)
+        let detection = BrowserDetection(
+            homeDirectory: temp.path,
+            cacheTTL: 0,
+            fileExists: { path in
+                if path == "/Applications/Google Chrome.app" {
+                    return true
+                }
+                if path == "/Applications/Microsoft Edge.app" {
+                    edgeProbeCount.withLock { $0 += 1 }
+                    return true
+                }
+                return FileManager.default.fileExists(atPath: path)
+            },
+            directoryContents: { path in
+                try? FileManager.default.contentsOfDirectory(atPath: path)
+            })
+        var preflightCount = 0
+
+        let firstCandidate = KeychainAccessGate.withTaskOverrideForTesting(false) {
+            KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
+                preflightCount += 1
+                return .allowed
+            } operation: {
+                ProviderInteractionContext.$current.withValue(.background) {
+                    Array([Browser.chrome, .edge]
+                        .lazyCookieImportCandidates(using: detection)
+                        .prefix(1))
+                }
+            }
+        }
+
+        #expect(firstCandidate == [.chrome])
+        #expect(preflightCount == 1)
+        #expect(edgeProbeCount.withLock { $0 } == 0)
+    }
+
+    @Test
     func `chrome requires profile data`() throws {
         let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
@@ -210,10 +261,6 @@ struct BrowserDetectionTests {
     @Test
     func `process filters chromium candidates despite false global keychain override`() throws {
         guard ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1" else { return }
-        KeychainAccessGate.resetOverrideForTesting()
-        defer { KeychainAccessGate.resetOverrideForTesting() }
-
-        KeychainAccessGate.isDisabled = false
 
         let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
@@ -232,7 +279,10 @@ struct BrowserDetectionTests {
 
         let detection = self.detection(homeDirectory: temp.path, installedBrowsers: [.chrome])
         let browsers: [Browser] = [.chrome, .safari]
-        #expect(browsers.cookieImportCandidates(using: detection) == [.safari])
+        let candidates = KeychainAccessGate.withStoredOverrideForTesting(false) {
+            browsers.cookieImportCandidates(using: detection)
+        }
+        #expect(candidates == [.safari])
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeWebBrowserFallbackTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebBrowserFallbackTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import os.lock
+import SweetCookieKit
+import Testing
+@testable import CodexBarCore
+
+#if os(macOS)
+@Suite(.serialized)
+struct ClaudeWebBrowserFallbackTests {
+    @Test
+    func `chrome without a Claude session falls through to Safari`() throws {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-browser-fallback-\(UUID().uuidString)", isDirectory: true)
+        let chromeCookies = temp
+            .appendingPathComponent("Library/Application Support/Google/Chrome/Default/Network/Cookies")
+        try FileManager.default.createDirectory(
+            at: chromeCookies.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: chromeCookies.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let detection = BrowserDetection(
+            homeDirectory: temp.path,
+            cacheTTL: 0,
+            fileExists: { path in
+                if path == "/Applications/Google Chrome.app" {
+                    return true
+                }
+                return FileManager.default.fileExists(atPath: path)
+            },
+            directoryContents: { path in
+                try? FileManager.default.contentsOfDirectory(atPath: path)
+            })
+        let attempts = OSAllocatedUnfairLock(initialState: [Browser]())
+        let browserOverride: @Sendable (Browser) throws -> ClaudeWebAPIFetcher.SessionKeyInfo? = { browser in
+            attempts.withLock { $0.append(browser) }
+            guard browser == .safari else { return nil }
+            return ClaudeWebAPIFetcher.SessionKeyInfo(
+                key: "sk-ant-safari-fallback",
+                sourceLabel: "Safari",
+                cookieCount: 1)
+        }
+
+        let sessionInfo = try BrowserCookieAccessGate.withShouldAttemptOverrideForTesting(true) {
+            try KeychainAccessGate.withTaskOverrideForTesting(false) {
+                try KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in .allowed } operation: {
+                    try ProviderInteractionContext.$current.withValue(.background) {
+                        try ClaudeWebSessionKeyImport.$browserOverrideForTesting.withValue(browserOverride) {
+                            try ClaudeWebAPIFetcher.sessionKeyInfo(browserDetection: detection)
+                        }
+                    }
+                }
+            }
+        }
+
+        #expect(attempts.withLock { $0 } == [.chrome, .safari])
+        #expect(sessionInfo.key == "sk-ant-safari-fallback")
+        #expect(sessionInfo.sourceLabel == "Safari")
+    }
+}
+#endif

--- a/Tests/CodexBarTests/KeychainCacheStoreTests.swift
+++ b/Tests/CodexBarTests/KeychainCacheStoreTests.swift
@@ -325,6 +325,90 @@ struct KeychainCacheStoreTests {
     }
 
     @Test
+    func `bundled ad hoc builds keep cookie cache in process memory`() {
+        KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        defer { KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting() }
+
+        let service = "adhoc-memory-\(UUID().uuidString)"
+        let key = KeychainCacheStore.Key.cookie(provider: .claude)
+        let entry = TestEntry(value: "sessionKey=memory", storedAt: Date(timeIntervalSince1970: 4))
+
+        KeychainCacheStore.withBundledAdHocProcessForTesting(true) {
+            KeychainCacheStore.withServiceOverrideForTesting(service) {
+                #expect(KeychainCacheStore.storeResult(key: key, entry: entry))
+                #expect(self.loadedEntry(for: key) == entry)
+                #expect(KeychainCacheStore.keys(category: "cookie") == [key])
+                #expect(KeychainCacheStore.clearResult(key: key) == .removed)
+                #expect(self.loadedEntry(for: key) == nil)
+            }
+        }
+    }
+
+    @Test
+    func `certificate signed builds keep cookie cache in persistent store`() {
+        KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer {
+            KeychainCacheStore.setTestStoreForTesting(false)
+            KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        }
+
+        let service = "signed-persistent-\(UUID().uuidString)"
+        let key = KeychainCacheStore.Key.cookie(provider: .claude)
+        let entry = TestEntry(value: "sessionKey=persistent", storedAt: Date(timeIntervalSince1970: 5))
+
+        KeychainCacheStore.withBundledAdHocProcessForTesting(false) {
+            KeychainCacheStore.withServiceOverrideForTesting(service) {
+                #expect(KeychainCacheStore.storeResult(key: key, entry: entry))
+                #expect(self.loadedEntry(for: key) == entry)
+            }
+        }
+
+        KeychainCacheStore.withBundledAdHocProcessForTesting(true) {
+            KeychainCacheStore.withServiceOverrideForTesting(service) {
+                #expect(self.loadedEntry(for: key) == nil)
+            }
+        }
+
+        KeychainCacheStore.withBundledAdHocProcessForTesting(false) {
+            KeychainCacheStore.withServiceOverrideForTesting(service) {
+                #expect(self.loadedEntry(for: key) == entry)
+                #expect(KeychainCacheStore.clearResult(key: key) == .removed)
+            }
+        }
+    }
+
+    @Test
+    func `code signing certificate detection recognizes signed system code`() {
+        #expect(KeychainCacheStore.hasCodeSigningCertificate(at: URL(fileURLWithPath: "/usr/bin/security")))
+        #expect(!KeychainCacheStore.hasCodeSigningCertificate(
+            at: URL(fileURLWithPath: "/path/that/does/not/exist")))
+    }
+
+    @Test
+    func `bundled ad hoc builds do not move OAuth credentials into memory`() {
+        KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+        defer {
+            KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
+            KeychainAccessGate.resetOverrideForTesting()
+        }
+
+        let service = "adhoc-memory-oauth-\(UUID().uuidString)"
+        let key = KeychainCacheStore.Key.oauth(provider: .claude)
+        let entry = TestEntry(value: "synthetic-oauth-credential", storedAt: Date(timeIntervalSince1970: 5))
+
+        KeychainAccessGate.withTaskOverrideForTesting(true) {
+            KeychainCacheStore.withBundledAdHocProcessForTesting(true) {
+                KeychainCacheStore.withServiceOverrideForTesting(service) {
+                    #expect(!KeychainCacheStore.storeResult(key: key, entry: entry))
+                    #expect(self.loadedEntry(for: key) == nil)
+                    #expect(KeychainCacheStore.keysResult(category: "oauth") == .failed)
+                }
+            }
+        }
+    }
+
+    @Test
     func `disabled keychain access does not retain OAuth entries in memory`() {
         KeychainCacheStore.resetDisabledAccessMemoryStoreForTesting()
         defer {

--- a/Tests/CodexBarTests/KeychainNoUIQueryTests.swift
+++ b/Tests/CodexBarTests/KeychainNoUIQueryTests.swift
@@ -51,6 +51,25 @@ struct KeychainNoUIQueryTests {
     }
 
     @Test
+    func `generic password preflight memo is scoped to one operation`() {
+        var checkCount = 0
+
+        KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
+            checkCount += 1
+            return .allowed
+        } operation: {
+            KeychainAccessPreflight.withMemoizedGenericPasswordChecks {
+                _ = KeychainAccessPreflight.checkGenericPassword(service: "Chrome Safe Storage", account: "Chrome")
+                _ = KeychainAccessPreflight.checkGenericPassword(service: "Chrome Safe Storage", account: "Chrome")
+                _ = KeychainAccessPreflight.checkGenericPassword(service: "Chrome Safe Storage", account: "Canary")
+            }
+            _ = KeychainAccessPreflight.checkGenericPassword(service: "Chrome Safe Storage", account: "Chrome")
+        }
+
+        #expect(checkCount == 3)
+    }
+
+    @Test
     func `decrypt ACL requires successful code signature validation without a prompt selector`() {
         #expect(KeychainAccessPreflight.decryptACLAllowsCurrentProcess(
             trustedApplicationValidationResults: [true],


### PR DESCRIPTION
## Summary

- keep Claude web-cookie refresh usable in bundled ad-hoc development builds by routing only cookie cache entries to the existing process-memory store
- preserve persistent Keychain storage for certificate-signed builds and OAuth credentials
- memoize no-UI Keychain preflight reads per import operation and evaluate browser candidates lazily
- prefer Chrome for Claude while preserving the full fallback order, including Chrome-without-session → Safari
- isolate the new tests from process-global Keychain and browser-gate state

## Why

After the stricter executable ACL validation, an ad-hoc rebuilt app can no longer read, update, or clear a cookie cache item created by a previous build without user interaction. Automatic Claude refresh can therefore return stale cached data even though a manual web-cookie retry eventually succeeds after permission is granted.

The eager browser candidate filter also performs Safe Storage preflights for later Chromium browsers before the preferred source is attempted, adding unnecessary work and potential prompt pressure.

## Validation

- [CI run 10604](https://github.com/steipete/CodexBar/actions/runs/32674345444) — passed on the current head, including lint, both macOS test shards, Linux x64/arm64, Linux musl, and the aggregate gate
- `swift test --filter 'KeychainCacheStoreTests|ClaudeWebBrowserFallbackTests|BrowserDetectionTests|KeychainNoUIQueryTests|BrowserCookieOrderLabelTests'` — 78 tests passed
- repeated the affected 78-test combination four times while validating test isolation
- `swift test --filter 'KeychainNoUIQueryTests|SpendDashboardDateTruthTests'` — 30 tests passed after rebasing onto current `upstream/main`, including the previously unrelated CHF fixture failure
- `make check` — passed with zero SwiftFormat/SwiftLint violations
- `swift build -c release` — passed
- `CodexBar.app/Contents/Helpers/CodexBarCLI --help` — passed against the packaged developed bundle
- independently reviewed; no remaining code or security findings

### Developed bundle smoke evidence

Built and launched the workspace bundle (not the public app) from the current head:

```text
==> Signing: adhoc (set APP_IDENTITY or install a dev cert to avoid keychain prompts)
==> Preserving CodexBar keychain entries (pass --clear-adhoc-keychain to reset adhoc keychain state)
Created /Users/xiaoxiawang/Desktop/CodexBar/CodexBar.app
==> launch app
OK: CodexBar is running.
```

Live behavior was tested with the developed ad-hoc bundle: the expected one-time Keychain permission flow completed, and subsequent Claude automatic refreshes succeeded without another permission prompt. Account values and cookies were intentionally omitted.
