### PR TITLE
fix: disclose saved menu layout overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.55.2 — Unreleased
 
 ### Fixed
+- Menu bar: label the All providers preview as the default and disclose enabled providers with saved overrides, with a targeted “Use all-providers layout” action (#3210). Thanks @Sedrak-Hovhannisyan!
 - Claude: respect the used/remaining fill preference for capped Extra Usage, so an exhausted cap is empty in remaining mode (#3213). Thanks @vinschger!
 - Codex: clear stale connectivity errors after an authorized successful fetch even when weekly usage is withheld, including persisted and stacked-account errors (#3214). Thanks @olddonkey!
 - Antigravity: select the most constrained known quota independently for session and weekly menu-bar layout tokens, so unused model families no longer mask consumed quota (#3206). Thanks @foobra!

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -128,13 +128,34 @@ enum MenuBarLayoutEditorMutations {
     }
 }
 
-private enum MenuBarLayoutEditorScope: Hashable {
+enum MenuBarLayoutEditorScope: Hashable {
     case all
     case provider(UsageProvider)
+
+    var previewLabel: String {
+        switch self {
+        case .all: L("menu_bar_layout_default_preview")
+        case .provider: L("menu_bar_layout_live_preview")
+        }
+    }
+
+    @MainActor
+    func providersWithOverrides(settings: SettingsStore) -> [UsageProvider] {
+        guard self == .all else { return [] }
+        let overrides = settings.menuBarLayoutOverrides
+        return settings.orderedFirstPartyProviders().filter {
+            settings.providerEnablement[$0.instanceID] == true && overrides[$0] != nil
+        }
+    }
 }
 
 @MainActor
 enum MenuBarLayoutEditorPersistence {
+    static func useAllProvidersLayout(for provider: UsageProvider, settings: SettingsStore) {
+        guard settings.providerEnablement[provider.instanceID] == true else { return }
+        settings.removeMenuBarLayoutOverride(for: provider)
+    }
+
     static func activate(
         _ layout: MenuBarLayout,
         for provider: UsageProvider?,
@@ -289,6 +310,7 @@ struct MenuBarLayoutEditor: View {
         VStack(alignment: .leading, spacing: 12) {
             self.header
             self.preview
+            self.overridesDisclosure
             self.layoutStrip
             self.removeDropTarget
 
@@ -347,11 +369,7 @@ struct MenuBarLayoutEditor: View {
             if case let .provider(provider) = self.scope,
                self.settings.menuBarLayoutOverrides[provider] != nil
             {
-                Button(L("menu_bar_layout_use_all")) {
-                    self.settings.removeMenuBarLayoutOverride(for: provider)
-                    self.selectedPosition = nil
-                }
-                .buttonStyle(.link)
+                self.useAllProvidersLayoutButton(for: provider)
             }
 
             Spacer(minLength: 8)
@@ -384,9 +402,39 @@ struct MenuBarLayoutEditor: View {
         }
     }
 
+    @ViewBuilder
+    private var overridesDisclosure: some View {
+        let providers = self.scope.providersWithOverrides(settings: self.settings)
+        if !providers.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(L("menu_bar_layout_overrides_notice"))
+                    .foregroundStyle(.secondary)
+                ForEach(providers, id: \.self) { provider in
+                    HStack {
+                        Text(L(self.store.metadata(for: provider).displayName))
+                        Spacer(minLength: 8)
+                        self.useAllProvidersLayoutButton(for: provider)
+                    }
+                }
+            }
+            .font(.caption)
+        }
+    }
+
+    private func useAllProvidersLayoutButton(for provider: UsageProvider) -> some View {
+        Button(L("menu_bar_layout_use_all")) {
+            MenuBarLayoutEditorPersistence.useAllProvidersLayout(for: provider, settings: self.settings)
+            self.selectedPosition = nil
+        }
+        .buttonStyle(.link)
+        .accessibilityLabel(L(
+            "menu_bar_layout_use_all_accessibility",
+            L(self.store.metadata(for: provider).displayName)))
+    }
+
     private var preview: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Text(L("menu_bar_layout_live_preview"))
+            Text(self.scope.previewLabel)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             MenuBarLayoutPreview(

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 "menu_bar_layout_preset_compact_stacked" = "مكدّس مضغوط";
 "menu_bar_layout_preset_custom" = "العرف";
 "menu_bar_layout_live_preview" = "معاينة مباشرة";
+"menu_bar_layout_default_preview" = "معاينة التخطيط الافتراضي";
+"menu_bar_layout_overrides_notice" = "يستخدم هؤلاء المزوّدون المفعّلون تخطيطاتهم المحفوظة الخاصة:";
+"menu_bar_layout_use_all_accessibility" = "%@: استخدام تخطيط جميع المزوّدين";
 "menu_bar_layout_strip" = "شريط القوائم";
 "menu_bar_layout_remove_line_break" = "إزالة فاصل السطر";
 "menu_bar_layout_chip_hint" = "حدّد أو اسحب لإعادة الترتيب أو استخدم إجراء الإزالة.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1372,6 +1372,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Apilat compacte";
 "menu_bar_layout_preset_custom" = "Personalitzat";
 "menu_bar_layout_live_preview" = "Previsualització en directe";
+"menu_bar_layout_default_preview" = "Previsualització del disseny per defecte";
+"menu_bar_layout_overrides_notice" = "Aquests proveïdors activats fan servir els seus propis dissenys desats:";
+"menu_bar_layout_use_all_accessibility" = "%@: Fes servir el disseny de tots els proveïdors";
 "menu_bar_layout_strip" = "Franja de la barra de menús";
 "menu_bar_layout_remove_line_break" = "Elimina el salt de línia";
 "menu_bar_layout_chip_hint" = "Selecciona, arrossega per reordenar o usa l’acció Elimina.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1370,6 +1370,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Kompakt gestapelt";
 "menu_bar_layout_preset_custom" = "Benutzerdefiniert";
 "menu_bar_layout_live_preview" = "Live-Vorschau";
+"menu_bar_layout_default_preview" = "Vorschau des Standardlayouts";
+"menu_bar_layout_overrides_notice" = "Diese aktivierten Anbieter verwenden eigene gespeicherte Layouts:";
+"menu_bar_layout_use_all_accessibility" = "%@: Layout für alle Anbieter verwenden";
 "menu_bar_layout_strip" = "Menüleistenstreifen";
 "menu_bar_layout_remove_line_break" = "Zeilenumbruch entfernen";
 "menu_bar_layout_chip_hint" = "Auswählen, zum Sortieren ziehen oder die Entfernen-Aktion verwenden.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1375,6 +1375,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Compact stacked";
 "menu_bar_layout_preset_custom" = "Custom";
 "menu_bar_layout_live_preview" = "Live preview";
+"menu_bar_layout_default_preview" = "Default layout preview";
+"menu_bar_layout_overrides_notice" = "These enabled providers use their own saved layouts:";
+"menu_bar_layout_use_all_accessibility" = "%@: Use all-providers layout";
 "menu_bar_layout_strip" = "Menu bar strip";
 "menu_bar_layout_remove_line_break" = "Remove line break";
 "menu_bar_layout_chip_hint" = "Select, drag to reorder, or use the Remove action.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1368,6 +1368,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Apilado compacto";
 "menu_bar_layout_preset_custom" = "Personalizado";
 "menu_bar_layout_live_preview" = "Vista previa en directo";
+"menu_bar_layout_default_preview" = "Vista previa del diseño predeterminado";
+"menu_bar_layout_overrides_notice" = "Estos proveedores habilitados usan sus propios diseños guardados:";
+"menu_bar_layout_use_all_accessibility" = "%@: Usar el diseño de todos los proveedores";
 "menu_bar_layout_strip" = "Franja de la barra de menús";
 "menu_bar_layout_remove_line_break" = "Quitar salto de línea";
 "menu_bar_layout_chip_hint" = "Selecciona, arrastra para reordenar o usa la acción Quitar.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 "menu_bar_layout_preset_compact_stacked" = "پشتهٔ فشرده";
 "menu_bar_layout_preset_custom" = "عرف";
 "menu_bar_layout_live_preview" = "پیش‌نمایش زنده";
+"menu_bar_layout_default_preview" = "پیش‌نمایش چیدمان پیش‌فرض";
+"menu_bar_layout_overrides_notice" = "این ارائه‌دهندگان فعال از چیدمان‌های ذخیره‌شدهٔ خود استفاده می‌کنند:";
+"menu_bar_layout_use_all_accessibility" = "%@: استفاده از چیدمان همهٔ ارائه‌دهندگان";
 "menu_bar_layout_strip" = "نوار منو";
 "menu_bar_layout_remove_line_break" = "حذف شکست خط";
 "menu_bar_layout_chip_hint" = "انتخاب کنید، برای مرتب‌سازی بکشید یا از عمل حذف استفاده کنید.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1369,6 +1369,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Empilement compact";
 "menu_bar_layout_preset_custom" = "Personnalisé";
 "menu_bar_layout_live_preview" = "Aperçu en direct";
+"menu_bar_layout_default_preview" = "Aperçu de la disposition par défaut";
+"menu_bar_layout_overrides_notice" = "Ces fournisseurs activés utilisent leurs propres dispositions enregistrées :";
+"menu_bar_layout_use_all_accessibility" = "%@ : Utiliser la disposition de tous les fournisseurs";
 "menu_bar_layout_strip" = "Bande de la barre des menus";
 "menu_bar_layout_remove_line_break" = "Supprimer le saut de ligne";
 "menu_bar_layout_chip_hint" = "Sélectionnez, faites glisser pour réorganiser ou utilisez l’action Supprimer.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1369,6 +1369,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Amontoado compacto";
 "menu_bar_layout_preset_custom" = "Personalizado";
 "menu_bar_layout_live_preview" = "Vista previa en directo";
+"menu_bar_layout_default_preview" = "Vista previa do deseño predeterminado";
+"menu_bar_layout_overrides_notice" = "Estes provedores activados usan os seus propios deseños gardados:";
+"menu_bar_layout_use_all_accessibility" = "%@: Usar o deseño de todos os provedores";
 "menu_bar_layout_strip" = "Franxa da barra de menús";
 "menu_bar_layout_remove_line_break" = "Retirar salto de liña";
 "menu_bar_layout_chip_hint" = "Selecciona, arrastra para reordenar ou usa a acción Retirar.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Tumpukan ringkas";
 "menu_bar_layout_preset_custom" = "Kustom";
 "menu_bar_layout_live_preview" = "Pratinjau langsung";
+"menu_bar_layout_default_preview" = "Pratinjau tata letak default";
+"menu_bar_layout_overrides_notice" = "Penyedia aktif ini menggunakan tata letak tersimpan sendiri:";
+"menu_bar_layout_use_all_accessibility" = "%@: Gunakan tata letak semua penyedia";
 "menu_bar_layout_strip" = "Strip bar menu";
 "menu_bar_layout_remove_line_break" = "Hapus pemisah baris";
 "menu_bar_layout_chip_hint" = "Pilih, seret untuk mengurutkan ulang, atau gunakan tindakan Hapus.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Compatto su due righe";
 "menu_bar_layout_preset_custom" = "Personalizzato";
 "menu_bar_layout_live_preview" = "Anteprima dal vivo";
+"menu_bar_layout_default_preview" = "Anteprima del layout predefinito";
+"menu_bar_layout_overrides_notice" = "Questi provider abilitati usano i propri layout salvati:";
+"menu_bar_layout_use_all_accessibility" = "%@: Usa il layout di tutti i provider";
 "menu_bar_layout_strip" = "Striscia della barra dei menu";
 "menu_bar_layout_remove_line_break" = "Rimuovi interruzione di riga";
 "menu_bar_layout_chip_hint" = "Seleziona, trascina per riordinare o usa l’azione Rimuovi.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1370,6 +1370,9 @@
 "menu_bar_layout_preset_compact_stacked" = "コンパクトな2段表示";
 "menu_bar_layout_preset_custom" = "カスタム";
 "menu_bar_layout_live_preview" = "ライブプレビュー";
+"menu_bar_layout_default_preview" = "デフォルトレイアウトのプレビュー";
+"menu_bar_layout_overrides_notice" = "次の有効なプロバイダーは独自の保存済みレイアウトを使用しています：";
+"menu_bar_layout_use_all_accessibility" = "%@：全プロバイダーのレイアウトを使用";
 "menu_bar_layout_strip" = "メニューバー表示";
 "menu_bar_layout_remove_line_break" = "改行を削除";
 "menu_bar_layout_chip_hint" = "選択、ドラッグで並べ替え、または削除アクションを使用します。";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1339,6 +1339,9 @@
 "menu_bar_layout_preset_compact_stacked" = "압축 스택";
 "menu_bar_layout_preset_custom" = "사용자 설정";
 "menu_bar_layout_live_preview" = "실시간 미리보기";
+"menu_bar_layout_default_preview" = "기본 레이아웃 미리보기";
+"menu_bar_layout_overrides_notice" = "다음 활성 제공자는 별도로 저장한 레이아웃을 사용합니다:";
+"menu_bar_layout_use_all_accessibility" = "%@: 모든 제공자 레이아웃 사용";
 "menu_bar_layout_strip" = "메뉴 막대 스트립";
 "menu_bar_layout_remove_line_break" = "줄 바꿈 제거";
 "menu_bar_layout_chip_hint" = "선택하거나 드래그해 순서를 바꾸거나 제거 동작을 사용하세요.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1369,6 +1369,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Compact gestapeld";
 "menu_bar_layout_preset_custom" = "Aangepast";
 "menu_bar_layout_live_preview" = "Livevoorvertoning";
+"menu_bar_layout_default_preview" = "Voorbeeld van standaardindeling";
+"menu_bar_layout_overrides_notice" = "Deze ingeschakelde providers gebruiken hun eigen opgeslagen indelingen:";
+"menu_bar_layout_use_all_accessibility" = "%@: Indeling voor alle providers gebruiken";
 "menu_bar_layout_strip" = "Menubalkstrook";
 "menu_bar_layout_remove_line_break" = "Regeleinde verwijderen";
 "menu_bar_layout_chip_hint" = "Selecteer, sleep om te herschikken of gebruik de actie Verwijderen.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Kompaktowy stos";
 "menu_bar_layout_preset_custom" = "Niestandardowe";
 "menu_bar_layout_live_preview" = "Podgląd na żywo";
+"menu_bar_layout_default_preview" = "Podgląd układu domyślnego";
+"menu_bar_layout_overrides_notice" = "Ci włączeni dostawcy używają własnych zapisanych układów:";
+"menu_bar_layout_use_all_accessibility" = "%@: Użyj układu dla wszystkich dostawców";
 "menu_bar_layout_strip" = "Pasek menu";
 "menu_bar_layout_remove_line_break" = "Usuń podział wiersza";
 "menu_bar_layout_chip_hint" = "Zaznacz, przeciągnij, aby zmienić kolejność, lub użyj akcji Usuń.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1370,6 +1370,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Empilhado compacto";
 "menu_bar_layout_preset_custom" = "Personalizado";
 "menu_bar_layout_live_preview" = "Prévia ao vivo";
+"menu_bar_layout_default_preview" = "Prévia do layout padrão";
+"menu_bar_layout_overrides_notice" = "Estes provedores ativados usam seus próprios layouts salvos:";
+"menu_bar_layout_use_all_accessibility" = "%@: Usar o layout de todos os provedores";
 "menu_bar_layout_strip" = "Faixa da barra de menus";
 "menu_bar_layout_remove_line_break" = "Remover quebra de linha";
 "menu_bar_layout_chip_hint" = "Selecione, arraste para reordenar ou use a ação Remover.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1371,6 +1371,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Компактно в две строки";
 "menu_bar_layout_preset_custom" = "Пользовательский";
 "menu_bar_layout_live_preview" = "Предпросмотр";
+"menu_bar_layout_default_preview" = "Предпросмотр макета по умолчанию";
+"menu_bar_layout_overrides_notice" = "Эти включённые провайдеры используют собственные сохранённые макеты:";
+"menu_bar_layout_use_all_accessibility" = "%@: Использовать макет для всех провайдеров";
 "menu_bar_layout_strip" = "Строка меню";
 "menu_bar_layout_remove_line_break" = "Удалить разрыв строки";
 "menu_bar_layout_chip_hint" = "Выберите, перетащите для изменения порядка или используйте действие удаления.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1368,6 +1368,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Kompakt staplad";
 "menu_bar_layout_preset_custom" = "Anpassat";
 "menu_bar_layout_live_preview" = "Liveförhandsvisning";
+"menu_bar_layout_default_preview" = "Förhandsvisning av standardlayout";
+"menu_bar_layout_overrides_notice" = "Dessa aktiverade leverantörer använder egna sparade layouter:";
+"menu_bar_layout_use_all_accessibility" = "%@: Använd layouten för alla leverantörer";
 "menu_bar_layout_strip" = "Menyradsremsa";
 "menu_bar_layout_remove_line_break" = "Ta bort radbrytning";
 "menu_bar_layout_chip_hint" = "Markera, dra för att ändra ordning eller använd åtgärden Ta bort.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 "menu_bar_layout_preset_compact_stacked" = "ซ้อนแบบกะทัดรัด";
 "menu_bar_layout_preset_custom" = "กําหนดเอง";
 "menu_bar_layout_live_preview" = "ตัวอย่างสด";
+"menu_bar_layout_default_preview" = "ตัวอย่างเค้าโครงเริ่มต้น";
+"menu_bar_layout_overrides_notice" = "ผู้ให้บริการที่เปิดใช้งานเหล่านี้ใช้เค้าโครงที่บันทึกไว้ของตนเอง:";
+"menu_bar_layout_use_all_accessibility" = "%@: ใช้เค้าโครงสำหรับผู้ให้บริการทั้งหมด";
 "menu_bar_layout_strip" = "แถบเมนู";
 "menu_bar_layout_remove_line_break" = "ลบการขึ้นบรรทัดใหม่";
 "menu_bar_layout_chip_hint" = "เลือก ลากเพื่อจัดลำดับใหม่ หรือใช้การทำงานลบ";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1371,6 +1371,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Kompakt yığın";
 "menu_bar_layout_preset_custom" = "Özel";
 "menu_bar_layout_live_preview" = "Canlı önizleme";
+"menu_bar_layout_default_preview" = "Varsayılan düzen önizlemesi";
+"menu_bar_layout_overrides_notice" = "Bu etkin sağlayıcılar kendi kayıtlı düzenlerini kullanır:";
+"menu_bar_layout_use_all_accessibility" = "%@: Tüm sağlayıcıların düzenini kullan";
 "menu_bar_layout_strip" = "Menü çubuğu şeridi";
 "menu_bar_layout_remove_line_break" = "Satır sonunu kaldır";
 "menu_bar_layout_chip_hint" = "Seçin, yeniden sıralamak için sürükleyin veya kaldırma eylemini kullanın.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1369,6 +1369,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Компактно у два рядки";
 "menu_bar_layout_preset_custom" = "Користувацький";
 "menu_bar_layout_live_preview" = "Попередній перегляд";
+"menu_bar_layout_default_preview" = "Перегляд типового макета";
+"menu_bar_layout_overrides_notice" = "Ці ввімкнені провайдери використовують власні збережені макети:";
+"menu_bar_layout_use_all_accessibility" = "%@: Використовувати макет для всіх провайдерів";
 "menu_bar_layout_strip" = "Смуга меню";
 "menu_bar_layout_remove_line_break" = "Видалити розрив рядка";
 "menu_bar_layout_chip_hint" = "Виберіть, перетягніть для зміни порядку або скористайтеся дією видалення.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1370,6 +1370,9 @@
 "menu_bar_layout_preset_compact_stacked" = "Xếp chồng gọn";
 "menu_bar_layout_preset_custom" = "Tùy chỉnh";
 "menu_bar_layout_live_preview" = "Xem trước trực tiếp";
+"menu_bar_layout_default_preview" = "Xem trước bố cục mặc định";
+"menu_bar_layout_overrides_notice" = "Các nhà cung cấp đang bật này dùng bố cục riêng đã lưu:";
+"menu_bar_layout_use_all_accessibility" = "%@: Dùng bố cục của tất cả nhà cung cấp";
 "menu_bar_layout_strip" = "Dải thanh menu";
 "menu_bar_layout_remove_line_break" = "Xóa ngắt dòng";
 "menu_bar_layout_chip_hint" = "Chọn, kéo để sắp xếp lại hoặc dùng thao tác Xóa.";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1370,6 +1370,9 @@
 "menu_bar_layout_preset_compact_stacked" = "紧凑堆叠";
 "menu_bar_layout_preset_custom" = "自定义";
 "menu_bar_layout_live_preview" = "实时预览";
+"menu_bar_layout_default_preview" = "默认布局预览";
+"menu_bar_layout_overrides_notice" = "以下已启用的提供商使用各自保存的布局：";
+"menu_bar_layout_use_all_accessibility" = "%@：使用所有提供商的布局";
 "menu_bar_layout_strip" = "菜单栏条带";
 "menu_bar_layout_remove_line_break" = "移除换行";
 "menu_bar_layout_chip_hint" = "选择、拖动以重新排序，或使用移除操作。";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1400,6 +1400,9 @@
 "menu_bar_layout_preset_compact_stacked" = "緊湊堆疊";
 "menu_bar_layout_preset_custom" = "自訂";
 "menu_bar_layout_live_preview" = "即時預覽";
+"menu_bar_layout_default_preview" = "預設佈局預覽";
+"menu_bar_layout_overrides_notice" = "以下已啟用的供應商使用各自儲存的佈局：";
+"menu_bar_layout_use_all_accessibility" = "%@：使用所有供應商的佈局";
 "menu_bar_layout_strip" = "選單列條帶";
 "menu_bar_layout_remove_line_break" = "移除換行";
 "menu_bar_layout_chip_hint" = "選取、拖曳以重新排序，或使用移除動作。";

--- a/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutEditorTests.swift
@@ -1,11 +1,94 @@
 import CodexBarCore
 import CoreTransferable
 import Foundation
+import Observation
 import Testing
 import UniformTypeIdentifiers
 @testable import CodexBar
 
 struct MenuBarLayoutEditorTests {
+    @Test
+    @MainActor
+    func `all scope discloses only enabled saved overrides in provider order including equal layouts`() throws {
+        let settings = try Self.overrideSettings()
+        let global = MenuBarLayout(lines: [[.providerName, .percent(window: .session)]])
+        settings.setMenuBarLayout(global, for: nil)
+        settings.setMenuBarLayout(global, for: .cursor)
+        settings.setMenuBarLayout(MenuBarLayout(lines: [[.percent(window: .weekly)]]), for: .claude)
+        settings.setMenuBarLayout(global, for: .codex)
+
+        #expect(MenuBarLayoutEditorScope.all.providersWithOverrides(settings: settings) == [.claude, .cursor])
+        #expect(MenuBarLayoutEditorScope.provider(.claude).providersWithOverrides(settings: settings).isEmpty)
+        #expect(MenuBarLayoutEditorScope.all.previewLabel == L("menu_bar_layout_default_preview"))
+        #expect(MenuBarLayoutEditorScope.provider(.claude).previewLabel == L("menu_bar_layout_live_preview"))
+    }
+
+    @Test
+    @MainActor
+    func `editor reset removes only its enabled provider and updates observed disclosure`() throws {
+        let settings = try Self.overrideSettings()
+        let global = MenuBarLayout(lines: [[.providerName]])
+        let override = MenuBarLayout(lines: [[.percent(window: .weekly)]])
+        settings.setMenuBarLayout(global, for: nil)
+        settings.setMenuBarLayout(override, for: .claude)
+        settings.setMenuBarLayout(global, for: .cursor)
+        settings.setMenuBarLayout(override, for: .codex)
+        let changed = LockIsolated(false)
+        withObservationTracking {
+            _ = MenuBarLayoutEditorScope.all.providersWithOverrides(settings: settings)
+        } onChange: {
+            changed.setValue(true)
+        }
+
+        MenuBarLayoutEditorPersistence.useAllProvidersLayout(for: .claude, settings: settings)
+
+        #expect(changed.value)
+        #expect(settings.menuBarLayout(for: .claude) == global)
+        #expect(settings.menuBarLayoutOverrides == [.cursor: global, .codex: override])
+        #expect(MenuBarLayoutEditorScope.all.providersWithOverrides(settings: settings) == [.cursor])
+
+        MenuBarLayoutEditorPersistence.useAllProvidersLayout(for: .cursor, settings: settings)
+        #expect(MenuBarLayoutEditorScope.all.providersWithOverrides(settings: settings).isEmpty)
+        #expect(settings.menuBarLayoutOverrides == [.codex: override])
+    }
+
+    @Test
+    @MainActor
+    func `editor reset leaves disabled and no longer enabled providers untouched`() throws {
+        let settings = try Self.overrideSettings()
+        let override = MenuBarLayout(lines: [[.percent(window: .weekly)]])
+        settings.setMenuBarLayout(override, for: .claude)
+        settings.setMenuBarLayout(override, for: .codex)
+        let metadata = try #require(ProviderDefaults.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: false)
+
+        MenuBarLayoutEditorPersistence.useAllProvidersLayout(for: .claude, settings: settings)
+        MenuBarLayoutEditorPersistence.useAllProvidersLayout(for: .codex, settings: settings)
+        MenuBarLayoutEditorPersistence.useAllProvidersLayout(for: .cursor, settings: settings)
+
+        #expect(MenuBarLayoutEditorScope.all.providersWithOverrides(settings: settings).isEmpty)
+        #expect(settings.menuBarLayoutOverrides == [.claude: override, .codex: override])
+        #expect(!settings.hasStoredMenuBarLayout)
+        #expect(settings.providerEnablement[.claude] == false)
+        #expect(settings.providerEnablement[.codex] == false)
+    }
+
+    @MainActor
+    private static func overrideSettings() throws -> SettingsStore {
+        try #require(SettingsStore.isRunningTests)
+        let enabled: [UsageProvider] = [.claude, .cursor, .kimi]
+        let order = enabled + UsageProvider.allCases.filter { !enabled.contains($0) }
+        return testSettingsStore(
+            suiteName: "MenuBarLayoutEditorTests-overrides",
+            config: CodexBarConfig(providers: order.map {
+                ProviderConfig(id: $0.instanceID, enabled: enabled.contains($0))
+            }),
+            prepareDefaults: { defaults in
+                defaults.set(AppGroupSupport.migrationVersion, forKey: AppGroupSupport.migrationVersionKey)
+                defaults.set(true, forKey: "debugDisableKeychainAccess")
+            })
+    }
+
     @Test
     func `time palette lists the compact run out token with a clear label`() {
         #expect(MenuBarLayoutPaletteTokens.time.contains(.runsOutCompact))

--- a/Tests/CodexBarTests/MenuBarLayoutTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutTests.swift
@@ -1050,6 +1050,77 @@ struct MenuBarLayoutTests {
 
     @Test
     @MainActor
+    func `global editor edits preserve saved overrides and targeted reset persists without unrelated changes`() throws {
+        try #require(SettingsStore.isRunningTests)
+        let settings = testSettingsStore(
+            suiteName: "MenuBarLayoutTests-global-override-edit",
+            config: CodexBarConfig(providers: UsageProvider.allCases.map {
+                ProviderConfig(id: $0.instanceID, enabled: $0 == .claude || $0 == .cursor)
+            }),
+            prepareDefaults: { defaults in
+                defaults.set(AppGroupSupport.migrationVersion, forKey: AppGroupSupport.migrationVersionKey)
+                defaults.set(true, forKey: "debugDisableKeychainAccess")
+            })
+        let global = MenuBarLayout(lines: [[.providerName]])
+        let edited = MenuBarLayout(lines: [[.providerName, .percent(window: .session)]])
+        let override = MenuBarLayout(lines: [[.percent(window: .weekly)]])
+        settings.setMenuBarLayout(global, for: nil)
+        settings.setMenuBarLayout(override, for: .claude)
+        settings.setMenuBarLayout(global, for: .cursor)
+        settings.setMenuBarLayout(override, for: .kimi)
+        settings.hidePersonalInfo = true
+        settings.menuBarLayoutSize = .small
+        settings.menuBarLayoutGap = .tight
+        settings.resetTimesShowAbsolute = true
+        let configBefore = try Data(contentsOf: settings.configStore.fileURL)
+
+        MenuBarLayoutEditorPersistence.activate(edited, for: nil, settings: settings)
+        #expect(settings.menuBarLayoutOverrides == [.claude: override, .cursor: global, .kimi: override])
+        #expect(settings.menuBarLayoutForGlobalEditing(representativeProvider: .claude) == edited)
+        #expect(settings.menuBarLayout(for: .claude) == override)
+        let reloaded = Self.reloadSettingsStore(settings)
+        #expect(reloaded.menuBarLayoutOverrides == settings.menuBarLayoutOverrides)
+
+        MenuBarLayoutEditorPersistence.useAllProvidersLayout(for: .claude, settings: reloaded)
+        let afterReset = Self.reloadSettingsStore(reloaded)
+        #expect(afterReset.menuBarLayout == edited)
+        #expect(afterReset.menuBarLayout(for: .claude) == edited)
+        #expect(afterReset.menuBarLayoutOverrides == [.cursor: global, .kimi: override])
+        #expect(afterReset.providerEnablement == settings.providerEnablement)
+        #expect(afterReset.providerOrder == settings.providerOrder)
+        #expect(afterReset.hidePersonalInfo)
+        #expect(afterReset.menuBarLayoutSize == .small)
+        #expect(afterReset.menuBarLayoutGap == .tight)
+        #expect(afterReset.resetTimeDisplayStyle == .absolute)
+        #expect(try Data(contentsOf: afterReset.configStore.fileURL) == configBefore)
+    }
+
+    @Test
+    @MainActor
+    func `first global edit still starts from the representative saved override`() throws {
+        try #require(SettingsStore.isRunningTests)
+        let settings = testSettingsStore(
+            suiteName: "MenuBarLayoutTests-global-editor-override-fallback",
+            prepareDefaults: { defaults in
+                defaults.set(AppGroupSupport.migrationVersion, forKey: AppGroupSupport.migrationVersionKey)
+                defaults.set(true, forKey: "debugDisableKeychainAccess")
+            })
+        let override = MenuBarLayout(lines: [[.percent(window: .weekly)]])
+        settings.setMenuBarLayout(override, for: .claude)
+
+        #expect(!settings.hasStoredMenuBarLayout)
+        let initial = settings.menuBarLayoutForGlobalEditing(representativeProvider: .claude)
+        #expect(initial == override)
+        let edited = MenuBarLayoutEditorMutations.append(.providerName, to: initial)
+        MenuBarLayoutEditorPersistence.activate(edited, for: nil, settings: settings)
+
+        #expect(settings.menuBarLayoutForGlobalEditing(representativeProvider: .claude) == edited)
+        #expect(settings.menuBarLayout(for: .claude) == override)
+        #expect(settings.menuBarLayoutOverrides == [.claude: override])
+    }
+
+    @Test
+    @MainActor
     func `global editing seeds the representative provider legacy layout`() throws {
         let settings = testSettingsStore(suiteName: "MenuBarLayoutTests-global-editor-migration")
         settings.setMenuBarMetricPreference(.primary, for: .kimi)

--- a/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
+++ b/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
@@ -14,6 +14,75 @@ final class MenuLayoutScreenshotRenderTests: XCTestCase {
     private static let width: CGFloat = 320
     private static let now = Date(timeIntervalSince1970: 1_782_000_000)
 
+    func test_renderLayoutOverrideDisclosureProof() throws {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_LAYOUT_OVERRIDE_SCREENSHOT_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_LAYOUT_OVERRIDE_SCREENSHOT_DIR to render the layout override proof.")
+        }
+        XCTAssertTrue(SettingsStore.isRunningTests)
+        guard SettingsStore.isRunningTests else { return }
+        XCTAssertTrue(CodexCredentialFileAccess.isTestContext)
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("layout-override-proof-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // This XCTest needs no credential files; keep authorization empty and the dashboard cache temporary.
+        try CodexCredentialFileAccess.withFixtureScope(.init()) {
+            try OpenAIDashboardCacheStore.$cacheURLOverride.withValue(root.appendingPathComponent("dashboard.json")) {
+                try CodexBarLocalizationOverride.$appLanguage.withValue("en") {
+                    let order: [UsageProvider] = [.claude, .cursor]
+                    let config =
+                        CodexBarConfig(providers: (order + UsageProvider.allCases.filter { !order.contains($0) })
+                            .map { ProviderConfig(id: $0.instanceID, enabled: order.contains($0)) })
+                    let settings = testSettingsStore(
+                        suiteName: "MenuLayoutScreenshotRenderTests-overrides",
+                        config: config,
+                        prepareDefaults: { defaults in
+                            defaults.set(AppGroupSupport.migrationVersion, forKey: AppGroupSupport.migrationVersionKey)
+                            defaults.set(true, forKey: "debugDisableKeychainAccess")
+                        })
+                    settings.menuBarIconStyle = .iconAndPercent
+                    let global = MenuBarLayout(lines: [[.providerName, .space, .percent(window: .session)]])
+                    let override = MenuBarLayout(lines: [[.percent(window: .weekly)]])
+                    settings.setMenuBarLayout(global, for: nil)
+                    settings.setMenuBarLayout(override, for: .claude)
+                    let browserDetection = BrowserDetection(
+                        homeDirectory: root.path,
+                        fileExists: { _ in false },
+                        directoryContents: { _ in nil })
+                    let store = UsageStore(
+                        fetcher: UsageFetcher(environment: [:]),
+                        browserDetection: browserDetection,
+                        settings: settings,
+                        historicalUsageHistoryStore: HistoricalUsageHistoryStore(
+                            fileURL: root.appendingPathComponent("history.json")),
+                        planUtilizationHistoryStore: PlanUtilizationHistoryStore(
+                            directoryURL: root.appendingPathComponent("plan-history")),
+                        startupBehavior: .testing,
+                        environmentBase: [:],
+                        widgetSnapshotURL: root.appendingPathComponent("widget.json"))
+                    XCTAssertEqual(store.enabledFirstPartyProvidersForDisplay(), order)
+                    XCTAssertTrue(store.snapshots.isEmpty)
+                    XCTAssertEqual(settings.menuBarLayoutForGlobalEditing(representativeProvider: .claude), global)
+                    XCTAssertEqual(settings.menuBarLayout(for: .claude), override)
+
+                    let view = AnyView(MenuBarLayoutEditor(settings: settings, store: store)
+                        .frame(width: 560)
+                        .padding(16)
+                        .environment(\.locale, Locale(identifier: "en_US_POSIX"))
+                        .environment(\.colorScheme, .dark)
+                        .background(Color(nsColor: .windowBackgroundColor)))
+                    let data = try XCTUnwrap(Self.pngData(for: view))
+                    let directory = URL(fileURLWithPath: dir, isDirectory: true)
+                    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                    try data.write(to: directory.appendingPathComponent("layout-override.png"))
+                    XCTAssertEqual(settings.menuBarLayoutOverrides, [.claude: override])
+                    XCTAssertEqual(settings.menuBarLayout, global)
+                }
+            }
+        }
+    }
+
     func test_renderClaudeExtraUsageFillProof() throws {
         guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_CLAUDE_EXTRA_USAGE_SCREENSHOT_DIR"] else {
             throw XCTSkip("Set CODEXBAR_CLAUDE_EXTRA_USAGE_SCREENSHOT_DIR to render the Claude Extra Usage proof.")

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1750,7 +1750,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuBarLayoutEditor.swift",
-            line: 856,
+            line: 904,
             anchor: "let provider = self.provider ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -1758,7 +1758,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuBarLayoutEditor.swift",
-            line: 886,
+            line: 934,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -124,13 +124,15 @@ func testConfigStore(suiteName: String, reset: Bool = true) -> CodexBarConfigSto
 func testSettingsStore(
     suiteName: String,
     tokenAccountStore: any ProviderTokenAccountStoring = InMemoryTokenAccountStore(),
-    config: CodexBarConfig? = nil) -> SettingsStore
+    config: CodexBarConfig? = nil,
+    prepareDefaults: ((UserDefaults) -> Void)? = nil) -> SettingsStore
 {
     let isolatedSuiteName = "\(suiteName)-\(UUID().uuidString)"
     guard let defaults = UserDefaults(suiteName: isolatedSuiteName) else {
         preconditionFailure("Could not create test defaults suite")
     }
     defaults.removePersistentDomain(forName: isolatedSuiteName)
+    prepareDefaults?(defaults)
     let configStore = testConfigStore(suiteName: isolatedSuiteName)
     if let config {
         do {

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -18,6 +18,10 @@ read_when:
 - Display → Menu Bar → Layout provides presets plus a token editor. Tokens can be clicked to append, dragged from the
   palette, reordered between one or two lines, dragged out, or removed with Delete. Layouts can be global or overridden
   per provider. Manual edits select the Custom preset.
+- All providers previews the default layout and lists enabled providers with saved overrides, even when an override
+  currently matches the default. Each “Use all-providers layout” action removes only that provider's override;
+  global edits preserve overrides, and disabled providers are left untouched. Before a default is first saved,
+  editing still starts from the representative provider's effective layout.
 - Small/Regular controls the token font scale. Tight/Regular controls status-item padding. Compact stacked uses two
   tightly spaced lines sized to fit the menu bar.
 


### PR DESCRIPTION
Fixes #3210.

## Summary

The All providers editor correctly edits the default layout, but a saved provider override can mask those edits at runtime. Make that precedence visible: label the preview as the default and list enabled providers with saved overrides, each with the existing targeted “Use all-providers layout” action.

Equal-valued overrides remain listed because they can diverge on the next default edit. Removing one override leaves other providers, disabled-provider layouts, global settings and persisted configuration unchanged. The existing first-edit representative-provider fallback is preserved. No new stored preference or precedence rule.

The reset action is shared with the provider-scoped editor and has a provider-specific accessibility label. Three strings are localized across all 23 catalogs. Documentation and changelog are updated; only two displaced architecture-test line anchors changed.

## Visual proof

Identical synthetic settings rendered through the actual `MenuBarLayoutEditor`: Claude and Cursor enabled, a provider-name/session default, and a saved Claude weekly override. The baseline was captured before production edits. The after image shows the default-preview label, override notice and targeted reset link.

| Before | After |
| --- | --- |
| ![Before: no indication of the saved Claude override](https://github.com/user-attachments/assets/fd0ec28c-8e04-45e8-bef1-c5a0510d83b8) | ![After: default preview and explicit Claude override reset](https://github.com/user-attachments/assets/232d98ba-1140-41f7-8410-98d3d93e6ad7) |

These are offscreen production-view renders at fixed width/appearance/locale. Native header menus and some display-option controls are absent in both captures; the All scope is established by the actual editor's initial state. This is not a live picker/click or VoiceOver session. Behavioral tests exercise the same reset/state method used by the displayed buttons.

## Verification

- 119 focused tests across editor, layout/persistence and provider architecture suites: passed.
- Coverage includes enabled-only ordered disclosure, equal overrides, observation invalidation, targeted reset, disablement races, global edits preserving overrides, reload, unchanged unrelated configuration and first-edit fallback.
- Screenshot XCTest before/after: passed; no-output-variable path skips before constructing fixtures.
- `make check`: passed, including all locale catalogs and zero SwiftLint violations.
- Independent complete-diff review: no actionable findings.
- Parent full `make test`: all 934 selections across 78 groups passed first try, with zero failures, retries or timeouts (846.0 seconds).
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33038069972): passed; both macOS shards and plugin goldens, Linux x64/ARM64 and musl builds/tests, lint and aggregate gate are green.

Fixtures use temporary settings/config/history/widget/dashboard state, empty Codex credential-file authorization, suppressed Keychain access, stubbed browser discovery and testing-only store startup. No account probe, status item, window or app launch. Initial fixture failures were an extra default-enabled provider and a test assignment to a derived read-only setting; both were corrected without changing production behavior or weakening assertions. The public bot review found no actionable code issues; its attempted Swift test was blocked by its unrelated pnpm setup, not a Swift test failure. Local and exact-head hosted Swift tests passed. Thanks @Sedrak-Hovhannisyan for the report.
