### PR TITLE
fix: accept OpenRouter activity timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.55.1 — Unreleased
 
+### Fixed
+- OpenRouter: accept the Activity API's space-separated timestamps when aggregating 30-day spend (#3174).
+
 ## 0.55.0 — 2026-08-24
 
 ### Highlights

--- a/Sources/CodexBarCore/Resources/Plugins/openrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openrouter.js
@@ -150,10 +150,12 @@ defineProvider({
             if (!row || typeof row !== "object" || Array.isArray(row)) {
               throw new TypeError(`activity.data[${index}] must be an object`);
             }
-            const date = typeof row.date === "string" ? row.date.trim() : "";
-            if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-              throw new TypeError(`activity.data[${index}].date must be YYYY-MM-DD`);
+            const rawDate = typeof row.date === "string" ? row.date.trim() : "";
+            const dateMatch = /^(\d{4}-\d{2}-\d{2})(?: (?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d)?$/.exec(rawDate);
+            if (!dateMatch) {
+              throw new TypeError(`activity.data[${index}].date must be YYYY-MM-DD or YYYY-MM-DD HH:MM:SS`);
             }
+            const date = dateMatch[1];
             const parsedDate = new Date(`${date}T00:00:00Z`);
             if (!Number.isFinite(parsedDate.getTime()) || parsedDate.toISOString().slice(0, 10) !== date) {
               throw new TypeError(`activity.data[${index}].date must be a real calendar date`);

--- a/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
+++ b/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
@@ -219,6 +219,52 @@ struct OpenRouterPluginGoldenTests {
     }
 
     @Test
+    func `activity accepts space separated timestamp dates`() async throws {
+        let activityBody = #"""
+        {"data":[{
+          "date":"2026-08-17 00:00:00",
+          "model_permaslug":"openai/gpt-5.6",
+          "prompt_tokens":10,
+          "completion_tokens":5,
+          "reasoning_tokens":2,
+          "requests":1,
+          "usage":1
+        }]}
+        """#
+
+        let usage = try await Self.fetch(activityBody: activityBody)
+        let cost = try #require(usage.costUsage)
+
+        #expect(cost.last30DaysCostUSD == 1)
+        #expect(cost.daily.map(\.date) == ["2026-08-17"])
+    }
+
+    @Test
+    func `activity deduplicates bare and timestamp dates`() async throws {
+        let activityBody = #"""
+        {"data":[
+          {
+            "date":"2026-08-17", "model":"openai/gpt-5.6", "endpoint_id":"same",
+            "prompt_tokens":10, "completion_tokens":5, "reasoning_tokens":2,
+            "requests":1, "usage":1
+          },
+          {
+            "date":"2026-08-17 00:00:00", "model":"openai/gpt-5.6", "endpoint_id":"same",
+            "prompt_tokens":10, "completion_tokens":5, "reasoning_tokens":2,
+            "requests":1, "usage":1
+          }
+        ]}
+        """#
+
+        let usage = try await Self.fetch(activityBody: activityBody)
+        let cost = try #require(usage.costUsage)
+
+        #expect(cost.last30DaysCostUSD == 1)
+        #expect(cost.daily.map(\.date) == ["2026-08-17"])
+        #expect(cost.daily.first?.requestCount == 1)
+    }
+
+    @Test
     func `server remaining drives monthly quota golden`() async throws {
         let usage = try await Self.fetch(keyBody: #"""
         {"data":{
@@ -535,6 +581,20 @@ struct OpenRouterPluginGoldenTests {
         #"""
         {"data":[{
           "date":"2026-02-31", "model":"openai/gpt-5.6",
+          "prompt_tokens":1, "completion_tokens":1, "reasoning_tokens":0,
+          "requests":1, "usage":1
+        }]}
+        """#,
+        #"""
+        {"data":[{
+          "date":"2026-02-31 00:00:00", "model":"openai/gpt-5.6",
+          "prompt_tokens":1, "completion_tokens":1, "reasoning_tokens":0,
+          "requests":1, "usage":1
+        }]}
+        """#,
+        #"""
+        {"data":[{
+          "date":"2026-08-17 24:00:00", "model":"openai/gpt-5.6",
           "prompt_tokens":1, "completion_tokens":1, "reasoning_tokens":0,
           "requests":1, "usage":1
         }]}


### PR DESCRIPTION
## Summary
- accept OpenRouter Activity dates in either `YYYY-MM-DD` or `YYYY-MM-DD HH:MM:SS` form
- normalize timestamps before cutoff, deduplication, and spend aggregation
- cover timestamp acceptance, mixed-format deduplication, and malformed date/time rejection

## Why
OpenRouter now returns Activity rows such as `2026-08-23 00:00:00`. The bundled provider required an exact date-only value, so valid responses degraded to "Response was invalid" and hid 30-day spend.

The parser now accepts only the two observed shapes, validates the clock and calendar date, then keeps the existing date-only aggregation path.

## Validation
Head: `523f8127ec6fc1c1d6a2e55bffee26bff552f0d5`

- temporary stub harness around the production plugin — base failed with `timestamp activity was rejected: Response was invalid`; head passed mixed timestamp/date deduplication and kept `24:00:00` rejected
- `swift build --target CodexBarCore` — passed
- focused `oxfmt` and `oxlint` checks for `openrouter.js` — passed
- `git diff --check origin/main...HEAD` — passed
- `make check` — portable, generated-file, JavaScript format/lint/type, docs, and SwiftFormat checks passed; SwiftLint could not load `sourcekitdInProc` on this Command Line Tools-only host
- `make test` and `swift test --filter OpenRouterPluginGoldenTests` — blocked before test discovery because this host lacks full Xcode's `Testing` module; macOS CI is authoritative
- no live provider, Keychain, or app-bundle validation was run
- Public Model Identifier Gate: PASS

## Behavior proof
- Before: a valid `YYYY-MM-DD HH:MM:SS` row produced no cost snapshot and reported "Response was invalid".
- After: timestamp and date-only rows normalize to one UTC day and deduplicate without double-counting.
- Invalid calendar dates and invalid clock values still degrade safely.

### AI assistance
Codex assisted with implementation, tests, and compatibility analysis.

Fixes #3174
