### PR TITLE
fix: resolve Antigravity quotas independently per cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.55.2 — Unreleased
 
 ### Fixed
+- Antigravity: select the most constrained known quota independently for session and weekly menu-bar layout tokens, so unused model families no longer mask consumed quota (#3206). Thanks @foobra!
 - OpenCode Go: preserve API percentage units so 1% usage no longer appears as 100%, including local-history overlays (#3216). Thanks @rodrigoalma!
 - CLI install: block inherited shell functions and startup hooks before helper validation and failure handling, and use absolute tools and a clean administrator-command environment while retaining approval and both existing symlink destinations (#3205, #3217).
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -61,6 +61,7 @@ public enum AntigravityProviderDescriptor {
                 iconWindowResolver: self.iconWindows,
                 // Provider-specific by design: Antigravity decorates its mixed-model usage with the Gemini badge.
                 iconDecorations: [.gemini, .antigravity],
+                semanticWindowResolver: self.semanticWindows,
                 requestedMenuBarLaneOrders: [
                     .primary: [.primary, .secondary, .tertiary],
                     .secondary: [.secondary, .primary, .tertiary],
@@ -86,6 +87,18 @@ public enum AntigravityProviderDescriptor {
 
     private static let quotaSummaryPrefix = "antigravity-quota-summary-"
     private static let compactFallbackPrefix = "antigravity-compact-fallback-"
+
+    private static func semanticWindows(snapshot: UsageSnapshot) -> ProviderSemanticWindows {
+        let rows = (snapshot.extraRateWindows ?? []).filter { $0.id.hasPrefix(self.quotaSummaryPrefix) }
+        guard !rows.isEmpty else {
+            return ProviderUsagePresentation.standardSemanticWindows(snapshot: snapshot)
+        }
+        // Family representatives can use different cadences; unavailable summary lanes must stay unavailable.
+        let known = rows.filter(\.usageKnown)
+        return ProviderSemanticWindows(
+            session: self.mostConstrained(windows: known, minutes: 300),
+            weekly: self.mostConstrained(windows: known, minutes: 7 * 24 * 60))
+    }
 
     private static func iconWindows(context: ProviderIconWindowContext) -> ProviderUsageWindowPair {
         let windows = (context.snapshot.extraRateWindows ?? [])

--- a/Sources/CodexBarCore/Providers/ProviderUsagePresentation.swift
+++ b/Sources/CodexBarCore/Providers/ProviderUsagePresentation.swift
@@ -598,7 +598,7 @@ public struct ProviderUsagePresentation: Sendable {
 
     public static func standardSemanticWindows(snapshot: UsageSnapshot) -> ProviderSemanticWindows {
         let candidates = [snapshot.primary, snapshot.secondary, snapshot.tertiary]
-            + (snapshot.extraRateWindows ?? []).map(\.window)
+            + (snapshot.extraRateWindows ?? []).filter(\.usageKnown).map(\.window)
         let usable = candidates.compactMap { window -> RateWindow? in
             guard let window, !window.isSyntheticPlaceholder else { return nil }
             return window

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+@testable import CodexBar
 @testable import CodexBarCore
 
 private final class AntigravityQuotaSummaryPathRecorder: @unchecked Sendable {
@@ -21,6 +22,66 @@ private final class AntigravityQuotaSummaryPathRecorder: @unchecked Sendable {
 }
 
 struct AntigravityQuotaSummaryTests {
+    @MainActor
+    @Test
+    func `semantic cadences resolve parsed quotas independently of family representatives`() throws {
+        let json = antigravityQuotaSummaryJSON(
+            geminiSession: 0.86,
+            geminiWeekly: 0.55,
+            claudeSession: 1,
+            claudeWeekly: 1)
+        let usage = try AntigravityStatusProbe.parseQuotaSummaryResponse(Data(json.utf8)).toUsageSnapshot()
+        let rows = try #require(usage.extraRateWindows)
+
+        #expect(rows.map { $0.window.remainingPercent.rounded() } == [86, 55, 100, 100])
+        #expect(rows.map(\.usageKnown) == [true, true, true, true])
+        #expect(usage.primary == rows[1].window)
+        #expect(usage.secondary == rows[2].window)
+
+        let windows = MenuBarLayoutSemanticWindowResolver.windows(provider: .antigravity, snapshot: usage)
+        #expect(windows.session == rows[0].window)
+        #expect(windows.weekly == rows[1].window)
+
+        let data = MenuBarLayoutRenderData(
+            provider: .antigravity,
+            iconKey: "antigravity",
+            providerName: nil,
+            accountLabel: nil,
+            laneLabels: MenuBarLayoutLaneLabels(provider: .antigravity, snapshot: usage),
+            primary: MenuBarLayoutRenderWindow(usage.primary),
+            secondary: MenuBarLayoutRenderWindow(usage.secondary),
+            tertiary: MenuBarLayoutRenderWindow(usage.tertiary),
+            session: MenuBarLayoutRenderWindow(windows.session),
+            weekly: MenuBarLayoutRenderWindow(windows.weekly),
+            scopedWeekly: nil,
+            scopedWeeklyTitle: nil,
+            automatic: nil,
+            automaticText: nil,
+            sessionPace: nil,
+            weeklyPace: nil,
+            automaticPace: nil,
+            runsOut: nil,
+            balance: nil,
+            costToday: nil,
+            cost30d: nil,
+            metrics: .unavailable)
+        let rendered = MenuBarLayoutRenderer().render(
+            layout: MenuBarLayout(lines: [[.percent(window: .session), .separatorDot, .percent(window: .weekly)]]),
+            data: data,
+            icon: nil,
+            options: MenuBarLayoutRenderOptions(
+                size: .regular,
+                highContrast: false,
+                showUsed: false,
+                conditionals: [],
+                appearanceName: "antigravity-proof",
+                isDebugApp: false,
+                now: Date(timeIntervalSince1970: 1_782_000_000)))
+
+        #expect(rendered.attributedTitle.string == "5h 86%\u{2009}·\u{2009}W 55%")
+        #expect(rendered.accessibilityLabel == "\(L("%@ %@", L("Session"), "86%")), \(L("%@ %@", L("Weekly"), "55%"))")
+    }
+
     @Test
     func `parses quota summary response into two model groups with session before weekly windows`() throws {
         let snapshot = try AntigravityStatusProbe.parseQuotaSummaryResponse(
@@ -371,7 +432,12 @@ struct AntigravityQuotaSummaryTests {
     }
 }
 
-private func antigravityQuotaSummaryJSON() -> String {
+func antigravityQuotaSummaryJSON(
+    geminiSession: Double = 0.91,
+    geminiWeekly: Double = 0.82,
+    claudeSession: Double = 0.73,
+    claudeWeekly: Double = 0.64) -> String
+{
     """
     {
       "response": {
@@ -384,14 +450,14 @@ private func antigravityQuotaSummaryJSON() -> String {
               {
                 "bucketId": "gemini-weekly",
                 "displayName": "Weekly Limit",
-                "remaining": { "remainingFraction": 0.82 },
+                "remaining": { "remainingFraction": \(geminiWeekly) },
                 "description": "You have used some of your weekly limit, it will fully refresh in 5 days, 11 hours.",
                 "resetTime": "2026-06-19T08:45:39Z"
               },
               {
                 "bucketId": "gemini-5h",
                 "displayName": "Five Hour Limit",
-                "remaining": { "remainingFraction": 0.91 },
+                "remaining": { "remainingFraction": \(geminiSession) },
                 "description": "You have used some of your 5-hour limit, it will fully refresh in 4 hours.",
                 "resetTime": "2026-06-15T11:39:34Z"
               }
@@ -404,14 +470,14 @@ private func antigravityQuotaSummaryJSON() -> String {
               {
                 "bucketId": "3p-weekly",
                 "displayName": "Weekly Limit",
-                "remaining": { "remainingFraction": 0.64 },
+                "remaining": { "remainingFraction": \(claudeWeekly) },
                 "description": "You have used some of your weekly limit, it will fully refresh in 6 days, 22 hours.",
                 "resetTime": "2026-06-20T00:39:54Z"
               },
               {
                 "bucketId": "3p-5h",
                 "displayName": "Five Hour Limit",
-                "remaining": { "remainingFraction": 0.73 },
+                "remaining": { "remainingFraction": \(claudeSession) },
                 "description": "You have used some of your 5-hour limit, it will fully refresh in 3 hours, 38 minutes.",
                 "resetTime": "2026-06-15T12:52:10Z"
               }

--- a/Tests/CodexBarTests/MenuBarLayoutTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutTests.swift
@@ -1,7 +1,7 @@
-import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
 // swiftlint:disable:next type_body_length
 struct MenuBarLayoutTests {
@@ -562,6 +562,129 @@ struct MenuBarLayoutTests {
 
         let trailingEmptyData = try JSONEncoder().encode(UnnormalizedLayout(lines: [[.icon], []]))
         #expect(try JSONDecoder().decode(MenuBarLayout.self, from: trailingEmptyData).lines == [[.icon], []])
+    }
+
+    @Test(arguments: [
+        (0.86, 0.55, 1.0, 1.0, (86.0, 55.0)),
+        (0.86, 0.55, 0.40, 0.80, (40.0, 55.0)),
+        (0.20, 0.90, 0.80, 0.30, (20.0, 30.0)),
+        (1.0, 1.0, 1.0, 1.0, (100.0, 100.0)),
+        (0.0, 0.45, 0.70, 0.0, (0.0, 0.0)),
+    ])
+    func `Antigravity semantic windows independently select each constrained known cadence`(
+        geminiSession: Double,
+        geminiWeekly: Double,
+        claudeSession: Double,
+        claudeWeekly: Double,
+        expected: (session: Double, weekly: Double)) throws
+    {
+        let json = antigravityQuotaSummaryJSON(
+            geminiSession: geminiSession,
+            geminiWeekly: geminiWeekly,
+            claudeSession: claudeSession,
+            claudeWeekly: claudeWeekly)
+        let snapshot = try AntigravityStatusProbe.parseQuotaSummaryResponse(Data(json.utf8)).toUsageSnapshot()
+        let windows = MenuBarLayoutSemanticWindowResolver.windows(provider: .antigravity, snapshot: snapshot)
+
+        #expect(windows.session?.remainingPercent.rounded() == expected.session)
+        #expect(windows.weekly?.remainingPercent.rounded() == expected.weekly)
+    }
+
+    @Test(arguments: [UsageProvider.antigravity, .zai])
+    func `semantic windows skip unknown extras before known quotas`(provider: UsageProvider) {
+        let prefix = provider == .antigravity ? "antigravity-quota-summary-" : "quota-"
+        let session = Self.semanticRow(prefix + "3p-5h", used: 14, minutes: 300)
+        let weekly = Self.semanticRow(prefix + "3p-weekly", used: 45, minutes: 10080)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: [
+                Self.semanticRow(prefix + "gemini-5h", used: 100, minutes: 300, known: false),
+                Self.semanticRow(prefix + "gemini-weekly", used: 0, minutes: 10080, known: false),
+                session,
+                weekly,
+            ],
+            updatedAt: Date())
+        let windows = MenuBarLayoutSemanticWindowResolver.windows(provider: provider, snapshot: snapshot)
+
+        #expect(windows.session == session.window)
+        #expect(windows.weekly == weekly.window)
+    }
+
+    @Test(arguments: [300, 10080], [false, true])
+    func `Antigravity semantic cadence stays unavailable when its summary rows are missing or unknown`(
+        knownMinutes: Int,
+        includesUnknown: Bool)
+    {
+        let missingMinutes = knownMinutes == 300 ? 10080 : 300
+        let known = Self.semanticRow("antigravity-quota-summary-gemini-known", used: 0, minutes: knownMinutes)
+        let unknown = Self.semanticRow(
+            "antigravity-quota-summary-gemini-unknown", used: 100, minutes: missingMinutes, known: false)
+        let snapshot = UsageSnapshot(
+            primary: Self.semanticRow("legacy-session", used: 90, minutes: 300).window,
+            secondary: Self.semanticRow("legacy-weekly", used: 95, minutes: 10080).window,
+            extraRateWindows: [known]
+                + (includesUnknown ? [unknown] : [])
+                + [Self.semanticRow("unrelated-quota", used: 99, minutes: missingMinutes)],
+            updatedAt: Date())
+        let windows = MenuBarLayoutSemanticWindowResolver.windows(provider: .antigravity, snapshot: snapshot)
+
+        #expect(windows.session == (knownMinutes == 300 ? known.window : nil))
+        #expect(windows.weekly == (knownMinutes == 10080 ? known.window : nil))
+    }
+
+    @Test
+    func `Antigravity semantic windows with all unknown summary rows do not fall back to representative slots`() {
+        let snapshot = UsageSnapshot(
+            primary: Self.semanticRow("legacy-session", used: 14, minutes: 300).window,
+            secondary: Self.semanticRow("legacy-weekly", used: 45, minutes: 10080).window,
+            extraRateWindows: [
+                Self.semanticRow("antigravity-quota-summary-gemini-5h", used: 0, minutes: 300, known: false),
+                Self.semanticRow("antigravity-quota-summary-gemini-weekly", used: 100, minutes: 10080, known: false),
+            ],
+            updatedAt: Date())
+        let windows = MenuBarLayoutSemanticWindowResolver.windows(provider: .antigravity, snapshot: snapshot)
+
+        #expect(windows.session == nil)
+        #expect(windows.weekly == nil)
+        #expect(snapshot.extraRateWindows?.count == 2)
+    }
+
+    @Test(arguments: [UsageProvider.antigravity, .zai], [false, true])
+    func `standard semantic fallback preserves representative and first known extra ordering`(
+        provider: UsageProvider,
+        hasRepresentatives: Bool)
+    {
+        let session = Self.semanticRow("legacy-session", used: 14, minutes: 300).window
+        let weekly = Self.semanticRow("legacy-weekly", used: 45, minutes: 10080).window
+        let extraSession = Self.semanticRow("extra-session", used: 60, minutes: 300)
+        let extraWeekly = Self.semanticRow("extra-weekly", used: 70, minutes: 10080)
+        let snapshot = UsageSnapshot(
+            primary: hasRepresentatives ? session : nil,
+            secondary: hasRepresentatives ? weekly : nil,
+            extraRateWindows: [
+                extraSession,
+                extraWeekly,
+                Self.semanticRow("later-session", used: 100, minutes: 300),
+                Self.semanticRow("later-weekly", used: 100, minutes: 10080),
+            ],
+            updatedAt: Date())
+        let windows = MenuBarLayoutSemanticWindowResolver.windows(provider: provider, snapshot: snapshot)
+
+        #expect(windows.session == (hasRepresentatives ? session : extraSession.window))
+        #expect(windows.weekly == (hasRepresentatives ? weekly : extraWeekly.window))
+    }
+
+    private static func semanticRow(_ id: String, used: Double, minutes: Int, known: Bool = true) -> NamedRateWindow {
+        NamedRateWindow(
+            id: id,
+            title: id,
+            window: RateWindow(
+                usedPercent: used,
+                windowMinutes: minutes,
+                resetsAt: Date(timeIntervalSince1970: Double(minutes)),
+                resetDescription: id),
+            usageKnown: known)
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
+++ b/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
@@ -1,8 +1,8 @@
 import AppKit
-import CodexBarCore
 import SwiftUI
 import XCTest
 @testable import CodexBar
+@testable import CodexBarCore
 
 /// Developer tool, skipped by default: renders the stacked (before) and compact
 /// (after) claude-swap multi-account menu layouts to PNGs for documentation.
@@ -13,6 +13,77 @@ import XCTest
 final class MenuLayoutScreenshotRenderTests: XCTestCase {
     private static let width: CGFloat = 320
     private static let now = Date(timeIntervalSince1970: 1_782_000_000)
+
+    func test_renderAntigravitySemanticLayoutProof() throws {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_ANTIGRAVITY_LAYOUT_SCREENSHOT_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_ANTIGRAVITY_LAYOUT_SCREENSHOT_DIR to render the Antigravity layout proof.")
+        }
+
+        let json = antigravityQuotaSummaryJSON(
+            geminiSession: 0.86,
+            geminiWeekly: 0.55,
+            claudeSession: 1,
+            claudeWeekly: 1)
+        let snapshot = try AntigravityStatusProbe.parseQuotaSummaryResponse(Data(json.utf8)).toUsageSnapshot()
+        let windows = MenuBarLayoutSemanticWindowResolver.windows(provider: .antigravity, snapshot: snapshot)
+        let data = MenuBarLayoutRenderData(
+            provider: .antigravity,
+            iconKey: "antigravity",
+            providerName: nil,
+            accountLabel: nil,
+            laneLabels: MenuBarLayoutLaneLabels(provider: .antigravity, snapshot: snapshot),
+            primary: MenuBarLayoutRenderWindow(snapshot.primary),
+            secondary: MenuBarLayoutRenderWindow(snapshot.secondary),
+            tertiary: MenuBarLayoutRenderWindow(snapshot.tertiary),
+            session: MenuBarLayoutRenderWindow(windows.session),
+            weekly: MenuBarLayoutRenderWindow(windows.weekly),
+            scopedWeekly: nil,
+            scopedWeeklyTitle: nil,
+            automatic: nil,
+            automaticText: nil,
+            sessionPace: nil,
+            weeklyPace: nil,
+            automaticPace: nil,
+            runsOut: nil,
+            balance: nil,
+            costToday: nil,
+            cost30d: nil,
+            metrics: .unavailable)
+        let rendered = MenuBarLayoutRenderer().render(
+            layout: MenuBarLayout(lines: [[.percent(window: .session), .separatorDot, .percent(window: .weekly)]]),
+            data: data,
+            icon: nil,
+            options: MenuBarLayoutRenderOptions(
+                size: .regular,
+                highContrast: false,
+                showUsed: false,
+                conditionals: [],
+                appearanceName: "antigravity-proof",
+                isDebugApp: false,
+                now: Self.now))
+        let view = AnyView(VStack(alignment: .leading, spacing: 12) {
+            Text("Antigravity · synthetic quota data")
+                .font(.headline)
+            Text("Remaining quota · session / weekly")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            MenuBarLayoutPreviewText(rendered: rendered)
+                .frame(height: 30)
+        }
+        .padding(16)
+        .frame(width: Self.width)
+        .environment(\.locale, Locale(identifier: "en_US_POSIX"))
+        .environment(\.colorScheme, .dark)
+        .background(Color(nsColor: .windowBackgroundColor)))
+
+        let directory = URL(fileURLWithPath: dir, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let png = try XCTUnwrap(Self.pngData(for: view), "Antigravity layout proof render failed")
+        let url = directory.appendingPathComponent("antigravity-semantic-layout.png")
+        try png.write(to: url, options: .atomic)
+        print("Rendered: \(rendered.attributedTitle.string); accessibility: \(rendered.accessibilityLabel)")
+        print("Wrote \(url.path)")
+    }
 
     func test_renderMultiAccountLayoutScreenshots() throws {
         guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_SCREENSHOT_DIR"] else {

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -234,6 +234,11 @@ shared OAuth file can still be used as a fallback credential source.
 - Some Antigravity local/CLI model config entries include reset metadata but omit `remainingFraction`. Those windows stay
   in `extraRateWindows` for reset context and are marked with `usageKnown: false`; clients should not render their
   `usedPercent` as a real exhausted quota.
+- Menu-bar layout Session and Weekly tokens independently select the most constrained known quota-summary row for
+  each cadence across model families. They do not use the Gemini and Claude/GPT family representatives, which can
+  represent different cadences. Unknown or missing summary cadences remain unavailable; snapshots without summary
+  rows retain the standard cadence fallback. Automatic selection, its exhausted-quota option, and explicit family
+  metrics retain their existing selection policies.
 - Antigravity reports every model family the plan covers, so an account that only uses Gemini still receives a
   Claude/GPT pair pinned at 0%. Menu cards and widgets hide a family once every lane in it reports known zero usage.
   A family with unknown usage stays visible, and every family remains visible when all are untouched, for example


### PR DESCRIPTION
## Summary

Fixes #3206.

Antigravity's Gemini and Claude/GPT representatives can describe different cadences. With Gemini at 86% session / 55% weekly remaining and Claude/GPT untouched, the old semantic resolver selected the untouched family's session and displayed `5h 100% · W 55%`.

Resolve Session and Weekly independently from the provider's known quota-summary rows, reusing its existing most-constrained helper. Preserve unavailable/missing cadences when summary rows exist and standard fallback when they do not. The shared fallback now ignores explicitly unknown extra rows without changing its representative-first/first-match policy for other providers.

Automatic selection, exhausted-quota preference, explicit family metrics, icon selection, raw snapshots and diagnostic rows are unchanged. Provider docs and changelog updated; thanks @foobra for the report.

## Before / after

Identical parsed synthetic fixture and identical opt-in harness, run before any production edit and after the fix. Both use the production semantic resolver, title renderer and preview view. No account data is present.

Before:

![Synthetic Antigravity quota before: session 100%, weekly 55%](https://github.com/user-attachments/assets/d0ea754b-ae48-42f3-8b76-076ae84f1858)

After:

![Synthetic Antigravity quota after: session 86%, weekly 55%](https://github.com/user-attachments/assets/64ba6fc8-c0b3-4bea-8115-3a3a45d0d42f)

This is offscreen production-render proof, not a live provider or desktop status-item capture. It verifies parsing-to-selection-to-rendered text and accessibility, not fetching, status-button assignment, placement or refresh propagation. The harness creates no controller, status bar, settings store, real window or account fixture, and skips before fixture creation unless explicitly enabled.

## Verification

- Before-fix regressions failed as expected, including the normal all-known 100%-versus-86% case.
- Focused tests passed: 93 tests in seven suites, covering competing families, unknown/missing/all-unknown rows, known zero and exhausted quotas, legacy fallback/ordering, existing provider overrides, unchanged automatic/explicit policies, menu cards and plugin presentation.
- Command: `swift test --filter 'AntigravityQuotaSummaryTests|MenuBarLayoutTests.*semantic|MenuBarMetricWindowResolverTests|MenuCardAntigravityTests|ProviderPresentationPolicyCharacterizationTests|UserPluginQuotaPresentationTests' --skip 'MenuBarLayoutTests.*Kimi lane overrides'` with test Keychain access suppressed/disabled and the allow override unset. The skip excludes an unrelated migration fixture accidentally matched by the broad name filter; the full suite runs without that exclusion.
- `swift test --filter MenuLayoutScreenshotRenderTests/test_renderAntigravitySemanticLayoutProof` passed with `CODEXBAR_ANTIGRAVITY_LAYOUT_SCREENSHOT_DIR` set separately for before and after. The opt-out invocation skipped cleanly. Both PNGs were inspected before upload.
- `make check` and `git diff --check` passed; generated provider/plugin artifacts remain current.
- Independent Codex review reported no actionable blockers. Parent `make check` also passed with zero violations.
- `env -u CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 make test` passed all 933 selections in 78 groups: every group first-pass, zero failures/retries/timeouts, 878.3 seconds. No focused-test exclusion was used.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33024060416) at `ba732e417c03b9e48856e7ac5f829664c2dc8bae` passed: lint, Linux x64/ARM builds/tests/smoke checks, musl build, both macOS shards, provider-engine goldens, and aggregate. No CI rerun was needed.

No real credentials, provider requests, app-bundle launch or persisted account/config changes were used.
