### PR TITLE
fix: preserve OpenCode Go API percentage units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.55.2 — Unreleased
 
 ### Fixed
+- OpenCode Go: preserve API percentage units so 1% usage no longer appears as 100%, including local-history overlays (#3216). Thanks @rodrigoalma!
 - CLI install: block inherited shell functions and startup hooks before helper validation and failure handling, and use absolute tools and a clean administrator-command environment while retaining approval and both existing symlink destinations (#3205, #3217).
 
 ## 0.55.1 — 2026-08-25

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -237,7 +237,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         guard let text = String(data: response.data, encoding: .utf8) else {
             throw OpenCodeGoUsageError.parseFailed("Response was not UTF-8.")
         }
-        return try self.parseSubscription(text: text, now: now)
+        return try self.parseAPIUsage(text: text, now: now)
     }
 
     static func requiredZenBalanceFallback(
@@ -471,6 +471,29 @@ extension OpenCodeGoUsageFetcher {
             throw OpenCodeGoUsageError.parseFailed("Missing usage fields.")
         }
         return text
+    }
+
+    static func parseAPIUsage(text: String, now: Date) throws -> OpenCodeGoUsageSnapshot {
+        guard let data = text.data(using: .utf8),
+              let dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let usage = dict["usage"] as? [String: Any],
+              let rolling = usage["rolling"] as? [String: Any]
+        else {
+            throw OpenCodeGoUsageError.parseFailed("Missing usage fields.")
+        }
+        let renewsAt = self.dateValue(from: self.value(from: usage, keys: self.renewAtKeys))
+            ?? self.dateValue(from: self.value(from: dict, keys: self.renewAtKeys))
+        guard let snapshot = self.buildSnapshot(
+            rolling: rolling,
+            weekly: usage["weekly"] as? [String: Any],
+            monthly: usage["monthly"] as? [String: Any],
+            now: now,
+            renewsAt: renewsAt,
+            directPercentEncoding: .percent)
+        else {
+            throw OpenCodeGoUsageError.parseFailed("Missing usage fields.")
+        }
+        return snapshot
     }
 
     static func parseSubscription(text: String, now: Date) throws -> OpenCodeGoUsageSnapshot {
@@ -751,25 +774,35 @@ extension OpenCodeGoUsageFetcher {
         return nil
     }
 
+    private enum DirectPercentEncoding {
+        case percent
+        case fractionOrPercent
+    }
+
     private static func buildSnapshot(
         rolling: [String: Any],
         weekly: [String: Any]?,
         monthly: [String: Any]?,
         now: Date,
-        renewsAt: Date? = nil) -> OpenCodeGoUsageSnapshot?
+        renewsAt: Date? = nil,
+        directPercentEncoding: DirectPercentEncoding = .fractionOrPercent) -> OpenCodeGoUsageSnapshot?
     {
-        guard let rollingWindow = self.parseWindow(rolling, now: now) else {
+        guard let rollingWindow = self.parseWindow(rolling, now: now, directPercentEncoding: directPercentEncoding)
+        else {
             return nil
         }
 
         let weeklyWindow: (percent: Double, resetInSec: Int)?
         if let weekly {
-            guard let parsed = self.parseWindow(weekly, now: now) else { return nil }
+            guard let parsed = self.parseWindow(weekly, now: now, directPercentEncoding: directPercentEncoding)
+            else { return nil }
             weeklyWindow = parsed
         } else {
             weeklyWindow = nil
         }
-        let monthlyWindow = monthly.flatMap { self.parseWindow($0, now: now) }
+        let monthlyWindow = monthly.flatMap {
+            self.parseWindow($0, now: now, directPercentEncoding: directPercentEncoding)
+        }
 
         return OpenCodeGoUsageSnapshot(
             hasWeeklyUsage: weeklyWindow != nil,
@@ -784,7 +817,11 @@ extension OpenCodeGoUsageFetcher {
             updatedAt: now)
     }
 
-    private static func parseWindow(_ dict: [String: Any], now: Date) -> (percent: Double, resetInSec: Int)? {
+    private static func parseWindow(
+        _ dict: [String: Any],
+        now: Date,
+        directPercentEncoding: DirectPercentEncoding = .fractionOrPercent) -> (percent: Double, resetInSec: Int)?
+    {
         var percent: Double?
 
         for key in self.percentKeys {
@@ -793,8 +830,7 @@ extension OpenCodeGoUsageFetcher {
                 break
             }
         }
-        // A direct percent field may arrive as a fraction (0...1) or a percent (0...100), so it goes
-        // through the `<= 1` heuristic below. A computed used/limit percent is already 0...100 and must not.
+        // Dashboard JSON may use fractions. API fields and computed used/limit percentages already use 0...100.
         let percentIsDirect = percent != nil
 
         if percent == nil {
@@ -820,7 +856,7 @@ extension OpenCodeGoUsageFetcher {
         }
 
         guard var resolvedPercent = percent else { return nil }
-        if percentIsDirect, resolvedPercent <= 1.0, resolvedPercent >= 0 {
+        if percentIsDirect, directPercentEncoding == .fractionOrPercent, resolvedPercent <= 1.0, resolvedPercent >= 0 {
             resolvedPercent *= 100
         }
         resolvedPercent = max(0, min(100, resolvedPercent))

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -43,22 +43,41 @@ private final class OpenCodeGoContinuationBox<Value: Sendable>: @unchecked Senda
 
 @Suite(.serialized)
 struct OpenCodeGoUsageFetcherErrorTests {
-    @Test
-    func `public usage API sends bearer token and parses all windows`() async throws {
+    @Test(arguments: [
+        (12, 8, 35),
+        (3, 1, 0),
+        (1, 1, 1),
+        (0, 0, 0),
+        (100, 100, 100),
+        (0.5, 0.5, 0.5),
+        (1, nil, nil),
+        (1, 1, nil),
+        (1, nil, 1),
+    ] as [(Double, Double?, Double?)])
+    func `public usage API sends bearer token and preserves percent units`(
+        rolling: Double,
+        weekly: Double?,
+        monthly: Double?) async throws
+    {
         defer { OpenCodeGoStubURLProtocol.handler = nil }
+        let resetDates = [
+            "2026-08-12T02:00:00.000Z",
+            "2026-08-18T00:00:00.000Z",
+            "2026-09-01T00:00:00.000Z",
+        ]
+        var windows: [String: Any] = ["rolling": ["percent": rolling, "resetsAt": resetDates[0]]]
+        if let weekly {
+            windows["weekly"] = ["percent": weekly, "resetsAt": resetDates[1]]
+        }
+        if let monthly {
+            windows["monthly"] = ["percent": monthly, "resetsAt": resetDates[2]]
+        }
+        let data = try JSONSerialization.data(withJSONObject: ["usage": windows])
+        let body = try #require(String(data: data, encoding: .utf8))
         let requests = OpenCodeGoRequestRecorder<URLRequest>()
         OpenCodeGoStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
             requests.append(request)
-            let body = """
-            {
-              "usage": {
-                "rolling": {"percent": 12, "resetsAt": "2026-08-12T02:00:00.000Z"},
-                "weekly": {"percent": 8, "resetsAt": "2026-08-18T00:00:00.000Z"},
-                "monthly": {"percent": 35, "resetsAt": "2026-09-01T00:00:00.000Z"}
-              }
-            }
-            """
             return Self.makeResponse(url: url, body: body, statusCode: 200, contentType: "application/json")
         }
 
@@ -72,11 +91,18 @@ struct OpenCodeGoUsageFetcherErrorTests {
         #expect(requests.values.count == 1)
         #expect(requests.values.first?.url?.path == "/zen/go/v1/usage")
         #expect(requests.values.first?.value(forHTTPHeaderField: "Authorization") == "Bearer go_secret")
-        #expect(snapshot.rollingUsagePercent == 12)
-        #expect(snapshot.weeklyUsagePercent == 8)
-        #expect(snapshot.monthlyUsagePercent == 35)
-        #expect(snapshot.hasWeeklyUsage)
-        #expect(snapshot.hasMonthlyUsage)
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == rolling)
+        #expect(usage.secondary?.usedPercent == weekly)
+        #expect(usage.tertiary?.usedPercent == monthly)
+        #expect(snapshot.hasWeeklyUsage == (weekly != nil))
+        #expect(snapshot.hasMonthlyUsage == (monthly != nil))
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        #expect(usage.primary?.resetsAt == formatter.date(from: resetDates[0]))
+        #expect(usage.secondary?.resetsAt == weekly.flatMap { _ in formatter.date(from: resetDates[1]) })
+        #expect(usage.tertiary?.resetsAt == monthly.flatMap { _ in formatter.date(from: resetDates[2]) })
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenCodeGoUsageParserTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageParserTests.swift
@@ -251,18 +251,22 @@ struct OpenCodeGoUsageParserTests {
         #expect(snapshot.weeklyResetInSec == 7200)
     }
 
-    @Test
-    func `computes usage percent from totals and treats monthly as optional`() throws {
+    @Test(arguments: [(25.0, 100.0, 25.0), (1, 100, 1), (1, 200, 0.5)])
+    func `computes usage percent from totals and treats monthly as optional`(
+        used: Double,
+        limit: Double,
+        percent: Double) throws
+    {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let payload: [String: Any] = [
             "rollingUsage": [
-                "used": 25,
-                "limit": 100,
+                "used": used,
+                "limit": limit,
                 "resetInSec": 600,
             ],
             "weeklyUsage": [
-                "used": 50,
-                "limit": 200,
+                "used": used * 2,
+                "limit": limit * 2,
                 "resetInSec": 3600,
             ],
         ]
@@ -272,8 +276,8 @@ struct OpenCodeGoUsageParserTests {
         let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: now)
         let usage = snapshot.toUsageSnapshot()
 
-        #expect(snapshot.rollingUsagePercent == 25)
-        #expect(snapshot.weeklyUsagePercent == 25)
+        #expect(snapshot.rollingUsagePercent == percent)
+        #expect(snapshot.weeklyUsagePercent == percent)
         #expect(snapshot.hasMonthlyUsage == false)
         #expect(snapshot.monthlyUsagePercent == 0)
         #expect(snapshot.monthlyResetInSec == 0)

--- a/Tests/CodexBarTests/OpenCodeGoWebOverlayTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoWebOverlayTests.swift
@@ -259,15 +259,15 @@ struct OpenCodeGoWebOverlayTests {
             },
             apiUsageOverlayFetcher: { _, apiKey in
                 observedKeys.append(apiKey)
-                return OpenCodeGoUsageSnapshot(
-                    hasMonthlyUsage: true,
-                    rollingUsagePercent: 11,
-                    weeklyUsagePercent: 22,
-                    monthlyUsagePercent: 33,
-                    rollingResetInSec: 18100,
-                    weeklyResetInSec: 266_500,
-                    monthlyResetInSec: 1_539_100,
-                    updatedAt: Self.updatedAt.addingTimeInterval(3))
+                return try OpenCodeGoUsageFetcher.parseAPIUsage(
+                    text: """
+                    {"usage": {
+                      "rolling": {"percent": 3, "resetInSec": 18100},
+                      "weekly": {"percent": 1, "resetInSec": 266500},
+                      "monthly": {"percent": 0, "resetInSec": 1539100}
+                    }}
+                    """,
+                    now: Self.updatedAt.addingTimeInterval(3))
             })
 
         let result = try await strategy.fetch(self.makeContext(
@@ -277,11 +277,14 @@ struct OpenCodeGoWebOverlayTests {
         #expect(result.sourceLabel == "local+api")
         #expect(observedKeys.values == ["go_test"])
         #expect(webCalls.values == ["auth=test"])
-        #expect(result.usage.primary?.usedPercent == 11)
-        #expect(result.usage.secondary?.usedPercent == 22)
-        #expect(result.usage.tertiary?.usedPercent == 33)
+        #expect(result.usage.primary?.usedPercent == 3)
+        #expect(result.usage.secondary?.usedPercent == 1)
+        #expect(result.usage.tertiary?.usedPercent == 0)
         #expect(result.usage.opencodegoUsage?.daily.count == 1)
+        #expect(result.usage.opencodegoUsage?.daily.first?.costUSD == 11.52)
+        #expect(result.usage.opencodegoUsage?.daily.first?.requestCount == 748)
         #expect(result.usage.providerCost?.used == 42.5)
+        #expect(result.usage.dataConfidence != .estimated)
     }
 
     @Test

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -17,6 +17,8 @@ read_when:
   - `subscription.get` (`7abeebee372f304e050aaaf92be863f4a86490e382f8c79db68fd94040d691b4`)
 
 ## Usage mapping
+- The Go usage API reports `usage.rolling/weekly/monthly.percent` in percentage units (0...100): `1` means 1%, and
+  `0.5` means 0.5%. Generic dashboard JSON still accepts fractional usage values (0...1).
 - Primary window: rolling 5-hour usage (`rollingUsage.usagePercent`, `rollingUsage.resetInSec`).
 - Secondary window: optional weekly usage (`weeklyUsage.usagePercent`, `weeklyUsage.resetInSec`).
 - Resets computed as `now + resetInSec`.


### PR DESCRIPTION
## Summary

Closes #3216.

OpenCode Go's public usage API returns percentages in 0...100 units. The generic dashboard parser also accepts fractions, so its heuristic turned an API value of 1 into 100 and 0.5 into 50. This repair makes the API's units explicit while preserving generic dashboard fraction support, computed ratios, reset parsing, optional windows, and local cost history.

Upstream contract: [OpenCode subscription usage calculations](https://github.com/anomalyco/opencode/blob/dev/packages/console/core/src/subscription.ts).

Thanks @rodrigoalma for the report and reproduction.

## Verification

- The new API regression failed on the old parser, reproducing the reported scaling error.
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter 'OpenCodeGoUsageFetcherErrorTests|OpenCodeGoUsageParserTests|OpenCodeGoWebOverlayTests|OpenCodeGoProviderStrategyTests|OpenCodeGoPercentUnitLinuxTests'` passed 80 tests across four macOS suites. This does not claim execution of the Linux-only suite; Linux execution is covered by CI.
- API response cases cover `3 / 1 / 0`, all windows at 1, 0 and 100, fractional percentages such as 0.5, reset timestamps and absent weekly/monthly windows. Parsed API overlays retain local daily cost/request history and authoritative confidence. Existing dashboard fraction and low computed-ratio behavior stays covered.
- `make check` and `git diff --check` passed.
- Independent Codex review reported no actionable blockers.
- Full `make test` passed all 78 groups (933 selections) on the first attempt, with no failures, retries or timeouts.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33016333157) passed for `7e127c21dfeceb042aad2f71e37e4c13dd76df98`: Linux x64/ARM builds, tests and smoke checks; Linux musl build; both macOS test shards; provider-engine goldens; lint and the aggregate check. GitGuardian passed as well.

No live credentials, account probes, cookie imports or app restart were used; endpoint responses are exercised with the existing URLSession stub seam. Authentication and persisted usage data are unchanged.
