### PR TITLE
Publish stable status item identity before callbacks

### DIFF
--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -327,8 +327,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             autosaveName: identity.autosaveName,
             legacyDefaultItemIndex: legacyDefaultItemIndex)
         let item = statusBar.statusItem(withLength: NSStatusItem.variableLength)
-        onCreated?(item)
         item.autosaveName = identity.autosaveName
+        onCreated?(item)
         if let button = item.button {
             let title = self.statusItemAccessibilityTitle(
                 isDebugApp: self.isDebugApp(bundleIdentifier: Bundle.main.bundleIdentifier))

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -215,6 +215,22 @@ struct StatusItemControllerSplitLifecycleTests {
     }
 
     @Test
+    func `status item publishes stable manager identity before creation callback`() {
+        let settings = self.makeSettings()
+        let statusBar = self.makeStatusBarForTesting()
+        var callbackAutosaveName: String?
+        let item = StatusItemController.makeStatusItem(
+            statusBar: statusBar,
+            identity: .merged,
+            defaults: settings.userDefaults,
+            legacyDefaultItemIndex: nil,
+            onCreated: { callbackAutosaveName = $0.autosaveName })
+        defer { statusBar.removeStatusItem(item) }
+
+        #expect(callbackAutosaveName == "codexbar-merged")
+    }
+
+    @Test
     func `status item identity returns stable autosave names`() {
         #expect(StatusItemController.StatusItemIdentity.merged.autosaveName == "codexbar-merged")
         #expect(StatusItemController.StatusItemIdentity.provider(.codex).autosaveName == "codexbar-codex")


### PR DESCRIPTION
Relates to #3201.

CodexBar currently publishes a newly created status item through `onCreated` while AppKit still exposes its transient `Item-0` autosave name. Bartender can persist that callback-time identity and treat each relaunch as a new item.

This assigns the existing `codexbar-*` autosave name before the callback runs. The regression test fails on the parent source with `Item-0` and passes once the stable identity is published first.

Tests:

- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter StatusItemControllerSplitLifecycleTests` — 26 passed
- `make check` — passed
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make test` — not green locally because two `AdaptiveRefreshTimerTests` hit their 30-second scheduling timeout; both failures reproduce unchanged on the untouched upstream base
- [Hosted CI](https://github.com/steipete/CodexBar/actions/runs/32936381134) — all 9 checks passed, including both macOS test shards

I could not run the closed-source Bartender relaunch check because Bartender is not installed here. Compatibility risk is limited to making the existing stable autosave name observable earlier; the useful review focus is whether any creation callback intentionally depends on AppKit's temporary `Item-*` name.
