### PR TITLE
fix: recover cancelled claude-swap version probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.55.1 — Unreleased
 
 ### Fixed
+- Claude: retry failed claude-swap version detection, ignore superseded startup probes, and clear stale adapter versions when disabled (#3126).
 - Alibaba Token Plan: try the signed-in Bailian CLI before browser cookies, with isolated subprocess credentials and region-aware 5-hour/weekly quotas (#3020, #3080). Thanks @Hek846!
 - Codex: preserve established local spend totals while newer session history catches up, without crossing accounts, history windows, or time zones; upgrade existing spend caches in place (#3051). Thanks @mauriciopolvora!
 - Codex: refresh open usage cards in place after weekly resets without clipping reset details or mixing account identities (#3168, #3189). Thanks @Zihao-Qi!

--- a/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
+++ b/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeSwapRefresh.swift
@@ -9,6 +9,7 @@ struct ClaudeSwapTransientState {
     var switchingAccountID: ProviderAccountIdentity?
     var task: Task<Void, Never>?
     var versionProbedPath: String?
+    var versionProbeGeneration: UInt64 = 0
 }
 
 extension UsageStore {
@@ -40,7 +41,9 @@ extension UsageStore {
             self.claudeSwapLastRefreshAt != nil || self.claudeSwapLastError != nil ||
             self.claudeSwapTransientState.lastError != nil ||
             self.claudeSwapTransientState.lastErrorAccountID != nil ||
-            self.claudeSwapTransientState.switchingAccountID != nil
+            self.claudeSwapTransientState.switchingAccountID != nil ||
+            self.claudeSwapTransientState.versionProbedPath != nil ||
+            self.claudeSwapDetectedVersion != nil
         self.claudeSwapRefreshTask?.cancel()
         self.claudeSwapRefreshTask = nil
         self.claudeSwapAccountSnapshots = []
@@ -49,6 +52,9 @@ extension UsageStore {
         self.claudeSwapTransientState.lastError = nil
         self.claudeSwapTransientState.lastErrorAccountID = nil
         self.claudeSwapTransientState.switchingAccountID = nil
+        self.claudeSwapTransientState.versionProbedPath = nil
+        self.claudeSwapTransientState.versionProbeGeneration &+= 1
+        self.claudeSwapDetectedVersion = nil
         if hadState {
             self.claudeSwapRevision &+= 1
         }
@@ -154,8 +160,13 @@ extension UsageStore {
 
     private func probeClaudeSwapVersionIfNeeded(executablePath: String) async {
         guard self.claudeSwapTransientState.versionProbedPath != executablePath else { return }
-        let version = await ClaudeSwapAccountReader.readVersion(executablePath: executablePath)
-        guard self.isCurrentClaudeSwapConfiguration(executablePath: executablePath) else { return }
+        self.claudeSwapTransientState.versionProbeGeneration &+= 1
+        let generation = self.claudeSwapTransientState.versionProbeGeneration
+        guard let version = await ClaudeSwapAccountReader.readVersion(executablePath: executablePath),
+              !Task.isCancelled,
+              self.claudeSwapTransientState.versionProbeGeneration == generation,
+              self.isCurrentClaudeSwapConfiguration(executablePath: executablePath)
+        else { return }
         self.claudeSwapTransientState.versionProbedPath = executablePath
         self.claudeSwapDetectedVersion = version
     }

--- a/Tests/CodexBarTests/ClaudeProviderRuntimeTests.swift
+++ b/Tests/CodexBarTests/ClaudeProviderRuntimeTests.swift
@@ -11,6 +11,8 @@ struct ClaudeProviderRuntimeTests {
         store.claudeSwapAccountSnapshots = [self.accountSnapshot()]
         store.claudeSwapLastRefreshAt = Date()
         store.claudeSwapLastError = "stale"
+        store.claudeSwapDetectedVersion = "0.25.0"
+        store.claudeSwapTransientState.versionProbedPath = "/stale/cswap"
         let runtime = ClaudeProviderRuntime()
 
         runtime.settingsDidChange(context: ProviderRuntimeContext(provider: .claude, settings: settings, store: store))
@@ -18,6 +20,8 @@ struct ClaudeProviderRuntimeTests {
         #expect(store.claudeSwapAccountSnapshots.isEmpty)
         #expect(store.claudeSwapLastRefreshAt == nil)
         #expect(store.claudeSwapLastError == nil)
+        #expect(store.claudeSwapDetectedVersion == nil)
+        #expect(store.claudeSwapTransientState.versionProbedPath == nil)
     }
 
     @Test
@@ -53,6 +57,55 @@ struct ClaudeProviderRuntimeTests {
 
         #expect(store.claudeSwapAccountSnapshots.isEmpty)
         #expect(store.claudeSwapLastRefreshAt == nil)
+    }
+
+    @Test
+    func `failed version probe retries on the next adapter refresh`() async throws {
+        let (settings, store) = self.makeStore()
+        let fixture = try self.makeVersionRecoveryExecutable(delayFirstProbe: false)
+        let metadata = try #require(ProviderRegistry.shared.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        settings.claudeSwapExecutablePath = fixture.executablePath
+        settings.claudeSwapEnabled = true
+
+        await store.refreshClaudeSwapAccounts()
+
+        #expect(store.claudeSwapDetectedVersion == nil)
+        #expect(store.claudeSwapTransientState.versionProbedPath == nil)
+        #expect(store.claudeSwapAccountSnapshots.count == 1)
+
+        await store.refreshClaudeSwapAccounts()
+
+        #expect(store.claudeSwapDetectedVersion == "0.25.0")
+        #expect(store.claudeSwapTransientState.versionProbedPath == fixture.executablePath)
+        #expect(try String(contentsOf: fixture.countURL, encoding: .utf8) == "2\n")
+    }
+
+    @Test
+    func `replacement refresh cannot publish a cancelled older version probe`() async throws {
+        let (settings, store) = self.makeStore()
+        let fixture = try self.makeVersionRecoveryExecutable(delayFirstProbe: true)
+        let metadata = try #require(ProviderRegistry.shared.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        settings.claudeSwapExecutablePath = fixture.executablePath
+        settings.claudeSwapEnabled = true
+
+        store.scheduleClaudeSwapAccountRefresh()
+        let first = try #require(store.claudeSwapRefreshTask)
+        for _ in 0..<100 where !FileManager.default.fileExists(atPath: fixture.countURL.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(FileManager.default.fileExists(atPath: fixture.countURL.path))
+
+        store.scheduleClaudeSwapAccountRefresh()
+        let replacement = try #require(store.claudeSwapRefreshTask)
+        await replacement.value
+        await first.value
+
+        #expect(store.claudeSwapDetectedVersion == "0.25.0")
+        #expect(store.claudeSwapTransientState.versionProbedPath == fixture.executablePath)
+        #expect(store.claudeSwapAccountSnapshots.count == 1)
+        #expect(try String(contentsOf: fixture.countURL, encoding: .utf8) == "2\n")
     }
 
     @Test
@@ -267,6 +320,36 @@ struct ClaudeProviderRuntimeTests {
         try script.write(to: url, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
         return url.path
+    }
+
+    private func makeVersionRecoveryExecutable(delayFirstProbe: Bool) throws -> (
+        executablePath: String,
+        countURL: URL)
+    {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-swap-version-recovery-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let executable = directory.appendingPathComponent("cswap")
+        let countURL = directory.appendingPathComponent("version-count.txt")
+        let firstProbeAction = delayFirstProbe ? "/bin/sleep 30" : "exit 9"
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "--version" ]; then
+          count=0
+          if [ -f '\(countURL.path)' ]; then count=$(/bin/cat '\(countURL.path)'); fi
+          count=$((count + 1))
+          printf '%s\\n' "$count" > '\(countURL.path)'
+          if [ "$count" -eq 1 ]; then \(firstProbeAction); fi
+          printf '%s\\n' 'cswap 0.25.0'
+          exit 0
+        fi
+        printf '%s\\n' '{"schemaVersion":1,"activeAccountNumber":1,"accounts":['
+        printf '%s\\n' '{"number":1,"email":"fixture@example.com","active":true,"usageStatus":"ok",'
+        printf '%s\\n' '"usage":{"fiveHour":{"pct":12.5}}}]}'
+        """
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return (executable.path, countURL)
     }
 
     private func makeSwitchExecutable(marker: URL) throws -> String {

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -139,6 +139,8 @@ The accepted multi-account design in
 
 - Setup: Preferences → Providers → Claude → "Read accounts from claude-swap", then set the path to the
   [`cswap`](https://github.com/realiti4/claude-swap) executable (for example `~/.local/bin/cswap`).
+- Version detection retries after a failed or cancelled startup probe; replaced refreshes cannot overwrite a newer
+  result, and disabling the adapter or changing its executable clears the previous detected version.
 - Behavior: on each Claude refresh, CodexBar runs `cswap --list --json` independently of the ambient Claude fetch (no
   shell, fixed arguments, bounded runtime and output), requires `schemaVersion == 1`, and parses only slot number,
   active state, usage status, email (display only), display-only `organizationName` (always present, may be empty),


### PR DESCRIPTION
Fixes #3126. Keep claude-swap version detection retryable after failed or cancelled probes, prevent superseded refreshes from publishing stale versions, and clear cached version/path state when the adapter is disabled or reconfigured. Scope the change to adapter state; shared subprocess logging remains unchanged. Regression coverage uses real isolated fake executables for first-failure/second-success recovery and cancellation during refresh replacement. Focused verification: 154 tests across Claude adapter, reader, pricing, Bailian, and provider architecture suites; formatting/lint and independent review passed.