### PR TITLE
ci: require Linux matrix success in aggregate checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,7 @@ jobs:
       - lint
       - swift-test-macos
       - build-linux-musl-cli
+      - build-linux-cli
     if: ${{ always() && !cancelled() }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -230,7 +231,8 @@ jobs:
             "${{ needs.swift-test-macos.result }}" \
             "${{ needs.changes.outputs.macos-tests-deferred }}" \
             "${{ needs.changes.outputs.linux-musl-build }}" \
-            "${{ needs.build-linux-musl-cli.result }}"
+            "${{ needs.build-linux-musl-cli.result }}" \
+            "${{ needs.build-linux-cli.result }}"
 
       - name: Summarize aggregate CI gate
         if: ${{ always() }}
@@ -245,6 +247,7 @@ jobs:
           LINUX_MUSL_BUILD: ${{ needs.changes.outputs.linux-musl-build }}
           LINUX_MUSL_BUILD_REASON: ${{ needs.changes.outputs.linux-musl-build-reason }}
           LINUX_MUSL_RESULT: ${{ needs.build-linux-musl-cli.result }}
+          LINUX_RESULT: ${{ needs.build-linux-cli.result }}
         run: |
           set -euo pipefail
           reason="${MACOS_TESTS_REASON:-<unset>}"
@@ -264,6 +267,7 @@ jobs:
             printf '| Linux musl build required | `%s` |\n' "${LINUX_MUSL_BUILD:-<unset>}"
             printf '| Linux musl gate reason | %s |\n' "$musl_reason"
             printf '| build-linux-musl-cli result | `%s` |\n' "$LINUX_MUSL_RESULT"
+            printf '| build-linux-cli matrix result | `%s` |\n' "$LINUX_RESULT"
           } >> "$GITHUB_STEP_SUMMARY"
 
   build-linux-musl-cli:

--- a/Scripts/ci_verify_test_jobs.sh
+++ b/Scripts/ci_verify_test_jobs.sh
@@ -9,6 +9,7 @@ macos_test_result="${4:-}"
 macos_tests_deferred="${5:-}"
 linux_musl_build_required="${6:-}"
 linux_musl_build_result="${7:-}"
+linux_build_result="${8-<missing>}"
 
 if [[ "$lint_result" != "success" ]]; then
   printf 'lint job finished with %s\n' "${lint_result:-<empty>}" >&2
@@ -17,6 +18,11 @@ fi
 
 if [[ "$changes_result" != "success" ]]; then
   printf 'changes job finished with %s\n' "${changes_result:-<empty>}" >&2
+  exit 1
+fi
+
+if [[ "$linux_build_result" != "success" ]]; then
+  printf 'build-linux-cli matrix finished with %s; expected success\n' "${linux_build_result:-<empty>}" >&2
   exit 1
 fi
 
@@ -38,6 +44,8 @@ case "${macos_tests_required}:${macos_tests_deferred}:${macos_test_result}" in
     exit 1
     ;;
 esac
+
+printf 'Linux glibc CLI matrix passed.\n'
 
 case "${linux_musl_build_required}:${linux_musl_build_result}" in
   true:success)

--- a/Scripts/test_ci_path_gate.sh
+++ b/Scripts/test_ci_path_gate.sh
@@ -199,10 +199,10 @@ if [[ -s "$unterminated_output" ]]; then
 fi
 
 verify="${ROOT_DIR}/Scripts/ci_verify_test_jobs.sh"
-"$verify" success success true success false true success >/dev/null
-"$verify" success success true success false false skipped >/dev/null
-"$verify" success success false skipped false true success >/dev/null
-"$verify" success success false skipped false false skipped >/dev/null
+"$verify" success success true success false true success success >/dev/null
+"$verify" success success true success false false skipped success >/dev/null
+"$verify" success success false skipped false true success success >/dev/null
+"$verify" success success false skipped false false skipped success >/dev/null
 
 assert_verify_fails() {
   if "$verify" "$@" >/dev/null 2>&1; then
@@ -211,16 +211,81 @@ assert_verify_fails() {
   fi
 }
 
-assert_verify_fails success success true skipped false true success
-assert_verify_fails success success true skipped true true success
-assert_verify_fails success success false skipped true true success
-assert_verify_fails success success true success true true success
-assert_verify_fails success success false success false true success
-assert_verify_fails success success "" skipped false true success
-assert_verify_fails failure success true success false true success
-assert_verify_fails success failure true success false true success
-assert_verify_fails success success true success false true skipped
-assert_verify_fails success success true success false false success
-assert_verify_fails success success true success false "" skipped
+assert_verify_fails success success true skipped false true success success
+assert_verify_fails success success true skipped true true success success
+assert_verify_fails success success false skipped true true success success
+assert_verify_fails success success true success true true success success
+assert_verify_fails success success false success false true success success
+assert_verify_fails success success "" skipped false true success success
+assert_verify_fails failure success true success false true success success
+assert_verify_fails success failure true success false true success success
+assert_verify_fails success success true success false true skipped success
+assert_verify_fails success success true success false false success success
+assert_verify_fails success success true success false "" skipped success
+
+assert_linux_verify_fails() {
+  local expected="$1"
+  local error_file="${tmp_dir}/linux-verify.error"
+  shift
+  if "$verify" "$@" >/dev/null 2>"$error_file"; then
+    printf 'unexpected Linux aggregate success: %s\n' "$*" >&2
+    exit 1
+  fi
+  if ! grep -Fxq "build-linux-cli matrix finished with ${expected}; expected success" "$error_file"; then
+    printf 'expected Linux matrix diagnostic for %s\n' "$expected" >&2
+    cat "$error_file" >&2
+    exit 1
+  fi
+}
+
+for macos_required in true false; do
+  macos_result=success
+  [[ "$macos_required" == true ]] || macos_result=skipped
+  for musl_required in true false; do
+    musl_result=success
+    [[ "$musl_required" == true ]] || musl_result=skipped
+    valid_args=(success success "$macos_required" "$macos_result" false "$musl_required" "$musl_result")
+    for linux_result in failure cancelled skipped '' unknown; do
+      assert_linux_verify_fails "${linux_result:-<empty>}" "${valid_args[@]}" "$linux_result"
+    done
+    assert_linux_verify_fails '<missing>' "${valid_args[@]}"
+
+    for failed_result in failure cancelled; do
+      assert_verify_fails "$failed_result" success "$macos_required" "$macos_result" \
+        false "$musl_required" "$musl_result" success
+      assert_verify_fails success "$failed_result" "$macos_required" "$macos_result" \
+        false "$musl_required" "$musl_result" success
+      if [[ "$macos_required" == true ]]; then
+        assert_verify_fails success success true "$failed_result" false "$musl_required" "$musl_result" success
+      fi
+      if [[ "$musl_required" == true ]]; then
+        assert_verify_fails success success "$macos_required" "$macos_result" false true "$failed_result" success
+      fi
+    done
+  done
+done
+
+# Check the actual aggregate dependency and shell argument, not summary text elsewhere in the workflow.
+python3 - "${ROOT_DIR}/.github/workflows/ci.yml" <<'PY'
+import pathlib
+import re
+import shlex
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text()
+aggregate = re.search(r"(?ms)^  lint-build-test:\n(.*?)(?=^  [\w-]+:|\Z)", workflow)
+if aggregate is None:
+    sys.exit("missing lint-build-test aggregate")
+body = aggregate.group(1)
+needs = re.search(r"(?m)^    needs:\n((?:      - [^\n]+\n)+)", body)
+if needs is None or "      - build-linux-cli" not in needs.group(1).splitlines():
+    sys.exit("lint-build-test must need build-linux-cli")
+command = re.search(r"(?m)^          \./Scripts/ci_verify_test_jobs\.sh(?:[^\n]*\\\n)+[^\n]*", body)
+if command is None:
+    sys.exit("missing aggregate verifier command")
+arguments = shlex.split(command.group(0).replace("\\\n", ""))
+if len(arguments) != 9 or arguments[8] != "${{ needs.build-linux-cli.result }}":
+    sys.exit("aggregate verifier argument eight must be needs.build-linux-cli.result")
+PY
 
 printf 'CI path gate tests passed.\n'

--- a/Tests/CodexBarTests/StatusMenuOverviewScrollTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOverviewScrollTests.swift
@@ -4,28 +4,76 @@ import Foundation
 import Testing
 @testable import CodexBar
 
+private final class OverviewScrollEvent: NSEvent {
+    private let delta: CGFloat
+    private let precise: Bool
+
+    init(deltaY: CGFloat, precise: Bool) {
+        self.delta = deltaY
+        self.precise = precise
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var type: NSEvent.EventType {
+        .scrollWheel
+    }
+
+    override var scrollingDeltaY: CGFloat {
+        self.delta
+    }
+
+    override var hasPreciseScrollingDeltas: Bool {
+        self.precise
+    }
+
+    override var momentumPhase: NSEvent.Phase {
+        []
+    }
+}
+
 @MainActor
 struct StatusMenuOverviewScrollTests {
-    private func makeController(suiteName: String) -> StatusItemController {
-        _ = NSApplication.shared
+    private func makeController(suiteName: String) throws -> StatusItemController {
+        let suite = "\(suiteName)-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        // Scroll navigation needs neither saved app-group data nor legacy account migration.
+        defaults.set(AppGroupSupport.migrationVersion, forKey: AppGroupSupport.migrationVersionKey)
+        defaults.set(true, forKey: "codexbar.legacySecretsMigrationCompleted")
+        let configStore = testConfigStore(suiteName: suite)
+        try configStore.save(CodexBarConfig(providers: UsageProvider.allCases.map {
+            ProviderConfig(id: $0.instanceID, enabled: false)
+        }))
         let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: suiteName),
+            userDefaults: defaults,
+            configStore: configStore,
             zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore(),
+            performInitialProviderDetection: false)
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
-        let fetcher = UsageFetcher()
+        settings.mergeIcons = true
+        let fetcher = UsageFetcher(environment: [:])
         let store = UsageStore(
             fetcher: fetcher,
             browserDetection: BrowserDetection(cacheTTL: 0),
-            settings: settings)
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
         return StatusItemController(
             store: store,
             settings: settings,
-            account: fetcher.loadAccountInfo(),
+            account: AccountInfo(email: nil, plan: nil),
             updater: DisabledUpdaterController(),
             preferencesSelection: PreferencesSelection(),
-            statusBar: .system)
+            statusBar: .system,
+            menuCardRenderingEnabled: false,
+            menuRefreshEnabled: false,
+            observeProviderConfigNotifications: false)
     }
 
     private func makeOverviewMenu() -> NSMenu {
@@ -39,40 +87,45 @@ struct StatusMenuOverviewScrollTests {
         return menu
     }
 
-    private func makeScrollEvent(deltaY: Double, precise: Bool) -> NSEvent? {
-        guard let cgEvent = CGEvent(
-            scrollWheelEvent2Source: nil,
-            units: precise ? .pixel : .line,
-            wheelCount: 1,
-            wheel1: Int32(deltaY),
-            wheel2: 0,
-            wheel3: 0)
-        else { return nil }
-        return NSEvent(cgEvent: cgEvent)
+    private func makeScrollEvent(deltaY: CGFloat, precise: Bool) -> NSEvent {
+        // CGEvent line-scroll conversion can yield zero deltas depending on host state.
+        // Supply the handler's NSEvent inputs directly without posting an event.
+        OverviewScrollEvent(deltaY: deltaY, precise: precise)
+    }
+
+    @Test(arguments: [CGFloat(-1), 0, 0.5, 1, 30, 500], [false, true])
+    func `synthetic scroll events preserve handler inputs`(deltaY: CGFloat, precise: Bool) {
+        let event = self.makeScrollEvent(deltaY: deltaY, precise: precise)
+        #expect(event.type == .scrollWheel)
+        #expect(event.scrollingDeltaY == deltaY)
+        #expect(event.hasPreciseScrollingDeltas == precise)
+        #expect(event.momentumPhase.isEmpty)
     }
 
     @Test
     func `coarse wheel steps move highlight and respect direction`() throws {
-        let controller = self.makeController(suiteName: "OverviewScroll-Direction")
+        let controller = try self.makeController(suiteName: "OverviewScroll-Direction")
         defer { controller.releaseStatusItemsForTesting() }
         let menu = self.makeOverviewMenu()
 
         var steps: [OverviewScrollStep] = []
         controller.overviewScrollNavigationHandlerForTesting = { steps.append($0) }
 
-        let scrollUp = try #require(self.makeScrollEvent(deltaY: 1, precise: false))
-        #expect(controller.handleOverviewScrollWheel(scrollUp, menu: menu))
+        let scrollUp = self.makeScrollEvent(deltaY: 1, precise: false)
+        let handledUp = controller.handleOverviewScrollWheel(scrollUp, menu: menu)
+        #expect(handledUp)
         #expect(steps == [.up])
 
         steps = []
-        let scrollDown = try #require(self.makeScrollEvent(deltaY: -1, precise: false))
-        #expect(controller.handleOverviewScrollWheel(scrollDown, menu: menu))
+        let scrollDown = self.makeScrollEvent(deltaY: -1, precise: false)
+        let handledDown = controller.handleOverviewScrollWheel(scrollDown, menu: menu)
+        #expect(handledDown)
         #expect(steps == [.down])
     }
 
     @Test
-    func `navigation targets only overview rows`() {
-        let controller = self.makeController(suiteName: "OverviewScroll-Targets")
+    func `navigation targets only overview rows`() throws {
+        let controller = try self.makeController(suiteName: "OverviewScroll-Targets")
         defer { controller.releaseStatusItemsForTesting() }
         let menu = self.makeOverviewMenu()
         let refresh = NSMenuItem(title: "Refresh", action: nil, keyEquivalent: "")
@@ -97,21 +150,22 @@ struct StatusMenuOverviewScrollTests {
 
     @Test
     func `precise trackpad scrolling is passed through to native menu scrolling`() throws {
-        let controller = self.makeController(suiteName: "OverviewScroll-Precise")
+        let controller = try self.makeController(suiteName: "OverviewScroll-Precise")
         defer { controller.releaseStatusItemsForTesting() }
         let menu = self.makeOverviewMenu()
 
         var steps: [OverviewScrollStep] = []
         controller.overviewScrollNavigationHandlerForTesting = { steps.append($0) }
 
-        let scroll = try #require(self.makeScrollEvent(deltaY: 30, precise: true))
-        #expect(!controller.handleOverviewScrollWheel(scroll, menu: menu))
+        let scroll = self.makeScrollEvent(deltaY: 30, precise: true)
+        let handled = controller.handleOverviewScrollWheel(scroll, menu: menu)
+        #expect(!handled)
         #expect(steps.isEmpty)
     }
 
     @Test
     func `precise trackpad scrolling clears wheel accumulation`() throws {
-        let controller = self.makeController(suiteName: "OverviewScroll-PreciseReset")
+        let controller = try self.makeController(suiteName: "OverviewScroll-PreciseReset")
         defer { controller.releaseStatusItemsForTesting() }
         let menu = self.makeOverviewMenu()
 
@@ -119,57 +173,61 @@ struct StatusMenuOverviewScrollTests {
         controller.overviewScrollNavigationHandlerForTesting = { steps.append($0) }
 
         controller.overviewScrollAccumulatedDelta = 0.5
-        let scroll = try #require(self.makeScrollEvent(deltaY: 30, precise: true))
-        #expect(!controller.handleOverviewScrollWheel(scroll, menu: menu))
+        let scroll = self.makeScrollEvent(deltaY: 30, precise: true)
+        let handled = controller.handleOverviewScrollWheel(scroll, menu: menu)
+        #expect(!handled)
         #expect(steps.isEmpty)
         #expect(controller.overviewScrollAccumulatedDelta == 0)
     }
 
     @Test
     func `coarse wheel lines step immediately`() throws {
-        let controller = self.makeController(suiteName: "OverviewScroll-Wheel")
+        let controller = try self.makeController(suiteName: "OverviewScroll-Wheel")
         defer { controller.releaseStatusItemsForTesting() }
         let menu = self.makeOverviewMenu()
 
         var steps: [OverviewScrollStep] = []
         controller.overviewScrollNavigationHandlerForTesting = { steps.append($0) }
 
-        let wheelNotch = try #require(self.makeScrollEvent(deltaY: -1, precise: false))
-        #expect(controller.handleOverviewScrollWheel(wheelNotch, menu: menu))
+        let wheelNotch = self.makeScrollEvent(deltaY: -1, precise: false)
+        let handled = controller.handleOverviewScrollWheel(wheelNotch, menu: menu)
+        #expect(handled)
         #expect(steps == [.down])
     }
 
     @Test
     func `fast flick is capped per event`() throws {
-        let controller = self.makeController(suiteName: "OverviewScroll-Cap")
+        let controller = try self.makeController(suiteName: "OverviewScroll-Cap")
         defer { controller.releaseStatusItemsForTesting() }
         let menu = self.makeOverviewMenu()
 
         var steps: [OverviewScrollStep] = []
         controller.overviewScrollNavigationHandlerForTesting = { steps.append($0) }
 
-        let flick = try #require(self.makeScrollEvent(deltaY: 500, precise: false))
-        #expect(controller.handleOverviewScrollWheel(flick, menu: menu))
+        let flick = self.makeScrollEvent(deltaY: 500, precise: false)
+        let handled = controller.handleOverviewScrollWheel(flick, menu: menu)
+        #expect(handled)
         #expect(steps == [.up, .up, .up])
     }
 
     @Test
     func `precise flick is passed through instead of being capped into highlight jumps`() throws {
-        let controller = self.makeController(suiteName: "OverviewScroll-PreciseFlick")
+        let controller = try self.makeController(suiteName: "OverviewScroll-PreciseFlick")
         defer { controller.releaseStatusItemsForTesting() }
         let menu = self.makeOverviewMenu()
 
         var steps: [OverviewScrollStep] = []
         controller.overviewScrollNavigationHandlerForTesting = { steps.append($0) }
 
-        let flick = try #require(self.makeScrollEvent(deltaY: 500, precise: true))
-        #expect(!controller.handleOverviewScrollWheel(flick, menu: menu))
+        let flick = self.makeScrollEvent(deltaY: 500, precise: true)
+        let handled = controller.handleOverviewScrollWheel(flick, menu: menu)
+        #expect(!handled)
         #expect(steps.isEmpty)
     }
 
     @Test
     func `open submenu suspends scroll navigation`() throws {
-        let controller = self.makeController(suiteName: "OverviewScroll-Submenu")
+        let controller = try self.makeController(suiteName: "OverviewScroll-Submenu")
         defer { controller.releaseStatusItemsForTesting() }
         let menu = self.makeOverviewMenu()
         let submenu = NSMenu()
@@ -180,14 +238,15 @@ struct StatusMenuOverviewScrollTests {
         var steps: [OverviewScrollStep] = []
         controller.overviewScrollNavigationHandlerForTesting = { steps.append($0) }
 
-        let scroll = try #require(self.makeScrollEvent(deltaY: 1, precise: false))
-        #expect(!controller.handleOverviewScrollWheel(scroll, menu: menu))
+        let scroll = self.makeScrollEvent(deltaY: 1, precise: false)
+        let handled = controller.handleOverviewScrollWheel(scroll, menu: menu)
+        #expect(!handled)
         #expect(steps.isEmpty)
     }
 
     @Test
     func `menus without overview rows ignore scrolling`() throws {
-        let controller = self.makeController(suiteName: "OverviewScroll-NonOverview")
+        let controller = try self.makeController(suiteName: "OverviewScroll-NonOverview")
         defer { controller.releaseStatusItemsForTesting() }
         let menu = NSMenu()
         menu.addItem(NSMenuItem(title: "Refresh", action: nil, keyEquivalent: ""))
@@ -195,8 +254,9 @@ struct StatusMenuOverviewScrollTests {
         var steps: [OverviewScrollStep] = []
         controller.overviewScrollNavigationHandlerForTesting = { steps.append($0) }
 
-        let scroll = try #require(self.makeScrollEvent(deltaY: 1, precise: false))
-        #expect(!controller.handleOverviewScrollWheel(scroll, menu: menu))
+        let scroll = self.makeScrollEvent(deltaY: 1, precise: false)
+        let handled = controller.handleOverviewScrollWheel(scroll, menu: menu)
+        #expect(!handled)
         #expect(steps.isEmpty)
         #expect(!menu.items.isEmpty)
     }

--- a/TestsLinux/AntigravityLocalhostSessionLifetimeTests.swift
+++ b/TestsLinux/AntigravityLocalhostSessionLifetimeTests.swift
@@ -12,10 +12,8 @@ import Musl
 #endif
 @testable import CodexBarCore
 
-/// Regression coverage for #2243: the Antigravity localhost probe must reuse one
-/// process-lifetime URLSession instead of creating and invalidating a session per
-/// request, which exercised a FoundationNetworking/libdispatch socket-teardown
-/// race on Linux (swiftlang/swift-corelibs-foundation#4791).
+/// Covers the process-lifetime session-reuse contract from the #2243 mitigation,
+/// without establishing the root cause of Linux FoundationNetworking/libdispatch crashes.
 struct AntigravityLocalhostSessionLifetimeTests {
     @Test
     func `localhost requests reuse one session and delegate`() {
@@ -28,42 +26,43 @@ struct AntigravityLocalhostSessionLifetimeTests {
 
     @Test
     func `concurrent requests to a closed localhost port all throw without teardown churn`() async throws {
-        let port = try Self.closedLoopbackPort()
-        let thrownCount = await withTaskGroup(of: Bool.self) { group in
-            for _ in 0..<32 {
-                group.addTask {
-                    do {
-                        _ = try await AntigravityStatusProbe.makeRequest(
-                            payload: AntigravityStatusProbe.RequestPayload(path: "/closed", body: [:]),
-                            context: AntigravityStatusProbe.RequestContext(
-                                endpoints: [
-                                    AntigravityStatusProbe.AntigravityConnectionEndpoint(
-                                        scheme: "http",
-                                        port: port,
-                                        csrfToken: "",
-                                        source: .languageServer),
-                                ],
-                                timeout: 0.5))
-                        return false
-                    } catch {
-                        return true
+        try await Self.withClosedLoopbackPort { port in
+            let thrownCount = await withTaskGroup(of: Bool.self) { group in
+                for _ in 0..<32 {
+                    group.addTask {
+                        do {
+                            _ = try await AntigravityStatusProbe.makeRequest(
+                                payload: AntigravityStatusProbe.RequestPayload(path: "/closed", body: [:]),
+                                context: AntigravityStatusProbe.RequestContext(
+                                    endpoints: [
+                                        AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                                            scheme: "http",
+                                            port: port,
+                                            csrfToken: "",
+                                            source: .languageServer),
+                                    ],
+                                    timeout: 0.5))
+                            return false
+                        } catch {
+                            return true
+                        }
                     }
                 }
+
+                var count = 0
+                for await didThrow in group where didThrow {
+                    count += 1
+                }
+                return count
             }
 
-            var count = 0
-            for await didThrow in group where didThrow {
-                count += 1
-            }
-            return count
+            #expect(thrownCount == 32)
         }
-
-        #expect(thrownCount == 32)
     }
 
-    /// Reserves an ephemeral loopback port and releases it so requests hit a
-    /// guaranteed-closed port (connection refused) without external traffic.
-    private static func closedLoopbackPort() throws -> Int {
+    /// Keeps an ephemeral loopback socket bound but not listening until requests finish,
+    /// preventing another process from reusing the port while connections are refused.
+    private static func withClosedLoopbackPort(_ operation: (Int) async -> Void) async throws {
         #if canImport(Glibc)
         let streamType = Int32(SOCK_STREAM.rawValue)
         #else
@@ -94,6 +93,6 @@ struct AntigravityLocalhostSessionLifetimeTests {
             }
         }
         guard nameResult == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
-        return Int(UInt16(bigEndian: address.sin_port))
+        await operation(Int(UInt16(bigEndian: address.sin_port)))
     }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -100,7 +100,7 @@ CodexBar/
 ├── Sources/CodexBarWidget/    # WidgetKit support
 ├── WidgetExtension/           # Xcode wrapper for the packaged widget extension
 ├── Tests/CodexBarTests/       # macOS app/core test suite (XCTest + Swift Testing)
-├── TestsLinux/                # Linux-specific CLI/core test coverage
+├── TestsLinux/                # Portable and Linux-specific CLI/core tests (target exists on macOS too)
 └── Scripts/                   # Build and packaging scripts
 ```
 
@@ -131,6 +131,20 @@ See the canonical [provider authoring guide](provider.md#adding-a-new-provider) 
 ```bash
 make test
 ```
+
+### CI Aggregate Contract
+
+The `lint-build-test` check in `.github/workflows/ci.yml` keeps its existing name and requires successful lint,
+change detection, and the full `build-linux-cli` glibc matrix (x86_64 and ARM64 build, tests, and smoke checks).
+Glibc Linux has no path or draft skip: failure, cancellation, skipped, empty, missing, or unknown matrix results
+fail verification. macOS tests and the musl build may skip only when their path gates allow it; required macOS
+tests deferred for a draft still leave the aggregate incomplete. Whole-workflow cancellation retains the existing
+`always() && !cancelled()` condition, so the verifier does not run in that case.
+
+`Scripts/test_ci_path_gate.sh` checks these result combinations and the workflow's Linux dependency and eighth
+verifier argument. `CodexBarLinuxTests` includes the portable `AntigravityLocalhostSessionLifetimeTests` suite on
+both macOS and Linux. It checks session reuse and concurrent synthetic loopback failures without credentials;
+this coverage does not establish or fix the cause of Linux dispatch crashes.
 
 ### Format Code
 ```bash


### PR DESCRIPTION
## Summary

Make the existing `lint-build-test` aggregate wait for and validate the glibc Linux build/test matrix. Previously it could report success while a regular Linux job failed. The check name, matrix fail-fast setting, macOS/musl path rules, draft behavior and branch-protection settings are unchanged.

The verifier now requires an explicit successful Linux result. Tests cover failure, cancellation, skipped, empty, missing and unknown results across the existing valid path combinations, preserve the older failure cases, and verify the real workflow dependency and argument wiring.

Move the existing portable `AntigravityLocalhostSessionLifetimeTests` into `CodexBarLinuxTests`, which runs on macOS and Linux, instead of leaving this Linux-related regression only in the macOS app target. Keep its synthetic loopback socket bound but non-listening until all concurrent requests finish, preventing port reuse during the test. Document the CI contract.

Full-suite validation also exposed a host-dependent Overview scroll test fixture: synthetic coarse CGEvents sometimes converted to zero NSEvent scroll deltas. A separate test-only follow-up now supplies deterministic NSEvent properties, validates those inputs, isolates settings/account state, and preserves all navigation assertions. Boolean assertions avoid dumping controller/store graphs. Production scroll behavior is unchanged; the underlying CoreGraphics trigger is not diagnosed or claimed fixed.

Related context: #2243. This does **not** identify or fix the cause of the intermittent Linux dispatch crash, change provider networking, upgrade toolchains, or add blanket test serialization/retries. The [observed ARM/glibc test failure](https://github.com/steipete/CodexBar/actions/runs/33015426853/job/98332283290) passed on one [exact-job retry](https://github.com/steipete/CodexBar/actions/runs/33015426853/job/98341427727); that is not root-cause proof.

## Verification

- `bash -n Scripts/ci_verify_test_jobs.sh Scripts/test_ci_path_gate.sh` passed.
- `./Scripts/test_ci_path_gate.sh` passed, including result matrix and workflow-wiring checks.
- `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter AntigravityLocalhostSessionLifetimeTests` passed both moved tests on macOS. Initial-head Linux x64/ARM CI also passed the moved suite; final-head CI remains required.
- `make check` passed with zero violations; the moved file also received explicit formatting/lint checks.
- Independent Codex review reported no actionable blockers.
- The first full `make test` stopped at group 68 on three existing `StatusMenuOverviewScrollTests` cases, repeated on the harness's group retry. The unchanged focused run reproduced them; safe probes observed zero coarse-event deltas and later normal values. The test-only follow-up passed the focused 10-test suite (including 12 fixture input combinations), the exact 115-test/11-suite group, `make check`, and independent review without retries.
- Final-head full `make test` passed all 933 selections in 78 groups: every group first-pass, zero failures, retries or timeouts, 799.2 seconds. Run with test Keychain access suppressed and the allow override unset.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33021300045) at `9582144959ef1e479d0edfa3023a6892a3e78117` passed: lint, Linux x64/ARM builds/tests/smoke checks, both macOS shards and provider-engine goldens, and the aggregate. Musl was correctly skipped by the unchanged path gate. GitHub initially did not create a run after the follow-up push; reopening the same PR retriggered CI without changing the commit. An earlier same-head run was superseded/cancelled, not a test failure; the final watcher recovered from a local network error.

No real provider account, saved credential, app restart, or external network probe was used. The loopback test uses only its reserved synthetic local port. No changelog entry is needed for this internal CI/test-only change.
