### PR TITLE
Fix tracked Codex card refresh

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -436,12 +436,15 @@ extension UsageMenuCardView.Model {
     }
 
     private static func hasCompatibleMetricLayout(_ current: Metric, _ candidate: Metric) -> Bool {
-        current.id == candidate.id &&
+        let currentMetaText = current.linePresentation(title: current.title).metaText
+        let candidateMetaText = candidate.linePresentation(title: candidate.title).metaText
+        return current.id == candidate.id &&
             current.title == candidate.title &&
             current.percentStyle == candidate.percentStyle &&
             (current.statusText == nil) == (candidate.statusText == nil) &&
             (current.resetText == nil) == (candidate.resetText == nil) &&
             (current.detailText == nil) == (candidate.detailText == nil) &&
+            (candidateMetaText == nil || currentMetaText != nil) &&
             current.cardStyle == candidate.cardStyle
     }
 

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -414,7 +414,7 @@ extension UsageMenuCardView.Model {
                   candidateText: candidate.creditsText,
                   candidateRemaining: candidate.creditsRemaining),
               self.creditsHintText == candidate.creditsHintText,
-              self.codexResetCredits == candidate.codexResetCredits,
+              Self.hasCompatibleCodexResetCreditsLayout(self.codexResetCredits, candidate.codexResetCredits),
               self.placeholder == candidate.placeholder,
               Self.hasCompatibleDashboardLayout(self.inlineUsageDashboard, candidate.inlineUsageDashboard),
               Self.hasCompatibleProviderCostLayout(self.providerCost, candidate.providerCost),
@@ -427,6 +427,14 @@ extension UsageMenuCardView.Model {
         return zip(self.metrics, candidate.metrics).allSatisfy(Self.hasCompatibleMetricLayout)
     }
 
+    private static func hasCompatibleCodexResetCreditsLayout(
+        _ current: CodexResetCreditsPresentation?,
+        _ candidate: CodexResetCreditsPresentation?) -> Bool
+    {
+        // The hosted section has a fixed shape; its count and expiry strings can update in place.
+        (current == nil) == (candidate == nil)
+    }
+
     private static func hasCompatibleMetricLayout(_ current: Metric, _ candidate: Metric) -> Bool {
         current.id == candidate.id &&
             current.title == candidate.title &&
@@ -434,8 +442,6 @@ extension UsageMenuCardView.Model {
             (current.statusText == nil) == (candidate.statusText == nil) &&
             (current.resetText == nil) == (candidate.resetText == nil) &&
             (current.detailText == nil) == (candidate.detailText == nil) &&
-            (current.detailLeftText == nil) == (candidate.detailLeftText == nil) &&
-            (current.detailRightText == nil) == (candidate.detailRightText == nil) &&
             current.cardStyle == candidate.cardStyle
     }
 

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -238,7 +238,10 @@ struct UsageMenuCardView: View {
 
                 VStack(alignment: .leading, spacing: 12) {
                     if hasUsage, !liveModel.creditsOnlyInlineUsageDashboard {
-                        UsageMenuCardUsageContentView(model: liveModel, showBottomDivider: false)
+                        UsageMenuCardUsageContentView(
+                            model: liveModel,
+                            layoutModel: self.layoutModel ?? self.model,
+                            showBottomDivider: false)
                     }
                     if hasUsage, !liveModel.creditsOnlyInlineUsageDashboard, hasCredits || hasCost {
                         Divider()
@@ -519,12 +522,14 @@ private struct TokenUsageSectionContent: View {
 
 private struct MetricRow: View {
     let metric: UsageMenuCardView.Model.Metric
+    let layoutMetric: UsageMenuCardView.Model.Metric
     let title: String
     let progressColor: Color
     @Environment(\.menuItemHighlighted) private var isHighlighted
 
     var body: some View {
         let presentation = self.metric.linePresentation(title: self.title)
+        let layoutPresentation = self.layoutMetric.linePresentation(title: self.title)
         VStack(alignment: .leading, spacing: 6) {
             if let statusText = self.metric.statusText {
                 Text(self.title)
@@ -538,6 +543,7 @@ private struct MetricRow: View {
                 MetricRowHeader(
                     title: presentation.titleText,
                     resetText: presentation.resetText,
+                    layoutResetText: layoutPresentation.resetText,
                     isHighlighted: self.isHighlighted)
                 UsageProgressBar(
                     percent: self.metric.percent,
@@ -548,19 +554,17 @@ private struct MetricRow: View {
                     warningMarkerPercents: self.metric.warningMarkerPercents,
                     workdayMarkerPercents: self.metric.workdayMarkerPercents,
                     workdayTickAppearance: self.metric.workdayTickAppearance)
-                if let metaText = presentation.metaText {
-                    Text(metaText)
-                        .font(.footnote)
-                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                        .lineLimit(2)
-                        .truncationMode(.tail)
-                        .fixedSize(horizontal: false, vertical: true)
+                if let layoutMetaText = layoutPresentation.metaText {
+                    self.layoutPreservingText(
+                        presentation.metaText,
+                        layoutText: layoutMetaText,
+                        lineLimit: 2)
                 }
-                if let detail = self.metric.detailText {
-                    Text(detail)
-                        .font(.footnote)
-                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-                        .lineLimit(1)
+                if let layoutDetailText = self.layoutMetric.detailText {
+                    self.layoutPreservingText(
+                        self.metric.detailText,
+                        layoutText: layoutDetailText,
+                        lineLimit: 1)
                 }
             }
         }
@@ -569,27 +573,51 @@ private struct MetricRow: View {
         .background(self.metric.cardStyle ? Color.secondary.opacity(self.isHighlighted ? 0.2 : 0.08) : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: self.metric.cardStyle ? 10 : 0))
     }
+
+    private func layoutPreservingText(
+        _ text: String?,
+        layoutText: String,
+        lineLimit: Int) -> some View
+    {
+        Text(layoutText)
+            .font(.footnote)
+            .lineLimit(lineLimit)
+            .fixedSize(horizontal: false, vertical: true)
+            .hidden()
+            .overlay(alignment: .topLeading) {
+                if let text, !text.isEmpty {
+                    Text(text)
+                        .font(.footnote)
+                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                        .lineLimit(lineLimit)
+                        .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .clipped()
+    }
 }
 
 private struct MetricRowHeader: View {
     let title: String
     let resetText: String?
+    let layoutResetText: String?
     let isHighlighted: Bool
 
     var body: some View {
-        if let resetText {
+        if let layoutResetText {
             ViewThatFits(in: .horizontal) {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
                     self.titleLabel
                         .fixedSize(horizontal: true, vertical: false)
                     Spacer(minLength: 8)
-                    self.resetLabel(resetText)
+                    self.layoutPreservingResetLabel(layoutResetText)
                         .fixedSize(horizontal: true, vertical: false)
                 }
                 VStack(alignment: .trailing, spacing: 2) {
                     self.titleLabel
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    self.resetLabel(resetText)
+                    self.layoutPreservingResetLabel(layoutResetText)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .trailing)
                 }
@@ -612,6 +640,17 @@ private struct MetricRowHeader: View {
             .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
             .lineLimit(2)
             .multilineTextAlignment(.trailing)
+    }
+
+    private func layoutPreservingResetLabel(_ layoutResetText: String) -> some View {
+        self.resetLabel(layoutResetText)
+            .hidden()
+            .overlay(alignment: .topTrailing) {
+                if let resetText, !resetText.isEmpty {
+                    self.resetLabel(resetText)
+                }
+            }
+            .clipped()
     }
 }
 
@@ -664,6 +703,7 @@ struct UsageMenuCardHeaderSectionView: View {
 
 private struct UsageMenuCardUsageContentView: View {
     let model: UsageMenuCardView.Model
+    let layoutModel: UsageMenuCardView.Model
     let showBottomDivider: Bool
     var showsSectionDividers = true
     @Environment(\.menuItemHighlighted) private var isHighlighted
@@ -693,6 +733,7 @@ private struct UsageMenuCardUsageContentView: View {
         ForEach(metrics, id: \.id) { metric in
             MetricRow(
                 metric: metric,
+                layoutMetric: self.layoutModel.metrics.first { $0.id == metric.id } ?? metric,
                 title: UsageMenuCardView.popupMetricTitle(provider: self.model.provider, metric: metric),
                 progressColor: self.model.progressColor)
         }
@@ -747,6 +788,7 @@ private struct UsageMenuCardUsageContentView: View {
 
 struct UsageMenuCardUsageSectionView: View {
     let model: UsageMenuCardView.Model
+    let layoutModel: UsageMenuCardView.Model
     let showBottomDivider: Bool
     let bottomPadding: CGFloat
     let width: CGFloat
@@ -757,6 +799,7 @@ struct UsageMenuCardUsageSectionView: View {
         let liveModel = self.liveModel
         UsageMenuCardUsageContentView(
             model: liveModel,
+            layoutModel: self.layoutModel,
             showBottomDivider: self.showBottomDivider,
             showsSectionDividers: self.showsSectionDividers)
             .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -542,6 +542,7 @@ private struct MetricRow: View {
             } else {
                 MetricRowHeader(
                     title: presentation.titleText,
+                    layoutTitle: layoutPresentation.titleText,
                     resetText: presentation.resetText,
                     layoutResetText: layoutPresentation.resetText,
                     isHighlighted: self.isHighlighted)
@@ -592,62 +593,6 @@ private struct MetricRow: View {
                         .lineLimit(lineLimit)
                         .truncationMode(.tail)
                         .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            .clipped()
-    }
-}
-
-private struct MetricRowHeader: View {
-    let title: String
-    let resetText: String?
-    let layoutResetText: String?
-    let isHighlighted: Bool
-
-    var body: some View {
-        if let layoutResetText {
-            ViewThatFits(in: .horizontal) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    self.titleLabel
-                        .fixedSize(horizontal: true, vertical: false)
-                    Spacer(minLength: 8)
-                    self.layoutPreservingResetLabel(layoutResetText)
-                        .fixedSize(horizontal: true, vertical: false)
-                }
-                VStack(alignment: .trailing, spacing: 2) {
-                    self.titleLabel
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    self.layoutPreservingResetLabel(layoutResetText)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .trailing)
-                }
-            }
-        } else {
-            self.titleLabel
-        }
-    }
-
-    private var titleLabel: some View {
-        Text(self.title)
-            .font(.body)
-            .fontWeight(.medium)
-            .lineLimit(1)
-    }
-
-    private func resetLabel(_ resetText: String) -> some View {
-        Text(resetText)
-            .font(.footnote)
-            .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
-            .lineLimit(2)
-            .multilineTextAlignment(.trailing)
-    }
-
-    private func layoutPreservingResetLabel(_ layoutResetText: String) -> some View {
-        self.resetLabel(layoutResetText)
-            .hidden()
-            .overlay(alignment: .topTrailing) {
-                if let resetText, !resetText.isEmpty {
-                    self.resetLabel(resetText)
                 }
             }
             .clipped()

--- a/Sources/CodexBar/StatusItemController+MenuTypes.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTypes.swift
@@ -50,6 +50,7 @@ struct OverviewMenuCardRowView: View {
             if self.hasUsageBlock {
                 UsageMenuCardUsageSectionView(
                     model: self.model,
+                    layoutModel: self.model,
                     showBottomDivider: false,
                     bottomPadding: 6,
                     width: self.width,

--- a/Sources/CodexBar/UsageMenuCardHeaderAndUsageSectionView.swift
+++ b/Sources/CodexBar/UsageMenuCardHeaderAndUsageSectionView.swift
@@ -22,3 +22,76 @@ struct UsageMenuCardHeaderAndUsageSectionView: View {
         .frame(width: self.width, alignment: .leading)
     }
 }
+
+struct MetricRowHeader: View {
+    let title: String
+    let layoutTitle: String
+    let resetText: String?
+    let layoutResetText: String?
+    let isHighlighted: Bool
+
+    var body: some View {
+        if let layoutResetText {
+            let resolvedResetText = self.resetText ?? layoutResetText
+            ViewThatFits(in: .horizontal) {
+                self.layoutPreservingHeader(
+                    layout: self.horizontalHeader(title: self.layoutTitle, resetText: layoutResetText),
+                    content: self.horizontalHeader(title: self.title, resetText: resolvedResetText))
+                self.layoutPreservingHeader(
+                    layout: self.verticalHeader(title: self.layoutTitle, resetText: layoutResetText),
+                    content: self.verticalHeader(title: self.title, resetText: resolvedResetText))
+            }
+        } else {
+            self.titleLabel(self.title)
+        }
+    }
+
+    private func horizontalHeader(title: String, resetText: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            self.titleLabel(title)
+                .fixedSize(horizontal: true, vertical: false)
+            Spacer(minLength: 8)
+            self.resetLabel(resetText)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func verticalHeader(title: String, resetText: String) -> some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            self.titleLabel(title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            self.resetLabel(resetText)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
+    private func titleLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.body)
+            .fontWeight(.medium)
+            .lineLimit(1)
+    }
+
+    private func resetLabel(_ resetText: String) -> some View {
+        Text(resetText)
+            .font(.footnote)
+            .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+            .lineLimit(2)
+            .multilineTextAlignment(.trailing)
+    }
+
+    private func layoutPreservingHeader(
+        layout: some View,
+        content: some View) -> some View
+    {
+        layout
+            .hidden()
+            .overlay(alignment: .topLeading) {
+                content
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+            .clipped()
+    }
+}

--- a/Sources/CodexBar/UsageMenuCardHeaderAndUsageSectionView.swift
+++ b/Sources/CodexBar/UsageMenuCardHeaderAndUsageSectionView.swift
@@ -14,6 +14,7 @@ struct UsageMenuCardHeaderAndUsageSectionView: View {
                 width: self.width)
             UsageMenuCardUsageSectionView(
                 model: self.model,
+                layoutModel: self.layoutModel,
                 showBottomDivider: false,
                 bottomPadding: self.bottomPadding,
                 width: self.width)

--- a/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
+++ b/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
@@ -100,15 +100,30 @@ struct CodexResetCreditsMenuCardTests {
         #expect(current.hasCompatibleTrackedLayout(with: candidate))
     }
 
+    @Test
+    func `metric metadata may disappear but cannot appear in frozen tracked layout`() throws {
+        let (withMetadata, withoutMetadata) = try Self.weeklyResetTransitionModels()
+        let currentWeekly = try #require(withMetadata.metrics.first { $0.id == "secondary" })
+        let candidateWeekly = try #require(withoutMetadata.metrics.first { $0.id == "secondary" })
+
+        #expect(currentWeekly.linePresentation(title: currentWeekly.title).metaText != nil)
+        #expect(candidateWeekly.linePresentation(title: candidateWeekly.title).metaText == nil)
+        #expect(withMetadata.hasCompatibleTrackedLayout(with: withoutMetadata))
+        #expect(!withoutMetadata.hasCompatibleTrackedLayout(with: withMetadata))
+    }
+
     @MainActor
     @Test
     func `refresh monitor publishes reset usage when reset credit countdown changes`() throws {
         let (frozen, resolved) = try Self.weeklyResetTransitionModels()
+        let frozenResetText = try #require(frozen.metrics.first { $0.id == "secondary" }?.resetText)
+        let resolvedResetText = try #require(resolved.metrics.first { $0.id == "secondary" }?.resetText)
         let monitor = MenuCardRefreshMonitor(
             resolveModel: { _ in resolved },
             isProviderRefreshActive: { _ in false })
         monitor.beginManualRefresh(frozenModels: [.codex: frozen], provider: .codex)
 
+        #expect(resolvedResetText.count > frozenResetText.count)
         #expect(monitor.publishResolvedModelIfCompatible(for: .codex))
         let visible = monitor.model(for: .codex, fallback: frozen)
         #expect(visible.metrics.map(\.percent) == resolved.metrics.map(\.percent))

--- a/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
+++ b/Tests/CodexBarTests/CodexResetCreditsMenuCardTests.swift
@@ -1,5 +1,7 @@
+import AppKit
 import CodexBarCore
 import Foundation
+import SwiftUI
 import Testing
 @testable import CodexBar
 
@@ -89,16 +91,45 @@ struct CodexResetCreditsMenuCardTests {
     }
 
     @Test
-    func `hosted usage model keeps reset inventory compatible with live refresh`() throws {
-        let now = Date(timeIntervalSince1970: 1_781_726_400)
-        let model = try Self.model(
-            snapshot: Self.snapshot(
-                now: now,
-                credits: [Self.credit(id: "finite", status: .available, now: now, expiresIn: 86400)]),
-            now: now)
+    func `changing reset credit countdown keeps hosted layout compatible`() throws {
+        let (current, candidate) = try Self.weeklyResetTransitionModels()
 
-        #expect(model.codexResetCredits != nil)
-        #expect(model.hasCompatibleTrackedLayout(with: model))
+        #expect(current.codexResetCredits?.expirySummaryText == "1d 6h")
+        #expect(candidate.codexResetCredits?.expirySummaryText == "18h")
+        #expect(current.codexResetCredits != candidate.codexResetCredits)
+        #expect(current.hasCompatibleTrackedLayout(with: candidate))
+    }
+
+    @MainActor
+    @Test
+    func `refresh monitor publishes reset usage when reset credit countdown changes`() throws {
+        let (frozen, resolved) = try Self.weeklyResetTransitionModels()
+        let monitor = MenuCardRefreshMonitor(
+            resolveModel: { _ in resolved },
+            isProviderRefreshActive: { _ in false })
+        monitor.beginManualRefresh(frozenModels: [.codex: frozen], provider: .codex)
+
+        #expect(monitor.publishResolvedModelIfCompatible(for: .codex))
+        let visible = monitor.model(for: .codex, fallback: frozen)
+        #expect(visible.metrics.map(\.percent) == resolved.metrics.map(\.percent))
+        #expect(visible.metrics.map(\.percent) != frozen.metrics.map(\.percent))
+        #expect(visible.codexResetCredits == resolved.codexResetCredits)
+
+        let width: CGFloat = 320
+        let constraint = CGSize(width: width, height: .greatestFiniteMagnitude)
+        let frozenSize = NSHostingController(rootView: UsageMenuCardUsageSectionView(
+            model: frozen,
+            layoutModel: frozen,
+            showBottomDivider: false,
+            bottomPadding: 6,
+            width: width)).sizeThatFits(in: constraint)
+        let resolvedSize = NSHostingController(rootView: UsageMenuCardUsageSectionView(
+            model: resolved,
+            layoutModel: frozen,
+            showBottomDivider: false,
+            bottomPadding: 6,
+            width: width)).sizeThatFits(in: constraint)
+        #expect(abs(resolvedSize.height - frozenSize.height) < 0.5)
     }
 
     @Test
@@ -115,6 +146,62 @@ struct CodexResetCreditsMenuCardTests {
         #expect(model.hasCompatibleTrackedLayout(with: model))
     }
 
+    @Test
+    func `adding or removing reset inventory requires hosted layout rebuild`() throws {
+        let now = Date(timeIntervalSince1970: 1_781_726_400)
+        let withInventory = try Self.model(
+            snapshot: Self.snapshot(
+                now: now,
+                credits: [Self.credit(id: "finite", status: .available, now: now, expiresIn: 86400)]),
+            now: now)
+        let withoutInventory = try Self.model(
+            snapshot: UsageSnapshot(primary: nil, secondary: nil, updatedAt: now),
+            now: now)
+
+        #expect(!withInventory.hasCompatibleTrackedLayout(with: withoutInventory))
+        #expect(!withoutInventory.hasCompatibleTrackedLayout(with: withInventory))
+    }
+
+    private static func weeklyResetTransitionModels() throws -> (
+        frozen: UsageMenuCardView.Model,
+        resolved: UsageMenuCardView.Model)
+    {
+        let now = Date(timeIntervalSince1970: 1_781_726_400)
+        let later = now.addingTimeInterval(12 * 60 * 60)
+        let credit = Self.credit(id: "finite", status: .available, now: now, expiresIn: 30 * 60 * 60)
+        let frozen = try Self.model(
+            snapshot: Self.snapshot(
+                now: now,
+                primary: RateWindow(
+                    usedPercent: 45,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(24 * 60 * 60),
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 18,
+                    windowMinutes: 10080,
+                    resetsAt: now.addingTimeInterval(2 * 24 * 60 * 60),
+                    resetDescription: nil),
+                credits: [credit]),
+            now: now)
+        let resolved = try Self.model(
+            snapshot: Self.snapshot(
+                now: later,
+                primary: RateWindow(
+                    usedPercent: 45,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(24 * 60 * 60),
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 0,
+                    windowMinutes: 10080,
+                    resetsAt: now.addingTimeInterval(9 * 24 * 60 * 60),
+                    resetDescription: nil),
+                credits: [credit]),
+            now: later)
+        return (frozen, resolved)
+    }
+
     private static func model(
         snapshot: UsageSnapshot,
         showOptionalUsage: Bool = true,
@@ -122,10 +209,23 @@ struct CodexResetCreditsMenuCardTests {
         now: Date) throws -> UsageMenuCardView.Model
     {
         let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let codexProjection = CodexConsumerProjection.make(
+            surface: .liveCard,
+            context: CodexConsumerProjection.Context(
+                snapshot: snapshot,
+                rawUsageError: nil,
+                liveCredits: nil,
+                rawCreditsError: nil,
+                liveDashboard: nil,
+                rawDashboardError: nil,
+                dashboardAttachmentAuthorized: false,
+                dashboardRequiresLogin: false,
+                now: now))
         return UsageMenuCardView.Model.make(UsageMenuCardView.Model.Input(
             provider: .codex,
             metadata: metadata,
             snapshot: snapshot,
+            codexProjection: codexProjection,
             credits: nil,
             creditsError: nil,
             dashboard: nil,
@@ -145,12 +245,14 @@ struct CodexResetCreditsMenuCardTests {
 
     private static func snapshot(
         now: Date,
+        primary: RateWindow? = nil,
+        secondary: RateWindow? = nil,
         credits: [CodexRateLimitResetCredit],
         availableCount: Int? = nil) -> UsageSnapshot
     {
         UsageSnapshot(
-            primary: nil,
-            secondary: nil,
+            primary: primary,
+            secondary: secondary,
             codexResetCredits: CodexRateLimitResetCreditsSnapshot(
                 credits: credits,
                 availableCount: availableCount ?? credits.count,

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1832,7 +1832,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 538,
+            line: 541,
             anchor: "if input.provider == .factory, snapshot.tertiary != nil {",
             expectedProviderIDs: ["alibabatokenplan", "amp", "crof", "cursor", "doubao", "factory", "grok", "sub2api"],
             expectedReferenceCount: 12,
@@ -1853,7 +1853,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 706,
+            line: 709,
             anchor: "case .minimax:",
             expectedProviderIDs: ["codex", "minimax", "poe"],
             expectedReferenceCount: 3,
@@ -1861,7 +1861,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 926,
+            line: 929,
             anchor: "if input.provider == .codex, !input.showOptionalCreditsAndExtraUsage {",
             expectedProviderIDs: ["claude", "codex", "copilot"],
             expectedReferenceCount: 4,
@@ -1869,7 +1869,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 951,
+            line: 954,
             anchor: "let resetText = input.provider == .sub2api && namedWindow.window.resetsAt == nil",
             expectedProviderIDs: ["doubao", "sub2api"],
             expectedReferenceCount: 3,
@@ -1877,7 +1877,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1014,
+            line: 1017,
             anchor: "guard provider == .kiro, namedWindow.id == \"kiro-overage\",",
             expectedProviderIDs: ["kiro"],
             expectedReferenceCount: 1,
@@ -1885,7 +1885,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1048,
+            line: 1051,
             anchor: "if input.provider == .antigravity,",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,
@@ -1893,7 +1893,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1082,
+            line: 1085,
             anchor: "if provider == .claude, window.windowMinutes != 10080 {",
             expectedProviderIDs: ["antigravity", "claude", "codex"],
             expectedReferenceCount: 4,
@@ -1901,7 +1901,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1114,
+            line: 1117,
             anchor: "guard input.provider == .antigravity else { return nil }",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,
@@ -1941,7 +1941,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 718,
+            line: 663,
             anchor: "guard self.model.provider == .doubao else { return nil }",
             expectedProviderIDs: ["doubao"],
             expectedReferenceCount: 1,
@@ -1949,7 +1949,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1102,
+            line: 1047,
             anchor: "if input.provider == .sub2api {",
             expectedProviderIDs: ["sub2api"],
             expectedReferenceCount: 1,
@@ -1957,7 +1957,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "The sub2api menu card localizes and groups provider-owned usage detail rows for display."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1174,
+            line: 1119,
             anchor: "if provider == .kiro,",
             expectedProviderIDs: ["kilo", "kiro"],
             expectedReferenceCount: 2,
@@ -1965,7 +1965,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1197,
+            line: 1142,
             anchor: "if provider == .minimax {",
             expectedProviderIDs: ["codex", "minimax"],
             expectedReferenceCount: 2,
@@ -1973,7 +1973,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1232,
+            line: 1177,
             anchor: "guard let loginMethod = snapshot?.loginMethod(for: .kilo) else {",
             expectedProviderIDs: ["kilo"],
             expectedReferenceCount: 1,
@@ -1981,7 +1981,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1311,
+            line: 1256,
             anchor: "if input.provider == .antigravity {",
             expectedProviderIDs: ["antigravity", "mistral"],
             expectedReferenceCount: 2,
@@ -1989,7 +1989,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1331,
+            line: 1276,
             anchor: "if input.provider == .codex, let codexProjection = input.codexProjection {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -1997,7 +1997,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1347,
+            line: 1292,
             anchor: "if input.provider != .codex, let weekly = snapshot.secondary {",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "codex", "perplexity", "sub2api"],
             expectedReferenceCount: 5,
@@ -2011,7 +2011,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1387,
+            line: 1332,
             anchor: "if input.provider == .kilo || input.provider == .kimi,",
             expectedProviderIDs: ["kilo", "kimi"],
             expectedReferenceCount: 2,
@@ -2019,7 +2019,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1444,
+            line: 1389,
             anchor: "if input.provider == .zai, let resetText = Self.localizedZaiPeriodicResetText(primary) {",
             expectedProviderIDs: ["zai"],
             expectedReferenceCount: 1,
@@ -2027,7 +2027,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1488,
+            line: 1433,
             anchor: "var paceDetail = if input.provider == .kimi {",
             expectedProviderIDs: ["kimi"],
             expectedReferenceCount: 1,
@@ -2035,7 +2035,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1504,
+            line: 1449,
             anchor: "if input.provider == .warp,",
             expectedProviderIDs: ["chutes", "kilo", "kiro", "litellm", "sub2api", "warp"],
             expectedReferenceCount: 6,
@@ -2043,7 +2043,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1537,
+            line: 1482,
             anchor: "if input.provider == .alibaba || input.provider == .alibabatokenplan,",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "copilot", "crof", "manus", "perplexity", "zenmux"],
             expectedReferenceCount: 8,
@@ -2060,7 +2060,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1578,
+            line: 1523,
             anchor: "if input.provider == .synthetic,",
             expectedProviderIDs: ["synthetic"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1832,7 +1832,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 532,
+            line: 538,
             anchor: "if input.provider == .factory, snapshot.tertiary != nil {",
             expectedProviderIDs: ["alibabatokenplan", "amp", "crof", "cursor", "doubao", "factory", "grok", "sub2api"],
             expectedReferenceCount: 12,
@@ -1853,7 +1853,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 700,
+            line: 706,
             anchor: "case .minimax:",
             expectedProviderIDs: ["codex", "minimax", "poe"],
             expectedReferenceCount: 3,
@@ -1861,7 +1861,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 920,
+            line: 926,
             anchor: "if input.provider == .codex, !input.showOptionalCreditsAndExtraUsage {",
             expectedProviderIDs: ["claude", "codex", "copilot"],
             expectedReferenceCount: 4,
@@ -1869,7 +1869,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 945,
+            line: 951,
             anchor: "let resetText = input.provider == .sub2api && namedWindow.window.resetsAt == nil",
             expectedProviderIDs: ["doubao", "sub2api"],
             expectedReferenceCount: 3,
@@ -1877,7 +1877,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1008,
+            line: 1014,
             anchor: "guard provider == .kiro, namedWindow.id == \"kiro-overage\",",
             expectedProviderIDs: ["kiro"],
             expectedReferenceCount: 1,
@@ -1885,7 +1885,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1042,
+            line: 1048,
             anchor: "if input.provider == .antigravity,",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,
@@ -1893,7 +1893,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1076,
+            line: 1082,
             anchor: "if provider == .claude, window.windowMinutes != 10080 {",
             expectedProviderIDs: ["antigravity", "claude", "codex"],
             expectedReferenceCount: 4,
@@ -1901,7 +1901,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1108,
+            line: 1114,
             anchor: "guard input.provider == .antigravity else { return nil }",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,
@@ -1933,7 +1933,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 496,
+            line: 499,
             anchor: "if self.provider != .codex || self.showsCodexHint,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -1941,7 +1941,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 678,
+            line: 718,
             anchor: "guard self.model.provider == .doubao else { return nil }",
             expectedProviderIDs: ["doubao"],
             expectedReferenceCount: 1,
@@ -1949,7 +1949,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1059,
+            line: 1102,
             anchor: "if input.provider == .sub2api {",
             expectedProviderIDs: ["sub2api"],
             expectedReferenceCount: 1,
@@ -1957,7 +1957,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "The sub2api menu card localizes and groups provider-owned usage detail rows for display."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1131,
+            line: 1174,
             anchor: "if provider == .kiro,",
             expectedProviderIDs: ["kilo", "kiro"],
             expectedReferenceCount: 2,
@@ -1965,7 +1965,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1154,
+            line: 1197,
             anchor: "if provider == .minimax {",
             expectedProviderIDs: ["codex", "minimax"],
             expectedReferenceCount: 2,
@@ -1973,7 +1973,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1189,
+            line: 1232,
             anchor: "guard let loginMethod = snapshot?.loginMethod(for: .kilo) else {",
             expectedProviderIDs: ["kilo"],
             expectedReferenceCount: 1,
@@ -1981,7 +1981,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1268,
+            line: 1311,
             anchor: "if input.provider == .antigravity {",
             expectedProviderIDs: ["antigravity", "mistral"],
             expectedReferenceCount: 2,
@@ -1989,7 +1989,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1288,
+            line: 1331,
             anchor: "if input.provider == .codex, let codexProjection = input.codexProjection {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -1997,7 +1997,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1304,
+            line: 1347,
             anchor: "if input.provider != .codex, let weekly = snapshot.secondary {",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "codex", "perplexity", "sub2api"],
             expectedReferenceCount: 5,
@@ -2011,7 +2011,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1344,
+            line: 1387,
             anchor: "if input.provider == .kilo || input.provider == .kimi,",
             expectedProviderIDs: ["kilo", "kimi"],
             expectedReferenceCount: 2,
@@ -2019,7 +2019,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1401,
+            line: 1444,
             anchor: "if input.provider == .zai, let resetText = Self.localizedZaiPeriodicResetText(primary) {",
             expectedProviderIDs: ["zai"],
             expectedReferenceCount: 1,
@@ -2027,7 +2027,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1445,
+            line: 1488,
             anchor: "var paceDetail = if input.provider == .kimi {",
             expectedProviderIDs: ["kimi"],
             expectedReferenceCount: 1,
@@ -2035,7 +2035,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1461,
+            line: 1504,
             anchor: "if input.provider == .warp,",
             expectedProviderIDs: ["chutes", "kilo", "kiro", "litellm", "sub2api", "warp"],
             expectedReferenceCount: 6,
@@ -2043,7 +2043,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1494,
+            line: 1537,
             anchor: "if input.provider == .alibaba || input.provider == .alibabatokenplan,",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "copilot", "crof", "manus", "perplexity", "zenmux"],
             expectedReferenceCount: 8,
@@ -2060,7 +2060,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1535,
+            line: 1578,
             anchor: "if input.provider == .synthetic,",
             expectedProviderIDs: ["synthetic"],
             expectedReferenceCount: 1,


### PR DESCRIPTION
## Summary
- keep an open tracked Codex card eligible for in-place refresh when reset-credit countdowns or pace/detail text change
- render refreshed values against frozen row geometry so percentages and reset data update without making the menu jump
- reject refreshes that introduce a metadata row absent from the frozen card
- let refreshed reset text use the full existing header width instead of the old label width
- cover the reported 18% to 0% weekly reset while preserving rebuilds for real section-shape changes

## Tests
- make check
- focused menu refresh/layout suites: 101 tests passed
- ProviderArchitectureGatekeeperTests: 38 tests passed
- initial implementation: four clean CI-equivalent make test shards, 930 selections, 0 failed groups, 0 retries, 0 timeouts
- GitHub CI reruns the full matrix for the revised head

## Runtime proof
Not included: reproducing the reported transition requires live provider reset timing. The PR includes deterministic projection, refresh-monitor, and SwiftUI geometry regressions without accessing real account credentials.

Closes #3168