### PR TITLE
Fix shortcut recorder app-language mismatch

### DIFF
--- a/Sources/CodexBar/PreferencesComponents.swift
+++ b/Sources/CodexBar/PreferencesComponents.swift
@@ -78,12 +78,19 @@ extension SettingsSectionFooter where Content == Text {
 struct OpenMenuShortcutRecorder: NSViewRepresentable {
     static let preferredWidth: CGFloat = 170
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
     func makeNSView(context: Context) -> KeyboardShortcuts.RecorderCocoa {
-        KeyboardShortcuts.RecorderCocoa(for: .openMenu)
+        let recorder = KeyboardShortcuts.RecorderCocoa(for: .openMenu)
+        context.coordinator.attach(to: recorder)
+        return recorder
     }
 
     func updateNSView(_ nsView: KeyboardShortcuts.RecorderCocoa, context: Context) {
         nsView.shortcutName = .openMenu
+        context.coordinator.attach(to: nsView)
     }
 
     func sizeThatFits(
@@ -97,6 +104,49 @@ struct OpenMenuShortcutRecorder: NSViewRepresentable {
 
     static func fittedSize(intrinsicHeight: CGFloat) -> CGSize {
         CGSize(width: self.preferredWidth, height: intrinsicHeight)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        private weak var recorder: KeyboardShortcuts.RecorderCocoa?
+
+        override init() {
+            super.init()
+            let center = NotificationCenter.default
+            center.addObserver(
+                self,
+                selector: #selector(self.textDidBeginEditing(_:)),
+                name: NSControl.textDidBeginEditingNotification,
+                object: nil)
+            center.addObserver(
+                self,
+                selector: #selector(self.textDidEndEditing(_:)),
+                name: NSControl.textDidEndEditingNotification,
+                object: nil)
+        }
+
+        deinit {
+            NotificationCenter.default.removeObserver(self)
+        }
+
+        func attach(to recorder: KeyboardShortcuts.RecorderCocoa) {
+            self.recorder = recorder
+            self.updatePlaceholder(isRecording: recorder.currentEditor() != nil)
+        }
+
+        @objc private func textDidBeginEditing(_ notification: Notification) {
+            guard notification.object as? KeyboardShortcuts.RecorderCocoa === self.recorder else { return }
+            self.updatePlaceholder(isRecording: true)
+        }
+
+        @objc private func textDidEndEditing(_ notification: Notification) {
+            guard notification.object as? KeyboardShortcuts.RecorderCocoa === self.recorder else { return }
+            self.updatePlaceholder(isRecording: false)
+        }
+
+        private func updatePlaceholder(isRecording: Bool) {
+            self.recorder?.placeholderString = L(isRecording ? "press_shortcut" : "record_shortcut")
+        }
     }
 }
 

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "section_keyboard_shortcut" = "اختصار لوحة المفاتيح";
 "open_menu_shortcut_title" = "قائمة مفتوحة";
 "open_menu_shortcut_subtitle" = "فعل قائمة شريط القوائم من أي مكان.";
+"record_shortcut" = "سجل اختصاراً";
+"press_shortcut" = "اضغط على الاختصار";
 "install_cli" = "تثبيت CLI";
 "install_cli_subtitle" = "Symlink CodexBarCLI إلى /usr/local/bin و /opt/homebrew/bin ك codexbar.";
 "cli_not_found" = "CodexBarCLI غير موجود في حزمة التطبيقات.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -639,6 +639,8 @@
 "section_keyboard_shortcut" = "Drecera de teclat";
 "open_menu_shortcut_title" = "Obriu el menú";
 "open_menu_shortcut_subtitle" = "Obriu el menú de la barra de menús des de qualsevol lloc.";
+"record_shortcut" = "Enregistra la drecera";
+"press_shortcut" = "Premeu la drecera";
 "install_cli" = "Instal·la la CLI";
 "install_cli_subtitle" = "Creeu un enllaç simbòlic de CodexBarCLI a /usr/local/bin i /opt/homebrew/bin com a codexbar.";
 "cli_not_found" = "No s'ha trobat CodexBarCLI al paquet de l'app.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -653,6 +653,8 @@
 "section_keyboard_shortcut" = "Tastenkombination";
 "open_menu_shortcut_title" = "Menü öffnen";
 "open_menu_shortcut_subtitle" = "Lösen Sie das Menü der Menüleiste von überall aus aus.";
+"record_shortcut" = "Kurzbefehl aufnehmen";
+"press_shortcut" = "Kurzbefehl wählen…";
 "install_cli" = "CLI installieren";
 "install_cli_subtitle" = "Verknüpfen Sie CodexBarCLI mit /usr/local/bin und /opt/homebrew/bin als Codexbar.";
 "cli_not_found" = "CodexBarCLI wurde im App-Bundle nicht gefunden.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -641,6 +641,8 @@
 "section_keyboard_shortcut" = "Keyboard shortcut";
 "open_menu_shortcut_title" = "Open menu";
 "open_menu_shortcut_subtitle" = "Trigger the menu bar menu from anywhere.";
+"record_shortcut" = "Record Shortcut";
+"press_shortcut" = "Press Shortcut";
 "install_cli" = "Install CLI";
 "install_cli_subtitle" = "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar.";
 "cli_not_found" = "CodexBarCLI not found in app bundle.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -647,6 +647,8 @@
 "section_keyboard_shortcut" = "Atajo de teclado";
 "open_menu_shortcut_title" = "Abrir menú";
 "open_menu_shortcut_subtitle" = "Abrir el menú de la barra de menús desde cualquier lugar.";
+"record_shortcut" = "Grabar atajo";
+"press_shortcut" = "Pulsar atajo";
 "install_cli" = "Instalar CLI";
 "install_cli_subtitle" = "Crear un enlace simbólico de CodexBarCLI en /usr/local/bin y /opt/homebrew/bin como codexbar.";
 "cli_not_found" = "No se encontró CodexBarCLI en el paquete de la app.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "section_keyboard_shortcut" = "میانبر کیبورد";
 "open_menu_shortcut_title" = "منوی باز";
 "open_menu_shortcut_subtitle" = "منوی نوار منو را از هر جایی فعال کنید.";
+"record_shortcut" = "ثبت میانبر";
+"press_shortcut" = "میانبر را فشار دهید";
 "install_cli" = "نصب CLI";
 "install_cli_subtitle" = "Symlink CodexBarCLI به /usr/local/bin و /opt/homebrew/bin به عنوان codexbar.";
 "cli_not_found" = "CodexBarCLI در بسته برنامه ها یافت نمی شود.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -655,6 +655,8 @@
 "section_keyboard_shortcut" = "Raccourci clavier";
 "open_menu_shortcut_title" = "Ouvrir le menu";
 "open_menu_shortcut_subtitle" = "Déclenchez le menu de la barre de menus depuis n'importe où.";
+"record_shortcut" = "Enregistrer le raccourci";
+"press_shortcut" = "Saisir un raccourci";
 "install_cli" = "Installer la CLI";
 "install_cli_subtitle" = "Lien symbolique CodexBarCLI vers /usr/local/bin et /opt/homebrew/bin en tant que codexbar.";
 "cli_not_found" = "CodexBarCLI introuvable dans l'ensemble d'applications.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -634,6 +634,8 @@
 "section_keyboard_shortcut" = "Atallo de teclado";
 "open_menu_shortcut_title" = "Abrir o menú";
 "open_menu_shortcut_subtitle" = "Abre o menú da barra de menús desde calquera lugar.";
+"record_shortcut" = "Gravar atallo";
+"press_shortcut" = "Preme o atallo";
 "install_cli" = "Instalar a CLI";
 "install_cli_subtitle" = "Crea un enlace simbólico de CodexBarCLI a /usr/local/bin e /opt/homebrew/bin como codexbar.";
 "cli_not_found" = "Non se atopou CodexBarCLI no paquete da aplicación.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -663,6 +663,8 @@
 "section_keyboard_shortcut" = "Pintasan keyboard";
 "open_menu_shortcut_title" = "Buka menu";
 "open_menu_shortcut_subtitle" = "Picu menu bar dari mana saja.";
+"record_shortcut" = "Rekam pintasan";
+"press_shortcut" = "Tekan pintasan";
 "install_cli" = "Pasang CLI";
 "install_cli_subtitle" = "Symlink CodexBarCLI ke /usr/local/bin dan /opt/homebrew/bin sebagai codexbar.";
 "cli_not_found" = "CodexBarCLI tidak ditemukan di bundel aplikasi.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -663,6 +663,8 @@
 "section_keyboard_shortcut" = "Scorciatoia tastiera";
 "open_menu_shortcut_title" = "Apri menu";
 "open_menu_shortcut_subtitle" = "Attiva il menu della barra da qualsiasi punto.";
+"record_shortcut" = "Registra scorciatoia";
+"press_shortcut" = "Premi scorciatoia";
 "install_cli" = "Installa CLI";
 "install_cli_subtitle" = "Crea il symlink di CodexBarCLI in /usr/local/bin e /opt/homebrew/bin come codexbar.";
 "cli_not_found" = "CodexBarCLI non trovato nel bundle dell'app.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -652,6 +652,8 @@
 "section_keyboard_shortcut" = "キーボードショートカット";
 "open_menu_shortcut_title" = "メニューを開く";
 "open_menu_shortcut_subtitle" = "どこからでもメニューバーのメニューを開きます。";
+"record_shortcut" = "キーを記録";
+"press_shortcut" = "キーを押してください";
 "install_cli" = "CLI をインストール";
 "install_cli_subtitle" = "CodexBarCLI を codexbar として /usr/local/bin と /opt/homebrew/bin にシンボリックリンクします。";
 "cli_not_found" = "アプリバンドル内に CodexBarCLI が見つかりません。";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -643,6 +643,8 @@
 "section_keyboard_shortcut" = "키보드 단축키";
 "open_menu_shortcut_title" = "메뉴 열기";
 "open_menu_shortcut_subtitle" = "어디서나 메뉴 막대 메뉴를 실행합니다.";
+"record_shortcut" = "단축키 등록";
+"press_shortcut" = "단축키 입력";
 "install_cli" = "CLI 설치";
 "install_cli_subtitle" = "CodexBarCLI를 codexbar로 /usr/local/bin 및 /opt/homebrew/bin에 심볼릭 링크합니다.";
 "cli_not_found" = "앱 번들에서 CodexBarCLI를 찾을 수 없습니다.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -655,6 +655,8 @@
 "section_keyboard_shortcut" = "Sneltoets";
 "open_menu_shortcut_title" = "Menu openen";
 "open_menu_shortcut_subtitle" = "Activeer het menubalkmenu vanaf elke locatie.";
+"record_shortcut" = "Toetscombinatie opnemen";
+"press_shortcut" = "Voer toetscombinatie in";
 "install_cli" = "Installeer CLI";
 "install_cli_subtitle" = "Symlink CodexBarCLI naar /usr/local/bin en /opt/homebrew/bin als codexbar.";
 "cli_not_found" = "CodexBarCLI niet gevonden in appbundel.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -663,6 +663,8 @@
 "section_keyboard_shortcut" = "Skrót klawiaturowy";
 "open_menu_shortcut_title" = "Skrót otwierania menu";
 "open_menu_shortcut_subtitle" = "Skrót klawiaturowy do otwierania menu CodexBar.";
+"record_shortcut" = "Nagraj skrót";
+"press_shortcut" = "Naciśnij skrót";
 "install_cli" = "Zainstaluj CLI";
 "install_cli_subtitle" = "Utwórz dowiązanie symboliczne CodexBarCLI do /usr/local/bin i /opt/homebrew/bin jako codexbar.";
 "cli_not_found" = "Nie znaleziono CodexBarCLI w pakiecie aplikacji.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -652,6 +652,8 @@
 "section_keyboard_shortcut" = "Atalho de teclado";
 "open_menu_shortcut_title" = "Abrir menu";
 "open_menu_shortcut_subtitle" = "Aciona o menu da barra de menus de qualquer lugar.";
+"record_shortcut" = "Gravar Atalho";
+"press_shortcut" = "Digite o Atalho";
 "install_cli" = "Instalar CLI";
 "install_cli_subtitle" = "Cria symlink de CodexBarCLI em /usr/local/bin e /opt/homebrew/bin como codexbar.";
 "cli_not_found" = "CodexBarCLI não encontrado no pacote do app.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -656,6 +656,8 @@
 "section_keyboard_shortcut" = "Сочетание клавиш";
 "open_menu_shortcut_title" = "Открыть меню";
 "open_menu_shortcut_subtitle" = "Вызывать меню строки меню из любого места.";
+"record_shortcut" = "Добавить";
+"press_shortcut" = "Запись…";
 "install_cli" = "Установить CLI";
 "install_cli_subtitle" = "Создать symlink CodexBarCLI как codexbar в /usr/local/bin и /opt/homebrew/bin.";
 "cli_not_found" = "CodexBarCLI не найден в комплекте приложения.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -654,6 +654,8 @@
 "section_keyboard_shortcut" = "Kortkommando";
 "open_menu_shortcut_title" = "Öppna meny";
 "open_menu_shortcut_subtitle" = "Öppna menyradsmenyn var du än är.";
+"record_shortcut" = "Spela in kortkommando";
+"press_shortcut" = "Tryck på kortkommandot";
 "install_cli" = "Installera CLI";
 "install_cli_subtitle" = "Symlänka CodexBarCLI till /usr/local/bin och /opt/homebrew/bin som codexbar.";
 "cli_not_found" = "CodexBarCLI hittades inte i apppaketet.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "section_keyboard_shortcut" = "แป้นพิมพ์ลัด";
 "open_menu_shortcut_title" = "เปิดเมนู";
 "open_menu_shortcut_subtitle" = "ทริกเกอร์เมนูแถบเมนูได้จากทุกที่";
+"record_shortcut" = "บันทึกปุ่มลัด";
+"press_shortcut" = "กดปุ่มลัด";
 "install_cli" = "ติดตั้ง CLI";
 "install_cli_subtitle" = "Symlink CodexBarCLI เป็น /usr/local/bin และ /opt/homebrew/bin เป็น codexbar";
 "cli_not_found" = "ไม่พบ CodexBarCLI ใน App Bundle";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "section_keyboard_shortcut" = "Klavye kısayolu";
 "open_menu_shortcut_title" = "Menüyü aç";
 "open_menu_shortcut_subtitle" = "Menü çubuğu menüsünü herhangi bir yerden tetikleyin.";
+"record_shortcut" = "Kısayolu kaydet";
+"press_shortcut" = "Kısayola basın";
 "install_cli" = "CLI'yi yükle";
 "install_cli_subtitle" = "CodexBarCLI'yi codexbar olarak /usr/local/bin ve /opt/homebrew/bin dizinlerine sembolik bağlayın.";
 "cli_not_found" = "CodexBarCLI uygulama paketinde bulunamadı.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -655,6 +655,8 @@
 "section_keyboard_shortcut" = "Комбінація клавіш";
 "open_menu_shortcut_title" = "Відкрити меню";
 "open_menu_shortcut_subtitle" = "Викликати меню панелі меню з будь-якого місця.";
+"record_shortcut" = "Записати комбінацію";
+"press_shortcut" = "Натисніть комбінацію";
 "install_cli" = "Встановіть CLI";
 "install_cli_subtitle" = "Символьне посилання CodexBarCLI на /usr/local/bin і /opt/homebrew/bin як codexbar.";
 "cli_not_found" = "CodexBarCLI не знайдено в пакеті програм.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -651,6 +651,8 @@
 "section_keyboard_shortcut" = "Phím tắt";
 "open_menu_shortcut_title" = "Mở menu";
 "open_menu_shortcut_subtitle" = "Kích hoạt menu thanh menu từ mọi nơi.";
+"record_shortcut" = "Ghi phím tắt";
+"press_shortcut" = "Nhấn phím tắt";
 "install_cli" = "Cài đặt CLI";
 "install_cli_subtitle" = "Liên kết tượng trưng CodexBarCLI tới /usr/local/bin và /opt/homebrew/bin dưới dạng codexbar.";
 "cli_not_found" = "Không tìm thấy CodexBarCLI trong gói ứng dụng.";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -628,6 +628,8 @@
 "section_keyboard_shortcut" = "快捷键";
 "open_menu_shortcut_title" = "打开菜单";
 "open_menu_shortcut_subtitle" = "从任意位置触发菜单栏菜单。";
+"record_shortcut" = "设置快捷键";
+"press_shortcut" = "按下快捷键";
 "install_cli" = "安装 CLI";
 "install_cli_subtitle" = "将 CodexBarCLI 作为 codexbar 符号链接到 /usr/local/bin 和 /opt/homebrew/bin。";
 "cli_not_found" = "在应用包中未找到 CodexBarCLI。";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -652,6 +652,8 @@
 "section_keyboard_shortcut" = "快速鍵";
 "open_menu_shortcut_title" = "開啟選單";
 "open_menu_shortcut_subtitle" = "從任意位置觸發選單列選單。";
+"record_shortcut" = "設定快速鍵";
+"press_shortcut" = "按下快速鍵";
 "install_cli" = "安裝 CLI";
 "install_cli_subtitle" = "將 CodexBarCLI 作為 codexbar 符號連結到 /usr/local/bin 和 /opt/homebrew/bin。";
 "cli_not_found" = "在 App 套件中找不到 CodexBarCLI。";

--- a/Tests/CodexBarTests/KeyboardShortcutsBundleTests.swift
+++ b/Tests/CodexBarTests/KeyboardShortcutsBundleTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Foundation
 import KeyboardShortcuts
 import Testing
 @testable import CodexBar
@@ -15,5 +17,35 @@ struct KeyboardShortcutsBundleTests {
         #expect(size.width == OpenMenuShortcutRecorder.preferredWidth)
         #expect(size.width > recorder.intrinsicContentSize.width)
         #expect(size.height == recorder.intrinsicContentSize.height)
+    }
+
+    @Test func `open menu recorder follows selected app language`() {
+        let recorder = KeyboardShortcuts.RecorderCocoa(for: .init("test.keyboardshortcuts.localization"))
+        let coordinator = OpenMenuShortcutRecorder.Coordinator()
+
+        CodexBarLocalizationOverride.$appLanguage.withValue("en") {
+            coordinator.attach(to: recorder)
+            #expect(recorder.placeholderString == "Record Shortcut")
+
+            NotificationCenter.default.post(
+                name: NSControl.textDidBeginEditingNotification,
+                object: recorder)
+            #expect(recorder.placeholderString == "Press Shortcut")
+
+            NotificationCenter.default.post(
+                name: NSControl.textDidEndEditingNotification,
+                object: recorder)
+            #expect(recorder.placeholderString == "Record Shortcut")
+        }
+
+        CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hans") {
+            coordinator.attach(to: recorder)
+            #expect(recorder.placeholderString == "设置快捷键")
+
+            NotificationCenter.default.post(
+                name: NSControl.textDidBeginEditingNotification,
+                object: recorder)
+            #expect(recorder.placeholderString == "按下快捷键")
+        }
     }
 }


### PR DESCRIPTION
## Summary

- make the keyboard shortcut recorder follow CodexBar's selected app language instead of the macOS system language
- keep both the idle and active recording prompts synchronized with the app language
- add recorder prompt translations for all 23 supported app languages and cover English/Simplified Chinese transitions

## Why

When CodexBar is explicitly set to English on a Mac using Simplified Chinese, the General settings pane mixes English app labels with the recorder's Chinese placeholder. The recorder comes from `KeyboardShortcuts`, whose resource bundle follows the system locale independently of CodexBar's in-app language override.

The wrapper now reapplies CodexBar-localized placeholders during the AppKit editing lifecycle without changing `AppleLanguages` or the dependency.

## Validation

- `swift test --filter KeyboardShortcutsBundleTests` — 3 tests passed
- `make check` — locale checks, SwiftFormat, and SwiftLint passed with 0 violations
- `make test` — 930 selections in 78 groups; 78 first-pass successes, 0 failures, 0 retries, 0 timeouts
