### PR TITLE
fix: isolate CLI installer shell environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.55.2 — Unreleased
 
+### Fixed
+- CLI install: remove inherited Bash startup hooks from the repository installer by using the system POSIX shell, absolute tools, and a clean environment while retaining administrator approval and both existing symlink destinations (#3205).
+
 ## 0.55.1 — 2026-08-25
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.55.2 — Unreleased
 
 ### Fixed
-- CLI install: remove inherited Bash startup hooks from the repository installer by using the system POSIX shell, absolute tools, and a clean environment while retaining administrator approval and both existing symlink destinations (#3205).
+- CLI install: block inherited shell functions and startup hooks before helper validation and failure handling, and use absolute tools and a clean administrator-command environment while retaining approval and both existing symlink destinations (#3205, #3217).
 
 ## 0.55.1 — 2026-08-25
 

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -53,6 +53,10 @@ check_package_info_plist() {
   "${ROOT_DIR}/Scripts/test_package_info_plist.sh"
 }
 
+check_cli_installer() {
+  /bin/bash "${ROOT_DIR}/Scripts/test_install_codexbar_cli.sh"
+}
+
 check_release_dsym_paths() {
   "${ROOT_DIR}/Scripts/test_release_dsym_paths.sh"
 }
@@ -188,6 +192,7 @@ cmd="${1:-lint}"
 case "$cmd" in
   lint)
     check_app_locales
+    check_cli_installer
     run_portable_checks
     run_javascript_checks
     run_swiftformat_lint
@@ -200,6 +205,7 @@ case "$cmd" in
     ;;
   lint-macos)
     check_app_locales
+    check_cli_installer
     run_javascript_checks
     run_swiftformat_lint
     ;;

--- a/Scripts/test_install_codexbar_cli.sh
+++ b/Scripts/test_install_codexbar_cli.sh
@@ -18,7 +18,7 @@ assert sys.platform == "darwin", "The installer regression test requires macOS A
 assert os.geteuid() != 0, "Run installer regression tests as a non-root user."
 source = Path(sys.argv[1]).read_text()
 temp = Path(sys.argv[2]).resolve()
-assert source.startswith("#!/bin/sh\nset -eu\n")
+assert source.startswith("#!/bin/sh -p\n")
 app_line = 'APP="/Applications/CodexBar.app"'
 assert source.count(app_line) == 1
 assert source.count("/usr/bin/osascript") == 1
@@ -53,10 +53,54 @@ fixture.write_text(source.replace(app_line, "APP=" + shlex.quote(str(app)))
 fixture.chmod(0o755)
 environment = {"PATH": "/usr/bin:/bin:/usr/sbin:/sbin", "HOME": str(temp)}
 
-def run_installer(env):
-    return subprocess.run([str(fixture)], env=env, capture_output=True, text=True)
+hook = temp / "startup-hook"
+hook.write_text("/bin/echo startup-hook-ran >&2\nexit 97\n")
+startup_hooks = {"BASH_ENV": str(hook), "ENV": str(hook), "PATH": str(temp)}
+function_returns = {name: 98 for name in (
+    "bash", "env", "osascript", "mkdir", "ln", "dirname", "echo", "printf",
+)}
+# Each override models a distinct way to bypass validation or fail-fast behavior.
+function_returns.update({"[": 1, "set": 0, "exit": 0})
 
-baseline = run_installer(environment)
+def run_command(command, functions=(), inherited=None):
+    if functions or inherited:
+        # Let the system Bash choose its actual function-export format. Inject hooks
+        # only after this exporter starts, so they reach the installer, not the test.
+        exports = "".join(
+            f"{name}() {{ /bin/echo inherited-function-ran:{name} >&2; "
+            f"return {function_returns[name]}; }}\nexport -f {shlex.quote(name)}\n"
+            for name in functions
+        )
+        launch = shlex.join(["/usr/bin/env"] + [
+            f"{key}={value}" for key, value in (inherited or {}).items()
+        ]) + ' "$@"'
+        command = ["/bin/bash", "--noprofile", "--norc", "-c", exports + launch,
+                   "installer-test", *command]
+    return subprocess.run(command, env=environment, capture_output=True, text=True)
+
+def run_installer(functions=(), inherited=None):
+    return run_command([str(fixture)], functions, inherited)
+
+# Prove these are genuinely inherited functions on this host, without invoking them.
+imported = run_command(["/bin/sh", "-c", "type -t '[' set exit"], ("[", "set", "exit"))
+assert imported.returncode == 0, imported.stderr
+assert imported.stdout.splitlines() == ["function"] * 3
+hook_probe = run_command(["/bin/bash", "--noprofile", "--norc", "-c", ":"], inherited=startup_hooks)
+assert hook_probe.returncode == 97
+assert hook_probe.stderr == "startup-hook-ran\n"
+
+cases = [
+    ("normal", (), {}),
+    ("test function", ("[",), {}),
+    ("set function", ("set",), {}),
+    ("exit function", ("exit",), {}),
+    ("all functions", tuple(function_returns), {}),
+    ("startup hooks", (), startup_hooks),
+    ("shell options", (), {"SHELLOPTS": "noexec"}),
+    ("all contamination", tuple(function_returns), dict(startup_hooks, SHELLOPTS="noexec")),
+]
+
+baseline = run_installer()
 assert baseline.returncode == 0, baseline.stderr
 assert "CodexBar CLI installed." in baseline.stdout
 expected_capture = json.loads(capture.read_text())
@@ -67,23 +111,23 @@ assert set(expected_capture["environment"]) <= {
     "PATH", "LC_CTYPE", "__CF_USER_TEXT_ENCODING",
 }, sorted(expected_capture["environment"])
 
-hook = temp / "startup-hook"
-hook.write_text("/bin/echo startup-hook-ran >&2\nexit 97\n")
-inherited = dict(environment, BASH_ENV=str(hook), ENV=str(hook), PATH=str(temp))
-for name in ("bash", "env", "osascript", "mkdir", "ln", "dirname", "echo", "printf", "set"):
-    for suffix in ("%%", "()"):
-        inherited[f"BASH_FUNC_{name}{suffix}"] = "() { /bin/echo inherited-function-ran >&2; return 98; }"
-contaminated = run_installer(inherited)
-assert contaminated.returncode == 0, contaminated.stderr
-assert contaminated.stdout == baseline.stdout
-assert contaminated.stderr == baseline.stderr
-assert json.loads(capture.read_text()) == expected_capture
+for label, functions, inherited in cases:
+    capture.unlink()
+    completed = run_installer(functions, inherited)
+    assert completed.returncode == 0, (label, completed.stderr)
+    assert completed.stdout == baseline.stdout, label
+    assert completed.stderr == baseline.stderr, label
+    assert json.loads(capture.read_text()) == expected_capture, label
 
 # An approval/installation error must propagate without a success banner.
 (temp / "exit-code").write_text("23")
-failed = run_installer(environment)
-assert failed.returncode == 23
-assert "installed" not in failed.stdout
+for label, functions, inherited in cases:
+    capture.unlink()
+    failed = run_installer(functions, inherited)
+    assert failed.returncode == 23, (label, failed.stderr)
+    assert failed.stdout == "", label
+    assert failed.stderr == "", label
+    assert json.loads(capture.read_text()) == expected_capture, label
 (temp / "exit-code").write_text("0")
 
 # Neither an absent nor a non-executable helper may request approval.
@@ -93,12 +137,14 @@ for missing in (False, True):
         helper.unlink()
     else:
         helper.chmod(0o644)
-    failed = run_installer(environment)
-    assert failed.returncode != 0
-    assert "helper not found" in failed.stderr
-    assert str(helper) in failed.stderr
-    assert "installed" not in failed.stdout
-    assert not capture.exists()
+    for label, functions, inherited in cases:
+        failed = run_installer(functions, inherited)
+        assert failed.returncode == 1, (label, failed.stderr)
+        assert failed.stderr == (
+            f"CodexBarCLI helper not found at {helper}. Please reinstall CodexBar.\n"
+        ), label
+        assert failed.stdout == "", label
+        assert not capture.exists(), label
 helper.write_text("#!/bin/sh\nexit 0\n")
 helper.chmod(0o755)
 

--- a/Scripts/test_install_codexbar_cli.sh
+++ b/Scripts/test_install_codexbar_cli.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-cli-installer.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+# macOS only: AppleScript evaluates the command as text, never with privileges.
+python3 - "$ROOT/bin/install-codexbar-cli.sh" "$TEMP_DIR" <<'PY'
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+assert sys.platform == "darwin", "The installer regression test requires macOS AppleScript."
+assert os.geteuid() != 0, "Run installer regression tests as a non-root user."
+source = Path(sys.argv[1]).read_text()
+temp = Path(sys.argv[2]).resolve()
+assert source.startswith("#!/bin/sh\nset -eu\n")
+app_line = 'APP="/Applications/CodexBar.app"'
+assert source.count(app_line) == 1
+assert source.count("/usr/bin/osascript") == 1
+assert 'HELPER="$APP/Contents/Helpers/CodexBarCLI"' in source
+
+app = temp / "CodexBar's spaced \"quoted\" $literal `name`\napp.app"
+helper = app / "Contents/Helpers/CodexBarCLI"
+helper.parent.mkdir(parents=True)
+helper.write_text("#!/bin/sh\nexit 0\n")
+helper.chmod(0o755)
+capture = temp / "capture.json"
+stub = temp / "osascript-stub"
+stub.write_text(f"#!{sys.executable}\n" + '''
+import json
+import os
+import sys
+from pathlib import Path
+
+temp = Path(__file__).parent
+(temp / "capture.json").write_text(json.dumps({
+    "args": sys.argv[1:], "script": sys.stdin.read(), "environment": dict(os.environ),
+}))
+sys.exit(int((temp / "exit-code").read_text()))
+''')
+stub.chmod(0o755)
+(temp / "exit-code").write_text("0")
+
+# Redirect only the helper fixture and osascript. No production test overrides.
+fixture = temp / "installer.sh"
+fixture.write_text(source.replace(app_line, "APP=" + shlex.quote(str(app)))
+                   .replace("/usr/bin/osascript", shlex.quote(str(stub))))
+fixture.chmod(0o755)
+environment = {"PATH": "/usr/bin:/bin:/usr/sbin:/sbin", "HOME": str(temp)}
+
+def run_installer(env):
+    return subprocess.run([str(fixture)], env=env, capture_output=True, text=True)
+
+baseline = run_installer(environment)
+assert baseline.returncode == 0, baseline.stderr
+assert "CodexBar CLI installed." in baseline.stdout
+expected_capture = json.loads(capture.read_text())
+assert expected_capture["args"] == ["-", str(helper)]
+assert expected_capture["environment"]["PATH"] == environment["PATH"]
+# Python/macOS may add locale metadata while starting the stub.
+assert set(expected_capture["environment"]) <= {
+    "PATH", "LC_CTYPE", "__CF_USER_TEXT_ENCODING",
+}, sorted(expected_capture["environment"])
+
+hook = temp / "startup-hook"
+hook.write_text("/bin/echo startup-hook-ran >&2\nexit 97\n")
+inherited = dict(environment, BASH_ENV=str(hook), ENV=str(hook), PATH=str(temp))
+for name in ("bash", "env", "osascript", "mkdir", "ln", "dirname", "echo", "printf", "set"):
+    for suffix in ("%%", "()"):
+        inherited[f"BASH_FUNC_{name}{suffix}"] = "() { /bin/echo inherited-function-ran >&2; return 98; }"
+contaminated = run_installer(inherited)
+assert contaminated.returncode == 0, contaminated.stderr
+assert contaminated.stdout == baseline.stdout
+assert contaminated.stderr == baseline.stderr
+assert json.loads(capture.read_text()) == expected_capture
+
+# An approval/installation error must propagate without a success banner.
+(temp / "exit-code").write_text("23")
+failed = run_installer(environment)
+assert failed.returncode == 23
+assert "installed" not in failed.stdout
+(temp / "exit-code").write_text("0")
+
+# Neither an absent nor a non-executable helper may request approval.
+for missing in (False, True):
+    capture.unlink(missing_ok=True)
+    if missing:
+        helper.unlink()
+    else:
+        helper.chmod(0o644)
+    failed = run_installer(environment)
+    assert failed.returncode != 0
+    assert "helper not found" in failed.stderr
+    assert str(helper) in failed.stderr
+    assert "installed" not in failed.stdout
+    assert not capture.exists()
+helper.write_text("#!/bin/sh\nexit 0\n")
+helper.chmod(0o755)
+
+# Return the actual AppleScript-generated command; never execute do shell script.
+applescript = expected_capture["script"]
+approval = "do shell script installCommand with administrator privileges"
+assert applescript.count(approval) == 1
+capture_script = applescript.replace(approval, "return installCommand")
+assert "do shell script" not in capture_script
+assert "administrator privileges" not in capture_script
+generated = subprocess.run(["/usr/bin/osascript", "-", str(helper)], input=capture_script,
+                           env=environment, capture_output=True, text=True, check=True).stdout
+assert shlex.split(generated) == [
+    "set", "-eu", "/bin/mkdir", "-p", "/usr/local/bin", "/opt/homebrew/bin",
+    "/bin/ln", "-sf", str(helper), "/usr/local/bin/codexbar",
+    "/bin/ln", "-sf", str(helper), "/opt/homebrew/bin/codexbar",
+]
+
+# Run only the captured shell body with both destinations replaced by temp paths.
+def local_command(case):
+    root = temp / case
+    command = generated.replace("/usr/local/bin", shlex.quote(str(root / "local/bin")))
+    command = command.replace("/opt/homebrew/bin", shlex.quote(str(root / "homebrew/bin")))
+    assert "/usr/local/bin" not in command and "/opt/homebrew/bin" not in command
+    return root, command
+
+root, command = local_command("success")
+subprocess.run(["/bin/sh", "-c", command], env=environment, check=True)
+for prefix in ("local", "homebrew"):
+    assert os.readlink(root / prefix / "bin/codexbar") == str(helper)
+
+for tool in ("/bin/mkdir", "/bin/ln"):
+    root, command = local_command(Path(tool).name + "-failure")
+    command = command.replace(tool, "/usr/bin/false", 1)
+    failed = subprocess.run(["/bin/sh", "-c", command], env=environment, capture_output=True)
+    assert failed.returncode != 0
+    assert not (root / "homebrew/bin/codexbar").is_symlink(), "Continued after an install failure"
+
+print("CLI installer tests passed (nonprivileged command capture and temporary symlinks).")
+PY

--- a/bin/install-codexbar-cli.sh
+++ b/bin/install-codexbar-cli.sh
@@ -1,29 +1,25 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 APP="/Applications/CodexBar.app"
 HELPER="$APP/Contents/Helpers/CodexBarCLI"
-TARGETS=("/usr/local/bin/codexbar" "/opt/homebrew/bin/codexbar")
 
-if [[ ! -x "$HELPER" ]]; then
-  echo "CodexBarCLI helper not found at $HELPER. Please reinstall CodexBar." >&2
+if [ ! -x "$HELPER" ]; then
+  /bin/echo "CodexBarCLI helper not found at $HELPER. Please reinstall CodexBar." >&2
   exit 1
 fi
 
-osascript - "$HELPER" <<'APPLESCRIPT'
+# Clear startup hooks and exported functions before entering the administrator shell.
+/usr/bin/env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin /usr/bin/osascript - "$HELPER" <<'APPLESCRIPT'
 on run argv
   set helperPath to item 1 of argv
-  set installCommand to "set -euo pipefail" & linefeed & ¬
-    "HELPER=" & quoted form of helperPath & linefeed & ¬
-    "TARGETS=(\"/usr/local/bin/codexbar\" \"/opt/homebrew/bin/codexbar\")" & linefeed & ¬
-    "for t in \"${TARGETS[@]}\"; do" & linefeed & ¬
-    "  mkdir -p \"$(dirname \"$t\")\"" & linefeed & ¬
-    "  ln -sf \"$HELPER\" \"$t\"" & linefeed & ¬
-    "  echo \"Linked $t -> $HELPER\"" & linefeed & ¬
-    "done"
+  set installCommand to "set -eu" & linefeed & ¬
+    "/bin/mkdir -p /usr/local/bin /opt/homebrew/bin" & linefeed & ¬
+    "/bin/ln -sf " & quoted form of helperPath & " /usr/local/bin/codexbar" & linefeed & ¬
+    "/bin/ln -sf " & quoted form of helperPath & " /opt/homebrew/bin/codexbar"
 
-  do shell script "bash -c " & quoted form of installCommand with administrator privileges
+  do shell script installCommand with administrator privileges
 end run
 APPLESCRIPT
 
-echo "CodexBar CLI installed. Try: codexbar usage"
+/bin/echo "CodexBar CLI installed. Try: codexbar usage"

--- a/bin/install-codexbar-cli.sh
+++ b/bin/install-codexbar-cli.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/sh -p
+# -p blocks inherited functions and startup hooks before validation; it does not elevate privileges.
 set -eu
 
 APP="/Applications/CodexBar.app"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,8 +13,13 @@ Use it when you need usage numbers in scripts, CI, or dashboards without UI.
 
 ## Install
 - In the app: **Preferences → Advanced → Install CLI**. This symlinks `CodexBarCLI` to `/usr/local/bin/codexbar` and `/opt/homebrew/bin/codexbar`.
-- From the repo, after installing `CodexBar.app` in `/Applications`: `./bin/install-codexbar-cli.sh` (same symlink targets).
+- From the repo, after installing `CodexBar.app` in `/Applications`: `./bin/install-codexbar-cli.sh` (same symlink targets; requires macOS administrator approval).
 - Manual: `ln -sf "/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI" /usr/local/bin/codexbar`.
+
+The repo installer requires an executable `/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI`; a missing
+helper is an error. It uses the system POSIX shell and absolute system tools, clears the inherited environment
+before requesting approval, and stops on installation failure. Caller shell startup hooks and exported shell
+functions are not passed to the administrator command. The in-app installer is separate and uses Foundation symlinks.
 
 ### Release tarball install (macOS/Linux)
 - Homebrew formula (Linux today): `brew install steipete/tap/codexbar`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,9 +17,10 @@ Use it when you need usage numbers in scripts, CI, or dashboards without UI.
 - Manual: `ln -sf "/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI" /usr/local/bin/codexbar`.
 
 The repo installer requires an executable `/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI`; a missing
-helper is an error. It uses the system POSIX shell and absolute system tools, clears the inherited environment
-before requesting approval, and stops on installation failure. Caller shell startup hooks and exported shell
-functions are not passed to the administrator command. The in-app installer is separate and uses Foundation symlinks.
+helper is an error. It starts the system POSIX shell with `-p` to ignore inherited functions and startup hooks
+before helper validation or failure handling. This shell mode does not elevate privileges; macOS administrator
+approval is still required. The installer uses absolute system tools, clears the inherited environment before
+requesting approval, and stops on installation failure. The in-app installer is separate and uses Foundation symlinks.
 
 ### Release tarball install (macOS/Linux)
 - Homebrew formula (Linux today): `brew install steipete/tap/codexbar`.


### PR DESCRIPTION
## Summary

Closes #3205.

The repository CLI installer previously launched a nested Bash process at the administrator boundary. This change starts the system POSIX shell with startup protection enabled, uses absolute system tools, and clears the inherited environment before starting AppleScript. The administrator approval requirement, helper validation, and both existing symlink destinations remain unchanged. Shell startup protection blocks inherited functions before validation and error handling; it does not elevate privileges.

Adds a focused regression test to local/macOS CI checks and documents the installer boundary. The in-app Foundation-based installer is unchanged.

## Verification

- `/bin/bash Scripts/test_install_codexbar_cli.sh` passed: actual macOS Bash-exported functions (including `[`, `set`, and `exit`), startup hooks, inherited shell options, quoting, missing or non-executable helper, fixed destinations, temporary symlink creation, and failure propagation. Positive controls confirm the unprotected system shell imports those functions.
- POSIX shell syntax, patch whitespace, and `make check` passed.
- Independent Codex review of the follow-up reported no actionable P0–P2 findings.
- Full `make test` passed: 933 selections across 78 groups, all passing on the first attempt, with no retries or timeouts. No Swift source changed afterward; focused installer checks and `make check` were rerun for the shell follow-up.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33012784084) passed for `be7cdba409ded64be6b678f279f8cc5f636b46c5`: Linux x64/ARM builds, tests and CLI smoke checks; both macOS Swift-test shards; installer/macOS lint checks; provider-engine goldens; and final aggregate. The unrelated musl job was skipped by the existing path gate. GitGuardian also passed.

No administrator request or real system-destination write was used for testing. AppleScript only returned the generated command; execution tests used temporary destinations. Actual macOS authorization behavior was not exercised.

Thanks @Vectrain51 for the report.
