### PR TITLE
Support multiple API-key OpenCode Go accounts

### DIFF
--- a/Sources/CodexBar/SettingsStore+TokenAccounts.swift
+++ b/Sources/CodexBar/SettingsStore+TokenAccounts.swift
@@ -2,6 +2,21 @@ import AppKit
 import CodexBarCore
 import Foundation
 
+/// Mirrors ProviderConfig.clean(_:)/CLIConfigCommand.cleanConfigSecret(_:) - trims whitespace and
+/// strips one matching pair of wrapping quote characters. A key saved via the Settings UI's own
+/// normalizer only trims whitespace, so without this a quoted legacy key and a clean new token
+/// for the same real credential compare as different and migrate a spurious duplicate account.
+private func cleanTokenAccountSecret(_ raw: String?) -> String? {
+    guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+        return nil
+    }
+    if (value.hasPrefix("\"") && value.hasSuffix("\"")) || (value.hasPrefix("'") && value.hasSuffix("'")) {
+        value = String(value.dropFirst().dropLast())
+    }
+    value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
+}
+
 extension SettingsStore {
     func tokenAccountsData(for provider: UsageProvider) -> ProviderTokenAccountData? {
         guard TokenAccountSupportCatalog.support(for: provider) != nil else { return nil }
@@ -78,7 +93,7 @@ extension SettingsStore {
         // otherwise silently stop tracking that existing subscription. Migrate it in first.
         let legacyKey = accounts.isEmpty
             && TokenAccountSupportCatalog.support(for: provider)?.migratesExistingAPIKeyOnFirstAccount == true
-            ? self.providerConfig(for: provider)?.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ? cleanTokenAccountSecret(self.providerConfig(for: provider)?.apiKey)
             : nil
         // If the account being added uses the same token as the existing single key, the user is
         // just naming their current subscription (e.g. via Add Account), not adding a second one.

--- a/Sources/CodexBar/SettingsStore+TokenAccounts.swift
+++ b/Sources/CodexBar/SettingsStore+TokenAccounts.swift
@@ -106,7 +106,13 @@ extension SettingsStore {
         // whitespace-trimmed) so a quoted paste of an already-stored key doesn't compare as a
         // different credential and migrate a spurious duplicate.
         let normalizedIncomingToken = cleanTokenAccountSecret(trimmedToken) ?? trimmedToken
-        if let legacyKey, !legacyKey.isEmpty, legacyKey != normalizedIncomingToken {
+        // The stray key can also already be sitting in an *existing* account rather than just
+        // the one being added right now - e.g. an unlabeled CLI set-api-key re-populates
+        // providerConfig.apiKey with a token that already has a Default account from an earlier
+        // migration. Without this check that already-represented key would be re-migrated as a
+        // second duplicate account every time another account is added.
+        let legacyKeyAlreadyRepresented = accounts.contains { cleanTokenAccountSecret($0.token) == legacyKey }
+        if let legacyKey, !legacyKey.isEmpty, legacyKey != normalizedIncomingToken, !legacyKeyAlreadyRepresented {
             accounts.append(ProviderTokenAccount(
                 id: UUID(),
                 label: "Default",

--- a/Sources/CodexBar/SettingsStore+TokenAccounts.swift
+++ b/Sources/CodexBar/SettingsStore+TokenAccounts.swift
@@ -80,7 +80,11 @@ extension SettingsStore {
             && TokenAccountSupportCatalog.support(for: provider)?.migratesExistingAPIKeyOnFirstAccount == true
             ? self.providerConfig(for: provider)?.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
             : nil
-        if let legacyKey, !legacyKey.isEmpty {
+        // If the account being added uses the same token as the existing single key, the user is
+        // just naming their current subscription (e.g. via Add Account), not adding a second one.
+        // Let the account appended below carry that label instead of also migrating a duplicate
+        // "Default" entry with the identical token, which would fetch and render it twice.
+        if let legacyKey, !legacyKey.isEmpty, legacyKey != trimmedToken {
             accounts.append(ProviderTokenAccount(
                 id: UUID(),
                 label: "Default",

--- a/Sources/CodexBar/SettingsStore+TokenAccounts.swift
+++ b/Sources/CodexBar/SettingsStore+TokenAccounts.swift
@@ -72,7 +72,22 @@ extension SettingsStore {
         let trimmedWorkspaceID = workspaceID?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalisedWorkspaceID = (trimmedWorkspaceID?.isEmpty ?? true) ? nil : trimmedWorkspaceID
         let existing = self.tokenAccountsData(for: provider)
-        let accounts = existing?.accounts ?? []
+        var accounts = existing?.accounts ?? []
+        // A previously configured single provider-level API key isn't visible to stacked
+        // fan-out (it only iterates tokenAccounts), so adding the first labeled account would
+        // otherwise silently stop tracking that existing subscription. Migrate it in first.
+        let legacyKey = accounts.isEmpty
+            && TokenAccountSupportCatalog.support(for: provider)?.migratesExistingAPIKeyOnFirstAccount == true
+            ? self.providerConfig(for: provider)?.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+            : nil
+        if let legacyKey, !legacyKey.isEmpty {
+            accounts.append(ProviderTokenAccount(
+                id: UUID(),
+                label: "Default",
+                token: legacyKey,
+                addedAt: Date().timeIntervalSince1970,
+                lastUsed: nil))
+        }
         let fallbackLabel = trimmedLabel.isEmpty ? "Account \(accounts.count + 1)" : trimmedLabel
         let account = ProviderTokenAccount(
             id: UUID(),
@@ -84,13 +99,14 @@ extension SettingsStore {
             usageScope: normalisedUsageScope,
             organizationID: normalisedOrganizationID,
             workspaceID: normalisedWorkspaceID)
+        accounts.append(account)
         let updated = ProviderTokenAccountData(
             version: existing?.version ?? 1,
-            accounts: accounts + [account],
-            activeIndex: accounts.count)
+            accounts: accounts,
+            activeIndex: accounts.count - 1)
         self.updateProviderConfig(provider: provider) { entry in
             entry.tokenAccounts = updated
-            if TokenAccountSupportCatalog.support(for: provider)?.clearsAPIKeyOnMutation == true {
+            if legacyKey != nil || TokenAccountSupportCatalog.support(for: provider)?.clearsAPIKeyOnMutation == true {
                 entry.apiKey = nil
             }
         }

--- a/Sources/CodexBar/SettingsStore+TokenAccounts.swift
+++ b/Sources/CodexBar/SettingsStore+TokenAccounts.swift
@@ -89,17 +89,24 @@ extension SettingsStore {
         let existing = self.tokenAccountsData(for: provider)
         var accounts = existing?.accounts ?? []
         // A previously configured single provider-level API key isn't visible to stacked
-        // fan-out (it only iterates tokenAccounts), so adding the first labeled account would
-        // otherwise silently stop tracking that existing subscription. Migrate it in first.
-        let legacyKey = accounts.isEmpty
-            && TokenAccountSupportCatalog.support(for: provider)?.migratesExistingAPIKeyOnFirstAccount == true
+        // fan-out (it only iterates tokenAccounts), so adding a labeled account would otherwise
+        // silently stop tracking that existing subscription. Not gated on accounts.isEmpty: a
+        // legacy key can still be sitting unmigrated even when tokenAccounts is already
+        // non-empty (e.g. a provider-level key configured after accounts already existed).
+        // Mirrors CLIConfigCommand.configSettingAPIKey, which migrates regardless of account
+        // count for the same reason.
+        let legacyKey = TokenAccountSupportCatalog.support(for: provider)?.migratesExistingAPIKeyOnFirstAccount == true
             ? cleanTokenAccountSecret(self.providerConfig(for: provider)?.apiKey)
             : nil
         // If the account being added uses the same token as the existing single key, the user is
         // just naming their current subscription (e.g. via Add Account), not adding a second one.
         // Let the account appended below carry that label instead of also migrating a duplicate
         // "Default" entry with the identical token, which would fetch and render it twice.
-        if let legacyKey, !legacyKey.isEmpty, legacyKey != trimmedToken {
+        // Normalize the incoming token the same way as the legacy key (quote-stripped, not just
+        // whitespace-trimmed) so a quoted paste of an already-stored key doesn't compare as a
+        // different credential and migrate a spurious duplicate.
+        let normalizedIncomingToken = cleanTokenAccountSecret(trimmedToken) ?? trimmedToken
+        if let legacyKey, !legacyKey.isEmpty, legacyKey != normalizedIncomingToken {
             accounts.append(ProviderTokenAccount(
                 id: UUID(),
                 label: "Default",

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -284,9 +284,33 @@ extension CodexBarCLI {
             cleanedWorkspaceID != nil
         guard hasAccountOptions else { return nil }
 
+        let hasTeamOptions = cleanedScope != nil || cleanedOrganizationID != nil || cleanedWorkspaceID != nil
+
+        // Plain --label with no team fields: allowed for any provider whose token accounts inject a
+        // plain API key (environment-variable based), so multiple named accounts of the same provider
+        // (e.g. several OpenCode Go subscriptions) can be stored and fanned out simultaneously.
+        guard hasTeamOptions else {
+            guard let label = cleanedLabel else { return nil }
+            guard let support = TokenAccountSupportCatalog.support(for: provider) else {
+                throw CLIArgumentError("--label is not supported for --provider \(provider.rawValue).")
+            }
+            guard case .environment = support.injection else {
+                throw CLIArgumentError(
+                    "--label requires an API-key based provider for \(provider.rawValue); " +
+                        "use Settings for cookie-based accounts.")
+            }
+            return ConfigAPIKeyAccountOptions(
+                label: label,
+                usageScope: .personal,
+                organizationID: nil,
+                workspaceID: nil)
+        }
+
         // Provider-specific by design: z.ai team tokens alone accept organization, workspace, and usage-scope fields.
         guard provider == .zai else {
-            throw CLIArgumentError("Token-account options are only supported for --provider zai.")
+            throw CLIArgumentError(
+                "Team account options (--usage-scope/--organization-id/--workspace-id) are only supported " +
+                    "for --provider zai.")
         }
 
         guard cleanedScope?.lowercased() == ZaiUsageScope.team.rawValue else {
@@ -362,8 +386,8 @@ extension CodexBarCLI {
 struct ConfigAPIKeyAccountOptions: Equatable {
     let label: String
     let usageScope: ZaiUsageScope
-    let organizationID: String
-    let workspaceID: String
+    let organizationID: String?
+    let workspaceID: String?
 }
 
 struct ConfigOptions: CommanderParsable {

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -242,8 +242,14 @@ extension CodexBarCLI {
             // "Default" entry with the identical token, which would fetch and render it twice.
             let migratesExistingKey = TokenAccountSupportCatalog.support(for: provider)?
                 .migratesExistingAPIKeyOnFirstAccount == true
-            let sanitizedLegacyKey = providerConfig.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let hasLegacyKey = !(sanitizedLegacyKey?.isEmpty ?? true)
+            // Normalize with the same cleanConfigSecret used for the incoming apiKey (line ~216)
+            // rather than a bare whitespace trim. A key saved via the Settings UI can retain
+            // wrapping quote characters (SettingsStore's normalizer only trims whitespace); if
+            // this side skipped quote-stripping while apiKey didn't, an already-identical
+            // credential could compare as different, firing a spurious migration that appends a
+            // broken, still-quoted duplicate "Default" account.
+            let sanitizedLegacyKey = Self.cleanConfigSecret(providerConfig.apiKey)
+            let hasLegacyKey = sanitizedLegacyKey != nil
             if accounts.isEmpty, migratesExistingKey, let legacyKey = sanitizedLegacyKey, hasLegacyKey,
                legacyKey != apiKey
             {

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -233,8 +233,12 @@ extension CodexBarCLI {
             var accounts = existing?.accounts ?? []
             // A previously configured single API key is about to be cleared below to make room
             // for the account list. Migrate it into that list first so adding a labeled account
-            // doesn't silently discard the only copy of an already-working credential.
-            if accounts.isEmpty, let legacyKey = providerConfig.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines),
+            // doesn't silently discard the only copy of an already-working credential. Opt-in
+            // per provider (see migratesExistingAPIKeyOnFirstAccount): most providers keep a
+            // configured single key deliberately separate from token accounts.
+            if accounts.isEmpty,
+               TokenAccountSupportCatalog.support(for: provider)?.migratesExistingAPIKeyOnFirstAccount == true,
+               let legacyKey = providerConfig.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines),
                !legacyKey.isEmpty
             {
                 accounts.append(ProviderTokenAccount(

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -262,7 +262,17 @@ extension CodexBarCLI {
             // tokenAccounts, run after accounts already existed). The clear below fires
             // whenever migratesExistingKey is true regardless of account count, so migration
             // must use the same condition or an unmigrated key gets silently discarded.
-            if migratesExistingKey, let legacyKey = sanitizedLegacyKey, hasLegacyKey, legacyKey != apiKey {
+            // The stray key can also already be sitting in an *existing* account rather than
+            // just the one being added right now - e.g. an unlabeled set-api-key re-populates
+            // providerConfig.apiKey with a token that already has a Default account from an
+            // earlier migration. Without this check that already-represented key would be
+            // re-migrated as a second duplicate account every time another account is added.
+            let legacyKeyAlreadyRepresented = sanitizedLegacyKey.map { key in
+                accounts.contains { Self.cleanConfigSecret($0.token) == key }
+            } ?? false
+            if migratesExistingKey, let legacyKey = sanitizedLegacyKey, hasLegacyKey, legacyKey != apiKey,
+               !legacyKeyAlreadyRepresented
+            {
                 accounts.append(ProviderTokenAccount(
                     id: UUID(),
                     label: "Default",

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -240,10 +240,11 @@ extension CodexBarCLI {
             // user is just naming their current subscription, not adding a second one. Let the
             // account appended below carry that label instead of also migrating a duplicate
             // "Default" entry with the identical token, which would fetch and render it twice.
-            if accounts.isEmpty,
-               TokenAccountSupportCatalog.support(for: provider)?.migratesExistingAPIKeyOnFirstAccount == true,
-               let legacyKey = providerConfig.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !legacyKey.isEmpty,
+            let migratesExistingKey = TokenAccountSupportCatalog.support(for: provider)?
+                .migratesExistingAPIKeyOnFirstAccount == true
+            let sanitizedLegacyKey = providerConfig.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let hasLegacyKey = !(sanitizedLegacyKey?.isEmpty ?? true)
+            if accounts.isEmpty, migratesExistingKey, let legacyKey = sanitizedLegacyKey, hasLegacyKey,
                legacyKey != apiKey
             {
                 accounts.append(ProviderTokenAccount(
@@ -268,7 +269,14 @@ extension CodexBarCLI {
                 version: existing?.version ?? 1,
                 accounts: accounts,
                 activeIndex: accounts.count - 1)
-            providerConfig.apiKey = nil
+            // Only clear the single-key field once its value is safely represented elsewhere
+            // (migrated into the account list, or it never held anything). A provider that
+            // hasn't opted into migration keeps its existing key untouched instead of losing it:
+            // once tokenAccounts is non-empty, fetches route through the selected account, so
+            // the leftover key is simply inert, not double-used.
+            if !hasLegacyKey || migratesExistingKey {
+                providerConfig.apiKey = nil
+            }
             if enableProvider {
                 providerConfig.enabled = true
             }

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -286,11 +286,16 @@ extension CodexBarCLI {
                 accounts: accounts,
                 activeIndex: accounts.count - 1)
             // Only clear the single-key field once its value is safely represented elsewhere
-            // (migrated into the account list, or it never held anything). A provider that
-            // hasn't opted into migration keeps its existing key untouched instead of losing it:
-            // once tokenAccounts is non-empty, fetches route through the selected account, so
-            // the leftover key is simply inert, not double-used.
-            if !hasLegacyKey || migratesExistingKey {
+            // (migrated into the account list, or it never held anything), or the provider
+            // explicitly wants a stale single-key value discarded on any account mutation
+            // (clearsAPIKeyOnMutation - e.g. Copilot, whose config-level GitHub token isn't
+            // meant to become a phantom "Default" account). A provider with neither flag keeps
+            // its existing key untouched instead of losing it: once tokenAccounts is non-empty,
+            // fetches route through the selected account, so the leftover key is simply inert,
+            // not double-used. Mirrors SettingsStore+TokenAccounts.swift, which already applies
+            // clearsAPIKeyOnMutation here.
+            let clearsOnMutation = TokenAccountSupportCatalog.support(for: provider)?.clearsAPIKeyOnMutation == true
+            if !hasLegacyKey || migratesExistingKey || clearsOnMutation {
                 providerConfig.apiKey = nil
             }
             if enableProvider {

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -193,7 +193,13 @@ extension CodexBarCLI {
         case .text:
             let name = ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
             let suffix = result.enabled ? " and enabled" : ""
-            let action = accountOptions == nil ? "stored API key" : "stored team token account"
+            let action = if accountOptions == nil {
+                "stored API key"
+            } else if accountOptions?.usageScope == .team {
+                "stored team token account"
+            } else {
+                "stored labeled account"
+            }
             print("Config: \(action) for \(name)\(suffix)")
         case .json:
             Self.printJSON(result, pretty: output.pretty)
@@ -250,9 +256,13 @@ extension CodexBarCLI {
             // broken, still-quoted duplicate "Default" account.
             let sanitizedLegacyKey = Self.cleanConfigSecret(providerConfig.apiKey)
             let hasLegacyKey = sanitizedLegacyKey != nil
-            if accounts.isEmpty, migratesExistingKey, let legacyKey = sanitizedLegacyKey, hasLegacyKey,
-               legacyKey != apiKey
-            {
+            // Not gated on accounts.isEmpty: a legacy key can still be sitting unmigrated even
+            // when tokenAccounts is already non-empty (e.g. a plain `set-api-key` with no
+            // --label, which always overwrites providerConfig.apiKey without touching
+            // tokenAccounts, run after accounts already existed). The clear below fires
+            // whenever migratesExistingKey is true regardless of account count, so migration
+            // must use the same condition or an unmigrated key gets silently discarded.
+            if migratesExistingKey, let legacyKey = sanitizedLegacyKey, hasLegacyKey, legacyKey != apiKey {
                 accounts.append(ProviderTokenAccount(
                     id: UUID(),
                     label: "Default",

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -230,7 +230,21 @@ extension CodexBarCLI {
         var providerConfig = updated.providerConfig(for: provider.instanceID) ?? ProviderConfig(id: provider.instanceID)
         if let accountOptions {
             let existing = providerConfig.tokenAccounts
-            let accounts = existing?.accounts ?? []
+            var accounts = existing?.accounts ?? []
+            // A previously configured single API key is about to be cleared below to make room
+            // for the account list. Migrate it into that list first so adding a labeled account
+            // doesn't silently discard the only copy of an already-working credential.
+            if accounts.isEmpty, let legacyKey = providerConfig.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !legacyKey.isEmpty
+            {
+                accounts.append(ProviderTokenAccount(
+                    id: UUID(),
+                    label: "Default",
+                    token: legacyKey,
+                    addedAt: Date().timeIntervalSince1970,
+                    lastUsed: nil,
+                    usageScope: ZaiUsageScope.personal.rawValue))
+            }
             let account = ProviderTokenAccount(
                 id: UUID(),
                 label: accountOptions.label,
@@ -240,10 +254,11 @@ extension CodexBarCLI {
                 usageScope: accountOptions.usageScope.rawValue,
                 organizationID: accountOptions.organizationID,
                 workspaceID: accountOptions.workspaceID)
+            accounts.append(account)
             providerConfig.tokenAccounts = ProviderTokenAccountData(
                 version: existing?.version ?? 1,
-                accounts: accounts + [account],
-                activeIndex: accounts.count)
+                accounts: accounts,
+                activeIndex: accounts.count - 1)
             providerConfig.apiKey = nil
             if enableProvider {
                 providerConfig.enabled = true

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -236,10 +236,15 @@ extension CodexBarCLI {
             // doesn't silently discard the only copy of an already-working credential. Opt-in
             // per provider (see migratesExistingAPIKeyOnFirstAccount): most providers keep a
             // configured single key deliberately separate from token accounts.
+            // If the account being added uses the same token as the existing single key, the
+            // user is just naming their current subscription, not adding a second one. Let the
+            // account appended below carry that label instead of also migrating a duplicate
+            // "Default" entry with the identical token, which would fetch and render it twice.
             if accounts.isEmpty,
                TokenAccountSupportCatalog.support(for: provider)?.migratesExistingAPIKeyOnFirstAccount == true,
                let legacyKey = providerConfig.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !legacyKey.isEmpty
+               !legacyKey.isEmpty,
+               legacyKey != apiKey
             {
                 accounts.append(ProviderTokenAccount(
                     id: UUID(),

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
@@ -14,7 +14,12 @@ public enum CopilotProviderDescriptor {
             requiresManualCookieSource: false,
             cookieName: nil,
             clearsAPIKeyOnMutation: true,
-            primaryAddActionTitle: "Add Account"))
+            primaryAddActionTitle: "Add Account",
+            // Provider-specific by design: Copilot already discards a stale single-key config
+            // value on mutation (clearsAPIKeyOnMutation above) rather than migrating it in as an
+            // account - a config-level GitHub token here isn't meant to become a phantom
+            // "Default" account alongside real OAuth-signed-in accounts.
+            migratesExistingAPIKeyOnFirstAccount: false))
 
     /// Budget imports stay Chrome-only to avoid prompting unrelated browsers.
     private static var browserCookieOrder: BrowserCookieImportOrder? {

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIProviderDescriptor.swift
@@ -14,7 +14,15 @@ public enum OpenAIAPIProviderDescriptor {
             injection: .environment(key: OpenAIAPISettingsReader.adminAPIKeyEnvironmentKey),
             requiresManualCookieSource: false,
             cookieName: nil,
-            environmentKeysToScrub: [OpenAIAPISettingsReader.projectIDEnvironmentKey]))
+            environmentKeysToScrub: [OpenAIAPISettingsReader.projectIDEnvironmentKey],
+            // Provider-specific by design: a configured single key here may be a
+            // project-scoped credential (additionalProjections above), a different kind of
+            // credential than an org-wide token account - selecting any token account already
+            // scrubs the project ID (environmentKeysToScrub) rather than carrying it per-account.
+            // Auto-migrating would silently turn a project-scoped key into an org-wide one, so
+            // this provider opts out of the environment-injection default and keeps its existing
+            // single key untouched instead.
+            migratesExistingAPIKeyOnFirstAccount: false))
 
     static func makeDescriptor() -> ProviderDescriptor {
         ProviderDescriptor(

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -121,16 +121,19 @@ public enum OpenCodeGoProviderDescriptor {
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
-        if context.sourceMode == .api {
-            return [OpenCodeGoAPIUsageFetchStrategy()]
-        }
-        if context.sourceMode == .web {
-            return [OpenCodeGoUsageFetchStrategy()]
-        }
         // Token accounts for this provider now inject a plain API key (see the .environment
         // injection on its TokenAccountSupport), so a per-account fetch should try the API
-        // strategy instead of the cookie-based web strategy the other scoped cases use.
-        // Two things this must not do:
+        // strategy instead of the cookie-based web strategy the other scoped cases use. This
+        // selected-account routing must run BEFORE the sourceMode == .api / .web early returns
+        // below, and must hold regardless of which explicit sourceMode was requested: an
+        // explicit --source web forced against a genuine API-key account has no per-account
+        // cookie to send (it would silently use an unrelated global/cached cookie and mislabel
+        // it as this account); an explicit --source api forced against a legacy cookie account
+        // would send that cookie as a bogus bearer token. Both fail closed (empty strategy list,
+        // surfaced as "no available fetch strategy") instead of silently using the wrong data
+        // source under this account's label.
+        //
+        // Two more things this must not do:
         //  - Reinterpret a token account saved *before* this change (a raw Cookie header) as an
         //    API key. Sniff the resolved token's shape and keep routing cookie-shaped values
         //    through the original cookie-first chain so upgraded accounts keep authenticating.
@@ -140,14 +143,33 @@ public enum OpenCodeGoProviderDescriptor {
         //    account's label instead of reporting the failure.
         if context.selectedTokenAccountID != nil {
             let resolvedToken = context.env[OpenCodeGoSettingsReader.apiKeyEnvironmentKey]
-            if let resolvedToken, Self.looksLikeCookieHeader(resolvedToken) {
-                return [
-                    OpenCodeGoUsageFetchStrategy(),
-                    OpenCodeGoLocalUsageFetchStrategy(),
-                    OpenCodeGoAPIUsageFetchStrategy(),
-                ]
+            let isLegacyCookie = resolvedToken.map(Self.looksLikeCookieHeader) ?? false
+            switch context.sourceMode {
+            case .api:
+                return isLegacyCookie ? [] : [OpenCodeGoAPIUsageFetchStrategy()]
+            case .web:
+                return isLegacyCookie
+                    ? [
+                        OpenCodeGoUsageFetchStrategy(),
+                        OpenCodeGoLocalUsageFetchStrategy(),
+                        OpenCodeGoAPIUsageFetchStrategy(),
+                    ]
+                    : []
+            default:
+                return isLegacyCookie
+                    ? [
+                        OpenCodeGoUsageFetchStrategy(),
+                        OpenCodeGoLocalUsageFetchStrategy(),
+                        OpenCodeGoAPIUsageFetchStrategy(),
+                    ]
+                    : [OpenCodeGoAPIUsageFetchStrategy()]
             }
+        }
+        if context.sourceMode == .api {
             return [OpenCodeGoAPIUsageFetchStrategy()]
+        }
+        if context.sourceMode == .web {
+            return [OpenCodeGoUsageFetchStrategy()]
         }
         if self.requiresScopedWebStrategy(context: context) {
             return [

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -19,7 +19,8 @@ public enum OpenCodeGoProviderDescriptor {
             injection: .environment(key: OpenCodeGoSettingsReader.apiKeyEnvironmentKey),
             requiresManualCookieSource: false,
             cookieName: nil,
-            legacyCookieDetector: Self.looksLikeCookieHeader),
+            legacyCookieDetector: Self.looksLikeCookieHeader,
+            migratesExistingAPIKeyOnFirstAccount: true),
         authDetector: { environment, _ in
             OpenCodeGoSettingsReader.apiKey(environment: environment) == nil ? [] : ["api"]
         })

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -13,11 +13,11 @@ public enum OpenCodeGoProviderDescriptor {
             return ProviderTokenResolution(token: token, source: .environment)
         },
         tokenAccountSupport: TokenAccountSupport(
-            title: "Session tokens",
-            subtitle: "Store multiple OpenCode Go Cookie headers.",
-            placeholder: "Cookie: …",
-            injection: .cookieHeader,
-            requiresManualCookieSource: true,
+            title: "API key accounts",
+            subtitle: "Store multiple OpenCode Go account API keys, tracked simultaneously.",
+            placeholder: "OpenCode API key",
+            injection: .environment(key: OpenCodeGoSettingsReader.apiKeyEnvironmentKey),
+            requiresManualCookieSource: false,
             cookieName: nil),
         authDetector: { environment, _ in
             OpenCodeGoSettingsReader.apiKey(environment: environment) == nil ? [] : ["api"]
@@ -124,6 +124,16 @@ public enum OpenCodeGoProviderDescriptor {
         }
         if context.sourceMode == .web {
             return [OpenCodeGoUsageFetchStrategy()]
+        }
+        // Token accounts for this provider inject a plain API key (see the .environment
+        // injection on its TokenAccountSupport), so a per-account fetch must try the API
+        // strategy first instead of the cookie-based web strategy the other scoped cases use.
+        if context.selectedTokenAccountID != nil {
+            return [
+                OpenCodeGoAPIUsageFetchStrategy(),
+                OpenCodeGoLocalUsageFetchStrategy(),
+                OpenCodeGoUsageFetchStrategy(),
+            ]
         }
         if self.requiresScopedWebStrategy(context: context) {
             return [

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -125,15 +125,27 @@ public enum OpenCodeGoProviderDescriptor {
         if context.sourceMode == .web {
             return [OpenCodeGoUsageFetchStrategy()]
         }
-        // Token accounts for this provider inject a plain API key (see the .environment
-        // injection on its TokenAccountSupport), so a per-account fetch must try the API
-        // strategy first instead of the cookie-based web strategy the other scoped cases use.
+        // Token accounts for this provider now inject a plain API key (see the .environment
+        // injection on its TokenAccountSupport), so a per-account fetch should try the API
+        // strategy instead of the cookie-based web strategy the other scoped cases use.
+        // Two things this must not do:
+        //  - Reinterpret a token account saved *before* this change (a raw Cookie header) as an
+        //    API key. Sniff the resolved token's shape and keep routing cookie-shaped values
+        //    through the original cookie-first chain so upgraded accounts keep authenticating.
+        //  - Fall an API-key account back to the unscoped local/cookie strategies on failure:
+        //    that fallback isn't scoped to this account, so a wrong or revoked key would
+        //    silently surface a different account's (or no account's) usage under this
+        //    account's label instead of reporting the failure.
         if context.selectedTokenAccountID != nil {
-            return [
-                OpenCodeGoAPIUsageFetchStrategy(),
-                OpenCodeGoLocalUsageFetchStrategy(),
-                OpenCodeGoUsageFetchStrategy(),
-            ]
+            let resolvedToken = context.env[OpenCodeGoSettingsReader.apiKeyEnvironmentKey]
+            if let resolvedToken, Self.looksLikeCookieHeader(resolvedToken) {
+                return [
+                    OpenCodeGoUsageFetchStrategy(),
+                    OpenCodeGoLocalUsageFetchStrategy(),
+                    OpenCodeGoAPIUsageFetchStrategy(),
+                ]
+            }
+            return [OpenCodeGoAPIUsageFetchStrategy()]
         }
         if self.requiresScopedWebStrategy(context: context) {
             return [
@@ -161,6 +173,12 @@ public enum OpenCodeGoProviderDescriptor {
             return true
         }
         return self.normalizedWorkspaceID(context.env["CODEXBAR_OPENCODEGO_WORKSPACE_ID"]) != nil
+    }
+
+    private static func looksLikeCookieHeader(_ token: String) -> Bool {
+        // A captured browser Cookie header always has at least one "name=value" pair; a Zen API
+        // key is an opaque bearer token ("sk-...") and never contains "=".
+        token.contains("=")
     }
 
     private static func normalizedWorkspaceID(_ value: String?) -> String? {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -18,7 +18,8 @@ public enum OpenCodeGoProviderDescriptor {
             placeholder: "OpenCode API key",
             injection: .environment(key: OpenCodeGoSettingsReader.apiKeyEnvironmentKey),
             requiresManualCookieSource: false,
-            cookieName: nil),
+            cookieName: nil,
+            legacyCookieDetector: Self.looksLikeCookieHeader),
         authDetector: { environment, _ in
             OpenCodeGoSettingsReader.apiKey(environment: environment) == nil ? [] : ["api"]
         })

--- a/Sources/CodexBarCore/Providers/ProviderCookieSettingsResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderCookieSettingsResolver.swift
@@ -8,9 +8,23 @@ public enum ProviderCookieSettingsResolver {
         selectedAccount: ProviderTokenAccount?) -> ProviderSettingsSnapshot.CookieProviderSettings
     {
         guard let support = TokenAccountSupportCatalog.support(for: provider),
-              case .cookieHeader = support.injection,
               let selectedAccount
         else {
+            return ProviderSettingsSnapshot.CookieProviderSettings(
+                cookieSource: configuredSource,
+                manualCookieHeader: configuredHeader)
+        }
+
+        let routesAsCookie: Bool = switch support.injection {
+        case .cookieHeader:
+            true
+        case .environment:
+            // A provider that migrated to API-key token accounts may still hold accounts saved
+            // under the old cookie-header injection; route those specific accounts as cookies
+            // instead of sending a stored Cookie header as a bogus bearer token.
+            support.legacyCookieDetector?(selectedAccount.token) ?? false
+        }
+        guard routesAsCookie else {
             return ProviderSettingsSnapshot.CookieProviderSettings(
                 cookieSource: configuredSource,
                 manualCookieHeader: configuredHeader)

--- a/Sources/CodexBarCore/Providers/ProviderCookieSettingsResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderCookieSettingsResolver.swift
@@ -15,25 +15,32 @@ public enum ProviderCookieSettingsResolver {
                 manualCookieHeader: configuredHeader)
         }
 
-        let routesAsCookie: Bool = switch support.injection {
+        switch support.injection {
         case .cookieHeader:
-            true
+            return ProviderSettingsSnapshot.CookieProviderSettings(
+                cookieSource: support.requiresManualCookieSource ? .manual : configuredSource,
+                manualCookieHeader: TokenAccountSupportCatalog.normalizedCookieHeader(
+                    for: provider,
+                    token: selectedAccount.token))
         case .environment:
             // A provider that migrated to API-key token accounts may still hold accounts saved
             // under the old cookie-header injection; route those specific accounts as cookies
-            // instead of sending a stored Cookie header as a bogus bearer token.
-            support.legacyCookieDetector?(selectedAccount.token) ?? false
-        }
-        guard routesAsCookie else {
+            // instead of sending a stored Cookie header as a bogus bearer token. The provider's
+            // own requiresManualCookieSource no longer implies manual mode here (it now reflects
+            // the API-key default), so force .manual unconditionally: OpenCodeWebCookieSupport
+            // only reads manualCookieHeader when the source is .manual, and leaving it at
+            // whatever the provider's default is (often .auto) would silently fall through to a
+            // different, unrelated cached/imported browser cookie instead of this account's.
+            guard support.legacyCookieDetector?(selectedAccount.token) == true else {
+                return ProviderSettingsSnapshot.CookieProviderSettings(
+                    cookieSource: configuredSource,
+                    manualCookieHeader: configuredHeader)
+            }
             return ProviderSettingsSnapshot.CookieProviderSettings(
-                cookieSource: configuredSource,
-                manualCookieHeader: configuredHeader)
+                cookieSource: .manual,
+                manualCookieHeader: TokenAccountSupportCatalog.normalizedCookieHeader(
+                    for: provider,
+                    token: selectedAccount.token))
         }
-
-        return ProviderSettingsSnapshot.CookieProviderSettings(
-            cookieSource: support.requiresManualCookieSource ? .manual : configuredSource,
-            manualCookieHeader: TokenAccountSupportCatalog.normalizedCookieHeader(
-                for: provider,
-                token: selectedAccount.token))
     }
 }

--- a/Sources/CodexBarCore/TokenAccountSupport.swift
+++ b/Sources/CodexBarCore/TokenAccountSupport.swift
@@ -27,6 +27,13 @@ public struct TokenAccountSupport: Sendable {
     /// migration keep authenticating. Nil for every provider that never had cookie-header token
     /// accounts, which is the default and does not change their behavior.
     public let legacyCookieDetector: (@Sendable (String) -> Bool)?
+    /// When true, adding the first token account also migrates an existing provider-level
+    /// single API key into the account list (as a "Default" account) instead of leaving it
+    /// orphaned outside tokenAccounts, where stacked fan-out never sees it. Off by default:
+    /// most providers intentionally keep a configured single key separate from token accounts
+    /// (it may be a placeholder/decoy left over from before accounts existed), so only a
+    /// provider that explicitly wants "single key -> first account" upgrade behavior opts in.
+    public let migratesExistingAPIKeyOnFirstAccount: Bool
     private let environmentOverride: @Sendable (String) -> [String: String]?
     private let environmentScrubber: @Sendable (inout [String: String], String) -> Void
     private let cookieHeaderNormalizer: @Sendable (String) -> String
@@ -46,6 +53,7 @@ public struct TokenAccountSupport: Sendable {
         showsTeamModeControls: Bool = false,
         primaryAddActionTitle: String? = nil,
         legacyCookieDetector: (@Sendable (String) -> Bool)? = nil,
+        migratesExistingAPIKeyOnFirstAccount: Bool = false,
         environmentOverride: (@Sendable (String) -> [String: String]?)? = nil,
         environmentScrubber: (@Sendable (inout [String: String], String) -> Void)? = nil,
         cookieHeaderNormalizer: (@Sendable (String) -> String)? = nil)
@@ -64,6 +72,7 @@ public struct TokenAccountSupport: Sendable {
         self.showsTeamModeControls = showsTeamModeControls
         self.primaryAddActionTitle = primaryAddActionTitle
         self.legacyCookieDetector = legacyCookieDetector
+        self.migratesExistingAPIKeyOnFirstAccount = migratesExistingAPIKeyOnFirstAccount
         self.environmentOverride = environmentOverride ?? { token in
             guard case let .environment(key) = injection else { return nil }
             return [key: token]

--- a/Sources/CodexBarCore/TokenAccountSupport.swift
+++ b/Sources/CodexBarCore/TokenAccountSupport.swift
@@ -19,6 +19,14 @@ public struct TokenAccountSupport: Sendable {
     public let showsOrganizationField: Bool
     public let showsTeamModeControls: Bool
     public let primaryAddActionTitle: String?
+    /// Optional escape hatch for a provider whose injection is `.environment` but whose token
+    /// accounts may still contain values saved under a prior `.cookieHeader` injection (e.g. a
+    /// provider migrated from cookie-only to API-key-only multi-account support). When set and
+    /// it returns true for a given account's resolved token, that token is routed through the
+    /// cookie/web path instead of being sent as a bearer API key, so accounts saved before the
+    /// migration keep authenticating. Nil for every provider that never had cookie-header token
+    /// accounts, which is the default and does not change their behavior.
+    public let legacyCookieDetector: (@Sendable (String) -> Bool)?
     private let environmentOverride: @Sendable (String) -> [String: String]?
     private let environmentScrubber: @Sendable (inout [String: String], String) -> Void
     private let cookieHeaderNormalizer: @Sendable (String) -> String
@@ -37,6 +45,7 @@ public struct TokenAccountSupport: Sendable {
         showsOrganizationField: Bool = false,
         showsTeamModeControls: Bool = false,
         primaryAddActionTitle: String? = nil,
+        legacyCookieDetector: (@Sendable (String) -> Bool)? = nil,
         environmentOverride: (@Sendable (String) -> [String: String]?)? = nil,
         environmentScrubber: (@Sendable (inout [String: String], String) -> Void)? = nil,
         cookieHeaderNormalizer: (@Sendable (String) -> String)? = nil)
@@ -54,6 +63,7 @@ public struct TokenAccountSupport: Sendable {
         self.showsOrganizationField = showsOrganizationField
         self.showsTeamModeControls = showsTeamModeControls
         self.primaryAddActionTitle = primaryAddActionTitle
+        self.legacyCookieDetector = legacyCookieDetector
         self.environmentOverride = environmentOverride ?? { token in
             guard case let .environment(key) = injection else { return nil }
             return [key: token]

--- a/Sources/CodexBarCore/TokenAccountSupport.swift
+++ b/Sources/CodexBarCore/TokenAccountSupport.swift
@@ -29,10 +29,14 @@ public struct TokenAccountSupport: Sendable {
     public let legacyCookieDetector: (@Sendable (String) -> Bool)?
     /// When true, adding the first token account also migrates an existing provider-level
     /// single API key into the account list (as a "Default" account) instead of leaving it
-    /// orphaned outside tokenAccounts, where stacked fan-out never sees it. Off by default:
-    /// most providers intentionally keep a configured single key separate from token accounts
-    /// (it may be a placeholder/decoy left over from before accounts existed), so only a
-    /// provider that explicitly wants "single key -> first account" upgrade behavior opts in.
+    /// inert outside tokenAccounts, where stacked fan-out and CLI --all-accounts never see it
+    /// (fetches route through the selected account once tokenAccounts is non-empty, so an
+    /// un-migrated key would silently stop being tracked). Defaults to true for any provider
+    /// whose token accounts inject a plain API key (.environment) - an existing single key for
+    /// those providers is a real, working credential that must not silently disappear the first
+    /// time a user names it or adds a second account. Cookie-header providers default to false:
+    /// their single-credential and token-account paths are already handled separately. A
+    /// provider can still override the default explicitly if it has a reason not to migrate.
     public let migratesExistingAPIKeyOnFirstAccount: Bool
     private let environmentOverride: @Sendable (String) -> [String: String]?
     private let environmentScrubber: @Sendable (inout [String: String], String) -> Void
@@ -53,7 +57,7 @@ public struct TokenAccountSupport: Sendable {
         showsTeamModeControls: Bool = false,
         primaryAddActionTitle: String? = nil,
         legacyCookieDetector: (@Sendable (String) -> Bool)? = nil,
-        migratesExistingAPIKeyOnFirstAccount: Bool = false,
+        migratesExistingAPIKeyOnFirstAccount: Bool? = nil,
         environmentOverride: (@Sendable (String) -> [String: String]?)? = nil,
         environmentScrubber: (@Sendable (inout [String: String], String) -> Void)? = nil,
         cookieHeaderNormalizer: (@Sendable (String) -> String)? = nil)
@@ -72,7 +76,13 @@ public struct TokenAccountSupport: Sendable {
         self.showsTeamModeControls = showsTeamModeControls
         self.primaryAddActionTitle = primaryAddActionTitle
         self.legacyCookieDetector = legacyCookieDetector
-        self.migratesExistingAPIKeyOnFirstAccount = migratesExistingAPIKeyOnFirstAccount
+        if let migratesExistingAPIKeyOnFirstAccount {
+            self.migratesExistingAPIKeyOnFirstAccount = migratesExistingAPIKeyOnFirstAccount
+        } else if case .environment = injection {
+            self.migratesExistingAPIKeyOnFirstAccount = true
+        } else {
+            self.migratesExistingAPIKeyOnFirstAccount = false
+        }
         self.environmentOverride = environmentOverride ?? { token in
             guard case let .environment(key) = injection else { return nil }
             return [key: token]

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -380,6 +380,40 @@ struct CLIConfigCommandTests {
     }
 
     @Test
+    func `config set api key clears a stale Copilot key when adding a labeled account`() throws {
+        let config = CodexBarConfig.makeDefault()
+        let withLegacyKey = CodexBarCLI.configSettingAPIKey(
+            config,
+            provider: .copilot,
+            apiKey: "gh-legacy",
+            enableProvider: true)
+
+        let options = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .copilot,
+            label: "Work",
+            usageScope: nil,
+            organizationID: nil,
+            workspaceID: nil))
+        let updated = CodexBarCLI.configSettingAPIKey(
+            withLegacyKey,
+            provider: .copilot,
+            apiKey: "gh-work",
+            enableProvider: true,
+            accountOptions: options)
+
+        let provider = try #require(updated.providerConfig(for: .copilot))
+        let accounts = provider.tokenAccounts?.accounts ?? []
+
+        // Copilot opts out of migratesExistingAPIKeyOnFirstAccount but opts into
+        // clearsAPIKeyOnMutation: a config-level GitHub token isn't meant to become a phantom
+        // "Default" account, but it must still be discarded on mutation rather than left behind
+        // as a stale, unused value - matching what the app's SettingsStore already does.
+        #expect(provider.apiKey == nil)
+        #expect(accounts.map(\.label) == ["Work"])
+        #expect(accounts.map(\.token) == ["gh-work"])
+    }
+
+    @Test
     func `config provider toggle parses provider and json flags`() throws {
         let parser = CommandParser(signature: CodexBarCLI._configProviderToggleSignatureForTesting())
         let parsed = try parser.parse(arguments: [

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -211,7 +211,7 @@ struct CLIConfigCommandTests {
     }
 
     @Test
-    func `config set api key preserves an existing key for a provider that does not migrate it`() throws {
+    func `config set api key migrates an existing key for any environment-injected provider`() throws {
         let config = CodexBarConfig.makeDefault()
         let withExistingKey = CodexBarCLI.configSettingAPIKey(
             config,
@@ -235,13 +235,13 @@ struct CLIConfigCommandTests {
         let provider = try #require(updated.providerConfig(for: .openrouter))
         let accounts = provider.tokenAccounts?.accounts ?? []
 
-        // OpenRouter does not opt into migratesExistingAPIKeyOnFirstAccount, so the existing
-        // single key must survive untouched instead of being silently deleted while only the
-        // new named account gets added.
-        #expect(provider.apiKey == "or-existing")
-        #expect(accounts.count == 1)
-        #expect(accounts[0].label == "Personal")
-        #expect(accounts[0].token == "or-personal")
+        // migratesExistingAPIKeyOnFirstAccount now defaults to true for every environment-
+        // injection provider (not just OpenCode Go): an existing single key is a real, working
+        // subscription that must not silently stop being tracked the first time a user names it
+        // or adds a second account, since fetches route through tokenAccounts once non-empty.
+        #expect(provider.apiKey == nil)
+        #expect(accounts.map(\.label) == ["Default", "Personal"])
+        #expect(accounts.map(\.token) == ["or-existing", "or-personal"])
     }
 
     @Test

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -279,6 +279,41 @@ struct CLIConfigCommandTests {
     }
 
     @Test
+    func `config set api key migrates a legacy key set after accounts already existed`() throws {
+        let config = CodexBarConfig.makeDefault()
+        let firstOptions = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego, label: "Acc1", usageScope: nil, organizationID: nil, workspaceID: nil))
+        let afterFirst = CodexBarCLI.configSettingAPIKey(
+            config, provider: .opencodego, apiKey: "sk-acc1", enableProvider: true, accountOptions: firstOptions)
+
+        let secondOptions = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego, label: "Acc2", usageScope: nil, organizationID: nil, workspaceID: nil))
+        let afterSecond = CodexBarCLI.configSettingAPIKey(
+            afterFirst, provider: .opencodego, apiKey: "sk-acc2", enableProvider: true, accountOptions: secondOptions)
+
+        // A plain set-api-key with no --label always overwrites providerConfig.apiKey without
+        // touching tokenAccounts, so this reaches a real, reachable state: 2 accounts already
+        // exist AND a stray legacy key sits unmigrated at the same time.
+        let withStrayKey = CodexBarCLI.configSettingAPIKey(
+            afterSecond, provider: .opencodego, apiKey: "sk-stray", enableProvider: true)
+        #expect(withStrayKey.providerConfig(for: .opencodego)?.apiKey == "sk-stray")
+        #expect(withStrayKey.providerConfig(for: .opencodego)?.tokenAccounts?.accounts.count == 2)
+
+        let thirdOptions = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego, label: "Acc3", usageScope: nil, organizationID: nil, workspaceID: nil))
+        let final = CodexBarCLI.configSettingAPIKey(
+            withStrayKey, provider: .opencodego, apiKey: "sk-acc3", enableProvider: true, accountOptions: thirdOptions)
+
+        let provider = try #require(final.providerConfig(for: .opencodego))
+        // The stray key must survive as its own "Default" account instead of being discarded:
+        // migration is gated on accounts.isEmpty, but the field-clear below it isn't, so an
+        // unmigrated legacy key set after accounts already existed was previously lost outright.
+        #expect(provider.apiKey == nil)
+        #expect(provider.tokenAccounts?.accounts.map(\.label) == ["Acc1", "Acc2", "Default", "Acc3"])
+        #expect(provider.tokenAccounts?.accounts.map(\.token) == ["sk-acc1", "sk-acc2", "sk-stray", "sk-acc3"])
+    }
+
+    @Test
     func `config set api key does not duplicate an identical legacy key when naming the same account`() throws {
         let config = CodexBarConfig.makeDefault()
         let withLegacyKey = CodexBarCLI.configSettingAPIKey(

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -122,6 +122,59 @@ struct CLIConfigCommandTests {
     }
 
     @Test
+    func `config set api key allows bare label for environment based provider`() throws {
+        let options = try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego,
+            label: "Work",
+            usageScope: nil,
+            organizationID: nil,
+            workspaceID: nil)
+        let account = try #require(options)
+
+        #expect(account.label == "Work")
+        #expect(account.usageScope == .personal)
+        #expect(account.organizationID == nil)
+        #expect(account.workspaceID == nil)
+    }
+
+    @Test
+    func `config set api key rejects bare label for provider without token account support`() {
+        // Moonshot has no tokenAccountSupport at all in its provider descriptor.
+        do {
+            _ = try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+                provider: .moonshot,
+                label: "Work",
+                usageScope: nil,
+                organizationID: nil,
+                workspaceID: nil)
+            Issue.record("Expected resolveConfigAPIKeyAccountOptions to throw")
+        } catch let error as CLIArgumentError {
+            #expect(error.message == "--label is not supported for --provider moonshot.")
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test
+    func `config set api key rejects bare label for cookie based provider`() {
+        // Claude's tokenAccountSupport uses cookieHeader injection, not environment.
+        do {
+            _ = try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+                provider: .claude,
+                label: "Work",
+                usageScope: nil,
+                organizationID: nil,
+                workspaceID: nil)
+            Issue.record("Expected resolveConfigAPIKeyAccountOptions to throw")
+        } catch let error as CLIArgumentError {
+            #expect(error.message ==
+                "--label requires an API-key based provider for claude; use Settings for cookie-based accounts.")
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test
     func `config provider toggle parses provider and json flags`() throws {
         let parser = CommandParser(signature: CodexBarCLI._configProviderToggleSignatureForTesting())
         let parsed = try parser.parse(arguments: [

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -211,6 +211,40 @@ struct CLIConfigCommandTests {
     }
 
     @Test
+    func `config set api key preserves an existing key for a provider that does not migrate it`() throws {
+        let config = CodexBarConfig.makeDefault()
+        let withExistingKey = CodexBarCLI.configSettingAPIKey(
+            config,
+            provider: .openrouter,
+            apiKey: "or-existing",
+            enableProvider: true)
+
+        let options = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .openrouter,
+            label: "Personal",
+            usageScope: nil,
+            organizationID: nil,
+            workspaceID: nil))
+        let updated = CodexBarCLI.configSettingAPIKey(
+            withExistingKey,
+            provider: .openrouter,
+            apiKey: "or-personal",
+            enableProvider: true,
+            accountOptions: options)
+
+        let provider = try #require(updated.providerConfig(for: .openrouter))
+        let accounts = provider.tokenAccounts?.accounts ?? []
+
+        // OpenRouter does not opt into migratesExistingAPIKeyOnFirstAccount, so the existing
+        // single key must survive untouched instead of being silently deleted while only the
+        // new named account gets added.
+        #expect(provider.apiKey == "or-existing")
+        #expect(accounts.count == 1)
+        #expect(accounts[0].label == "Personal")
+        #expect(accounts[0].token == "or-personal")
+    }
+
+    @Test
     func `config set api key does not duplicate an identical legacy key when naming the same account`() throws {
         let config = CodexBarConfig.makeDefault()
         let withLegacyKey = CodexBarCLI.configSettingAPIKey(

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -414,6 +414,35 @@ struct CLIConfigCommandTests {
     }
 
     @Test
+    func `config set api key does not re-migrate a stray key already represented in accounts`() throws {
+        let config = CodexBarConfig.makeDefault()
+        let firstOptions = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego, label: "Default", usageScope: nil, organizationID: nil, workspaceID: nil))
+        let withFirstAccount = CodexBarCLI.configSettingAPIKey(
+            config, provider: .opencodego, apiKey: "sk-a", enableProvider: true, accountOptions: firstOptions)
+
+        // A plain (unlabeled) set-api-key re-populates providerConfig.apiKey with a token that
+        // already has an account from the migration above.
+        let withStrayDuplicateKey = CodexBarCLI.configSettingAPIKey(
+            withFirstAccount, provider: .opencodego, apiKey: "sk-a", enableProvider: true)
+
+        let secondOptions = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego, label: "Work", usageScope: nil, organizationID: nil, workspaceID: nil))
+        let updated = CodexBarCLI.configSettingAPIKey(
+            withStrayDuplicateKey,
+            provider: .opencodego,
+            apiKey: "sk-b",
+            enableProvider: true,
+            accountOptions: secondOptions)
+
+        let provider = try #require(updated.providerConfig(for: .opencodego))
+
+        #expect(provider.apiKey == nil)
+        #expect(provider.tokenAccounts?.accounts.map(\.label) == ["Default", "Work"])
+        #expect(provider.tokenAccounts?.accounts.map(\.token) == ["sk-a", "sk-b"])
+    }
+
+    @Test
     func `config provider toggle parses provider and json flags`() throws {
         let parser = CommandParser(signature: CodexBarCLI._configProviderToggleSignatureForTesting())
         let parsed = try parser.parse(arguments: [

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -211,6 +211,37 @@ struct CLIConfigCommandTests {
     }
 
     @Test
+    func `config set api key does not duplicate an identical legacy key when naming the same account`() throws {
+        let config = CodexBarConfig.makeDefault()
+        let withLegacyKey = CodexBarCLI.configSettingAPIKey(
+            config,
+            provider: .opencodego,
+            apiKey: "sk-same",
+            enableProvider: true)
+
+        let options = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego,
+            label: "Personal",
+            usageScope: nil,
+            organizationID: nil,
+            workspaceID: nil))
+        let updated = CodexBarCLI.configSettingAPIKey(
+            withLegacyKey,
+            provider: .opencodego,
+            apiKey: "sk-same",
+            enableProvider: true,
+            accountOptions: options)
+
+        let accounts = updated.providerConfig(for: .opencodego)?.tokenAccounts?.accounts ?? []
+
+        // Same token as the existing single key: the user is naming their current subscription,
+        // not adding a second one. Must not fetch and render the same subscription twice.
+        #expect(accounts.count == 1)
+        #expect(accounts[0].label == "Personal")
+        #expect(accounts[0].token == "sk-same")
+    }
+
+    @Test
     func `config set api key does not duplicate the legacy key when accounts already exist`() throws {
         let config = CodexBarConfig.makeDefault()
         let firstOptions = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -175,6 +175,77 @@ struct CLIConfigCommandTests {
     }
 
     @Test
+    func `config set api key migrates an existing single key into the account list`() throws {
+        let config = CodexBarConfig.makeDefault()
+        let withLegacyKey = CodexBarCLI.configSettingAPIKey(
+            config,
+            provider: .opencodego,
+            apiKey: "sk-legacy",
+            enableProvider: true)
+
+        let options = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego,
+            label: "Work",
+            usageScope: nil,
+            organizationID: nil,
+            workspaceID: nil))
+        let updated = CodexBarCLI.configSettingAPIKey(
+            withLegacyKey,
+            provider: .opencodego,
+            apiKey: "sk-work",
+            enableProvider: true,
+            accountOptions: options)
+
+        let provider = try #require(updated.providerConfig(for: .opencodego))
+        let accounts = provider.tokenAccounts?.accounts ?? []
+
+        // The previously configured single key must survive as its own account instead of being
+        // discarded when providerConfig.apiKey is cleared to make room for the account list.
+        #expect(provider.apiKey == nil)
+        #expect(accounts.count == 2)
+        #expect(accounts[0].label == "Default")
+        #expect(accounts[0].token == "sk-legacy")
+        #expect(accounts[1].label == "Work")
+        #expect(accounts[1].token == "sk-work")
+        #expect(provider.tokenAccounts?.activeIndex == 1)
+    }
+
+    @Test
+    func `config set api key does not duplicate the legacy key when accounts already exist`() throws {
+        let config = CodexBarConfig.makeDefault()
+        let firstOptions = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego,
+            label: "Personal",
+            usageScope: nil,
+            organizationID: nil,
+            workspaceID: nil))
+        let withFirstAccount = CodexBarCLI.configSettingAPIKey(
+            config,
+            provider: .opencodego,
+            apiKey: "sk-personal",
+            enableProvider: true,
+            accountOptions: firstOptions)
+
+        let secondOptions = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego,
+            label: "Work",
+            usageScope: nil,
+            organizationID: nil,
+            workspaceID: nil))
+        let updated = CodexBarCLI.configSettingAPIKey(
+            withFirstAccount,
+            provider: .opencodego,
+            apiKey: "sk-work",
+            enableProvider: true,
+            accountOptions: secondOptions)
+
+        let accounts = updated.providerConfig(for: .opencodego)?.tokenAccounts?.accounts ?? []
+
+        #expect(accounts.count == 2)
+        #expect(accounts.map(\.label) == ["Personal", "Work"])
+    }
+
+    @Test
     func `config provider toggle parses provider and json flags`() throws {
         let parser = CommandParser(signature: CodexBarCLI._configProviderToggleSignatureForTesting())
         let parsed = try parser.parse(arguments: [

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -211,6 +211,40 @@ struct CLIConfigCommandTests {
     }
 
     @Test
+    func `config set api key recognizes a quoted legacy key as identical to the clean new token`() throws {
+        let config = CodexBarConfig.makeDefault()
+        // Simulates a key saved via the Settings UI, whose normalizer only trims whitespace and
+        // does not strip wrapping quote characters (unlike the CLI's own cleanConfigSecret).
+        let withQuotedLegacyKey = CodexBarCLI.configSettingAPIKey(
+            config,
+            provider: .opencodego,
+            apiKey: "\"sk-same\"",
+            enableProvider: true)
+
+        let options = try #require(try CodexBarCLI.resolveConfigAPIKeyAccountOptions(
+            provider: .opencodego,
+            label: "Personal",
+            usageScope: nil,
+            organizationID: nil,
+            workspaceID: nil))
+        let updated = CodexBarCLI.configSettingAPIKey(
+            withQuotedLegacyKey,
+            provider: .opencodego,
+            apiKey: "sk-same",
+            enableProvider: true,
+            accountOptions: options)
+
+        let accounts = updated.providerConfig(for: .opencodego)?.tokenAccounts?.accounts ?? []
+
+        // The quoted legacy value and the clean new token are the same real credential once
+        // normalized identically; must rename into one account, not append a second, broken,
+        // still-quoted "Default" entry that would fail to authenticate.
+        #expect(accounts.count == 1)
+        #expect(accounts[0].label == "Personal")
+        #expect(accounts[0].token == "sk-same")
+    }
+
+    @Test
     func `config set api key migrates an existing key for any environment-injected provider`() throws {
         let config = CodexBarConfig.makeDefault()
         let withExistingKey = CodexBarCLI.configSettingAPIKey(

--- a/Tests/CodexBarTests/CopilotMultiAccountTests.swift
+++ b/Tests/CodexBarTests/CopilotMultiAccountTests.swift
@@ -80,6 +80,12 @@ struct CopilotAPIKeyFallbackTests {
         #expect(settings.tokenAccounts(for: .copilot).first?.label == "existing")
     }
 
+    @Test
+    func `copilot opts out of migrating an existing key so it never becomes a phantom account`() {
+        let support = TokenAccountSupportCatalog.support(for: .copilot)
+        #expect(support?.migratesExistingAPIKeyOnFirstAccount == false)
+    }
+
     private static func makeSettingsStore(suite: String) -> SettingsStore {
         SettingsStore(
             configStore: testConfigStore(suiteName: suite),

--- a/Tests/CodexBarTests/OpenAIAPIProjectScopeTests.swift
+++ b/Tests/CodexBarTests/OpenAIAPIProjectScopeTests.swift
@@ -14,7 +14,12 @@ struct OpenAIAPIProjectScopeTests {
         settings[providerConfig: .openai, field: .secretWorkspace(logField: "projectID")] = "proj_config"
         settings.addTokenAccount(provider: .openai, label: "Configured account", token: "first-account-token")
         settings.addTokenAccount(provider: .openai, label: "Selected account", token: "selected-account-token")
-        let selectedAccount = settings.tokenAccounts(for: .openai)[1]
+        // migratesExistingAPIKeyOnFirstAccount now defaults to true for environment-injection
+        // providers, so the first addTokenAccount call above also migrated "config-token" in as
+        // a "Default" account: [Default, Configured account, Selected account].
+        let accounts = settings.tokenAccounts(for: .openai)
+        #expect(accounts.map(\.label) == ["Default", "Configured account", "Selected account"])
+        let selectedAccount = accounts[2]
 
         let env = ProviderRegistry.makeEnvironment(
             base: [OpenAIAPISettingsReader.projectIDEnvironmentKey: "proj_env"],

--- a/Tests/CodexBarTests/OpenAIAPIProjectScopeTests.swift
+++ b/Tests/CodexBarTests/OpenAIAPIProjectScopeTests.swift
@@ -7,6 +7,12 @@ import Testing
 @Suite(.serialized)
 struct OpenAIAPIProjectScopeTests {
     @Test
+    func `OpenAI opts out of migrating an existing key so project scope is never silently dropped`() {
+        let support = TokenAccountSupportCatalog.support(for: .openai)
+        #expect(support?.migratesExistingAPIKeyOnFirstAccount == false)
+    }
+
+    @Test
     @MainActor
     func `token account strips configured project in app environment builder`() {
         let settings = Self.makeSettingsStore(suite: "OpenAIAPIProjectScopeTests-app")
@@ -14,12 +20,13 @@ struct OpenAIAPIProjectScopeTests {
         settings[providerConfig: .openai, field: .secretWorkspace(logField: "projectID")] = "proj_config"
         settings.addTokenAccount(provider: .openai, label: "Configured account", token: "first-account-token")
         settings.addTokenAccount(provider: .openai, label: "Selected account", token: "selected-account-token")
-        // migratesExistingAPIKeyOnFirstAccount now defaults to true for environment-injection
-        // providers, so the first addTokenAccount call above also migrated "config-token" in as
-        // a "Default" account: [Default, Configured account, Selected account].
+        // OpenAI opts out of migratesExistingAPIKeyOnFirstAccount (see OpenAIAPIProviderDescriptor):
+        // "config-token" is a project-scoped credential, a different kind from an org-wide token
+        // account, so it stays untouched outside tokenAccounts instead of migrating in as "Default".
         let accounts = settings.tokenAccounts(for: .openai)
-        #expect(accounts.map(\.label) == ["Default", "Configured account", "Selected account"])
-        let selectedAccount = accounts[2]
+        #expect(accounts.map(\.label) == ["Configured account", "Selected account"])
+        #expect(settings.providerConfig(for: .openai)?.apiKey == "config-token")
+        let selectedAccount = accounts[1]
 
         let env = ProviderRegistry.makeEnvironment(
             base: [OpenAIAPISettingsReader.projectIDEnvironmentKey: "proj_env"],

--- a/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
@@ -59,6 +59,39 @@ struct OpenCodeGoAddTokenAccountTests {
         #expect(accounts[0].token == "sk-same")
     }
 
+    @Test
+    func `a quoted incoming token is recognized as identical to the clean legacy key`() {
+        let settings = Self.makeSettings(suite: "OpenCodeGoAddTokenAccountTests-quoted-incoming")
+        // Reverse of the above: the stored legacy key is already clean, but the user pastes a
+        // quoted copy of the same credential into Add Account.
+        settings[providerConfig: .opencodego, field: .apiKey] = "sk-same"
+
+        settings.addTokenAccount(provider: .opencodego, label: "Personal", token: "\"sk-same\"")
+
+        let accounts = settings.tokenAccounts(for: .opencodego)
+        #expect(accounts.count == 1)
+        #expect(accounts[0].label == "Personal")
+    }
+
+    @Test
+    func `adding an account migrates a stray legacy key even when accounts already exist`() {
+        let settings = Self.makeSettings(suite: "OpenCodeGoAddTokenAccountTests-stray")
+        settings.addTokenAccount(provider: .opencodego, label: "Acc1", token: "sk-acc1")
+        settings.addTokenAccount(provider: .opencodego, label: "Acc2", token: "sk-acc2")
+
+        // Simulates a provider-level key set through some other path (e.g. the CLI's plain
+        // `set-api-key` with no --label) after accounts already existed - a reachable state
+        // where the key sits unmigrated alongside a non-empty account list.
+        settings[providerConfig: .opencodego, field: .apiKey] = "sk-stray"
+
+        settings.addTokenAccount(provider: .opencodego, label: "Acc3", token: "sk-acc3")
+
+        let accounts = settings.tokenAccounts(for: .opencodego)
+        #expect(accounts.map(\.label) == ["Acc1", "Acc2", "Default", "Acc3"])
+        #expect(accounts.map(\.token) == ["sk-acc1", "sk-acc2", "sk-stray", "sk-acc3"])
+        #expect(settings.providerConfig(for: .opencodego)?.apiKey == nil)
+    }
+
     private static func makeSettings(suite: String) -> SettingsStore {
         testSettingsStore(
             suiteName: "\(suite)-\(UUID().uuidString)",

--- a/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
@@ -32,16 +32,16 @@ struct OpenCodeGoAddTokenAccountTests {
     }
 
     @Test
-    func `migration is scoped to opencodego and does not apply to providers without the opt-in flag`() {
+    func `migration defaults on for every environment-injected provider, not just opencodego`() {
         let settings = Self.makeSettings(suite: "OpenCodeGoAddTokenAccountTests-scope")
-        settings[providerConfig: .openrouter, field: .apiKey] = "decoy-token"
+        settings[providerConfig: .openrouter, field: .apiKey] = "or-existing"
 
         settings.addTokenAccount(provider: .openrouter, label: "Personal", token: "test-key")
 
         let accounts = settings.tokenAccounts(for: .openrouter)
-        #expect(accounts.count == 1)
-        #expect(accounts[0].label == "Personal")
-        #expect(!accounts.contains { $0.token == "decoy-token" })
+        #expect(accounts.map(\.label) == ["Default", "Personal"])
+        #expect(accounts.map(\.token) == ["or-existing", "test-key"])
+        #expect(settings.providerConfig(for: .openrouter)?.apiKey == nil)
     }
 
     private static func makeSettings(suite: String) -> SettingsStore {

--- a/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
@@ -44,6 +44,21 @@ struct OpenCodeGoAddTokenAccountTests {
         #expect(settings.providerConfig(for: .openrouter)?.apiKey == nil)
     }
 
+    @Test
+    func `a quoted legacy key is recognized as identical to the clean new token`() {
+        let settings = Self.makeSettings(suite: "OpenCodeGoAddTokenAccountTests-quoted")
+        // Simulates a key saved via the Settings UI, whose normalizer only trims whitespace and
+        // does not strip wrapping quote characters.
+        settings[providerConfig: .opencodego, field: .apiKey] = "\"sk-same\""
+
+        settings.addTokenAccount(provider: .opencodego, label: "Personal", token: "sk-same")
+
+        let accounts = settings.tokenAccounts(for: .opencodego)
+        #expect(accounts.count == 1)
+        #expect(accounts[0].label == "Personal")
+        #expect(accounts[0].token == "sk-same")
+    }
+
     private static func makeSettings(suite: String) -> SettingsStore {
         testSettingsStore(
             suiteName: "\(suite)-\(UUID().uuidString)",

--- a/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
@@ -92,6 +92,23 @@ struct OpenCodeGoAddTokenAccountTests {
         #expect(settings.providerConfig(for: .opencodego)?.apiKey == nil)
     }
 
+    @Test
+    func `adding an account does not re-migrate a stray key already represented in accounts`() {
+        let settings = Self.makeSettings(suite: "OpenCodeGoAddTokenAccountTests-already-represented")
+        settings.addTokenAccount(provider: .opencodego, label: "Default", token: "sk-a")
+
+        // Simulates a plain (unlabeled) set-api-key re-populating the provider-level field with
+        // a token that is already represented by an existing account.
+        settings[providerConfig: .opencodego, field: .apiKey] = "sk-a"
+
+        settings.addTokenAccount(provider: .opencodego, label: "Work", token: "sk-b")
+
+        let accounts = settings.tokenAccounts(for: .opencodego)
+        #expect(accounts.map(\.label) == ["Default", "Work"])
+        #expect(accounts.map(\.token) == ["sk-a", "sk-b"])
+        #expect(settings.providerConfig(for: .opencodego)?.apiKey == nil)
+    }
+
     private static func makeSettings(suite: String) -> SettingsStore {
         testSettingsStore(
             suiteName: "\(suite)-\(UUID().uuidString)",

--- a/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoAddTokenAccountTests.swift
@@ -1,0 +1,52 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct OpenCodeGoAddTokenAccountTests {
+    @Test
+    func `adding the first account migrates an existing single API key as Default`() {
+        let settings = Self.makeSettings(suite: "OpenCodeGoAddTokenAccountTests-migrate")
+        settings[providerConfig: .opencodego, field: .apiKey] = "sk-legacy"
+
+        settings.addTokenAccount(provider: .opencodego, label: "Work", token: "sk-work")
+
+        let accounts = settings.tokenAccounts(for: .opencodego)
+        #expect(accounts.map(\.label) == ["Default", "Work"])
+        #expect(accounts.map(\.token) == ["sk-legacy", "sk-work"])
+        #expect(settings.providerConfig(for: .opencodego)?.apiKey == nil)
+    }
+
+    @Test
+    func `adding an account with the same token as the existing key renames it instead of duplicating`() {
+        let settings = Self.makeSettings(suite: "OpenCodeGoAddTokenAccountTests-rename")
+        settings[providerConfig: .opencodego, field: .apiKey] = "sk-same"
+
+        settings.addTokenAccount(provider: .opencodego, label: "Personal", token: "sk-same")
+
+        let accounts = settings.tokenAccounts(for: .opencodego)
+        #expect(accounts.count == 1)
+        #expect(accounts[0].label == "Personal")
+        #expect(accounts[0].token == "sk-same")
+    }
+
+    @Test
+    func `migration is scoped to opencodego and does not apply to providers without the opt-in flag`() {
+        let settings = Self.makeSettings(suite: "OpenCodeGoAddTokenAccountTests-scope")
+        settings[providerConfig: .openrouter, field: .apiKey] = "decoy-token"
+
+        settings.addTokenAccount(provider: .openrouter, label: "Personal", token: "test-key")
+
+        let accounts = settings.tokenAccounts(for: .openrouter)
+        #expect(accounts.count == 1)
+        #expect(accounts[0].label == "Personal")
+        #expect(!accounts.contains { $0.token == "decoy-token" })
+    }
+
+    private static func makeSettings(suite: String) -> SettingsStore {
+        testSettingsStore(
+            suiteName: "\(suite)-\(UUID().uuidString)",
+            tokenAccountStore: InMemoryTokenAccountStore())
+    }
+}

--- a/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
@@ -85,6 +85,58 @@ struct OpenCodeGoProviderStrategyTests {
     }
 
     @Test
+    func `explicit api source uses the api strategy for a selected API-key token account`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(
+                sourceMode: .api,
+                env: [OpenCodeGoSettingsReader.apiKeyEnvironmentKey: "sk-abc123"],
+                selectedTokenAccountID: UUID()))
+
+        #expect(strategies.map(\.id) == ["opencodego.api"])
+    }
+
+    @Test
+    func `explicit api source fails closed for a selected legacy cookie token account`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(
+                sourceMode: .api,
+                env: [OpenCodeGoSettingsReader.apiKeyEnvironmentKey: "session=abc; other=def"],
+                selectedTokenAccountID: UUID()))
+
+        // A legacy cookie can't authenticate as an API key. Fail closed instead of sending the
+        // cookie as a bogus bearer token.
+        #expect(strategies.isEmpty)
+    }
+
+    @Test
+    func `explicit web source uses the cookie chain for a selected legacy cookie token account`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(
+                sourceMode: .web,
+                env: [OpenCodeGoSettingsReader.apiKeyEnvironmentKey: "session=abc; other=def"],
+                selectedTokenAccountID: UUID()))
+
+        #expect(strategies.map(\.id) == ["opencodego.web", "opencodego.local", "opencodego.api"])
+    }
+
+    @Test
+    func `explicit web source fails closed for a selected API-key token account`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(
+                sourceMode: .web,
+                env: [OpenCodeGoSettingsReader.apiKeyEnvironmentKey: "sk-abc123"],
+                selectedTokenAccountID: UUID()))
+
+        // An API-key account has no per-account cookie. Fail closed instead of silently using an
+        // unrelated global/cached cookie and mislabeling it as this account.
+        #expect(strategies.isEmpty)
+    }
+
+    @Test
     // swiftlint:disable:next line_length
     func `auto source keeps the cookie-first ordering for manual cookies and workspace overrides without a selected token account`() async {
         // Selected token accounts inject a plain API key, so they reorder to API-first (see

--- a/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
@@ -50,12 +50,37 @@ struct OpenCodeGoProviderStrategyTests {
     }
 
     @Test
-    func `auto source tries web before local for selected token accounts`() async {
+    func `auto source tries API before local for selected token accounts`() async {
         let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
         let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
             self.makeContext(selectedTokenAccountID: UUID()))
 
-        #expect(strategies.map(\.id) == ["opencodego.web", "opencodego.local", "opencodego.api"])
+        #expect(strategies.map(\.id) == ["opencodego.api", "opencodego.local", "opencodego.web"])
+    }
+
+    @Test
+    // swiftlint:disable:next line_length
+    func `auto source keeps the cookie-first ordering for manual cookies and workspace overrides without a selected token account`() async {
+        // Selected token accounts inject a plain API key, so they reorder to API-first (see
+        // above). The other requiresScopedWebStrategy() triggers still authenticate via a
+        // cookie header, so they must keep the original cookie-first ordering.
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let manualCookieSettings = ProviderSettingsSnapshot.make(opencodego: .init(
+            cookieSource: .manual,
+            manualCookieHeader: "auth=selected",
+            workspaceID: nil))
+        let workspaceOverrideSettings = ProviderSettingsSnapshot.make(opencodego: .init(
+            cookieSource: .auto,
+            manualCookieHeader: nil,
+            workspaceID: "wrk_team"))
+
+        let manualCookieStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(settings: manualCookieSettings))
+        let workspaceOverrideStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(settings: workspaceOverrideSettings))
+
+        #expect(manualCookieStrategies.map(\.id) == ["opencodego.web", "opencodego.local", "opencodego.api"])
+        #expect(workspaceOverrideStrategies.map(\.id) == ["opencodego.web", "opencodego.local", "opencodego.api"])
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoProviderStrategyTests.swift
@@ -50,12 +50,38 @@ struct OpenCodeGoProviderStrategyTests {
     }
 
     @Test
-    func `auto source tries API before local for selected token accounts`() async {
+    func `auto source uses only the API strategy for a selected API-key token account`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(
+                env: [OpenCodeGoSettingsReader.apiKeyEnvironmentKey: "sk-abc123"],
+                selectedTokenAccountID: UUID()))
+
+        // No unscoped local/cookie fallback: a wrong or revoked key must surface as a failure
+        // for this account, never silently show a different account's usage under its label.
+        #expect(strategies.map(\.id) == ["opencodego.api"])
+    }
+
+    @Test
+    func `auto source keeps the cookie-first ordering for a selected legacy cookie token account`() async {
+        let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeContext(
+                env: [OpenCodeGoSettingsReader.apiKeyEnvironmentKey: "session=abc; other=def"],
+                selectedTokenAccountID: UUID()))
+
+        // Token accounts saved before the API-key switch stored a raw Cookie header. Those must
+        // keep authenticating as cookies instead of being sent as a bogus API key.
+        #expect(strategies.map(\.id) == ["opencodego.web", "opencodego.local", "opencodego.api"])
+    }
+
+    @Test
+    func `auto source treats a missing token as an API-key selected account`() async {
         let descriptor = OpenCodeGoProviderDescriptor.makeDescriptor()
         let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
             self.makeContext(selectedTokenAccountID: UUID()))
 
-        #expect(strategies.map(\.id) == ["opencodego.api", "opencodego.local", "opencodego.web"])
+        #expect(strategies.map(\.id) == ["opencodego.api"])
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenRouterMultiAccountTests.swift
+++ b/Tests/CodexBarTests/OpenRouterMultiAccountTests.swift
@@ -95,35 +95,41 @@ struct OpenRouterMultiAccountTests {
     }
 
     @Test
-    func `two OpenRouter accounts fetch with isolated keys and caches`() async throws {
+    func `OpenRouter accounts fetch with isolated keys and caches, including a migrated legacy key`() async throws {
         let settings = Self.makeSettings(suite: "OpenRouterMultiAccountTests-fetch")
-        settings[providerConfig: .openrouter, field: .apiKey] = "decoy-token"
+        // A previously configured single key. migratesExistingAPIKeyOnFirstAccount now defaults
+        // to true for environment-injection providers, so adding the first labeled account
+        // migrates this in as "Default" instead of leaving it inert and untracked.
+        settings[providerConfig: .openrouter, field: .apiKey] = "legacy-key"
         settings.addTokenAccount(provider: .openrouter, label: "Personal", token: "test-key")
         settings.addTokenAccount(provider: .openrouter, label: "Work", token: "test-auth-token")
         let accounts = settings.tokenAccounts(for: .openrouter)
+        #expect(accounts.map(\.label) == ["Default", "Personal", "Work"])
         let recorder = OpenRouterAccountFetchRecorder()
         let store = try Self.makeStore(settings: settings, recorder: recorder)
 
         await store.refreshTokenAccounts(provider: .openrouter, accounts: accounts)
 
         let requests = await recorder.requests
-        #expect(Set(requests.compactMap(\.accountValue)) == ["test-key", "test-auth-token"])
+        #expect(Set(requests.compactMap(\.accountValue)) == ["legacy-key", "test-key", "test-auth-token"])
         #expect(Set(requests.compactMap(\.accountID)) == Set(accounts.map(\.id)))
-        #expect(!requests.contains {
-            $0.accountValue == "decoy-token" || $0.accountValue == "test-token-placeholder"
-        })
+        // The isolation invariant that matters: nothing leaks the unrelated global/cached
+        // environment default (used when no account is selected at all) into a per-account
+        // fetch. A migrated legacy key is now a real, legitimate account credential, not a leak.
+        #expect(!requests.contains { $0.accountValue == "test-token-placeholder" })
 
         let snapshots = try #require(store.accountSnapshots[.openrouter])
         #expect(snapshots.map(\.account.id) == accounts.map(\.id))
-        #expect(snapshots.map { $0.snapshot?.accountEmail(for: .openrouter) } == ["Personal", "Work"])
-        #expect(snapshots.map { $0.snapshot?.detailRow(label: "Remaining")?.value } == ["$90.00", "$60.00"])
-        #expect(Set(snapshots.map(\.cacheKey)).count == 2)
+        #expect(snapshots.map { $0.snapshot?.accountEmail(for: .openrouter) } == ["Default", "Personal", "Work"])
+        #expect(
+            snapshots.map { $0.snapshot?.detailRow(label: "Remaining")?.value } == ["$60.00", "$90.00", "$60.00"])
+        #expect(Set(snapshots.map(\.cacheKey)).count == 3)
 
-        settings.setActiveTokenAccountIndex(0, for: .openrouter)
-        store.activateCachedTokenAccountSnapshot(provider: .openrouter, accountID: accounts[0].id)
-        #expect(store.snapshot(for: .openrouter)?.detailRow(label: "Remaining")?.value == "$90.00")
         settings.setActiveTokenAccountIndex(1, for: .openrouter)
         store.activateCachedTokenAccountSnapshot(provider: .openrouter, accountID: accounts[1].id)
+        #expect(store.snapshot(for: .openrouter)?.detailRow(label: "Remaining")?.value == "$90.00")
+        settings.setActiveTokenAccountIndex(2, for: .openrouter)
+        store.activateCachedTokenAccountSnapshot(provider: .openrouter, accountID: accounts[2].id)
         #expect(store.snapshot(for: .openrouter)?.detailRow(label: "Remaining")?.value == "$60.00")
     }
 

--- a/Tests/CodexBarTests/ProviderCookieSettingsResolverTests.swift
+++ b/Tests/CodexBarTests/ProviderCookieSettingsResolverTests.swift
@@ -61,6 +61,30 @@ struct ProviderCookieSettingsResolverTests {
     }
 
     @Test
+    func `legacy cookie shaped token accounts still route as cookies for opencodego`() {
+        let settings = ProviderCookieSettingsResolver.resolve(
+            provider: .opencodego,
+            configuredSource: .auto,
+            configuredHeader: nil,
+            selectedAccount: Self.account(token: "session=legacy; other=value"))
+
+        #expect(settings.cookieSource == .auto)
+        #expect(settings.manualCookieHeader == "session=legacy; other=value")
+    }
+
+    @Test
+    func `api key shaped token accounts do not become cookie credentials for opencodego`() {
+        let settings = ProviderCookieSettingsResolver.resolve(
+            provider: .opencodego,
+            configuredSource: .auto,
+            configuredHeader: "configured=true",
+            selectedAccount: Self.account(token: "sk-abc123"))
+
+        #expect(settings.cookieSource == .auto)
+        #expect(settings.manualCookieHeader == "configured=true")
+    }
+
+    @Test
     func `providers without token account support ignore selected account`() {
         let settings = ProviderCookieSettingsResolver.resolve(
             provider: .mimo,

--- a/Tests/CodexBarTests/ProviderCookieSettingsResolverTests.swift
+++ b/Tests/CodexBarTests/ProviderCookieSettingsResolverTests.swift
@@ -61,14 +61,17 @@ struct ProviderCookieSettingsResolverTests {
     }
 
     @Test
-    func `legacy cookie shaped token accounts still route as cookies for opencodego`() {
+    func `legacy cookie shaped token accounts force manual cookie source for opencodego`() {
         let settings = ProviderCookieSettingsResolver.resolve(
             provider: .opencodego,
             configuredSource: .auto,
             configuredHeader: nil,
             selectedAccount: Self.account(token: "session=legacy; other=value"))
 
-        #expect(settings.cookieSource == .auto)
+        // OpenCodeWebCookieSupport only reads manualCookieHeader when the source is .manual, so
+        // a detected legacy cookie must force .manual regardless of the configured default
+        // (.auto here) or it would silently fall through to a different cached/imported cookie.
+        #expect(settings.cookieSource == .manual)
         #expect(settings.manualCookieHeader == "session=legacy; other=value")
     }
 

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -413,15 +413,18 @@ struct SettingsStoreCoverageTests {
     }
 
     @Test
-    func `opencode go token accounts force manual cookie routing`() {
+    func `opencode go token accounts inject as api keys without forcing cookie routing`() {
+        // OpenCode Go token accounts now inject as OPENCODE_API_KEY (requiresManualCookieSource:
+        // false), not as a cookie header - fetch strategy selection per-request already
+        // distinguishes an API key from a legacy cookie-shaped value via legacyCookieDetector, so
+        // adding an account must not force the global cookie source into manual.
         let settings = Self.makeSettingsStore()
-        settings.addTokenAccount(provider: .opencodego, label: "Go", token: "auth=go-cookie")
+        settings.addTokenAccount(provider: .opencodego, label: "Go", token: "sk-work")
 
         let snapshot = settings.opencodegoSettingsSnapshot(tokenOverride: nil)
 
-        #expect(settings.opencodegoCookieSource == .manual)
-        #expect(snapshot.cookieSource == .manual)
-        #expect(snapshot.manualCookieHeader == "auth=go-cookie")
+        #expect(settings.opencodegoCookieSource == .auto)
+        #expect(snapshot.cookieSource == .auto)
     }
 
     @Test

--- a/Tests/CodexBarTests/TokenAccountSupportTests.swift
+++ b/Tests/CodexBarTests/TokenAccountSupportTests.swift
@@ -1,0 +1,43 @@
+import CodexBarCore
+import Testing
+
+struct TokenAccountSupportTests {
+    private static func makeSupport(
+        injection: TokenAccountInjection,
+        migratesExistingAPIKeyOnFirstAccount: Bool? = nil) -> TokenAccountSupport
+    {
+        TokenAccountSupport(
+            title: "Accounts",
+            subtitle: "Test",
+            placeholder: "token",
+            injection: injection,
+            requiresManualCookieSource: false,
+            cookieName: nil,
+            migratesExistingAPIKeyOnFirstAccount: migratesExistingAPIKeyOnFirstAccount)
+    }
+
+    @Test
+    func `defaults to migrating an existing key for environment injected providers`() {
+        let support = Self.makeSupport(injection: .environment(key: "TEST_API_KEY"))
+        #expect(support.migratesExistingAPIKeyOnFirstAccount == true)
+    }
+
+    @Test
+    func `defaults to not migrating for cookie header injected providers`() {
+        let support = Self.makeSupport(injection: .cookieHeader)
+        #expect(support.migratesExistingAPIKeyOnFirstAccount == false)
+    }
+
+    @Test
+    func `an explicit override always wins over the injection-based default`() {
+        let environmentOptedOut = Self.makeSupport(
+            injection: .environment(key: "TEST_API_KEY"),
+            migratesExistingAPIKeyOnFirstAccount: false)
+        let cookieOptedIn = Self.makeSupport(
+            injection: .cookieHeader,
+            migratesExistingAPIKeyOnFirstAccount: true)
+
+        #expect(environmentOptedOut.migratesExistingAPIKeyOnFirstAccount == false)
+        #expect(cookieOptedIn.migratesExistingAPIKeyOnFirstAccount == true)
+    }
+}

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -33,8 +33,11 @@ read_when:
   import only runs when the cached cookie fails.
 - OpenCode Go unscoped Auto mode tries daily cost history derived from local `opencode-go` assistant costs first,
   overlays authoritative API windows when an API key is configured, then falls back through the API and legacy web
-  sources when local history is unavailable. Auto stays web-first when a token account, manual cookie, or workspace
-  override scopes the request, because local history is device-wide.
+  sources when local history is unavailable. Auto stays web-first when a manual cookie or workspace override scopes
+  the request, because local history is device-wide. A selected token account instead routes by credential shape:
+  an API-key account (the default for token accounts saved through Settings or the CLI) goes straight to the API
+  strategy; only a token account saved before this shape existed, whose stored value still looks like a cookie
+  header, keeps the legacy web-first chain.
 - The local monthly window is an estimate anchored at the earliest local row and can drift from the real billing
   cycle. The local strategy prefers API-reported rolling/weekly/monthly percentages and reset timestamps. When no API
   key is configured, a cached or manual session cookie can still overlay the legacy web values (plus Zen balance).


### PR DESCRIPTION
## Summary

- OpenCode Go's token accounts currently inject a Cookie header (`.cookieHeader`), which only supports one *browser session* per account and requires manual cookie capture. This switches the injection to a plain API key (`.environment(key: OpenCodeGoSettingsReader.apiKeyEnvironmentKey)`), reusing the exact generic token-account infrastructure z.ai already uses (`TokenAccountSupport`, `multiAccountMenuLayout == .stacked`, `shouldFetchAllTokenAccounts`) — no new UI or fetch machinery needed, just the right injection type.
- `requiresManualCookieSource` is now `false`, so the Session tokens ("API key accounts") section is visible without first flipping the provider to manual cookie mode.
- Per-account fetch now tries the API strategy before the cookie/web strategy when a token account is selected — previously the descriptor unconditionally scoped to the cookie/web path first, which is correct for cookie-based accounts but wrong once accounts are API-key based.
- Relaxes the CLI's `config set-api-key --label` guard, which previously hard-required `--provider zai` for *any* account option including a bare `--label`. It now only requires `zai` for the team-specific options (`--usage-scope`/`--organization-id`/`--workspace-id`); a bare `--label` is allowed for any provider whose `TokenAccountSupport.injection` is `.environment`, so multiple OpenCode Go accounts (or any other API-key provider) can be added from the CLI, not just the Settings UI.

## Why

Closes the "add API-key accounts for OpenCode Go" gap described in #1843 (multi-account/multi-instance support for the same provider) and unblocks the OpenCode Go case specifically called out as unsolved in #81. I have 3 separate OpenCode Go subscriptions (personal, side, and a company account) and wanted to see all three's session/weekly/monthly windows at once instead of switching credentials by hand.

## What I deliberately left out

I also patched `PersonalInfoRedactor` locally (masking emails like `v***y@gmail.com` under "Hide personal information" instead of blanking them entirely) while testing this with 3 real accounts on screen. That's a separate, app-wide UX/privacy-default decision unrelated to the multi-account fix, and I have no test coverage for it yet — happy to open it as its own issue/PR if there's interest, but keeping this PR scoped to the OpenCode Go multi-account fix.

## Test plan

- [ ] `make check` clean
- [ ] `swift test --filter OpenCodeGoProviderStrategyTests` — updated the existing strategy-ordering assertion for the selected-token-account case (now API-first, was cookie-first) and added coverage confirming the other scoped-web-strategy triggers (manual cookie source / workspace override) are unaffected
- [ ] `swift test --filter CLIConfigCommandTests` — added cases for: bare `--label` succeeding on an `.environment`-injection provider, rejection when the provider has no token-account support at all, rejection when the provider is cookie-based
- [ ] `swift build -c release` clean
- [ ] Manually verified against 3 real OpenCode Go accounts: all three fetch live usage via `source: "api"` and render as stacked cards simultaneously in the menu

Addresses the OpenCode Go case from #1843 (the broader "any provider" ask stays open — this only covers API-key-based providers, not cookie-based ones like Claude). Related to #81.
