### PR TITLE
fix: honor Claude extra usage fill preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.55.2 — Unreleased
 
 ### Fixed
+- Claude: respect the used/remaining fill preference for capped Extra Usage, so an exhausted cap is empty in remaining mode (#3213). Thanks @vinschger!
 - Codex: clear stale connectivity errors after an authorized successful fetch even when weekly usage is withheld, including persisted and stacked-account errors (#3214). Thanks @olddonkey!
 - Antigravity: select the most constrained known quota independently for session and weekly menu-bar layout tokens, so unused model families no longer mask consumed quota (#3206). Thanks @foobra!
 - OpenCode Go: preserve API percentage units so 1% usage no longer appears as 100%, including local-history overlays (#3216). Thanks @rodrigoalma!

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -37,11 +37,11 @@ struct ProviderCostContent: View {
                             .layoutPriority(1)
                     }
                 }
-                if let percentUsed = self.section.percentUsed {
+                if let percent = self.section.displayPercent {
                     UsageProgressBar(
-                        percent: percentUsed,
+                        percent: percent,
                         tint: self.progressColor,
-                        accessibilityLabel: L("Extra usage spent"))
+                        accessibilityLabel: self.section.progressAccessibilityLabel)
                 }
                 HStack(alignment: .firstTextBaseline) {
                     Text(self.section.spendLine).font(.footnote).lineLimit(1)
@@ -68,6 +68,14 @@ extension UsageMenuCardView.Model.ProviderCostSection {
         case inlineValue
     }
 
+    var displayPercent: Double? {
+        self.percentUsed.map { self.percentStyle == .used ? $0 : 100 - $0 }
+    }
+
+    var progressAccessibilityLabel: String {
+        self.percentStyle == .used ? L("Extra usage spent") : self.percentStyle.accessibilityLabel
+    }
+
     init(
         title: String,
         percentUsed: Double?,
@@ -75,7 +83,8 @@ extension UsageMenuCardView.Model.ProviderCostSection {
         percentLine: String?,
         balanceLine: String? = nil,
         presentation: Presentation = .detail,
-        showsInProviderDetails: Bool = true)
+        showsInProviderDetails: Bool = true,
+        percentStyle: UsageMenuCardView.Model.PercentStyle = .used)
     {
         self.init(
             title: title,
@@ -85,7 +94,8 @@ extension UsageMenuCardView.Model.ProviderCostSection {
             balanceLine: balanceLine,
             personalSpendLine: nil,
             presentation: presentation,
-            showsInProviderDetails: showsInProviderDetails)
+            showsInProviderDetails: showsInProviderDetails,
+            percentStyle: percentStyle)
     }
 }
 
@@ -397,6 +407,7 @@ extension UsageMenuCardView.Model {
     static func providerCostSection(
         cost: ProviderCostSnapshot?,
         style: ProviderCostMenuCardStyle,
+        percentStyle: PercentStyle = .used,
         isClaudeAdminAPI: Bool = false,
         preferredCurrencyCode: String = "auto") -> ProviderCostSection?
     {
@@ -504,7 +515,8 @@ extension UsageMenuCardView.Model {
                 spendLine: "\(periodLabel): \(used) / \(limit)",
                 percentLine: String(format: L("%.0f%% used"), min(100, max(0, percentUsed))),
                 balanceLine: balanceLine,
-                showsInProviderDetails: false)
+                showsInProviderDetails: false,
+                percentStyle: percentStyle)
         }
 
         if style == .apiSpend {

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -160,6 +160,7 @@ struct UsageMenuCardView: View {
             var personalSpendLine: String?
             var presentation: Presentation = .detail
             var showsInProviderDetails = true
+            var percentStyle: PercentStyle = .used
         }
 
         let provider: UsageProvider
@@ -980,6 +981,7 @@ extension UsageMenuCardView.Model {
             Self.providerCostSection(
                 cost: input.snapshot?.providerCost,
                 style: providerCostStyle,
+                percentStyle: input.usageBarsShowUsed ? .used : .left,
                 isClaudeAdminAPI: isClaudeAdminAPI,
                 preferredCurrencyCode: input.preferredCurrencyCode)
         }

--- a/Tests/CodexBarTests/ClaudeMenuCardCostTests.swift
+++ b/Tests/CodexBarTests/ClaudeMenuCardCostTests.swift
@@ -4,187 +4,197 @@ import Testing
 @testable import CodexBar
 
 struct ClaudeMenuCardCostTests {
-    @Test
-    func `claude extra usage card shows balance above monthly cap`() throws {
-        let now = Date()
-        let metadata = try #require(ProviderDefaults.metadata[.claude])
-        let snapshot = UsageSnapshot(
-            primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            tertiary: nil,
-            providerCost: ProviderCostSnapshot(
-                used: 5,
-                limit: 20,
-                currencyCode: "USD",
-                period: "Monthly cap",
-                balance: 100,
-                updatedAt: now),
-            updatedAt: now,
-            identity: nil)
+    private static let now = Date(timeIntervalSince1970: 1_782_000_000)
 
-        let model = UsageMenuCardView.Model.make(.init(
-            provider: .claude,
-            metadata: metadata,
-            snapshot: snapshot,
-            credits: nil,
-            creditsError: nil,
-            dashboard: nil,
-            dashboardError: nil,
-            tokenSnapshot: nil,
-            tokenError: nil,
-            account: AccountInfo(email: nil, plan: nil),
-            isRefreshing: false,
-            lastError: nil,
-            usageBarsShowUsed: false,
-            resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
-            showOptionalCreditsAndExtraUsage: true,
-            hidePersonalInfo: false,
-            now: now))
+    @Test(arguments: [
+        (used: 0.0, percent: 0.0, spend: "$0.00"),
+        (used: 25.0, percent: 25.0, spend: "$25.00"),
+        (used: 100.0, percent: 100.0, spend: "$100.00"),
+        (used: 125.0, percent: 100.0, spend: "$125.00"),
+    ], [false, true])
+    func `claude capped extra usage fill follows the preference without changing spend`(
+        sample: (used: Double, percent: Double, spend: String),
+        showUsed: Bool) throws
+    {
+        let model = try Self.makeModel(cost: Self.cost(used: sample.used, limit: 100), showUsed: showUsed)
+        let section = try #require(model.providerCost)
 
-        #expect(model.providerCost?.title == "Extra usage")
-        #expect(model.providerCost?.balanceLine == "Balance: $100.00")
-        #expect(model.providerCost?.spendLine == "Monthly cap: $5.00 / $20.00")
-        #expect(model.providerCost?.percentUsed == 25)
-        #expect(model.providerCost?.percentLine == "25% used")
-        #expect(model.providerCost?.presentation == .detail)
-        #expect(model.providerCost?.showsInProviderDetails == false)
+        #expect(section.percentUsed == sample.percent)
+        #expect(section.displayPercent == (showUsed ? sample.percent : 100 - sample.percent))
+        #expect(section.percentStyle == (showUsed ? .used : .left))
+        #expect(section.progressAccessibilityLabel == (showUsed ? "Extra usage spent" : "Usage remaining"))
+        #expect(section.spendLine == "Monthly cap: \(sample.spend) / $100.00")
+        #expect(section.percentLine == "\(Int(sample.percent))% used")
     }
 
-    @Test
-    func `claude balance only card stays compact`() throws {
-        let now = Date()
-        let metadata = try #require(ProviderDefaults.metadata[.claude])
-        let snapshot = UsageSnapshot(
-            primary: nil,
-            secondary: nil,
-            providerCost: ProviderCostSnapshot(
-                used: 0,
-                limit: 0,
-                currencyCode: "USD",
-                period: "Usage credits",
-                balance: 100,
-                updatedAt: now),
-            updatedAt: now)
+    @Test(arguments: [false, true])
+    func `claude extra usage card shows balance above monthly cap`(showUsed: Bool) throws {
+        let model = try Self.makeModel(cost: Self.cost(used: 5, limit: 20, balance: 100), showUsed: showUsed)
+        let section = try #require(model.providerCost)
 
-        let model = UsageMenuCardView.Model.make(.init(
-            provider: .claude,
-            metadata: metadata,
-            snapshot: snapshot,
-            credits: nil,
-            creditsError: nil,
-            dashboard: nil,
-            dashboardError: nil,
-            tokenSnapshot: nil,
-            tokenError: nil,
-            account: AccountInfo(email: nil, plan: nil),
-            isRefreshing: false,
-            lastError: nil,
-            usageBarsShowUsed: false,
-            resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
-            showOptionalCreditsAndExtraUsage: true,
-            hidePersonalInfo: false,
-            now: now))
-
-        #expect(model.providerCost?.title == "Credits")
-        #expect(model.providerCost?.spendLine == "$100.00")
-        #expect(model.providerCost?.balanceLine == nil)
-        #expect(model.providerCost?.percentUsed == nil)
-        #expect(model.providerCost?.percentLine == nil)
-        #expect(model.providerCost?.presentation == .inlineValue)
-        #expect(model.providerCost?.showsInProviderDetails == false)
+        #expect(section.title == "Extra usage")
+        #expect(section.balanceLine == "Balance: $100.00")
+        #expect(section.spendLine == "Monthly cap: $5.00 / $20.00")
+        #expect(section.percentUsed == 25)
+        #expect(section.displayPercent == (showUsed ? 25 : 75))
+        #expect(section.percentLine == "25% used")
+        #expect(section.presentation == .detail)
+        #expect(section.showsInProviderDetails == false)
     }
 
-    @Test
-    func `claude admin api spend remains visible without prepaid balance`() throws {
-        let now = Date()
-        let metadata = try #require(ProviderDefaults.metadata[.claude])
-        let snapshot = UsageSnapshot(
-            primary: nil,
-            secondary: nil,
-            providerCost: ProviderCostSnapshot(
-                used: 12.34,
-                limit: 0,
-                currencyCode: "USD",
-                period: "Last 30 days",
-                updatedAt: now),
-            updatedAt: now,
-            identity: ProviderIdentitySnapshot(
-                providerID: .claude,
-                accountEmail: "admin@example.com",
-                accountOrganization: nil,
-                loginMethod: "Admin API"))
+    @Test(arguments: [0.0, -1.0], [false, true])
+    func `claude balance only card stays compact`(limit: Double, showUsed: Bool) throws {
+        let model = try Self.makeModel(cost: Self.cost(used: 0, limit: limit, balance: 100), showUsed: showUsed)
+        let section = try #require(model.providerCost)
 
-        let model = UsageMenuCardView.Model.make(.init(
-            provider: .claude,
-            metadata: metadata,
-            snapshot: snapshot,
-            credits: nil,
-            creditsError: nil,
-            dashboard: nil,
-            dashboardError: nil,
-            tokenSnapshot: nil,
-            tokenError: nil,
-            account: AccountInfo(email: nil, plan: nil),
-            isRefreshing: false,
-            lastError: nil,
-            usageBarsShowUsed: false,
-            resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
-            costSummaryInlineEnabled: true,
-            showOptionalCreditsAndExtraUsage: false,
-            hidePersonalInfo: false,
-            now: now))
-
-        #expect(model.providerCost?.title == "API spend")
-        #expect(model.providerCost?.spendLine == "Last 30 days: $12.34")
-        #expect(model.providerCost?.presentation == .detail)
-        #expect(model.providerCost?.showsInProviderDetails == true)
+        #expect(section.title == "Credits")
+        #expect(section.spendLine == "$100.00")
+        #expect(section.balanceLine == nil)
+        #expect(section.percentUsed == nil)
+        #expect(section.displayPercent == nil)
+        #expect(section.percentLine == nil)
+        #expect(section.presentation == .inlineValue)
+        #expect(section.showsInProviderDetails == false)
     }
 
-    @Test
-    func `claude monthly cap stays visible when prepaid balance is unavailable`() throws {
-        let now = Date()
-        let metadata = try #require(ProviderDefaults.metadata[.claude])
-        let snapshot = UsageSnapshot(
-            primary: nil,
-            secondary: nil,
-            providerCost: ProviderCostSnapshot(
-                used: 0.49,
-                limit: 50,
-                currencyCode: "USD",
-                period: "Monthly cap",
-                updatedAt: now),
-            updatedAt: now)
+    @Test(arguments: [0.0, -1.0], [false, true])
+    func `claude extra usage without a positive cap or balance stays absent`(limit: Double, showUsed: Bool) throws {
+        let model = try Self.makeModel(cost: Self.cost(used: 25, limit: limit), showUsed: showUsed)
+        #expect(model.providerCost == nil)
+    }
 
-        let model = UsageMenuCardView.Model.make(.init(
-            provider: .claude,
-            metadata: metadata,
-            snapshot: snapshot,
-            credits: nil,
-            creditsError: nil,
-            dashboard: nil,
-            dashboardError: nil,
-            tokenSnapshot: nil,
-            tokenError: nil,
-            account: AccountInfo(email: nil, plan: nil),
-            isRefreshing: false,
-            lastError: nil,
-            usageBarsShowUsed: false,
-            resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
-            showOptionalCreditsAndExtraUsage: true,
-            hidePersonalInfo: false,
-            now: now))
+    @Test(arguments: [false, true])
+    func `claude missing cost stays absent`(showUsed: Bool) throws {
+        let model = try Self.makeModel(cost: nil, showUsed: showUsed)
+        #expect(model.providerCost == nil)
+    }
 
-        #expect(model.providerCost?.title == "Extra usage")
-        #expect(model.providerCost?.balanceLine == nil)
-        #expect(model.providerCost?.spendLine == "Monthly cap: $0.49 / $50.00")
-        let percentUsed = try #require(model.providerCost?.percentUsed)
+    @Test(arguments: [0.0, 100.0], [false, true])
+    func `claude optional extra usage and balances stay hidden`(limit: Double, showUsed: Bool) throws {
+        let model = try Self.makeModel(
+            cost: Self.cost(used: 25, limit: limit, balance: 100),
+            showUsed: showUsed,
+            showOptional: false)
+        #expect(model.providerCost == nil)
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func `claude admin api spend remains visible without prepaid balance`(
+        showUsed: Bool,
+        showOptional: Bool) throws
+    {
+        let model = try Self.makeModel(
+            cost: Self.cost(used: 12.34, limit: 0, period: "Last 30 days"),
+            showUsed: showUsed,
+            showOptional: showOptional,
+            isAdminAPI: true)
+        let section = try #require(model.providerCost)
+
+        #expect(section.title == "API spend")
+        #expect(section.spendLine == "Last 30 days: $12.34")
+        #expect(section.percentUsed == nil)
+        #expect(section.displayPercent == nil)
+        #expect(section.percentLine == nil)
+        #expect(section.presentation == .detail)
+        #expect(section.showsInProviderDetails == true)
+    }
+
+    @Test(arguments: [false, true])
+    func `claude admin api spend still follows summary visibility`(showUsed: Bool) throws {
+        let model = try Self.makeModel(
+            cost: Self.cost(used: 12.34, limit: 0, period: "Last 30 days"),
+            showUsed: showUsed,
+            isAdminAPI: true,
+            costSummaryInlineEnabled: false)
+        #expect(model.providerCost == nil)
+    }
+
+    @Test(arguments: [false, true])
+    func `claude monthly cap stays visible when prepaid balance is unavailable`(showUsed: Bool) throws {
+        let model = try Self.makeModel(cost: Self.cost(used: 0.49, limit: 50), showUsed: showUsed)
+        let section = try #require(model.providerCost)
+
+        #expect(section.title == "Extra usage")
+        #expect(section.balanceLine == nil)
+        #expect(section.spendLine == "Monthly cap: $0.49 / $50.00")
+        let percentUsed = try #require(section.percentUsed)
+        let displayPercent = try #require(section.displayPercent)
         #expect(abs(percentUsed - 0.98) < 0.0001)
-        #expect(model.providerCost?.percentLine == "1% used")
-        #expect(model.providerCost?.presentation == .detail)
-        #expect(model.providerCost?.showsInProviderDetails == false)
+        #expect(abs(displayPercent - (showUsed ? 0.98 : 99.02)) < 0.0001)
+        #expect(section.percentLine == "1% used")
+        #expect(section.presentation == .detail)
+        #expect(section.showsInProviderDetails == false)
+    }
+
+    @Test(arguments: [ProviderCostMenuCardStyle.generic, .clawRouter], [false, true])
+    func `other capped provider costs keep used fill`(style: ProviderCostMenuCardStyle, showUsed: Bool) throws {
+        let section = try #require(UsageMenuCardView.Model.providerCostSection(
+            cost: Self.cost(used: 25, limit: 100),
+            style: style,
+            percentStyle: showUsed ? .used : .left,
+            preferredCurrencyCode: "USD"))
+
+        #expect(section.percentStyle == .used)
+        #expect(section.percentUsed == 25)
+        #expect(section.displayPercent == 25)
+        #expect(section.progressAccessibilityLabel == "Extra usage spent")
+        #expect(section.spendLine == "Monthly cap: $25.00 / $100.00")
+        #expect(section.percentLine == "25% used")
+    }
+
+    private static func cost(
+        used: Double,
+        limit: Double,
+        balance: Double? = nil,
+        period: String = "Monthly cap") -> ProviderCostSnapshot
+    {
+        ProviderCostSnapshot(
+            used: used,
+            limit: limit,
+            currencyCode: "USD",
+            period: period,
+            balance: balance,
+            updatedAt: self.now)
+    }
+
+    private static func makeModel(
+        cost: ProviderCostSnapshot?,
+        showUsed: Bool,
+        showOptional: Bool = true,
+        isAdminAPI: Bool = false,
+        costSummaryInlineEnabled: Bool = true) throws -> UsageMenuCardView.Model
+    {
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: cost,
+            updatedAt: self.now,
+            identity: isAdminAPI ? ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Admin API") : nil)
+        return UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: showUsed,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            costSummaryInlineEnabled: costSummaryInlineEnabled,
+            showOptionalCreditsAndExtraUsage: showOptional,
+            hidePersonalInfo: true,
+            preferredCurrencyCode: "USD",
+            now: self.now))
     }
 }

--- a/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
+++ b/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
@@ -14,6 +14,63 @@ final class MenuLayoutScreenshotRenderTests: XCTestCase {
     private static let width: CGFloat = 320
     private static let now = Date(timeIntervalSince1970: 1_782_000_000)
 
+    func test_renderClaudeExtraUsageFillProof() throws {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_CLAUDE_EXTRA_USAGE_SCREENSHOT_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_CLAUDE_EXTRA_USAGE_SCREENSHOT_DIR to render the Claude Extra Usage proof.")
+        }
+
+        let metadata = try XCTUnwrap(ProviderDefaults.metadata[.claude])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 25, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 25,
+                limit: 100,
+                currencyCode: "USD",
+                period: "Monthly",
+                updatedAt: Self.now),
+            updatedAt: Self.now)
+        let directory = URL(fileURLWithPath: dir, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        for showUsed in [true, false] {
+            let model = UsageMenuCardView.Model.make(.init(
+                provider: .claude,
+                metadata: metadata,
+                snapshot: snapshot,
+                credits: nil,
+                creditsError: nil,
+                dashboard: nil,
+                dashboardError: nil,
+                tokenSnapshot: nil,
+                tokenError: nil,
+                account: AccountInfo(email: nil, plan: nil),
+                isRefreshing: false,
+                lastError: nil,
+                usageBarsShowUsed: showUsed,
+                resetTimeDisplayStyle: .countdown,
+                tokenCostUsageEnabled: false,
+                showOptionalCreditsAndExtraUsage: true,
+                hidePersonalInfo: true,
+                usesLiveSubtitle: false,
+                preferredCurrencyCode: "USD",
+                now: Self.now))
+            let view = AnyView(UsageMenuCardExtraUsageSectionView(
+                model: model,
+                topPadding: 12,
+                bottomPadding: 12,
+                width: Self.width)
+                .environment(\.locale, Locale(identifier: "en_US_POSIX"))
+                .environment(\.colorScheme, .dark)
+                .background(Color(nsColor: .windowBackgroundColor)))
+            let mode = showUsed ? "used" : "remaining"
+            let png = try XCTUnwrap(Self.pngData(for: view), "Claude Extra Usage \(mode) render failed")
+            let url = directory.appendingPathComponent("claude-extra-usage-\(mode).png")
+            try png.write(to: url, options: .atomic)
+            print("Wrote \(url.path)")
+        }
+    }
+
     func test_renderAntigravitySemanticLayoutProof() throws {
         guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_ANTIGRAVITY_LAYOUT_SCREENSHOT_DIR"] else {
             throw XCTSkip("Set CODEXBAR_ANTIGRAVITY_LAYOUT_SCREENSHOT_DIR to render the Antigravity layout proof.")

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1774,7 +1774,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+Costs.swift",
-            line: 194,
+            line: 204,
             anchor: "let sessionLabel = if provider == .bedrock || provider == .mistral {",
             expectedProviderIDs: ["bedrock", "mistral"],
             expectedReferenceCount: 2,
@@ -1782,7 +1782,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+Costs.swift",
-            line: 217,
+            line: 227,
             anchor: "} else if provider == .mistral,",
             expectedProviderIDs: ["mistral"],
             expectedReferenceCount: 1,
@@ -1790,7 +1790,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+Costs.swift",
-            line: 471,
+            line: 482,
             anchor: "if style == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -1931,7 +1931,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 199,
+            line: 200,
             anchor: "if provider == .openrouter, metric.id == \"primary\" {",
             expectedProviderIDs: ["openrouter"],
             expectedReferenceCount: 1,
@@ -1939,7 +1939,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 500,
+            line: 501,
             anchor: "if self.provider != .codex || self.showsCodexHint,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -1947,7 +1947,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 664,
+            line: 665,
             anchor: "guard self.model.provider == .doubao else { return nil }",
             expectedProviderIDs: ["doubao"],
             expectedReferenceCount: 1,
@@ -1955,7 +1955,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1049,
+            line: 1051,
             anchor: "if input.provider == .sub2api {",
             expectedProviderIDs: ["sub2api"],
             expectedReferenceCount: 1,
@@ -1963,7 +1963,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "The sub2api menu card localizes and groups provider-owned usage detail rows for display."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1121,
+            line: 1123,
             anchor: "if provider == .kiro,",
             expectedProviderIDs: ["kilo", "kiro"],
             expectedReferenceCount: 2,
@@ -1971,7 +1971,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1144,
+            line: 1146,
             anchor: "if provider == .minimax {",
             expectedProviderIDs: ["codex", "minimax"],
             expectedReferenceCount: 2,
@@ -1979,7 +1979,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1179,
+            line: 1181,
             anchor: "guard let loginMethod = snapshot?.loginMethod(for: .kilo) else {",
             expectedProviderIDs: ["kilo"],
             expectedReferenceCount: 1,
@@ -1987,7 +1987,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1258,
+            line: 1260,
             anchor: "if input.provider == .antigravity {",
             expectedProviderIDs: ["antigravity", "mistral"],
             expectedReferenceCount: 2,
@@ -1995,7 +1995,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1278,
+            line: 1280,
             anchor: "if input.provider == .codex, let codexProjection = input.codexProjection {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2003,7 +2003,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1294,
+            line: 1296,
             anchor: "if input.provider != .codex, let weekly = snapshot.secondary {",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "codex", "perplexity", "sub2api"],
             expectedReferenceCount: 5,
@@ -2017,7 +2017,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1334,
+            line: 1336,
             anchor: "if input.provider == .kilo || input.provider == .kimi,",
             expectedProviderIDs: ["kilo", "kimi"],
             expectedReferenceCount: 2,
@@ -2025,7 +2025,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1391,
+            line: 1393,
             anchor: "if input.provider == .zai, let resetText = Self.localizedZaiPeriodicResetText(primary) {",
             expectedProviderIDs: ["zai"],
             expectedReferenceCount: 1,
@@ -2033,7 +2033,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1435,
+            line: 1437,
             anchor: "var paceDetail = if input.provider == .kimi {",
             expectedProviderIDs: ["kimi"],
             expectedReferenceCount: 1,
@@ -2041,7 +2041,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1451,
+            line: 1453,
             anchor: "if input.provider == .warp,",
             expectedProviderIDs: ["chutes", "kilo", "kiro", "litellm", "sub2api", "warp"],
             expectedReferenceCount: 6,
@@ -2049,7 +2049,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1484,
+            line: 1486,
             anchor: "if input.provider == .alibaba || input.provider == .alibabatokenplan,",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "copilot", "crof", "manus", "perplexity", "zenmux"],
             expectedReferenceCount: 8,
@@ -2066,7 +2066,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1525,
+            line: 1527,
             anchor: "if input.provider == .synthetic,",
             expectedProviderIDs: ["synthetic"],
             expectedReferenceCount: 1,

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -64,6 +64,7 @@ model-generic token label while the rendered menu-bar prefix and accessibility l
 - Manual refresh updates the open card subtitle and persistent Refresh-row spinner in place. Repeated clicks share the
   active request, and the existing row geometry remains fixed through success or failure.
 - Codex credits can add a separate “Buy Credits…” menu action.
+- Claude capped Extra Usage follows the used/remaining fill preference; spending amounts and “% used” copy stay unchanged.
 - Codex OpenAI web extras: code review remaining and usage breakdown render when dashboard data is attached.
 - Token accounts: optional account switcher bar or stacked account cards (up to 6) when multiple manual tokens exist.
 - Provider storage usage is opt-in from Advanced settings. When enabled, overview rows and provider detail cards can show


### PR DESCRIPTION
Fixes #3213.

## Summary

Claude's capped Extra Usage bar always filled with the used percentage, even when the global preference selected remaining allowance. Carry the existing `PercentStyle` through that cost section and use it for displayed fill and accessibility. An exhausted cap is now empty in remaining mode and full in used mode.

Raw used percentage, spending amounts, “% used” copy, balances, optional visibility and Admin API behavior stay unchanged. Other provider cost sections retain used-fill semantics. The test refactor adds parameterized endpoint/over-cap coverage; architecture-gate edits update 19 displaced line anchors without changing its rules or assertions.

## Visual proof

Identical synthetic $25-used/$100-cap input through `Model.make` and the actual `UsageMenuCardExtraUsageSectionView`, at fixed width, appearance, locale and time. Both baseline images were captured before production edits. Remaining fill changes from 25% to 75%; the used-mode PNG is byte-for-byte unchanged.

| Remaining mode before | Remaining mode after |
| --- | --- |
| ![Before: remaining mode incorrectly fills 25 percent](https://github.com/user-attachments/assets/dc3f4c65-7512-47db-afda-23df1e67570a) | ![After: remaining mode correctly fills 75 percent](https://github.com/user-attachments/assets/1773c335-10fe-460c-98b3-25eccec6aea4) |

This is offscreen production model-to-view proof with no account, store, status item or live subtitle. It is not a live preferences-toggle or account capture.

## Verification

- 51 focused Swift Testing tests across three suites, including the architecture gate, plus the screenshot XCTest: passed. The first architecture run caught displaced line anchors; the corrected run passed without changing gate rules or assertions.
- `make check`: passed, zero SwiftLint violations.
- Endpoint coverage: 0/25/100/over-cap usage in both modes; accessibility, exact spend copy, absent/nonpositive caps, balance-only rows, hiding, Admin API and other capped providers.
- Independent complete-diff review: no actionable findings.
- Parent full `make test`: all 934 selections across 78 groups passed first try, with zero failures, retries or timeouts (897.2 seconds).
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33035206668): passed both macOS shards, provider-engine goldens, Linux x64/ARM build/test/smoke, Linux musl build, lint and aggregate gate.

Tests run with Keychain allowance unset and Keychain suppression/Codex file isolation enabled. No live credential access, provider probe or application launch. Thanks @vinschger for the report.
