### PR TITLE
test: isolate Codex credential files from ambient accounts

### DIFF
--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -9,6 +9,10 @@ RETRY_NON_TIMEOUT_FAILURES="${CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES:-1}"
 
 cd "${ROOT_DIR}"
 
+# Inherited by release-built tests and arbitrary CLI children as well as the test runner.
+export CODEXBAR_TEST_CODEX_FILE_ISOLATION=1
+unset CODEXBAR_TEST_CODEX_FILE_FIXTURES
+
 # Defense in depth: test processes also self-detect, but keep this explicit so runner changes cannot
 # expose the user's login Keychain. Deliberate isolated Keychain tests must opt in by setting the allow flag.
 if [[ "${CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS:-}" != "1" ]]; then

--- a/Scripts/test_codex_file_isolation_child.sh
+++ b/Scripts/test_codex_file_isolation_child.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROOF_DIR="$(mktemp -d "${TMPDIR:-/tmp}/codex-file-child.XXXXXX")"
+trap 'rm -rf "$PROOF_DIR"' EXIT
+
+# Compile the actual policy and detector without DEBUG. Only unrelated link dependencies are stubbed;
+# this is policy/child proof, not a release build of the entire app or credential store.
+cat > "$PROOF_DIR/Proof.swift" <<'SWIFT'
+import Foundation
+
+enum CodexOAuthCredentialsError: Error { case notFound }
+enum KeychainAccessGate {
+    static let disableAccessEnvironmentKey = "CODEXBAR_DISABLE_KEYCHAIN_ACCESS"
+    static var isDisabled: Bool { fatalError("The file policy must not consult Keychain state") }
+}
+
+@main
+struct Proof {
+    static func main() throws {
+        let args = CommandLine.arguments
+        let root = URL(fileURLWithPath: args[2])
+        let childRoot = root.appendingPathComponent("child")
+        let childFile = childRoot.appendingPathComponent("auth.json")
+        let parentFile = root.appendingPathComponent("parent-auth.json")
+        if args[1] == "launch" {
+            try FileManager.default.createDirectory(at: childRoot, withIntermediateDirectories: true)
+            try Data("synthetic-child".utf8).write(to: childFile)
+            try Data("synthetic-parent".utf8).write(to: parentFile)
+            let inherited = [CodexCredentialFileAccess.isolationEnvironmentKey: "1",
+                             "CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS": "1",
+                             "CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS": "1",
+                             "CODEX_HOME": root.path]
+            for mode in ["deny", "fixture", "production"] {
+                let child = Process()
+                child.executableURL = URL(fileURLWithPath: args[0])
+                child.arguments = [mode, root.path]
+                if mode == "fixture" {
+                    let parentScope = CodexCredentialFileAccess.FixtureScope(files: [parentFile])
+                    let base = try parentScope.childEnvironment(base: inherited)
+                    child.environment = try CodexCredentialFileAccess.FixtureScope(roots: [childRoot])
+                        .childEnvironment(base: base)
+                } else {
+                    child.environment = mode == "production" ? [:] : inherited
+                }
+                try child.run()
+                child.waitUntilExit()
+                precondition(child.terminationStatus == 0, "Child policy proof failed")
+            }
+            print("Optimized policy child: deny, scoped fixture, parent-grant replacement, and pure non-test decision passed")
+            return
+        }
+        if args[1] == "production" {
+            precondition(!CodexCredentialFileAccess.isTestContext)
+            precondition(CodexCredentialFileAccess.permits(URL(fileURLWithPath: "/fictitious/auth.json")))
+            return
+        }
+        let allowed = args[1] != "deny"
+        precondition(CodexCredentialFileAccess.isTestContext)
+        precondition(CodexCredentialFileAccess.fileExists(at: childFile) == allowed)
+        if allowed {
+            let data = try CodexCredentialFileAccess.read(at: childFile)
+            precondition(data == Data("synthetic-child".utf8))
+        } else {
+            do {
+                _ = try CodexCredentialFileAccess.read(at: childFile)
+                fatalError("An existing but unregistered fixture was read")
+            } catch CodexOAuthCredentialsError.notFound {}
+        }
+        precondition(!CodexCredentialFileAccess.permits(parentFile))
+    }
+}
+SWIFT
+
+swiftc -O -parse-as-library \
+  "$ROOT_DIR/Sources/CodexBarCore/CodexCredentialFileAccess.swift" \
+  "$ROOT_DIR/Sources/CodexBarCore/KeychainSecurity.swift" \
+  "$PROOF_DIR/Proof.swift" -o "$PROOF_DIR/codex-file-child"
+"$PROOF_DIR/codex-file-child" launch "$PROOF_DIR/fixtures"

--- a/Sources/CodexBar/CodexAccountPromotionExecution.swift
+++ b/Sources/CodexBar/CodexAccountPromotionExecution.swift
@@ -82,6 +82,9 @@ struct CodexDisplacedLivePreservationExecutor {
         }
 
         let importedHomeURL = self.homeFactory.makeHomeURL()
+        guard CodexCredentialFileAccess.permits(CodexAccountPromotionService.authFileURL(for: importedHomeURL)) else {
+            throw CodexAccountPromotionError.displacedLiveImportFailed
+        }
         let importedAccountID = Self.accountID(for: importedHomeURL)
 
         do {
@@ -234,6 +237,10 @@ struct CodexDisplacedLivePreservationExecutor {
                 lastAuthenticatedAt: now)
 
             let refreshedHomeURL = URL(fileURLWithPath: persistedManagedAccount.managedHomePath, isDirectory: true)
+            guard CodexCredentialFileAccess.permits(CodexAccountPromotionService.authFileURL(for: refreshedHomeURL))
+            else {
+                throw CodexAccountPromotionError.displacedLiveImportFailed
+            }
             do {
                 try self.homeFactory.validateManagedHomeForDeletion(refreshedHomeURL)
             } catch {
@@ -258,6 +265,7 @@ struct CodexDisplacedLivePreservationExecutor {
 
     private func writeManagedAuthData(_ data: Data, to homeURL: URL) throws {
         let authFileURL = CodexAccountPromotionService.authFileURL(for: homeURL)
+        guard CodexCredentialFileAccess.permits(authFileURL) else { throw CodexOAuthCredentialsError.notFound }
         try data.write(to: authFileURL, options: .atomic)
         try self.fileManager.setAttributes(
             [.posixPermissions: NSNumber(value: Int16(0o600))],
@@ -265,6 +273,7 @@ struct CodexDisplacedLivePreservationExecutor {
     }
 
     private func removeManagedHomeIfSafe(_ homeURL: URL) throws {
+        guard CodexCredentialFileAccess.permits(CodexAccountPromotionService.authFileURL(for: homeURL)) else { return }
         try self.homeFactory.validateManagedHomeForDeletion(homeURL)
         if self.fileManager.fileExists(atPath: homeURL.path) {
             try self.fileManager.removeItem(at: homeURL)

--- a/Sources/CodexBar/CodexAccountPromotionService.swift
+++ b/Sources/CodexBar/CodexAccountPromotionService.swift
@@ -41,18 +41,20 @@ struct SettingsStoreCodexAccountReconciliationSnapshotLoader: CodexAccountReconc
 struct DefaultCodexAuthMaterialReader: CodexAuthMaterialReading {
     func readAuthData(homeURL: URL) throws -> Data? {
         let authFileURL = CodexAccountPromotionService.authFileURL(for: homeURL)
-        guard FileManager.default.fileExists(atPath: authFileURL.path) else {
+        guard CodexCredentialFileAccess.fileExists(at: authFileURL) else {
             return nil
         }
-        return try Data(contentsOf: authFileURL)
+        return try CodexCredentialFileAccess.read(at: authFileURL)
     }
 }
 
 struct DefaultCodexLiveAuthSwapper: CodexLiveAuthSwapping {
     func swapLiveAuthData(_ data: Data, liveHomeURL: URL) throws {
-        try FileManager.default.createDirectory(at: liveHomeURL, withIntermediateDirectories: true)
-
         let liveAuthURL = CodexAccountPromotionService.authFileURL(for: liveHomeURL)
+        guard CodexCredentialFileAccess.permits(liveAuthURL) else { throw CodexOAuthCredentialsError.notFound }
+        if try CodexCredentialFileAccess.substituteWriteForTesting(at: liveAuthURL) { return }
+        try CodexCredentialFileAccess.createDirectory(forCredentialAt: liveAuthURL)
+
         let stagedAuthURL = liveHomeURL.appendingPathComponent(
             "auth.json.codexbar-staged-\(UUID().uuidString)",
             isDirectory: false)

--- a/Sources/CodexBarCore/CodexCredentialFileAccess.swift
+++ b/Sources/CodexBarCore/CodexCredentialFileAccess.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+/// Codex-owned test isolation. Credential environments select paths; they never authorize them.
+public enum CodexCredentialFileAccess {
+    public static let isolationEnvironmentKey = "CODEXBAR_TEST_CODEX_FILE_ISOLATION"
+    private static let fixtureEnvironmentKey = "CODEXBAR_TEST_CODEX_FILE_FIXTURES"
+
+    public struct FixtureScope: Codable, Sendable {
+        private struct Grant: Codable, Sendable {
+            let url: URL
+            let resolvedURL: URL
+            let isRoot: Bool
+        }
+
+        private let grants: [Grant]
+
+        public init(files: [URL] = [], roots: [URL] = []) {
+            self.grants = files.map { Grant(
+                url: $0.standardizedFileURL,
+                resolvedURL: CodexCredentialFileAccess.resolve($0.deletingLastPathComponent())
+                    .appendingPathComponent($0.lastPathComponent),
+                isRoot: false) } + roots.map { Grant(
+                url: $0.standardizedFileURL,
+                resolvedURL: CodexCredentialFileAccess.resolve($0.deletingLastPathComponent())
+                    .appendingPathComponent($0.lastPathComponent),
+                isRoot: true) }
+        }
+
+        fileprivate func permits(_ url: URL) -> Bool {
+            let candidate = url.standardizedFileURL
+            // Reject unregistered targets before even resolving symlinks (a metadata operation).
+            return self.grants.contains { grant in
+                guard Self.contains(candidate, in: grant.url, isRoot: grant.isRoot) else { return false }
+                // Foundation may leave dangling symlinks unresolved. Inspect each fixture component
+                // before resolving or opening it, including destinations that do not exist yet.
+                var component = grant.url
+                guard CodexCredentialFileAccess.isNonSymlink(component) else { return false }
+                for name in candidate.pathComponents.dropFirst(grant.url.pathComponents.count) {
+                    component.appendPathComponent(name)
+                    guard CodexCredentialFileAccess.isNonSymlink(component) else { return false }
+                }
+                guard CodexCredentialFileAccess.resolve(grant.url).path == grant.resolvedURL.path else {
+                    return false
+                }
+                return true
+            }
+        }
+
+        func including(root: URL) -> Self {
+            Self(grants: self.grants + Self(roots: [root]).grants)
+        }
+
+        private init(grants: [Grant]) {
+            self.grants = grants
+        }
+
+        private static func contains(_ url: URL, in parent: URL, isRoot: Bool) -> Bool {
+            guard url.isFileURL, parent.isFileURL else { return false }
+            if !isRoot { return url.pathComponents == parent.pathComponents }
+            return url.pathComponents.starts(with: parent.pathComponents)
+        }
+
+        /// Supply only this child's fixtures; never copy a parent's fixture authorization.
+        public func childEnvironment(base: [String: String]) throws -> [String: String] {
+            var environment = base
+            environment[CodexCredentialFileAccess.isolationEnvironmentKey] = "1"
+            try environment[CodexCredentialFileAccess.fixtureEnvironmentKey] =
+                String(data: JSONEncoder().encode(self), encoding: .utf8)
+            return environment
+        }
+    }
+
+    @TaskLocal public static var fixtureScope: FixtureScope?
+
+    public static var isTestContext: Bool {
+        self.isTestContext(
+            processName: ProcessInfo.processInfo.processName,
+            environment: ProcessInfo.processInfo.environment)
+    }
+
+    static func isTestContext(processName: String, environment: [String: String]) -> Bool {
+        environment[self.isolationEnvironmentKey] == "1"
+            || KeychainTestSafety.isRunningUnderTests(processName: processName, environment: environment)
+    }
+
+    public static func permits(_ url: URL) -> Bool {
+        guard self.isTestContext else { return true }
+        if let fixtureScope { return fixtureScope.permits(url) }
+        let environment = ProcessInfo.processInfo.environment
+        guard let encoded = environment[self.fixtureEnvironmentKey]?.data(using: .utf8),
+              let scope = try? JSONDecoder().decode(FixtureScope.self, from: encoded)
+        else { return false }
+        return scope.permits(url)
+    }
+
+    public static func withFixtureScope<T>(_ scope: FixtureScope?, operation: () throws -> T) rethrows -> T {
+        try self.$fixtureScope.withValue(scope, operation: operation)
+    }
+
+    public static func withFixtureScope<T>(
+        _ scope: FixtureScope?,
+        isolation _: isolated (any Actor)? = #isolation,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$fixtureScope.withValue(scope) {
+            try await operation()
+        }
+    }
+
+    /// Small substitution seam for boundary tests; never changes authorization.
+    public enum Operation: Sendable { case read, existence, metadata, directory, write }
+    #if DEBUG
+    @TaskLocal public static var testIO: (@Sendable (Operation, URL) throws -> Data)?
+    #endif
+
+    private static func resolve(_ url: URL) -> URL {
+        #if DEBUG
+        if let testIO {
+            guard let data = try? testIO(.metadata, url),
+                  let path = String(data: data, encoding: .utf8)
+            else { return URL(fileURLWithPath: "/") }
+            return URL(fileURLWithPath: path).standardizedFileURL
+        }
+        #endif
+        return url.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    private static func isNonSymlink(_ url: URL) -> Bool {
+        #if DEBUG
+        if let testIO { return (try? testIO(.metadata, url)) != nil }
+        #endif
+        do {
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            return attributes[.type] as? FileAttributeType != .typeSymbolicLink
+        } catch {
+            let error = error as NSError
+            let underlying = (error.userInfo[NSUnderlyingErrorKey] as? NSError) ?? error
+            // A missing child (including a regular-file parent) cannot be a symlink. Let the
+            // existing reader/writer classify that fixture error instead of masking it as denial.
+            return (error.domain == NSCocoaErrorDomain && error.code == CocoaError.fileReadNoSuchFile.rawValue)
+                || (underlying.domain == NSPOSIXErrorDomain
+                    && [POSIXErrorCode.ENOENT.rawValue, POSIXErrorCode.ENOTDIR.rawValue]
+                    .contains(Int32(underlying.code)))
+        }
+    }
+
+    public static func read(at url: URL, options: Data.ReadingOptions = []) throws -> Data {
+        guard self.permits(url) else { throw CodexOAuthCredentialsError.notFound }
+        #if DEBUG
+        if let testIO { return try testIO(.read, url) }
+        #endif
+        return try Data(contentsOf: url, options: options)
+    }
+
+    public static func fileExists(at url: URL, fileManager: FileManager = .default) -> Bool {
+        guard self.permits(url) else { return false }
+        #if DEBUG
+        if let testIO { return (try? testIO(.existence, url)) != nil }
+        #endif
+        return fileManager.fileExists(atPath: url.path)
+    }
+
+    public static func createDirectory(forCredentialAt url: URL) throws {
+        guard self.permits(url) else { throw CodexOAuthCredentialsError.notFound }
+        let directory = url.deletingLastPathComponent()
+        #if DEBUG
+        if let testIO {
+            _ = try testIO(.directory, directory)
+            return
+        }
+        #endif
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    /// Called after authorization, before the complete read/modify/publish operation.
+    public static func substituteWriteForTesting(at url: URL) throws -> Bool {
+        #if DEBUG
+        guard let testIO else { return false }
+        _ = try testIO(.write, url)
+        return true
+        #else
+        return false
+        #endif
+    }
+}

--- a/Sources/CodexBarCore/CodexManagedAccounts.swift
+++ b/Sources/CodexBarCore/CodexManagedAccounts.swift
@@ -83,8 +83,8 @@ public enum CodexAuthFingerprint {
 
     public static func fingerprint(homePath: String, fileManager: FileManager = .default) -> String? {
         let url = self.authFileURL(homePath: homePath)
-        guard fileManager.fileExists(atPath: url.path),
-              let data = try? Data(contentsOf: url)
+        guard CodexCredentialFileAccess.fileExists(at: url, fileManager: fileManager),
+              let data = try? CodexCredentialFileAccess.read(at: url)
         else {
             return nil
         }

--- a/Sources/CodexBarCore/ManagedCodexAccountStore.swift
+++ b/Sources/CodexBarCore/ManagedCodexAccountStore.swift
@@ -100,6 +100,10 @@ public struct FileManagedCodexAccountStore: ManagedCodexAccountStoring, @uncheck
     }
 
     public static func defaultURL() -> URL {
+        if CodexCredentialFileAccess.isTestContext {
+            return FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+                .appendingPathComponent("managed-codex-accounts.json")
+        }
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? FileManager.default.homeDirectoryForCurrentUser
         return base

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
@@ -159,6 +159,9 @@ public enum CodexOAuthCredentialsStore {
         homeDirectory: URL?,
         allowExternalSources: Bool) throws -> CodexOAuthCredentials
     {
+        guard CodexCredentialFileAccess.permits(self.authFilePath(env: env, homeDirectory: homeDirectory)) else {
+            throw CodexOAuthCredentialsError.notFound
+        }
         do {
             return try self.loadNative(env: env, homeDirectory: homeDirectory)
         } catch let nativeError as CodexOAuthCredentialsError {
@@ -232,11 +235,12 @@ public enum CodexOAuthCredentialsStore {
     }
 
     private static func readAuthData(at url: URL) throws -> Data {
+        guard CodexCredentialFileAccess.permits(url) else { throw CodexOAuthCredentialsError.notFound }
         do {
             // Read once instead of checking existence first. Codex publishes auth.json atomically,
             // so a single read avoids a TOCTOU window and lets us distinguish a missing file from a
             // transiently unreadable/partially published one without logging credentials.
-            return try Data(contentsOf: url, options: [.mappedIfSafe])
+            return try CodexCredentialFileAccess.read(at: url, options: [.mappedIfSafe])
         } catch {
             let nsError = error as NSError
             let missingFile =
@@ -320,9 +324,11 @@ public enum CodexOAuthCredentialsStore {
             throw CodexOAuthCredentialsError.readOnlySource
         }
         let url = self.authFilePath(env: env)
+        guard CodexCredentialFileAccess.permits(url) else { throw CodexOAuthCredentialsError.notFound }
+        if try CodexCredentialFileAccess.substituteWriteForTesting(at: url) { return }
 
         var json: [String: Any] = [:]
-        if let data = try? Data(contentsOf: url),
+        if let data = try? CodexCredentialFileAccess.read(at: url),
            let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         {
             json = existing
@@ -348,8 +354,7 @@ public enum CodexOAuthCredentialsStore {
 
         let data = try JSONSerialization.data(
             withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
-        let directory = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try CodexCredentialFileAccess.createDirectory(forCredentialAt: url)
         try CredentialFileWriter.writePrivate(data, to: url)
     }
 
@@ -520,10 +525,13 @@ extension CodexOAuthCredentialsStore {
         homeDirectory: URL,
         allowExternalSources: Bool = false) throws -> CodexOAuthCredentials
     {
-        try self.loadForUsage(
-            env: env,
-            homeDirectory: homeDirectory,
-            allowExternalSources: allowExternalSources)
+        let scope = (CodexCredentialFileAccess.fixtureScope ?? .init()).including(root: homeDirectory)
+        return try CodexCredentialFileAccess.withFixtureScope(scope) {
+            try self.loadForUsage(
+                env: env,
+                homeDirectory: homeDirectory,
+                allowExternalSources: allowExternalSources)
+        }
     }
 
     static func _parseOpenCodeForTesting(data: Data) throws -> CodexOAuthCredentials {
@@ -535,6 +543,7 @@ extension CodexOAuthCredentialsStore {
         to url: URL,
         beforePublish: @escaping (URL) throws -> Void) throws
     {
+        guard CodexCredentialFileAccess.permits(url) else { throw CodexOAuthCredentialsError.notFound }
         try CredentialFileWriter.writePrivate(data, to: url, beforePublish: beforePublish)
     }
 }

--- a/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceIdentityCache.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceIdentityCache.swift
@@ -84,6 +84,10 @@ public struct CodexOpenAIWorkspaceIdentityCache: @unchecked Sendable {
         }
         #endif
 
+        if CodexCredentialFileAccess.isTestContext {
+            return FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+                .appendingPathComponent("codex-openai-workspaces.json")
+        }
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? FileManager.default.homeDirectoryForCurrentUser
         return base

--- a/Tests/CodexBarTests/CLIOpenAIDashboardCacheTests.swift
+++ b/Tests/CodexBarTests/CLIOpenAIDashboardCacheTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import CodexBarCLI
 @testable import CodexBarCore
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 struct CLIOpenAIDashboardCacheTests {
     @Test
     func `cached dashboard restores when authority allows cached reuse`() throws {
@@ -370,7 +370,7 @@ struct CLIOpenAIDashboardCacheTests {
     }
 
     private func makeAuthHome(email: String?, accountId: String? = nil) throws -> URL {
-        let homeURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let homeURL = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try self.writeCodexAuthFile(homeURL: homeURL, email: email, accountId: accountId)
@@ -378,7 +378,7 @@ struct CLIOpenAIDashboardCacheTests {
     }
 
     private func makeEmptyHome() -> URL {
-        let homeURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let homeURL = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try? FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -462,9 +462,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-444444444444"))
         let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-333333333333"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-token-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-token-sibling-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: targetHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: siblingHome, withIntermediateDirectories: true)
@@ -567,9 +567,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-121212121212"))
         let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-131313131313"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-auth-file-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-auth-file-sibling-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: targetHome,
@@ -669,9 +669,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-161616161616"))
         let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-171717171717"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-current-failure-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-current-sibling-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: targetHome,
@@ -771,9 +771,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-141414141414"))
         let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-151515151515"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-auth-success-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent(
                 "codex-visible-managed-auth-success-sibling-\(UUID().uuidString)",
                 isDirectory: true)
@@ -887,9 +887,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-171717171717"))
         let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-181818181818"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-migrated-managed-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent(
                 "codex-visible-migrated-managed-sibling-\(UUID().uuidString)",
                 isDirectory: true)
@@ -1011,9 +1011,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-191919191919"))
         let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-202020202020"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-auth-email-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent(
                 "codex-visible-managed-auth-email-sibling-\(UUID().uuidString)",
                 isDirectory: true)
@@ -1130,7 +1130,7 @@ extension CodexAccountScopedRefreshTests {
             suite: "CodexAccountScopedRefreshTests-managed-auth-file-fingerprint")
         settings.refreshFrequency = .manual
         let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-555555555555"))
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-managed-auth-file-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: managedHome,
@@ -1284,7 +1284,7 @@ extension CodexAccountScopedRefreshTests {
         settings.refreshFrequency = .manual
 
         let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-161616161616"))
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-managed-provider-email-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: managedHome,
@@ -1339,7 +1339,7 @@ extension CodexAccountScopedRefreshTests {
         settings.refreshFrequency = .manual
 
         let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-171717171717"))
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-managed-usage-without-email-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: managedHome,
@@ -1399,7 +1399,7 @@ extension CodexAccountScopedRefreshTests {
         settings.refreshFrequency = .manual
 
         let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-181818181818"))
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent(
                 "codex-managed-provider-email-without-email-\(UUID().uuidString)",
                 isDirectory: true)

--- a/Tests/CodexBarTests/CodexAccountEmailOnlyHistoryBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountEmailOnlyHistoryBackfillTests.swift
@@ -14,9 +14,9 @@ extension CodexAccountScopedRefreshTests {
 
         let activeID = try #require(UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-333333333333"))
         let siblingID = try #require(UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-444444444444"))
-        let activeHome = FileManager.default.temporaryDirectory
+        let activeHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-active-email-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-sibling-email-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: activeHome,

--- a/Tests/CodexBarTests/CodexAccountPromotionExecutionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionExecutionTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexAccountPromotionExecutionTests {
     @Test

--- a/Tests/CodexBarTests/CodexAccountPromotionPlanningTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionPlanningTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexAccountPromotionPlanningTests {
     @Test

--- a/Tests/CodexBarTests/CodexAccountPromotionPreparationTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionPreparationTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexAccountPromotionPreparationTests {
     @Test

--- a/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexAccountPromotionServiceTests {
     @Test

--- a/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
@@ -23,7 +23,7 @@ final class CodexAccountPromotionTestContainer {
         workspaceIdentities: [String: CodexOpenAIWorkspaceIdentity] = [:]) throws
     {
         self.suiteName = suiteName
-        self.rootURL = FileManager.default.temporaryDirectory
+        self.rootURL = CodexCredentialFixtures.root
             .appendingPathComponent("codex-account-promotion-tests", isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         self.liveHomeURL = self.rootURL.appendingPathComponent("liveHome", isDirectory: true)

--- a/Tests/CodexBarTests/CodexAccountReconciliationTests.swift
+++ b/Tests/CodexBarTests/CodexAccountReconciliationTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 struct CodexAccountReconciliationTests {
     @MainActor
     private static func makeSettings(suite: String) throws -> SettingsStore {
@@ -99,7 +99,7 @@ struct CodexAccountReconciliationTests {
     func `settings store reconciliation environment override drives live observation with synthetic store`() throws {
         let suite = "CodexAccountReconciliationTests-environment-only"
         let settings = try Self.makeSettings(suite: suite)
-        let ambientHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let ambientHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try Self.writeCodexAuthFile(homeURL: ambientHome, email: "ambient@example.com", plan: "pro")
@@ -129,7 +129,7 @@ struct CodexAccountReconciliationTests {
     func `settings store can reuse short lived codex reconciliation snapshot`() throws {
         let suite = "CodexAccountReconciliationTests-short-lived-cache"
         let settings = try Self.makeSettings(suite: suite)
-        let ambientHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let ambientHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try Self.writeCodexAuthFile(homeURL: ambientHome, email: "cached@example.com", plan: "pro")
@@ -157,7 +157,7 @@ struct CodexAccountReconciliationTests {
     func `codex active source write invalidates short lived reconciliation snapshot`() throws {
         let suite = "CodexAccountReconciliationTests-active-source-cache-invalidation"
         let settings = try Self.makeSettings(suite: suite)
-        let ambientHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let ambientHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try Self.writeCodexAuthFile(homeURL: ambientHome, email: "before@example.com", plan: "pro")
@@ -521,7 +521,7 @@ struct CodexAccountReconciliationTests {
 
     @Test
     func `provider account does not collapse with email only live account on same email`() throws {
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
@@ -842,7 +842,7 @@ struct CodexAccountReconciliationTests {
     func `selecting authenticated managed account keeps managed source for split identity rows`() throws {
         let suite = "CodexAccountReconciliationTests-select-authenticated-managed-split"
         let settings = try Self.makeSettings(suite: suite)
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         let storeURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)

--- a/Tests/CodexBarTests/CodexAccountRefreshProjectionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountRefreshProjectionTests.swift
@@ -68,9 +68,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-202020202020"))
         let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-212121212121"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-auth-removed-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent(
                 "codex-visible-managed-auth-removed-sibling-\(UUID().uuidString)",
                 isDirectory: true)
@@ -165,7 +165,7 @@ extension CodexAccountScopedRefreshTests {
         settings.multiAccountMenuLayout = .stacked
 
         let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-222222222222"))
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-managed-startup-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: managedHome,

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshDashboardCleanupTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshDashboardCleanupTests.swift
@@ -8,7 +8,7 @@ extension CodexAccountScopedRefreshTests {
     func `dashboard refresh accepted via unresolved routing fallback during account scoped refresh`() async throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-dashboard-unresolved-routing-fallback")
-        let isolatedHome = FileManager.default.temporaryDirectory
+        let isolatedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-dashboard-unresolved-routing-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: isolatedHome, withIntermediateDirectories: true)
         let codexMetadata = try #require(ProviderDescriptorRegistry.metadata[.codex])
@@ -61,7 +61,7 @@ extension CodexAccountScopedRefreshTests {
         defer { OpenAIDashboardCacheStore.clear() }
 
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-dashboard-fail-closed-cleanup")
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
         try Self.writeCodexAuthFile(
@@ -127,7 +127,7 @@ extension CodexAccountScopedRefreshTests {
 
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-dashboard-fail-closed-token-rotation-cleanup")
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
         try Self.writeCodexAuthFile(

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
@@ -68,7 +68,7 @@ extension CodexAccountScopedRefreshTests {
     }
 
     func makeUsageStore(settings: SettingsStore, environmentBase: [String: String] = [:]) -> UsageStore {
-        let root = FileManager.default.temporaryDirectory
+        let root = CodexCredentialFixtures.root
             .appendingPathComponent("codexbar-tests", isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         var environment = [
@@ -547,7 +547,7 @@ extension CodexAccountScopedRefreshTests {
         suite: String,
         snapshotStore: (any CodexAccountUsageSnapshotStoring)? = nil) -> UsageStore
     {
-        let root = FileManager.default.temporaryDirectory
+        let root = CodexCredentialFixtures.root
             .appendingPathComponent("codexbar-weekly-publication-tests", isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let environment = [

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexAccountScopedRefreshTests {
     @Test
@@ -223,7 +223,7 @@ struct CodexAccountScopedRefreshTests {
     func `managed refresh invalidation keeps state when provider account is unchanged`() throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-managed-renamed-email")
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
         try Self.writeCodexAuthFile(
@@ -276,7 +276,7 @@ struct CodexAccountScopedRefreshTests {
     @Test
     func `credits refresh returns quickly when no live codex account is available`() async {
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-credits-no-live-account")
-        let isolatedHome = FileManager.default.temporaryDirectory
+        let isolatedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-credits-no-live-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: isolatedHome, withIntermediateDirectories: true)
         settings.refreshFrequency = .manual
@@ -327,7 +327,7 @@ struct CodexAccountScopedRefreshTests {
     @Test
     func `dashboard refresh fail closes when live identity is unresolved without trusted continuity`() async {
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-dashboard-unresolved-fail-closed")
-        let isolatedHome = FileManager.default.temporaryDirectory
+        let isolatedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-openai-web-unresolved-fail-closed-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: isolatedHome, withIntermediateDirectories: true)
         settings.refreshFrequency = .manual
@@ -365,7 +365,7 @@ struct CodexAccountScopedRefreshTests {
     func `dashboard refresh attaches for unresolved live identity with trusted non dashboard continuity`() async {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-dashboard-unresolved-trusted-continuity")
-        let isolatedHome = FileManager.default.temporaryDirectory
+        let isolatedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-openai-web-unresolved-trusted-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: isolatedHome, withIntermediateDirectories: true)
         settings.refreshFrequency = .manual
@@ -457,7 +457,7 @@ struct CodexAccountScopedRefreshTests {
     @Test
     func `dashboard display only keeps dashboard visible and clears dashboard derived data`() async throws {
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-dashboard-display-only-cleanup")
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
         try Self.writeCodexAuthFile(
@@ -519,7 +519,7 @@ struct CodexAccountScopedRefreshTests {
         defer { OpenAIDashboardCacheStore.clear() }
 
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-dashboard-downgrade")
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
         try Self.writeCodexAuthFile(
@@ -578,7 +578,7 @@ struct CodexAccountScopedRefreshTests {
     @Test
     func `dashboard refresh rejects stale completion during live account reconciliation lag`() async {
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-dashboard-reject-stale-live-lag")
-        let isolatedHome = FileManager.default.temporaryDirectory
+        let isolatedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-openai-web-stale-live-lag-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: isolatedHome, withIntermediateDirectories: true)
         settings.refreshFrequency = .manual
@@ -678,7 +678,7 @@ struct CodexAccountScopedRefreshTests {
     @Test
     func `live switch invalidates stale codex state even when only last known live email remains`() async {
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-invalidate-with-stale-last-known")
-        let isolatedHome = FileManager.default.temporaryDirectory
+        let isolatedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-invalidate-stale-last-known-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: isolatedHome, withIntermediateDirectories: true)
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
@@ -14,9 +14,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-222222222222"))
         let siblingID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-333333333333"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-target-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-sibling-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: targetHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: siblingHome, withIntermediateDirectories: true)
@@ -223,9 +223,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "CCCCCCCC-DDDD-EEEE-FFFF-111111111111"))
         let siblingID = try #require(UUID(uuidString: "CCCCCCCC-DDDD-EEEE-FFFF-222222222222"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-selected-history-target-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-selected-history-sibling-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: targetHome,
@@ -323,9 +323,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-444444444444"))
         let siblingID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-555555555555"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-cache-target-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-cache-sibling-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: targetHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: siblingHome, withIntermediateDirectories: true)
@@ -427,9 +427,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-666666666666"))
         let siblingID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-777777777777"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-current-target-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-current-sibling-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: targetHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: siblingHome, withIntermediateDirectories: true)
@@ -558,9 +558,9 @@ extension CodexAccountScopedRefreshTests {
         let targetID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-888888888888"))
         let oldID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-999999999999"))
         let siblingID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-AAAAAAAAAAAA"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-prior-target-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-prior-sibling-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: targetHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: siblingHome, withIntermediateDirectories: true)
@@ -664,9 +664,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-111111111111"))
         let siblingID = try #require(UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-222222222222"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-history-target-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-history-sibling-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: targetHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: siblingHome, withIntermediateDirectories: true)
@@ -755,9 +755,9 @@ extension CodexAccountScopedRefreshTests {
         settings.multiAccountMenuLayout = .stacked
 
         let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-111111111111"))
-        let liveHome = FileManager.default.temporaryDirectory
+        let liveHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-live-prior-\(UUID().uuidString)", isDirectory: true)
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-live-prior-managed-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
@@ -841,9 +841,9 @@ extension CodexAccountScopedRefreshTests {
         settings.multiAccountMenuLayout = .stacked
 
         let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-222222222222"))
-        let liveHome = FileManager.default.temporaryDirectory
+        let liveHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-live-prior-auth-\(UUID().uuidString)", isDirectory: true)
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-live-prior-auth-managed-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
@@ -940,9 +940,9 @@ extension CodexAccountScopedRefreshTests {
         settings.multiAccountMenuLayout = .stacked
 
         let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-333333333333"))
-        let liveHome = FileManager.default.temporaryDirectory
+        let liveHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-live-active-auth-\(UUID().uuidString)", isDirectory: true)
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-live-active-auth-managed-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
@@ -1043,9 +1043,9 @@ extension CodexAccountScopedRefreshTests {
         settings.multiAccountMenuLayout = .stacked
 
         let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-444444444444"))
-        let liveHome = FileManager.default.temporaryDirectory
+        let liveHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-selected-auth-\(UUID().uuidString)", isDirectory: true)
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-selected-auth-managed-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
@@ -1172,9 +1172,9 @@ extension CodexAccountScopedRefreshTests {
         settings.multiAccountMenuLayout = .stacked
 
         let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-888888888888"))
-        let liveHome = FileManager.default.temporaryDirectory
+        let liveHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-selected-token-\(UUID().uuidString)", isDirectory: true)
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-selected-token-managed-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
@@ -1290,9 +1290,9 @@ extension CodexAccountScopedRefreshTests {
         settings.multiAccountMenuLayout = .stacked
 
         let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-777777777777"))
-        let liveHome = FileManager.default.temporaryDirectory
+        let liveHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-selected-email-\(UUID().uuidString)", isDirectory: true)
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-selected-email-managed-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
@@ -1428,9 +1428,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-555555555555"))
         let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-666666666666"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-provider-email-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-visible-provider-email-sibling-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: targetHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: siblingHome, withIntermediateDirectories: true)

--- a/Tests/CodexBarTests/CodexAccountsSettingsSectionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountsSettingsSectionTests.swift
@@ -4,6 +4,7 @@ import Testing
 @testable import CodexBar
 
 @MainActor
+@Suite(CodexCredentialFixtures())
 struct CodexAccountsSettingsSectionTests {
     @Test
     func `codex accounts section shows live badge only for live only multi account row`() throws {
@@ -134,7 +135,7 @@ struct CodexAccountsSettingsSectionTests {
         let settings = Self.makeSettingsStore(suite: "CodexAccountsSettingsSectionTests-select-split")
         let store = Self.makeUsageStore(settings: settings)
         let managedStoreURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer {

--- a/Tests/CodexBarTests/CodexBackgroundRefreshCoalescingTests.swift
+++ b/Tests/CodexBarTests/CodexBackgroundRefreshCoalescingTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import CodexBar
 @testable import CodexBarCore
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexBackgroundRefreshCoalescingTests {
     @Test
@@ -1240,7 +1240,7 @@ extension CodexBackgroundRefreshCoalescingTests {
     }
 
     func makeStore(settings: SettingsStore) -> UsageStore {
-        let root = FileManager.default.temporaryDirectory
+        let root = CodexCredentialFixtures.root
             .appendingPathComponent("codexbar-tests", isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let environment = [
@@ -1267,7 +1267,7 @@ extension CodexBackgroundRefreshCoalescingTests {
     }
 
     private static func makeManagedAccount(email: String) throws -> ManagedCodexAccount {
-        let managedHomeURL = FileManager.default.temporaryDirectory
+        let managedHomeURL = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: managedHomeURL,

--- a/Tests/CodexBarTests/CodexBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/CodexBaselineCharacterizationTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 struct CodexBaselineCharacterizationTests {
     private func makeContext(
         runtime: ProviderRuntime,
@@ -115,14 +115,14 @@ struct CodexBaselineCharacterizationTests {
     }
 
     private func makeEmptyCodexHome() throws -> URL {
-        let homeURL = FileManager.default.temporaryDirectory
+        let homeURL = CodexCredentialFixtures.root
             .appendingPathComponent("codex-empty-home-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
         return homeURL
     }
 
     private func makeUnavailableOAuthHome() throws -> URL {
-        let homeURL = FileManager.default.temporaryDirectory
+        let homeURL = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-home-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
 

--- a/Tests/CodexBarTests/CodexCredentialFileAccessTests.swift
+++ b/Tests/CodexBarTests/CodexCredentialFileAccessTests.swift
@@ -1,0 +1,338 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct CodexCredentialFileAccessTests {
+    private final class IO: @unchecked Sendable {
+        private let lock = NSLock()
+        private var operations: [CodexCredentialFileAccess.Operation] = []
+        private var paths: [String] = []
+        let files: [String: Data]?
+        let bytes = Data(
+            #"{"tokens":{"access_token":"synthetic","refresh_token":"fixture"},"personal_access_token":"fixture-pat"}"#
+                .utf8)
+
+        init(files: [String: Data]? = nil) {
+            self.files = files
+        }
+
+        func call(_ operation: CodexCredentialFileAccess.Operation, _ url: URL) throws -> Data {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            self.operations.append(operation)
+            if operation == .read || operation == .existence { self.paths.append(url.path) }
+            if operation == .read, let files {
+                guard let data = files[url.path] else { throw CocoaError(.fileReadNoSuchFile) }
+                return data
+            }
+            return operation == .metadata ? Data(url.standardizedFileURL.path.utf8) : self.bytes
+        }
+
+        var targets: [String] {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.paths
+        }
+
+        var calls: [CodexCredentialFileAccess.Operation] {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.operations
+        }
+    }
+
+    @Test
+    func `all ambient entry points deny before IO regardless of credential environment`() throws {
+        let io = IO()
+        let home = URL(fileURLWithPath: "/fictitious-codex-user")
+        let environments: [[String: String]] = [
+            [:], ["CODEX_HOME": ""], ["CODEX_HOME": " \n "], ["HOME": home.path],
+            ["CODEX_HOME": "/inherited-codex-home"],
+            ["XDG_DATA_HOME": "/fictitious-opencode-data"],
+            ["CODEX_HOME": "/fictitious/managed-codex-homes/id", "HOME": home.path],
+            ["CODEX_HOME": "/fictitious/managed-store-unreadable"],
+            ["CODEX_HOME": "/fictitious/profile", "HOME": home.path],
+            ["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS": "1", "LIVE_TEST": "1"],
+        ]
+        try CodexCredentialFileAccess.withFixtureScope(.init()) {
+            try CodexCredentialFileAccess.$testIO.withValue(io.call) {
+                let credentials = try CodexOAuthCredentialsStore.parse(data: io.bytes)
+                for environment in environments {
+                    #expect(throws: CodexOAuthCredentialsError.self) {
+                        try CodexOAuthCredentialsStore.load(env: environment)
+                    }
+                    #expect(throws: CodexOAuthCredentialsError.self) {
+                        try CodexOAuthCredentialsStore.loadOAuthTokens(env: environment)
+                    }
+                    #expect(throws: CodexOAuthCredentialsError.self) {
+                        try CodexOAuthCredentialsStore.loadPAT(env: environment)
+                    }
+                    #expect(throws: CodexOAuthCredentialsError.self) {
+                        try CodexOAuthCredentialsStore.loadPATResolvingScopedHome(env: environment)
+                    }
+                    for external in [false, true] {
+                        #expect(throws: CodexOAuthCredentialsError.self) {
+                            try CodexOAuthCredentialsStore.loadForUsage(
+                                env: environment, allowExternalSources: external)
+                        }
+                    }
+                    #expect(throws: CodexOAuthCredentialsError.self) {
+                        try CodexOAuthCredentialsStore.save(credentials, env: environment)
+                    }
+                    #expect(UsageFetcher(environment: environment).loadAccountInfo().email == nil)
+                    #expect(CodexAuthFingerprint.fingerprint(env: environment) == nil)
+                }
+                #expect(CodexAuthFingerprint.fingerprint(homePath: home.path) == nil)
+                #expect(try DefaultCodexAuthMaterialReader().readAuthData(homeURL: home) == nil)
+                #expect(throws: CodexOAuthCredentialsError.self) {
+                    try DefaultCodexLiveAuthSwapper().swapLiveAuthData(io.bytes, liveHomeURL: home)
+                }
+                #expect(throws: CodexOAuthCredentialsError.self) {
+                    try CodexCredentialFileAccess
+                        .createDirectory(forCredentialAt: home.appendingPathComponent("auth.json"))
+                }
+                for operation in [CodexCredentialFileAccess.Operation.read, .existence, .metadata, .directory, .write] {
+                    #expect(io.calls.filter { $0 == operation }.isEmpty)
+                }
+            }
+        }
+    }
+
+    @Test
+    func `explicit file fixtures allow synthetic reads and whole write substitution`() throws {
+        let io = IO()
+        let home = URL(fileURLWithPath: "/fictitious-owned-fixture")
+        let auth = home.appendingPathComponent("auth.json")
+        try CodexCredentialFileAccess.$testIO.withValue(io.call) {
+            try CodexCredentialFileAccess.withFixtureScope(.init(files: [auth])) {
+                let env = ["CODEX_HOME": home.path]
+                let credentials = try CodexOAuthCredentialsStore.load(env: env)
+                #expect(credentials.accessToken == "synthetic")
+                #expect(try CodexOAuthCredentialsStore.loadOAuthTokens(env: env) == credentials)
+                #expect(try CodexOAuthCredentialsStore.loadPAT(env: env).token == "fixture-pat")
+                #expect(try CodexOAuthCredentialsStore.loadForUsage(env: env) == credentials)
+                #expect(CodexAuthFingerprint.fingerprint(env: env) == CodexAuthFingerprint.fingerprint(data: io.bytes))
+                #expect(try DefaultCodexAuthMaterialReader().readAuthData(homeURL: home) == io.bytes)
+                try CodexOAuthCredentialsStore.save(credentials, env: env)
+                try DefaultCodexLiveAuthSwapper().swapLiveAuthData(io.bytes, liveHomeURL: home)
+                #expect(!CodexCredentialFileAccess.permits(home.appendingPathComponent("other.json")))
+            }
+        }
+        #expect(io.calls.count(where: { $0 == .write }) == 2)
+        #expect(io.calls.contains(.existence))
+        #expect(io.calls.contains(.read))
+        #expect(!CodexCredentialFileAccess.permits(auth))
+    }
+
+    @Test
+    func `and child detection ignores keychain and live permissions`() {
+        for process in ["swiftpm-testing-helper", "CodexBarPackageTests", "example.xctest"] {
+            #expect(CodexCredentialFileAccess.isTestContext(
+                processName: process, environment: ["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS": "1", "LIVE_TEST": "1"]))
+        }
+        #expect(CodexCredentialFileAccess.isTestContext(
+            processName: "codexbar", environment: [CodexCredentialFileAccess.isolationEnvironmentKey: "1"]))
+        #expect(!CodexCredentialFileAccess.isTestContext(processName: "codexbar", environment: [:]))
+        #expect(!CodexCredentialFileAccess.isTestContext(
+            processName: "codexbar", environment: ["CODEX_HOME": "/fictitious", "HOME": "/fictitious"]))
+    }
+
+    @Test
+    func `task scopes clean up and detached tasks fail closed unless explicitly scoped`() async {
+        let first = URL(fileURLWithPath: "/fictitious-first/auth.json")
+        let second = URL(fileURLWithPath: "/fictitious-second/auth.json")
+        let io = IO()
+        await CodexCredentialFileAccess.$testIO.withValue(io.call) {
+            let firstScope = CodexCredentialFileAccess.FixtureScope(files: [first])
+            let secondScope = CodexCredentialFileAccess.FixtureScope(files: [second])
+            await withTaskGroup(of: Void.self) { group in
+                for (scope, allowed, denied) in [(firstScope, first, second), (secondScope, second, first)] {
+                    group.addTask {
+                        await CodexCredentialFileAccess.withFixtureScope(scope) {
+                            await Task.yield()
+                            #expect(CodexCredentialFileAccess.permits(allowed))
+                            #expect(!CodexCredentialFileAccess.permits(denied))
+                            let detachedDenied = await Task.detached {
+                                !CodexCredentialFileAccess.permits(allowed)
+                            }.value
+                            #expect(detachedDenied)
+                            let detachedAllowed = await Task.detached {
+                                CodexCredentialFileAccess.$testIO.withValue(io.call) {
+                                    CodexCredentialFileAccess.withFixtureScope(scope) {
+                                        CodexCredentialFileAccess.permits(allowed)
+                                    }
+                                }
+                            }.value
+                            #expect(detachedAllowed)
+                        }
+                    }
+                }
+            }
+            enum Expected: Error { case stop }
+            #expect(throws: Expected.stop) {
+                try CodexCredentialFileAccess.withFixtureScope(firstScope) { throw Expected.stop }
+            }
+        }
+        #expect(!CodexCredentialFileAccess.permits(first))
+        #expect(!CodexCredentialFileAccess.permits(second))
+    }
+
+    @Test
+    func `external fallback visits only authorized native legacy and OpenCode candidates`() throws {
+        let home = URL(fileURLWithPath: "/fictitious-fixture-home")
+        let native = home.appendingPathComponent(".codex/auth.json").path
+        let legacy = home.appendingPathComponent(".config/codex/auth.json").path
+        let oauth = IO().bytes
+        let external = Data(#"{"openai":{"type":"oauth","access":"external-fixture"}}"#.utf8)
+        for configured in [false, true] {
+            let dataHome = configured ? home.appendingPathComponent("xdg") : home.appendingPathComponent(".local/share")
+            let openCode = dataHome.appendingPathComponent("opencode/auth.json").path
+            let env = configured ? ["XDG_DATA_HOME": dataHome.path] : [:]
+            for winner in [native, legacy, openCode] {
+                let files = [native: oauth, legacy: oauth, openCode: external].filter { key, _ in
+                    winner == native || (winner == legacy ? key != native : key == openCode)
+                }
+                let io = IO(files: files)
+                let credentials = try CodexCredentialFileAccess.$testIO.withValue(io.call) {
+                    try CodexOAuthCredentialsStore._loadForUsageForTesting(
+                        env: env, homeDirectory: home, allowExternalSources: true)
+                }
+                #expect(credentials
+                    .source == (winner == native ? .codexHome : winner == legacy ? .legacyCodexHome : .openCode))
+                #expect(io.targets == (winner == native ? [native] : winner == legacy ? [native, legacy] : [
+                    native,
+                    legacy,
+                    openCode,
+                ]))
+            }
+        }
+    }
+
+    @Test
+    func `authorized external root cannot bypass a denied native home`() {
+        let io = IO()
+        CodexCredentialFileAccess.$testIO.withValue(io.call) {
+            let scope = CodexCredentialFileAccess.FixtureScope(roots: [URL(fileURLWithPath: "/fictitious-xdg")])
+            let before = io.calls.count
+            _ = CodexCredentialFileAccess.withFixtureScope(scope) {
+                #expect(throws: CodexOAuthCredentialsError.self) {
+                    try CodexOAuthCredentialsStore.loadForUsage(
+                        env: ["XDG_DATA_HOME": "/fictitious-xdg"], allowExternalSources: true)
+                }
+            }
+            #expect(io.calls.count == before)
+        }
+    }
+
+    @Test
+    func `unregistered OpenCode is not probed after an authorized native miss`() {
+        let home = URL(fileURLWithPath: "/fictitious-owned-home")
+        let io = IO(files: [
+            "/fictitious-unregistered-xdg/opencode/auth.json":
+                Data(#"{"openai":{"type":"oauth","access":"must-not-read"}}"#.utf8),
+        ])
+        _ = CodexCredentialFileAccess.$testIO.withValue(io.call) {
+            #expect(throws: CodexOAuthCredentialsError.self) {
+                try CodexOAuthCredentialsStore._loadForUsageForTesting(
+                    env: ["XDG_DATA_HOME": "/fictitious-unregistered-xdg"],
+                    homeDirectory: home,
+                    allowExternalSources: true)
+            }
+        }
+        #expect(io.targets == [
+            home.appendingPathComponent(".codex/auth.json").path,
+            home.appendingPathComponent(".config/codex/auth.json").path,
+        ])
+    }
+
+    @Test
+    func `profile PAT miss cannot escape its scope into ambient HOME`() {
+        let home = URL(fileURLWithPath: "/fictitious-profile")
+        let auth = home.appendingPathComponent("auth.json")
+        let io = IO(files: [auth.path: Data(#"{"tokens":{}}"#.utf8)])
+        CodexCredentialFileAccess.$testIO.withValue(io.call) {
+            CodexCredentialFileAccess.withFixtureScope(.init(roots: [home])) { () in
+                #expect(throws: CodexOAuthCredentialsError.self) {
+                    try CodexOAuthCredentialsStore.loadPATResolvingScopedHome(
+                        env: ["CODEX_HOME": home.path, "HOME": "/fictitious-ambient"])
+                }
+            }
+        }
+        #expect(io.targets == [auth.path])
+    }
+
+    @Test(CodexCredentialFixtures())
+    func `owned roots reject sibling prefixes traversal and symlink escapes`() throws {
+        let root = CodexCredentialFixtures.root
+        let owned = root.appendingPathComponent("owned", isDirectory: true)
+        let outside = root.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: owned, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        let escape = owned.appendingPathComponent("escape", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: escape, withDestinationURL: outside)
+        let authLink = owned.appendingPathComponent("auth.json")
+        try FileManager.default.createSymbolicLink(
+            at: authLink,
+            withDestinationURL: outside.appendingPathComponent("auth.json"))
+        CodexCredentialFileAccess.withFixtureScope(.init(roots: [owned])) {
+            #expect(CodexCredentialFileAccess.permits(owned.appendingPathComponent("new/auth.json")))
+            #expect(!CodexCredentialFileAccess.permits(root.appendingPathComponent("owned-sibling/auth.json")))
+            #expect(!CodexCredentialFileAccess.permits(owned.appendingPathComponent("../outside/auth.json")))
+            #expect(!CodexCredentialFileAccess.permits(escape.appendingPathComponent("auth.json")))
+            #expect(!CodexCredentialFileAccess.permits(authLink))
+        }
+        CodexCredentialFileAccess.withFixtureScope(.init(files: [authLink], roots: [escape])) {
+            #expect(!CodexCredentialFileAccess.permits(authLink))
+            #expect(!CodexCredentialFileAccess.permits(escape.appendingPathComponent("auth.json")))
+        }
+    }
+
+    @Test
+    func `Codex metadata defaults are isolated and explicit overrides survive`() throws {
+        let accounts = FileManagedCodexAccountStore.defaultURL()
+        let workspaces = CodexOpenAIWorkspaceIdentityCache.defaultURL()
+        let temporary = FileManager.default.temporaryDirectory.standardizedFileURL.pathComponents
+        #expect(accounts.standardizedFileURL.pathComponents.starts(with: temporary))
+        #expect(workspaces.standardizedFileURL.pathComponents.starts(with: temporary))
+        #expect(accounts != FileManagedCodexAccountStore.defaultURL())
+        #expect(workspaces != CodexOpenAIWorkspaceIdentityCache.defaultURL())
+        #expect(try FileManagedCodexAccountStore().loadAccounts().accounts.isEmpty)
+        #expect(CodexOpenAIWorkspaceIdentityCache().workspaceLabel(for: "synthetic") == nil)
+        CodexOpenAIWorkspaceIdentityCache.withFileURLOverrideForTesting(workspaces) {
+            #expect(CodexOpenAIWorkspaceIdentityCache.defaultURL() == workspaces)
+        }
+    }
+
+    @Test
+    func `credential owners do not bypass guarded readers or whole write authorization`() throws {
+        let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
+        for path in [
+            "Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift",
+            "Sources/CodexBarCore/CodexManagedAccounts.swift",
+            "Sources/CodexBar/CodexAccountPromotionService.swift",
+        ] {
+            let source = try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
+            #expect(
+                !source.contains("Data(contentsOf:"),
+                "Route Codex credential reads through the file policy: \(path)")
+            #expect(!source.contains("fileExists(atPath:"), "Guard Codex credential probes: \(path)")
+        }
+        for (path, signature) in [
+            ("Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift", "public static func save("),
+            (
+                "Sources/CodexBar/CodexAccountPromotionService.swift",
+                "func swapLiveAuthData(_ data: Data, liveHomeURL: URL) throws {"),
+        ] {
+            let source = try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
+            let start = try #require(source.range(of: signature)?.upperBound)
+            let body = source[start...]
+            let guardPosition = try #require(body.range(of: "guard CodexCredentialFileAccess.permits("))
+            let ioPosition = try #require(body.range(of: "substituteWriteForTesting("))
+            let directoryPosition = try #require(body.range(of: "createDirectory("))
+            #expect(guardPosition.lowerBound < ioPosition.lowerBound)
+            #expect(ioPosition.lowerBound < directoryPosition.lowerBound)
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodexCredentialFixtures.swift
+++ b/Tests/CodexBarTests/CodexCredentialFixtures.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+/// Each test owns one root. No process-wide authorization, including between parallel test cases.
+struct CodexCredentialFixtures: TestTrait, SuiteTrait, TestScoping {
+    @TaskLocal private static var currentRoot: URL?
+
+    static var root: URL {
+        guard let currentRoot else { preconditionFailure("Add CodexCredentialFixtures to this test or suite") }
+        return currentRoot
+    }
+
+    var isRecursive: Bool {
+        true
+    }
+
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void) async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-credential-fixture-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await Self.$currentRoot.withValue(root) {
+            try await CodexCredentialFileAccess.withFixtureScope(.init(roots: [root])) {
+                try await OpenAIDashboardCacheStore.$cacheURLOverride.withValue(
+                    root.appendingPathComponent("openai-dashboard.json"))
+                {
+                    try await function()
+                }
+            }
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodexDashboardWorkedExampleParityTests.swift
+++ b/Tests/CodexBarTests/CodexDashboardWorkedExampleParityTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import CodexBarCLI
 @testable import CodexBarCore
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexDashboardWorkedExampleParityTests {
     @Test
@@ -460,7 +460,7 @@ struct CodexDashboardWorkedExampleParityTests {
     }
 
     private func makeAuthHome(email: String?, accountId: String? = nil) throws -> URL {
-        let homeURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let homeURL = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try self.writeCodexAuthFile(homeURL: homeURL, email: email, accountId: accountId)
@@ -468,7 +468,7 @@ struct CodexDashboardWorkedExampleParityTests {
     }
 
     private func makeEmptyHome() -> URL {
-        let homeURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let homeURL = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try? FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)

--- a/Tests/CodexBarTests/CodexLimitResetOwnerKeyTests.swift
+++ b/Tests/CodexBarTests/CodexLimitResetOwnerKeyTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexLimitResetOwnerKeyTests {
     @Test

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebRefreshTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import CodexBar
 @testable import CodexBarCore
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexManagedOpenAIWebRefreshTests {
     @Test
@@ -14,7 +14,7 @@ struct CodexManagedOpenAIWebRefreshTests {
         if let codexMeta = ProviderRegistry.shared.metadata[.codex] {
             settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
         }
-        let managedHomeURL = FileManager.default.temporaryDirectory
+        let managedHomeURL = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? Self.writeCodexAuthFile(
             homeURL: managedHomeURL,
@@ -110,7 +110,7 @@ struct CodexManagedOpenAIWebRefreshTests {
         if let codexMeta = ProviderRegistry.shared.metadata[.codex] {
             settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
         }
-        let managedHomeURL = FileManager.default.temporaryDirectory
+        let managedHomeURL = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? Self.writeCodexAuthFile(
             homeURL: managedHomeURL,
@@ -166,7 +166,7 @@ struct CodexManagedOpenAIWebRefreshTests {
         if let codexMeta = ProviderRegistry.shared.metadata[.codex] {
             settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
         }
-        let managedHomeURL = FileManager.default.temporaryDirectory
+        let managedHomeURL = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? Self.writeCodexAuthFile(
             homeURL: managedHomeURL,
@@ -242,7 +242,7 @@ struct CodexManagedOpenAIWebRefreshTests {
         if let codexMeta = ProviderRegistry.shared.metadata[.codex] {
             settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
         }
-        let managedHomeURL = FileManager.default.temporaryDirectory
+        let managedHomeURL = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? Self.writeCodexAuthFile(
             homeURL: managedHomeURL,
@@ -334,7 +334,7 @@ struct CodexManagedOpenAIWebRefreshTests {
     func `manual cookie import bypasses same account refresh coalescing`() async throws {
         let settings = try self.makeSettingsStore(
             suite: "CodexManagedOpenAIWebRefreshTests-manual-import-bypass-coalesce")
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-managed-openai-web-refresh-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: managedHome,

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebTestSupport.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebTestSupport.swift
@@ -7,7 +7,7 @@ extension CodexManagedOpenAIWebTests {
     @Test
     func `same account dashboard refresh requests coalesce while one is in flight`() async throws {
         let settings = self.makeSettingsStore(suite: "CodexManagedOpenAIWebTests-refresh-coalesce")
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-openai-web-coalesce-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
         try Self.writeCodexAuthFile(

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebTests.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import CodexBar
 @testable import CodexBarCore
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexManagedOpenAIWebTests {
     @Test
@@ -52,7 +52,7 @@ struct CodexManagedOpenAIWebTests {
     @Test
     func `managed codex open A I web targets runtime auth backed email for selected account`() throws {
         let settings = self.makeSettingsStore(suite: "CodexManagedOpenAIWebTests-managed-runtime-email")
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
         try Self.writeCodexAuthFile(

--- a/Tests/CodexBarTests/CodexManagedRoutingTests.swift
+++ b/Tests/CodexBarTests/CodexManagedRoutingTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import CodexBar
 @testable import CodexBarCore
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexManagedRoutingTests {
     @Test
@@ -176,7 +176,7 @@ struct CodexManagedRoutingTests {
     @Test
     func `provider registry prefers live system routing when managed and live share email`() {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-same-email-prefers-live")
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         let liveHomePath = "/tmp/system-remote-home"
@@ -216,7 +216,7 @@ struct CodexManagedRoutingTests {
     @Test
     func `provider registry keeps managed routing when same email rows differ by identity strength`() throws {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-same-email-split-by-identity")
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         let liveHomePath = "/tmp/system-remote-home"
@@ -291,7 +291,7 @@ struct CodexManagedRoutingTests {
     @Test
     func `codex provider refresh persists live correction for stale managed source`() async {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-provider-refresh-persists-correction")
-        let ambientHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let ambientHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: ambientHome) }
@@ -320,7 +320,7 @@ struct CodexManagedRoutingTests {
     @Test
     func `full refresh persists live correction for stale managed source`() async {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-full-refresh-persists-correction")
-        let ambientHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let ambientHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: ambientHome) }
@@ -525,7 +525,7 @@ struct CodexManagedRoutingTests {
     @Test
     func `provider registry ignores debug managed home override without explicit managed source`() throws {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-debug-home-override")
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
@@ -548,7 +548,7 @@ struct CodexManagedRoutingTests {
     @Test
     func `provider registry builds codex fetcher scoped to managed home`() throws {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-registry-fetcher")
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
@@ -577,7 +577,7 @@ struct CodexManagedRoutingTests {
     @Test
     func `usage store builds codex fetch context with source override without persisting selection`() throws {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-usage-source-override")
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
@@ -621,7 +621,7 @@ struct CodexManagedRoutingTests {
     @Test
     func `usage store builds codex token account fetcher scoped to managed home`() throws {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-usage-store")
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
@@ -648,7 +648,7 @@ struct CodexManagedRoutingTests {
     @Test
     func `usage store builds codex credits fetcher scoped to managed home`() throws {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-credits-fetcher")
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
@@ -673,7 +673,7 @@ struct CodexManagedRoutingTests {
 
     @Test
     func `default managed codex identity reader preserves provider account from scoped auth`() throws {
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
@@ -693,7 +693,7 @@ struct CodexManagedRoutingTests {
 
     @Test
     func `codex O auth strategy availability reads auth from context env`() async throws {
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }
@@ -714,7 +714,7 @@ struct CodexManagedRoutingTests {
 
     @Test
     func `codex O auth credentials store loads and saves using explicit env`() throws {
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: managedHome) }

--- a/Tests/CodexBarTests/CodexOAuthCredentialReadTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthCredentialReadTests.swift
@@ -2,10 +2,11 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+@Suite(CodexCredentialFixtures())
 struct CodexOAuthCredentialReadTests {
     @Test
     func `missing auth json maps to a not found credential error`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-missing-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
 
@@ -20,7 +21,7 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `unreadable auth json maps to an unreadable credential error`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-unreadable-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
@@ -225,9 +226,9 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `expired external oauth fetch fails closed without mutating its source`() async throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-stale-fetch-home-\(UUID().uuidString)", isDirectory: true)
-        let dataHome = FileManager.default.temporaryDirectory
+        let dataHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-stale-fetch-data-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: home)
@@ -355,9 +356,9 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `consented external OAuth fetch uses the token without mutating its source`() async throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-fetch-home-\(UUID().uuidString)", isDirectory: true)
-        let dataHome = FileManager.default.temporaryDirectory
+        let dataHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-fetch-data-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: home)
@@ -431,7 +432,7 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `credential save preserves the supplied refresh timestamp`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-save-timestamp-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
         let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
@@ -472,9 +473,9 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `native codex home wins over external oauth sources`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-native-home-\(UUID().uuidString)", isDirectory: true)
-        let dataHome = FileManager.default.temporaryDirectory
+        let dataHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-native-data-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: home)
@@ -512,9 +513,9 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `legacy codex home wins before open code fallback`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-legacy-home-\(UUID().uuidString)", isDirectory: true)
-        let dataHome = FileManager.default.temporaryDirectory
+        let dataHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-legacy-data-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: home)
@@ -554,7 +555,7 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `legacy API keys are rejected by the external OAuth fallback`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-legacy-api-key-home-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
         let legacyDirectory = home
@@ -578,9 +579,9 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `usage credential loading falls back to isolated open code data`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-fallback-home-\(UUID().uuidString)", isDirectory: true)
-        let dataHome = FileManager.default.temporaryDirectory
+        let dataHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-fallback-data-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: home)
@@ -610,9 +611,9 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `external fallback does not mask an unreadable native auth file`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-unreadable-native-\(UUID().uuidString)", isDirectory: true)
-        let dataHome = FileManager.default.temporaryDirectory
+        let dataHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-unreadable-external-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: home)
@@ -642,7 +643,7 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `external fallback does not mask malformed native auth json`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-malformed-native-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
         let nativeDirectory = home.appendingPathComponent(".codex", isDirectory: true)
@@ -663,7 +664,7 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `external fallback does not mask native auth without oauth tokens`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-missing-tokens-native-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
         let nativeDirectory = home.appendingPathComponent(".codex", isDirectory: true)
@@ -684,9 +685,9 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `external OAuth fallback is disabled without explicit consent`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-consent-home-\(UUID().uuidString)", isDirectory: true)
-        let dataHome = FileManager.default.temporaryDirectory
+        let dataHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-consent-data-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: home)
@@ -713,9 +714,9 @@ struct CodexOAuthCredentialReadTests {
 
     @Test
     func `explicit codex home does not borrow open code credentials`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-isolated-home-\(UUID().uuidString)", isDirectory: true)
-        let dataHome = FileManager.default.temporaryDirectory
+        let dataHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-isolated-data-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: home)

--- a/Tests/CodexBarTests/CodexOAuthCredentialsStorePermissionsTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthCredentialsStorePermissionsTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+@Suite(CodexCredentialFixtures())
 struct CodexOAuthCredentialsStorePermissionsTests {
     private enum PublishProbeError: Error, Equatable {
         case stop
@@ -10,7 +11,7 @@ struct CodexOAuthCredentialsStorePermissionsTests {
     @Test
     func `saving O auth credentials keeps auth json private`() throws {
         #if os(macOS) || os(Linux)
-        let codexHome = FileManager.default.temporaryDirectory
+        let codexHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-permissions-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: codexHome) }
 
@@ -35,7 +36,7 @@ struct CodexOAuthCredentialsStorePermissionsTests {
     @Test
     func `auth json is private before atomic publication`() throws {
         #if os(macOS) || os(Linux)
-        let codexHome = FileManager.default.temporaryDirectory
+        let codexHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-oauth-staging-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: codexHome) }
         try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)

--- a/Tests/CodexBarTests/CodexOAuthManagedWorkspaceRecoveryTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthManagedWorkspaceRecoveryTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+@Suite(CodexCredentialFixtures())
 struct CodexOAuthManagedWorkspaceRecoveryTests {
     @Test
     func `automatic mode does not expose unscoped CLI fallback for a managed workspace`() async {
@@ -13,7 +14,7 @@ struct CodexOAuthManagedWorkspaceRecoveryTests {
 
     @Test
     func `native refresh recovery is unavailable when managed workspace scope is selected`() async throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codexbar-native-refresh-managed-workspace-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: home) }

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+@Suite(CodexCredentialFixtures())
 struct CodexOAuthTests {
     private func makeContext(
         runtime: ProviderRuntime = .app,
@@ -87,7 +88,7 @@ struct CodexOAuthTests {
 
     @Test
     func `reset-credit token load ignores an API key beside O auth tokens`() throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codexbar-reset-credit-oauth-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: home) }
@@ -811,7 +812,7 @@ struct CodexOAuthTests {
 
     @Test
     func `native refresh recovery is unavailable when Codex CLI is missing`() async throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codexbar-native-refresh-no-cli-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: home) }

--- a/Tests/CodexBarTests/CodexPATAppPublicationTests.swift
+++ b/Tests/CodexBarTests/CodexPATAppPublicationTests.swift
@@ -13,7 +13,7 @@ extension CodexAccountScopedRefreshTests {
         settings._test_liveSystemCodexAccount = self.liveAccount(email: "live-oauth@example.com")
 
         let managedID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-999999999999"))
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-pat-managed-\(UUID().uuidString)", isDirectory: true)
         let managedAccount = ManagedCodexAccount(
             id: managedID,
@@ -26,7 +26,7 @@ extension CodexAccountScopedRefreshTests {
         settings._test_managedCodexAccountStoreURL = managedStoreURL
         settings.codexActiveSource = .managedAccount(id: managedID)
 
-        let ambientRoot = FileManager.default.temporaryDirectory
+        let ambientRoot = CodexCredentialFixtures.root
             .appendingPathComponent("codex-pat-ambient-\(UUID().uuidString)", isDirectory: true)
         let ambientCodexHome = ambientRoot.appendingPathComponent(".codex", isDirectory: true)
         try FileManager.default.createDirectory(
@@ -80,7 +80,7 @@ extension CodexAccountScopedRefreshTests {
         settings.codexUsageDataSource = .auto
         settings._test_liveSystemCodexAccount = self.liveAccount(email: "live-oauth@example.com")
 
-        let profileHome = FileManager.default.temporaryDirectory
+        let profileHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-pat-profile-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: profileHome, withIntermediateDirectories: true)
         try Data(#"{"personal_access_token":"at-profile-only"}"#.utf8)
@@ -90,7 +90,7 @@ extension CodexAccountScopedRefreshTests {
             entry.codexActiveSource = .profileHome(path: profileHome.path)
         }
 
-        let ambientRoot = FileManager.default.temporaryDirectory
+        let ambientRoot = CodexCredentialFixtures.root
             .appendingPathComponent(
                 "codex-pat-ambient-empty-\(UUID().uuidString)", isDirectory: true)
         let ambientCodexHome = ambientRoot.appendingPathComponent(".codex", isDirectory: true)

--- a/Tests/CodexBarTests/CodexPATTests.swift
+++ b/Tests/CodexBarTests/CodexPATTests.swift
@@ -6,6 +6,7 @@ import Testing
 import FoundationNetworking
 #endif
 
+@Suite(CodexCredentialFixtures())
 struct CodexPATTests {
     @Test
     func `parses personal access token credentials`() throws {
@@ -258,9 +259,9 @@ struct CodexPATTests {
         let failClosed = "/Users/test/Library/Application Support/CodexBar/managed-store-unreadable"
         let managedHome =
             "/Users/test/Library/Application Support/CodexBar/managed-codex-homes/00000000-0000-0000-0000-000000000001"
-        let profileHome = FileManager.default.temporaryDirectory
+        let profileHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-pat-profile-\(UUID().uuidString)", isDirectory: true)
-        let profileWithPAT = FileManager.default.temporaryDirectory
+        let profileWithPAT = CodexCredentialFixtures.root
             .appendingPathComponent("codex-pat-profile-with-pat-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: profileHome)
@@ -294,10 +295,10 @@ struct CodexPATTests {
 
     @Test
     func `PAT ambient fallback uses env HOME instead of the process user home`() throws {
-        let ambientRoot = FileManager.default.temporaryDirectory
+        let ambientRoot = CodexCredentialFixtures.root
             .appendingPathComponent("codex-pat-home-\(UUID().uuidString)", isDirectory: true)
         let ambientCodexHome = ambientRoot.appendingPathComponent(".codex", isDirectory: true)
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-pat-managed-\(UUID().uuidString)", isDirectory: true)
         defer {
             try? FileManager.default.removeItem(at: ambientRoot)

--- a/Tests/CodexBarTests/CodexPresentationCharacterizationTests.swift
+++ b/Tests/CodexBarTests/CodexPresentationCharacterizationTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexPresentationCharacterizationTests {
     @Test
@@ -220,7 +220,7 @@ struct CodexPresentationCharacterizationTests {
     func `Codex menu prefers snapshot identity over conflicting fallback account info`() throws {
         let settings = self.makeSettingsStore(suite: "CodexPresentationCharacterizationTests-snapshot-precedence")
         settings.statusChecksEnabled = false
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-presentation-fallback-\(UUID().uuidString)", isDirectory: true)
         let managedAccount = ManagedCodexAccount(
             id: UUID(),
@@ -280,7 +280,7 @@ struct CodexPresentationCharacterizationTests {
     func `Codex menu falls back per field when snapshot identity is partial`() {
         let settings = self.makeSettingsStore(suite: "CodexPresentationCharacterizationTests-partial-fallback")
         settings.statusChecksEnabled = false
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-presentation-partial-\(UUID().uuidString)", isDirectory: true)
         let managedAccount = ManagedCodexAccount(
             id: UUID(),

--- a/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
+++ b/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 struct CodexProfileHomeAccountTests {
     @MainActor
     private static func makeSettings(suite: String) throws -> SettingsStore {
@@ -24,10 +24,10 @@ struct CodexProfileHomeAccountTests {
     func `settings store discovers configured codex profile homes`() throws {
         let suite = "CodexProfileHomeAccountTests-discovery"
         let settings = try Self.makeSettings(suite: suite)
-        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let missingLiveHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
-        let profileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let profileHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try Self.writeCodexAuthFile(
@@ -69,7 +69,7 @@ struct CodexProfileHomeAccountTests {
     func `provider registry scopes selected codex profile home`() throws {
         let suite = "CodexProfileHomeAccountTests-routing"
         let settings = try Self.makeSettings(suite: suite)
-        let profileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let profileHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try Self.writeCodexAuthFile(
@@ -225,10 +225,10 @@ struct CodexProfileHomeAccountTests {
     func `removed profile home falls back without routing stale path`() throws {
         let suite = "CodexProfileHomeAccountTests-stale-routing"
         let settings = try Self.makeSettings(suite: suite)
-        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let missingLiveHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
-        let removedProfileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let removedProfileHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         settings._test_codexReconciliationEnvironment = ["CODEX_HOME": missingLiveHome.path]
@@ -266,10 +266,10 @@ struct CodexProfileHomeAccountTests {
     func `external config removal immediately invalidates profile routing caches`() throws {
         let suite = "CodexProfileHomeAccountTests-external-removal"
         let settings = try Self.makeSettings(suite: suite)
-        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let missingLiveHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
-        let profileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let profileHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try Self.writeCodexAuthFile(
@@ -338,10 +338,10 @@ struct CodexProfileHomeAccountTests {
     func `unreadable configured profile home remains selected and routed`() throws {
         let suite = "CodexProfileHomeAccountTests-unreadable-routing"
         let settings = try Self.makeSettings(suite: suite)
-        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let missingLiveHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
-        let unreadableProfileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let unreadableProfileHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         settings._test_codexReconciliationEnvironment = ["CODEX_HOME": missingLiveHome.path]
@@ -374,10 +374,10 @@ struct CodexProfileHomeAccountTests {
     func `profile without verified email refuses open A I cookie import`() async throws {
         let suite = "CodexProfileHomeAccountTests-missing-web-email"
         let settings = try Self.makeSettings(suite: suite)
-        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let missingLiveHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
-        let unreadableProfileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let unreadableProfileHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         settings._test_codexReconciliationEnvironment = ["CODEX_HOME": missingLiveHome.path]
@@ -419,7 +419,7 @@ struct CodexProfileHomeAccountTests {
     func `profile home matching live home resolves to visible live account`() throws {
         let suite = "CodexProfileHomeAccountTests-live-duplicate"
         let settings = try Self.makeSettings(suite: suite)
-        let liveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let liveHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         let liveAccount = ObservedSystemCodexAccount(
@@ -449,7 +449,7 @@ struct CodexProfileHomeAccountTests {
     func `profile home matching managed home resolves to visible managed account`() throws {
         let suite = "CodexProfileHomeAccountTests-managed-duplicate"
         let settings = try Self.makeSettings(suite: suite)
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         let managedAccount = ManagedCodexAccount(
@@ -501,7 +501,7 @@ struct CodexProfileHomeAccountTests {
         settings.costUsageEnabled = true
         settings.costSummaryDisplayStyle = .both
         settings.codexLocalSessionCostLedgerEnabled = localLedgerEnabled
-        let root = FileManager.default.temporaryDirectory
+        let root = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let firstHome = root.appendingPathComponent("profile-a", isDirectory: true)
         let secondHome = root.appendingPathComponent("profile-b", isDirectory: true)

--- a/Tests/CodexBarTests/CodexResetBackfillSemanticsTests.swift
+++ b/Tests/CodexBarTests/CodexResetBackfillSemanticsTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
+@Suite(CodexCredentialFixtures())
 struct CodexResetBackfillSemanticsTests {
     @Test
     func `merged reset cache preserves semantic lanes across swapped snapshots`() throws {
@@ -274,9 +275,9 @@ extension CodexAccountScopedRefreshTests {
 
         let targetID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-424242424242"))
         let siblingID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-434343434343"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-email-only-target-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-email-only-sibling-\(UUID().uuidString)", isDirectory: true)
         try Self.writeCodexAuthFile(
             homeURL: targetHome,

--- a/Tests/CodexBarTests/CodexSystemAccountObserverTests.swift
+++ b/Tests/CodexBarTests/CodexSystemAccountObserverTests.swift
@@ -3,11 +3,11 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 struct CodexSystemAccountObserverTests {
     @Test
     func `observer reads ambient CODEX_HOME when present`() throws {
-        let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let home = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
         try Self.writeCodexAuthFile(
             homeURL: home,
@@ -25,7 +25,7 @@ struct CodexSystemAccountObserverTests {
 
     @Test
     func `observer falls back to nil when ambient home has no readable email`() throws {
-        let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let home = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
 
@@ -37,7 +37,7 @@ struct CodexSystemAccountObserverTests {
 
     @Test
     func `observer records observation timestamp`() throws {
-        let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let home = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
         try Self.writeCodexAuthFile(homeURL: home, email: "user@example.com", plan: "team")
 
@@ -51,7 +51,7 @@ struct CodexSystemAccountObserverTests {
 
     @Test
     func `observer preserves provider account identity from scoped auth`() throws {
-        let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let home = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }
         try Self.writeCodexAuthFile(
             homeURL: home,
@@ -67,7 +67,7 @@ struct CodexSystemAccountObserverTests {
 
     @Test
     func `observer uses cached workspace label for provider account`() throws {
-        let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let home = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let cacheURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("codex-openai-workspaces-\(UUID().uuidString).json")
         defer {

--- a/Tests/CodexBarTests/CodexSystemPromotionUITests.swift
+++ b/Tests/CodexBarTests/CodexSystemPromotionUITests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexSystemPromotionUITests {
     @Test

--- a/Tests/CodexBarTests/CodexUsageOwnerRaceTests.swift
+++ b/Tests/CodexBarTests/CodexUsageOwnerRaceTests.swift
@@ -154,7 +154,7 @@ extension CodexAccountScopedRefreshTests {
             email: "stacked-a@example.com",
             identity: .providerAccount(id: "stacked-owner-a"))
         let managedID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-515151515151"))
-        let managedHome = FileManager.default.temporaryDirectory
+        let managedHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-stacked-owner-race-\(UUID().uuidString)", isDirectory: true)
         let managedAccount = try self.makeManagedCodexWeeklyPublicationAccount(
             id: managedID,

--- a/Tests/CodexBarTests/CodexWebDashboardStrategyAuthorityTests.swift
+++ b/Tests/CodexBarTests/CodexWebDashboardStrategyAuthorityTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct CodexWebDashboardStrategyAuthorityTests {
     @Test
@@ -381,7 +381,7 @@ struct CodexWebDashboardStrategyAuthorityTests {
     }
 
     private func makeAuthHome(email: String?, accountId: String? = nil) throws -> URL {
-        let homeURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let homeURL = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         try self.writeCodexAuthFile(homeURL: homeURL, email: email, accountId: accountId)

--- a/Tests/CodexBarTests/CodexWeeklyResetPublicationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetPublicationTests.swift
@@ -1119,9 +1119,9 @@ extension CodexAccountScopedRefreshTests {
         let suite = "CodexWeeklyResetPublicationTests-stacked-response-email-mismatch"
         let targetID = try #require(UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
         let siblingID = try #require(UUID(uuidString: "66666666-7777-8888-9999-AAAAAAAAAAAA"))
-        let targetHome = FileManager.default.temporaryDirectory
+        let targetHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-stacked-mismatch-target-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-stacked-mismatch-sibling-\(UUID().uuidString)", isDirectory: true)
         let target = try self.makeManagedCodexWeeklyPublicationAccount(
             id: targetID,
@@ -1189,9 +1189,9 @@ extension CodexAccountScopedRefreshTests {
 
         let suspiciousID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-303030303030"))
         let siblingID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-313131313131"))
-        let suspiciousHome = FileManager.default.temporaryDirectory
+        let suspiciousHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-weekly-suspicious-\(UUID().uuidString)", isDirectory: true)
-        let siblingHome = FileManager.default.temporaryDirectory
+        let siblingHome = CodexCredentialFixtures.root
             .appendingPathComponent("codex-weekly-sibling-\(UUID().uuidString)", isDirectory: true)
         let suspiciousAccount = try self.makeManagedCodexWeeklyPublicationAccount(
             id: suspiciousID,

--- a/Tests/CodexBarTests/CodexWithheldPublicationErrorTests.swift
+++ b/Tests/CodexBarTests/CodexWithheldPublicationErrorTests.swift
@@ -222,7 +222,7 @@ extension CodexAccountScopedRefreshTests {
         settings.codexCookieSource = .off
         settings.codexUsageDataSource = .oauth
         settings.multiAccountMenuLayout = stacked ? .stacked : .segmented
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString)
         let targetHome = root.appendingPathComponent("target")
         let siblingHome = root.appendingPathComponent("sibling")
         let target = try self.makeManagedCodexWeeklyPublicationAccount(

--- a/Tests/CodexBarTests/CodexbarTests.swift
+++ b/Tests/CodexBarTests/CodexbarTests.swift
@@ -878,7 +878,9 @@ struct CodexBarTests {
         try data.write(to: authURL)
 
         let fetcher = UsageFetcher(environment: ["CODEX_HOME": tmp.path])
-        let account = fetcher.loadAccountInfo()
+        let account = CodexCredentialFileAccess.withFixtureScope(.init(files: [authURL])) {
+            fetcher.loadAccountInfo()
+        }
         #expect(account.email == "user@example.com")
         #expect(account.plan == "pro")
     }
@@ -899,7 +901,9 @@ struct CodexBarTests {
         try data.write(to: authURL)
 
         let fetcher = UsageFetcher(environment: ["CODEX_HOME": tmp.path])
-        let account = fetcher.loadAccountInfo()
+        let account = CodexCredentialFileAccess.withFixtureScope(.init(files: [authURL])) {
+            fetcher.loadAccountInfo()
+        }
         #expect(account.email == "user@example.com")
         #expect(account.plan == "pro")
     }

--- a/Tests/CodexBarTests/ManagedCodexAccountServiceTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountServiceTests.swift
@@ -3,12 +3,12 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct ManagedCodexAccountServiceTests {
     @Test
     func `upsert preserves uuid for matching canonical email`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
         let fileURL = root.appendingPathComponent("managed.json", isDirectory: false)
@@ -36,7 +36,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `new authentication appends managed account without implicit selection side effect`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
         let firstID = try #require(UUID(uuidString: "11111111-1111-1111-1111-111111111111"))
@@ -69,7 +69,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `same email provider backed workspaces coexist across sequential add account flows`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
         let store = InMemoryManagedCodexAccountStore(
@@ -115,7 +115,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `same workspace provider id with different emails does not overwrite existing account`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let existingHome = root.appendingPathComponent("accounts/existing", isDirectory: true)
         try FileManager.default.createDirectory(at: existingHome, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -166,7 +166,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `selected workspace is persisted and used as account identity`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
         let store = InMemoryManagedCodexAccountStore(
@@ -212,7 +212,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `reauth keeps previous home when store write fails`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let existingHome = root.appendingPathComponent("accounts/existing", isDirectory: true)
         try FileManager.default.createDirectory(at: existingHome, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -251,7 +251,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `reauth reconciles by provider account id before existing account id`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let alphaHome = root.appendingPathComponent("accounts/alpha", isDirectory: true)
         let betaHome = root.appendingPathComponent("accounts/beta", isDirectory: true)
         try FileManager.default.createDirectory(at: alphaHome, withIntermediateDirectories: true)
@@ -309,7 +309,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `reauth to different account does not overwrite existing account id match`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let aliceHome = root.appendingPathComponent("accounts/alice", isDirectory: true)
         try FileManager.default.createDirectory(at: aliceHome, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -355,7 +355,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `reauth on same email different workspace does not overwrite selected workspace`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let personalHome = root.appendingPathComponent("accounts/personal", isDirectory: true)
         try FileManager.default.createDirectory(at: personalHome, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -407,7 +407,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `legacy row collapses onto provider backed row when provider id resolves elsewhere`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let legacyHome = root.appendingPathComponent("accounts/legacy", isDirectory: true)
         let providerHome = root.appendingPathComponent("accounts/provider", isDirectory: true)
         try FileManager.default.createDirectory(at: legacyHome, withIntermediateDirectories: true)
@@ -456,7 +456,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `fresh provider login removes stale legacy row without explicit existing account id`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let legacyHome = root.appendingPathComponent("accounts/legacy", isDirectory: true)
         let providerHome = root.appendingPathComponent("accounts/provider", isDirectory: true)
         try FileManager.default.createDirectory(at: legacyHome, withIntermediateDirectories: true)
@@ -504,7 +504,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `authentication persists workspace metadata and tolerates missing workspace label`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
         let store = InMemoryManagedCodexAccountStore(
@@ -539,7 +539,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `reauth preserves stored provider metadata when refresh cannot resolve account id`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let existingHome = root.appendingPathComponent("accounts/existing", isDirectory: true)
         try FileManager.default.createDirectory(at: existingHome, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -586,7 +586,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `auth failure cleanup uses managed root safety check`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let outsideHome = FileManager.default.temporaryDirectory.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
@@ -615,7 +615,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `auth failure preserves codex login result output`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
         let loginResult = CodexLoginRunner.Result(
@@ -645,7 +645,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `remove deletes managed home under managed root`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let home = root.appendingPathComponent("accounts/account-a", isDirectory: true)
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -675,7 +675,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `remove keeps remaining managed account records`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let firstHome = root.appendingPathComponent("accounts/account-a", isDirectory: true)
         let secondHome = root.appendingPathComponent("accounts/account-b", isDirectory: true)
         try FileManager.default.createDirectory(at: firstHome, withIntermediateDirectories: true)
@@ -718,7 +718,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `remove keeps persisted account when store write fails`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let home = root.appendingPathComponent("accounts/account-a", isDirectory: true)
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -751,7 +751,7 @@ struct ManagedCodexAccountServiceTests {
 
     @Test
     func `remove drops account but leaves unsafe home untouched`() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let outsideRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)

--- a/Tests/CodexBarTests/ManagedCodexAccountStoreTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountStoreTests.swift
@@ -159,9 +159,9 @@ func `FileManagedCodexAccountStore drops duplicate canonical emails on load`() t
     #expect(loaded.accounts.first?.managedHomePath == "/tmp/managed-home-1")
 }
 
-@Test
+@Test(CodexCredentialFixtures())
 func `FileManagedCodexAccountStore keeps same email rows when hydrated provider account I Ds differ`() throws {
-    let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
     defer { try? FileManager.default.removeItem(at: root) }
 
     let fileURL = root.appendingPathComponent("managed.json", isDirectory: false)
@@ -237,9 +237,9 @@ func `managed account set keeps same provider account I D when emails differ`() 
     #expect(set.account(email: "mich.aelfmk5542@gmail.com", providerAccountID: "team-4107")?.id == secondID)
 }
 
-@Test
+@Test(CodexCredentialFixtures())
 func `FileManagedCodexAccountStore hydrates provider account I D from id token when account field is absent`() throws {
-    let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
     defer { try? FileManager.default.removeItem(at: root) }
 
     let fileURL = root.appendingPathComponent("managed.json", isDirectory: false)
@@ -390,9 +390,9 @@ func `FileManagedCodexAccountStore ignores legacy active account key on load`() 
     #expect(loaded.account(id: accountID)?.email == "user@example.com")
 }
 
-@Test
+@Test(CodexCredentialFixtures())
 func `FileManagedCodexAccountStore upgrades v1 rows and writes readable v2 file without reauth`() throws {
-    let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
     defer { try? FileManager.default.removeItem(at: root) }
 
     let fileURL = root.appendingPathComponent("managed.json", isDirectory: false)

--- a/Tests/CodexBarTests/MenuDescriptorCodexManagedFallbackTests.swift
+++ b/Tests/CodexBarTests/MenuDescriptorCodexManagedFallbackTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 @MainActor
 struct MenuDescriptorCodexManagedFallbackTests {
-    @Test
+    @Test(CodexCredentialFixtures())
     func `codex account section prefers managed fallback over ambient account`() throws {
         let suite = "MenuDescriptorCodexManagedFallbackTests"
         let defaults = try #require(UserDefaults(suiteName: suite))
@@ -30,10 +30,10 @@ struct MenuDescriptorCodexManagedFallbackTests {
             tokenAccountStore: InMemoryTokenAccountStore())
         settings.statusChecksEnabled = false
 
-        let ambientHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let ambientHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer {

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -367,13 +367,13 @@ struct ProvidersPaneCoverageTests {
         #expect(picker?.trailingActions.first?.isVisible?() == false)
     }
 
-    @Test
+    @Test(CodexCredentialFixtures())
     func `codex providers pane uses managed account fallback instead of ambient account`() throws {
         let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-codex-managed-fallback")
-        let ambientHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let ambientHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         defer {

--- a/Tests/CodexBarTests/SpendDashboardCachedPresentationTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardCachedPresentationTests.swift
@@ -245,9 +245,9 @@ struct SpendDashboardCachedPresentationTests {
         #expect(SpendDashboardSource.codexCacheRoot(for: second).lastPathComponent == "second-cache")
     }
 
-    @Test
+    @Test(CodexCredentialFixtures())
     func `cached Codex totals reject an account rotation during hydration`() async throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("SpendDashboardCachedAuth-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: home) }

--- a/Tests/CodexBarTests/SpendDashboardControllerTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardControllerTests.swift
@@ -53,9 +53,9 @@ struct SpendDashboardControllerTests {
         #expect(contexts.first?.includePiSessions == false)
     }
 
-    @Test
+    @Test(CodexCredentialFixtures())
     func `Codex auth rotation invalidates stale spend while retaining unrelated providers`() async throws {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent(
                 "SpendDashboardControllerTests-auth-rotation-\(UUID().uuidString)",
                 isDirectory: true)

--- a/Tests/CodexBarTests/SpendDashboardModelTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardModelTests.swift
@@ -778,10 +778,10 @@ struct SpendDashboardModelTests {
         #expect(spendDashboardModelHistoryPresentation(group) == .partial)
     }
 
-    @Test
+    @Test(CodexCredentialFixtures())
     func `Codex requests freeze source home auth and cache identity`() throws {
         let id = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("SpendDashboardModelTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: home) }

--- a/Tests/CodexBarTests/SpendDashboardPublicationTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardPublicationTests.swift
@@ -129,15 +129,15 @@ struct SpendDashboardPublicationTests {
             .snapshot.last30DaysCostUSD == 2.5)
     }
 
-    @Test
+    @Test(CodexCredentialFixtures())
     func `shared publication starts and stops in-flight Codex dashboard catch-up`() async throws {
         let settings = testSettingsStore(suiteName: "SpendDashboardPublicationTests-codex-catch-up")
         settings.costUsageEnabled = true
         let metadata = try #require(ProviderRegistry.shared.metadata[.codex])
         settings.setProviderEnabled(provider: .codex, metadata: metadata, enabled: true)
-        let missingLiveHome = FileManager.default.temporaryDirectory
+        let missingLiveHome = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let profileHome = FileManager.default.temporaryDirectory
+        let profileHome = CodexCredentialFixtures.root
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try Self.writeCodexAuthFile(homeURL: profileHome)
         settings._test_codexReconciliationEnvironment = ["CODEX_HOME": missingLiveHome.path]

--- a/Tests/CodexBarTests/SpendDashboardSourceConcurrencyTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardSourceConcurrencyTests.swift
@@ -5,9 +5,9 @@ import Testing
 
 @MainActor
 struct SpendDashboardSourceConcurrencyTests {
-    @Test
+    @Test(CodexCredentialFixtures())
     func `Codex batch revalidates completed and failed accounts after later scans`() async throws {
-        let root = FileManager.default.temporaryDirectory
+        let root = CodexCredentialFixtures.root
             .appendingPathComponent("SpendDashboardSourceConcurrencyTests-auth-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -532,9 +532,9 @@ struct SpendDashboardSourceConcurrencyTests {
         #expect(controller.model.groups.first?.totalCost == 12)
     }
 
-    @Test
+    @Test(CodexCredentialFixtures())
     func `Codex concurrent loads restore configured order when completing out of order`() async throws {
-        let root = FileManager.default.temporaryDirectory
+        let root = CodexCredentialFixtures.root
             .appendingPathComponent(
                 "SpendDashboardSourceConcurrencyTests-order-\(UUID().uuidString)",
                 isDirectory: true)

--- a/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
@@ -824,7 +824,7 @@ struct StatusMenuCodexSwitcherTests {
         #expect(state.canAddAccount == false)
     }
 
-    @Test
+    @Test(CodexCredentialFixtures())
     func `codex menu switcher can select managed row when same email rows split by identity`() throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
@@ -833,7 +833,7 @@ struct StatusMenuCodexSwitcherTests {
         settings.mergeIcons = false
         self.enableOnlyCodex(settings)
 
-        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
             UUID().uuidString,
             isDirectory: true)
         let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-222222222222"))

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -178,7 +178,7 @@ func withStatusItemControllerForTesting<T>(
     let controller = StatusItemController(
         store: store,
         settings: settings,
-        account: account ?? fetcher.loadAccountInfo(),
+        account: account ?? AccountInfo(email: nil, plan: nil),
         updater: DisabledUpdaterController(),
         preferencesSelection: PreferencesSelection(),
         statusBar: statusBar)
@@ -199,7 +199,7 @@ func withStatusItemControllerForTesting<T>(
     let controller = StatusItemController(
         store: store,
         settings: settings,
-        account: account ?? fetcher.loadAccountInfo(),
+        account: account ?? AccountInfo(email: nil, plan: nil),
         updater: DisabledUpdaterController(),
         preferencesSelection: PreferencesSelection(),
         statusBar: statusBar)

--- a/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
+++ b/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
@@ -163,7 +163,7 @@ struct ZaiTokenAccountEnvironmentPrecedenceTests {
     }
 }
 
-@Suite(.serialized)
+@Suite(.serialized, CodexCredentialFixtures())
 @MainActor
 struct TokenAccountEnvironmentPrecedenceTests {
     @Test
@@ -614,7 +614,7 @@ struct TokenAccountEnvironmentPrecedenceTests {
 
     @Test
     func `codex all accounts selection exposes configured accounts and scopes CLI homes`() throws {
-        let root = FileManager.default.temporaryDirectory
+        let root = CodexCredentialFixtures.root
             .appendingPathComponent("codex-cli-all-accounts-\(UUID().uuidString)", isDirectory: true)
         let ambientHome = root.appendingPathComponent("ambient", isDirectory: true)
         let firstHome = root.appendingPathComponent("first", isDirectory: true)
@@ -720,7 +720,7 @@ struct TokenAccountEnvironmentPrecedenceTests {
 
     @Test
     func `codex CLI ignores relative profile homes`() throws {
-        let root = FileManager.default.temporaryDirectory
+        let root = CodexCredentialFixtures.root
             .appendingPathComponent("codex-cli-relative-profile-\(UUID().uuidString)", isDirectory: true)
         let ambientHome = root.appendingPathComponent("ambient", isDirectory: true)
         let managedStoreURL = root.appendingPathComponent("managed-codex-accounts.json")
@@ -1131,7 +1131,7 @@ extension TokenAccountEnvironmentPrecedenceTests {
     }
 
     fileprivate static func makeTempCodexHome(email: String, plan: String, accountId: String) -> URL {
-        let home = FileManager.default.temporaryDirectory
+        let home = CodexCredentialFixtures.root
             .appendingPathComponent("codex-known-owner-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         let credentials = CodexOAuthCredentials(

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -281,10 +281,10 @@ struct UsageStoreCoverageTests {
         #expect(menuLines.contains { $0.hasPrefix("Amp Free:") })
     }
 
-    @Test
+    @Test(CodexCredentialFixtures())
     func `account info caches codex auth parsing until config revision changes`() throws {
         let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-account-info-cache")
-        let home = FileManager.default.temporaryDirectory.appendingPathComponent(
+        let home = CodexCredentialFixtures.root.appendingPathComponent(
             "usage-store-account-info-\(UUID().uuidString)",
             isDirectory: true)
         defer { try? FileManager.default.removeItem(at: home) }

--- a/TestsLinux/CodexOAuthCredentialsStoreLinuxTests.swift
+++ b/TestsLinux/CodexOAuthCredentialsStoreLinuxTests.swift
@@ -18,7 +18,9 @@ struct CodexOAuthCredentialsStoreLinuxTests {
             accountId: "account-123",
             lastRefresh: Date())
 
-        try CodexOAuthCredentialsStore.save(credentials, env: ["CODEX_HOME": codexHome.path])
+        try CodexCredentialFileAccess.withFixtureScope(.init(roots: [codexHome])) {
+            try CodexOAuthCredentialsStore.save(credentials, env: ["CODEX_HOME": codexHome.path])
+        }
 
         let authURL = codexHome.appendingPathComponent("auth.json")
         let attributes = try FileManager.default.attributesOfItem(atPath: authURL.path)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -132,6 +132,39 @@ See the canonical [provider authoring guide](provider.md#adding-a-new-provider) 
 make test
 ```
 
+### Codex credential fixtures
+
+Ordinary tests deny Codex credential-file access at the Codex-owned I/O boundaries, before reads,
+existence probes, or writes. Detection uses the actual process name/environment, independently of
+the credential environment under test. `HOME`, `CODEX_HOME`, `XDG_DATA_HOME`, and
+`CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS` do not authorize files. The disabled live-account test remains
+disabled; neither `LIVE_TEST` nor Keychain permission alone bypasses this boundary.
+
+Use `CodexCredentialFileAccess.withFixtureScope(.init(files: [...], roots: [...]))` for an explicitly
+owned fixture. Synchronous and asynchronous forms restore the previous scope on return or throw.
+Roots use path components, reject symlinks within the fixture, and never implicitly authorize all
+of `/tmp`. The `CodexCredentialFixtures` test trait creates and cleans up one owned root per test;
+credential/account fixtures allocate their homes under `CodexCredentialFixtures.root`. Promotion
+and scoped-refresh containers share that helper. The trait also binds the existing dashboard-cache
+URL override to its owned root, so cache reads, writes, and clears stay local to the test.
+`_loadForUsageForTesting` adds only its explicit
+home fixture to the current scope; configured external roots still need explicit authorization.
+Pure parsers and `fingerprint(data:)` need no scope. Default managed-account and workspace-cache
+stores use fresh temporary paths in tests; explicit file overrides retain their existing behavior.
+
+Task-local scopes inherit through structured tasks, but not detached work. Capture the immutable
+`fixtureScope` and explicitly re-enter it in a detached task when fixture access is required; lost
+context fails closed. Never authorize a path just because it appears in an environment dictionary.
+
+`Scripts/test.sh` exports `CODEXBAR_TEST_CODEX_FILE_ISOLATION=1` and removes inherited fixture grants.
+Direct test commands that launch children should export the same signal. A child needing files must
+receive `FixtureScope(files: ..., roots: ...).childEnvironment(base: ...)` naming only that child's
+fixtures; this replaces any inherited grants without changing global environment state. The signal,
+scope decoding, and denial are compiled in release builds too. `bash Scripts/test_codex_file_isolation_child.sh`
+compiles the actual policy and detector with optimization and without `DEBUG`, then checks denied,
+scoped-child, and non-test decisions against synthetic temporary files. It does not build or exercise
+the complete release CLI, refresh a real account, or establish isolation for other providers.
+
 ### CI Aggregate Contract
 
 The `lint-build-test` check in `.github/workflows/ci.yml` keeps its existing name and requires successful lint,


### PR DESCRIPTION
## Summary

Ordinary tests already suppress Keychain access, but legacy UI helpers can still call Codex's file-backed account loader. Empty credential environments also fall back to the process user's home. Put the test boundary at the Codex-owned file operations instead of relying on every caller to remember a fake environment.

The policy denies unregistered native, legacy and OpenCode credential reads, fingerprints and complete save/promotion operations in actual test contexts. Explicit immutable task-local fixture scopes permit only named files or owned roots, with component containment and symlink rejection. The test runner passes an isolation signal to children; scoped child environments replace inherited fixture grants. Default managed-account/workspace metadata stores use temporary paths during tests. Production source selection, parsing, storage formats and refresh behavior are unchanged.

Most changed test files only move existing temporary homes under the per-test fixture root. Existing credential, permission, fallback and account assertions remain intact. The two shared controller helpers now default to empty account information.

## Verification

- 405 focused macOS tests in 18 suites, including the architecture gate, plus the portable credential-permission test executed on macOS: passed. The final fixture follow-up passed 32 fixture/policy tests and 38 architecture tests in separate runs. A combined focused run hit the existing publication wait while the architecture scan occupied the main actor; the tests pass separately with their original timeout and assertions unchanged.
- `make check`: passed, zero SwiftLint violations.
- `bash Scripts/test_codex_file_isolation_child.sh`: passed. Compiles the actual policy/detector with optimization and without `DEBUG`; proves denied access, scoped access, replacement of parent fixture grants and non-test decisions using synthetic temporary files.
- Denied-operation tests record zero read, existence, metadata, directory and write calls. Regressions cover fallback escape, task cleanup/concurrency, prefix collisions, traversal and dangling symlinks.
- Independent complete-diff review: no actionable findings.
- Full `make test`: 934 selections across 78 groups, all first-pass; zero failures, retries or timeouts (1067.6 seconds). The first full run exposed three dashboard-cache tests whose synthetic auth homes still needed explicit fixture registration. Those and sibling credential fixtures now use owned roots without changing their authority assertions; the fixture trait also scopes the existing dashboard-cache URL override.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33033035702): all required checks passed, including lint, Linux x64/ARM/musl, both macOS shards/provider-engine goldens and the aggregate gate.

The child harness stubs unrelated link dependencies; it does not exercise the complete release CLI. This is Codex-owned file isolation, not an OS sandbox or proof of isolation for every provider. No live account probes or application launch were used. The existing deliberately disabled live-account test remains disabled. Internal test safety only; no changelog entry or release.
