### PR TITLE
fix: publish Codex local-only cost refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.55.2 — Unreleased
 
 ### Fixed
+- Codex: refresh local session cost estimates when global cost tracking is off, without repeatedly rejecting successful scans as stale. Thanks @vinschger!
 - Codex: fairly resume older partial session files during busy local cost scans without increasing scan limits or rebuilding compatible caches (#3207). Thanks @IchenDEV!
 - Menu bar: label the All providers preview as the default and disclose enabled providers with saved overrides, with a targeted “Use all-providers layout” action (#3210). Thanks @Sedrak-Hovhannisyan!
 - Claude: respect the used/remaining fill preference for capped Extra Usage, so an exhausted cap is empty in remaining mode (#3213). Thanks @vinschger!

--- a/Sources/CodexBar/UsageStore+TokenCost.swift
+++ b/Sources/CodexBar/UsageStore+TokenCost.swift
@@ -418,7 +418,7 @@ extension UsageStore {
     {
         guard self.providerPublicationRevisionIsCurrent(publicationRevision, for: provider),
               self.settings.providerConfigRevision(for: provider) == providerConfigRevision,
-              self.settings.costUsageEnabled,
+              self.settings.isCostUsageEffectivelyEnabled(for: provider),
               self.isEnabled(provider),
               self.settings.costUsageHistoryDays == historyDays
         else {

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
@@ -5,15 +5,9 @@ import Testing
 
 extension CodexAccountScopedRefreshTests {
     func makeSettingsStore(suite: String) -> SettingsStore {
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        defaults.set(true, forKey: "providerDetectionCompleted")
-        let configStore = testConfigStore(suiteName: suite)
-        let settings = SettingsStore(
-            userDefaults: defaults,
-            configStore: configStore,
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+        let settings = testSettingsStore(suiteName: suite, prepareDefaults: {
+            $0.set(true, forKey: "providerDetectionCompleted")
+        })
         settings._test_activeManagedCodexAccount = nil
         settings._test_activeManagedCodexRemoteHomePath = nil
         settings._test_unreadableManagedCodexAccountStore = false

--- a/Tests/CodexBarTests/CodexLocalSessionCostSettingsTests.swift
+++ b/Tests/CodexBarTests/CodexLocalSessionCostSettingsTests.swift
@@ -90,17 +90,16 @@ struct CodexLocalSessionCostSettingsTests {
     }
 
     private func makeSettingsFixture(suite: String) throws -> Fixture {
-        let defaults = try #require(UserDefaults(suiteName: suite))
-        defaults.removePersistentDomain(forName: suite)
-        let settings = SettingsStore(
-            userDefaults: defaults,
-            configStore: testConfigStore(suiteName: suite),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+        let settings = testSettingsStore(suiteName: suite)
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        settings._test_managedCodexAccountStoreURL = root.appendingPathComponent("accounts.json")
+        let environment = ["HOME": root.path, "CODEX_HOME": root.appendingPathComponent("codex").path]
         let store = UsageStore(
-            fetcher: UsageFetcher(environment: [:]),
-            browserDetection: BrowserDetection(cacheTTL: 0),
-            settings: settings)
+            fetcher: UsageFetcher(environment: environment),
+            browserDetection: BrowserDetection(homeDirectory: root.path, cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: environment)
         return Fixture(settings: settings, store: store)
     }
 

--- a/Tests/CodexBarTests/UsageStoreDisabledProviderCleanupTests.swift
+++ b/Tests/CodexBarTests/UsageStoreDisabledProviderCleanupTests.swift
@@ -652,11 +652,16 @@ struct UsageStoreDisabledProviderCleanupTests {
     }
 
     private static func makeUsageStore(settings: SettingsStore) -> UsageStore {
-        UsageStore(
+        let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings,
+            startupBehavior: .testing,
             environmentBase: [:])
+        store._test_codexCostCatchUpStatusOverride = { _ in
+            CostUsageFetcher.CodexScanCatchUpStatus(pending: false, progressKey: "isolated-complete")
+        }
+        return store
     }
 
     private static func setOnlyProvider(

--- a/Tests/CodexBarTests/UsageStoreLocalLedgerPublicationTests.swift
+++ b/Tests/CodexBarTests/UsageStoreLocalLedgerPublicationTests.swift
@@ -1,0 +1,382 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+@Suite(.serialized)
+struct UsageStoreLocalLedgerPublicationTests {
+    @Test(arguments: [false, true], [false, true])
+    func `regular refresh publishes local ledger results once`(globalEnabled: Bool, empty: Bool) async throws {
+        try await Self.withFixture(globalEnabled: globalEnabled) { fixture in
+            let store = fixture.store
+            let old = Self.snapshot(cost: 1, updatedAt: Date(timeIntervalSince1970: 1))
+            store.installCachedTokenSnapshot(old, for: .codex)
+            store.tokenErrors[.codex] = "Previous scan failed"
+            _ = store.tokenFailureGates[.codex]?.shouldSurfaceError(onFailureWithPriorData: false)
+            let revision = store.tokenSnapshotPublicationRevision(for: .codex)
+            let fresh = Self.snapshot(cost: 2, empty: empty)
+            fixture.results = [.success(fresh)]
+
+            await store.refreshTokenUsageNow(for: .codex, force: false)
+
+            #expect(store.tokenSnapshotPublicationRevision(for: .codex) == revision + 1)
+            let publication = store.tokenSnapshotPublicationForCurrentProviderConfig(for: .codex)
+            #expect(publication != nil)
+            #expect(publication?.snapshot == (empty ? nil : fresh))
+            #expect(store.tokenSnapshot(for: .codex) == (empty ? nil : fresh))
+            #expect(store.tokenError(for: .codex) == (empty ? UsageStore.tokenCostNoDataMessage(for: .codex) : nil))
+            #expect(store.tokenFailureGates[.codex]?.streak == 0)
+            #expect(store.lastTokenFetchScope[.codex] == store.tokenSnapshotScopeSignature(for: .codex))
+            #expect(store.lastTokenFetchAt[.codex] != nil)
+            fixture.expectIdle(loadCount: 1)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `global cost setting still publishes without local mode`(localEnabled: Bool) async throws {
+        try await Self.withFixture(globalEnabled: true, localEnabled: localEnabled) { fixture in
+            let fresh = Self.snapshot(cost: 2)
+            fixture.results = [.success(fresh)]
+
+            await fixture.store.refreshTokenUsageNow(for: .codex, force: false)
+
+            #expect(fixture.store.tokenSnapshot(for: .codex) == fresh)
+            fixture.expectIdle(loadCount: 1)
+        }
+    }
+
+    @Test
+    func `both off skips Codex and local mode does not enable unrelated scanners`() async throws {
+        try await Self.withFixture(localEnabled: false) { fixture in
+            await fixture.store.refreshTokenUsageNow(for: .codex, force: false)
+            #expect(fixture.store.tokenSnapshotPublicationRevision(for: .codex) == 0)
+            fixture.expectIdle(loadCount: 0)
+
+            fixture.store.settings.codexLocalSessionCostLedgerEnabled = true
+            for provider in [UsageProvider.claude, .cursor] {
+                fixture.store.settings.setProviderEnabled(
+                    provider: provider, metadata: fixture.store.metadata(for: provider), enabled: true)
+                await fixture.store.refreshTokenUsageNow(for: provider, force: false)
+                #expect(!fixture.store.settings.isCostUsageEffectivelyEnabled(for: provider))
+                #expect(fixture.store.tokenSnapshotPublicationRevision(for: provider) == 0)
+                #expect(fixture.store.tokenError(for: provider) == nil)
+            }
+            fixture.expectIdle(loadCount: 0)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `local ledger failures retain the failure gate and recover without stale retries`(cached: Bool) async throws {
+        try await Self.withFixture { fixture in
+            let store = fixture.store
+            let old = Self.snapshot(cost: 1)
+            if cached { store.installCachedTokenSnapshot(old, for: .codex) }
+            fixture.results = [.failure(ScanError.failed), .failure(ScanError.failed), .success(Self.snapshot(cost: 2))]
+
+            await store.refreshTokenUsageNow(for: .codex, force: false)
+
+            #expect(store.tokenSnapshot(for: .codex) == (cached ? old : nil))
+            #expect(store.tokenError(for: .codex) == (cached ? nil : ScanError.failed.localizedDescription))
+            #expect(store.tokenFailureGates[.codex]?.streak == 1)
+            fixture.expectIdle(loadCount: 1)
+            // Do not wait on a replacement sequence if a regression has parked an unexpected retry.
+            guard store.tokenRefreshSequenceTask == nil else { return }
+
+            await store.refreshTokenUsageNow(for: .codex, force: true)
+            #expect(store.tokenSnapshot(for: .codex) == nil)
+            #expect(store.tokenError(for: .codex) == ScanError.failed.localizedDescription)
+            #expect(store.tokenFailureGates[.codex]?.streak == 2)
+            fixture.expectIdle(loadCount: 2)
+            guard store.tokenRefreshSequenceTask == nil else { return }
+
+            await store.refreshTokenUsageNow(for: .codex, force: true)
+            #expect(store.tokenSnapshot(for: .codex)?.sessionCostUSD == 2)
+            #expect(store.tokenError(for: .codex) == nil)
+            #expect(store.tokenFailureGates[.codex]?.streak == 0)
+            fixture.expectIdle(loadCount: 3)
+        }
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func `disabling during a regular fetch rejects its result`(disableProvider: Bool, fail: Bool) async throws {
+        try await Self.withFixture { fixture in
+            let store = fixture.store
+            fixture.results = [fail ? .failure(ScanError.failed) : .success(Self.snapshot(cost: 9))]
+            let gate = fixture.gate(load: 1)
+            store.scheduleTokenRefresh()
+            let task = try #require(store.tokenRefreshSequenceTask)
+            try await Self.waitUntil { gate.isWaiting }
+
+            if disableProvider {
+                store.settings.setProviderEnabled(
+                    provider: .codex,
+                    metadata: store.metadata(for: .codex),
+                    enabled: false)
+            } else {
+                store.settings.codexLocalSessionCostLedgerEnabled = false
+            }
+            gate.release()
+            await task.value
+
+            #expect(fixture.loads.count == 1)
+            #expect(store.tokenSnapshotPublicationRevision(for: .codex) == 0)
+            #expect(store.tokenSnapshot(for: .codex) == nil)
+            #expect(store.tokenError(for: .codex) == nil)
+            #expect(store.lastTokenFetchAt[.codex] == nil)
+            #expect(store.lastTokenFetchScope[.codex] == nil)
+            #expect(store.tokenRefreshSequenceTask == nil)
+        }
+    }
+
+    enum ScopeChange: CaseIterable {
+        case history, account, managedHome, providerConfig, generation, reenabled, localMode
+    }
+
+    @Test(arguments: ScopeChange.allCases, [false, true])
+    func `changed scope rejects stale completion and retries only the new scope`(
+        change: ScopeChange, fail: Bool) async throws
+    {
+        try await Self
+            .withFixture(globalEnabled: change == .managedHome, localEnabled: change != .managedHome) { fixture in
+                let store = fixture.store
+                let firstHome = fixture.root.appendingPathComponent("first-home").path
+                if change == .managedHome {
+                    store.settings._test_activeManagedCodexRemoteHomePath = firstHome
+                    store.settings.codexActiveSource = .managedAccount(id: UUID())
+                }
+                fixture.results = [
+                    fail ? .failure(ScanError.failed) : .success(Self.snapshot(cost: 9)),
+                    .success(Self.snapshot(cost: 2)),
+                ]
+                let staleGate = fixture.gate(load: 1)
+                let retryGate = fixture.gate(load: 2)
+                store.scheduleTokenRefresh()
+                try await Self.waitUntil { staleGate.isWaiting }
+
+                switch change {
+                case .history:
+                    store.settings.costUsageHistoryDays = 7
+                case .account:
+                    store.settings.codexActiveSource = .managedAccount(id: UUID())
+                case .managedHome:
+                    store.settings._test_activeManagedCodexRemoteHomePath = fixture.root
+                        .appendingPathComponent("second-home")
+                        .path
+                case .providerConfig:
+                    store.settings.codexUsageDataSource = .cli
+                case .generation:
+                    store.clearProviderRuntimeState(.codex)
+                case .reenabled:
+                    store.settings.setProviderEnabled(
+                        provider: .codex,
+                        metadata: store.metadata(for: .codex),
+                        enabled: false)
+                    store.settings.setProviderEnabled(
+                        provider: .codex,
+                        metadata: store.metadata(for: .codex),
+                        enabled: true)
+                case .localMode:
+                    store.settings.costUsageEnabled = true
+                    store.settings.codexLocalSessionCostLedgerEnabled = false
+                }
+                staleGate.release()
+                try await Self.waitUntil { retryGate.isWaiting }
+
+                #expect(store.tokenSnapshotPublicationRevision(for: .codex) == 0)
+                #expect(store.tokenSnapshot(for: .codex) == nil)
+                #expect(store.tokenError(for: .codex) == nil)
+                #expect(fixture.loads[1].historyDays == (change == .history ? 7 : 30))
+                if change == .managedHome {
+                    #expect(fixture.loads[0].home == firstHome)
+                    #expect(fixture.loads[1].home == fixture.root.appendingPathComponent("second-home").path)
+                }
+                let retry = try #require(store.tokenRefreshSequenceTask)
+                retryGate.release()
+                await retry.value
+
+                #expect(store.tokenSnapshot(for: .codex)?.sessionCostUSD == 2)
+                #expect(store.tokenSnapshotPublicationRevision(for: .codex) == 1)
+                #expect(store.tokenError(for: .codex) == nil)
+                fixture.expectIdle(loadCount: 2)
+            }
+    }
+
+    @Test
+    func `cancelled local ledger refresh neither publishes nor retries`() async throws {
+        try await Self.withFixture { fixture in
+            let store = fixture.store
+            fixture.results = [.success(Self.snapshot(cost: 9))]
+            let gate = fixture.gate(load: 1)
+            store.scheduleTokenRefresh()
+            let task = try #require(store.tokenRefreshSequenceTask)
+            try await Self.waitUntil { gate.isWaiting }
+            task.cancel()
+            gate.release()
+            await task.value
+
+            #expect(store.tokenSnapshotPublicationRevision(for: .codex) == 0)
+            #expect(store.tokenError(for: .codex) == nil)
+            #expect(store.lastTokenFetchAt[.codex] == nil)
+            #expect(store.lastTokenFetchScope[.codex] == nil)
+            fixture.expectIdle(loadCount: 1)
+        }
+    }
+
+    private static func snapshot(
+        cost: Double,
+        empty: Bool = false,
+        updatedAt: Date = Date()) -> CostUsageTokenSnapshot
+    {
+        CostUsageTokenSnapshot(
+            sessionTokens: empty ? nil : 10,
+            sessionCostUSD: empty ? nil : cost,
+            last30DaysTokens: empty ? nil : 10,
+            last30DaysCostUSD: empty ? nil : cost,
+            daily: empty ? [] : [CostUsageDailyReport.Entry(
+                date: "2026-08-26",
+                inputTokens: 4,
+                outputTokens: 6,
+                totalTokens: 10,
+                costUSD: cost,
+                modelsUsed: nil,
+                modelBreakdowns: nil)],
+            updatedAt: updatedAt)
+    }
+
+    private static func waitUntil(_ condition: () -> Bool) async throws {
+        // Bound observation turns rather than wall time: architecture checks can occupy the main actor.
+        for _ in 0..<1000 where !condition() {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        try #require(condition(), "Timed out waiting for the isolated snapshot loader")
+    }
+
+    private static func withFixture(
+        globalEnabled: Bool = false,
+        localEnabled: Bool = true,
+        body: (Fixture) async throws -> Void) async throws
+    {
+        let fixture = try Fixture(globalEnabled: globalEnabled, localEnabled: localEnabled)
+        do {
+            try await body(fixture)
+        } catch {
+            await fixture.tearDown()
+            throw error
+        }
+        await fixture.tearDown()
+    }
+
+    private enum ScanError: LocalizedError {
+        case failed
+        var errorDescription: String? {
+            "Isolated local scan failed"
+        }
+    }
+
+    @MainActor
+    private final class Gate {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var released = false
+        var isWaiting: Bool {
+            self.continuation != nil
+        }
+
+        func wait() async {
+            guard !self.released else { return }
+            await withCheckedContinuation { self.continuation = $0 }
+        }
+
+        func release() {
+            self.released = true
+            self.continuation?.resume()
+            self.continuation = nil
+        }
+    }
+
+    @MainActor
+    private final class Fixture {
+        let store: UsageStore
+        let root: URL
+        var results: [Result<CostUsageTokenSnapshot, Error>] = []
+        var loads: [(provider: UsageProvider, home: String?, historyDays: Int)] = []
+        private var gates: [Int: Gate] = [:]
+        private var stopping = false
+
+        init(globalEnabled: Bool, localEnabled: Bool) throws {
+            self.root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let settings = testSettingsStore(suiteName: "UsageStoreLocalLedgerPublicationTests")
+            settings._test_managedCodexAccountStoreURL = self.root.appendingPathComponent("accounts.json")
+            settings.costUsageEnabled = globalEnabled
+            settings.codexLocalSessionCostLedgerEnabled = localEnabled
+            settings.costUsageHistoryDays = 30
+            settings.refreshFrequency = .manual
+            settings.openAIWebAccessEnabled = false
+            settings.providerDetectionCompleted = true
+            for provider in UsageProvider.allCases {
+                let metadata = try #require(ProviderRegistry.shared.metadata[provider])
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            }
+            let environment = ["HOME": self.root.path, "CODEX_HOME": self.root.appendingPathComponent("codex").path]
+            self.store = UsageStore(
+                fetcher: UsageFetcher(environment: environment),
+                browserDetection: BrowserDetection(homeDirectory: self.root.path, cacheTTL: 0),
+                settings: settings,
+                startupBehavior: .testing,
+                environmentBase: environment)
+            self.store._test_codexCostCatchUpStatusOverride = { _ in
+                CostUsageFetcher.CodexScanCatchUpStatus(pending: false, progressKey: "isolated-complete")
+            }
+            self.store._test_widgetSnapshotSaveOverride = { _ in }
+            self.store._test_tokenUsageSnapshotLoaderOverride = { [weak self] provider, _, _, home, historyDays in
+                guard let self, !self.stopping else { throw CancellationError() }
+                self.loads.append((provider, home, historyDays))
+                let count = self.loads.count
+                // Unexpected retries must park rather than spin, including on the unfixed production code.
+                if count > self.results.count || self.gates[count] != nil {
+                    await self.gate(load: count).wait()
+                }
+                guard !self.stopping else { throw CancellationError() }
+                return try self.results[count - 1].get()
+            }
+        }
+
+        func gate(load: Int) -> Gate {
+            if let gate = self.gates[load] { return gate }
+            let gate = Gate()
+            self.gates[load] = gate
+            return gate
+        }
+
+        func expectIdle(loadCount: Int) {
+            #expect(self.loads.count == loadCount)
+            #expect(self.store.tokenRefreshRetryProviders.isEmpty)
+            #expect(self.store.tokenRefreshSequenceTask == nil)
+            #expect(self.store.tokenRefreshSequenceToken == nil)
+            #expect(self.store.tokenRefreshInFlight.isEmpty)
+            #expect(!self.store.pendingForcedTokenRefresh)
+        }
+
+        func tearDown() async {
+            self.stopping = true
+            self.store.settings.costUsageEnabled = false
+            self.store.settings.codexLocalSessionCostLedgerEnabled = false
+            let sequence = self.store.tokenRefreshSequenceTask
+            sequence?.cancel()
+            for gate in self.gates.values {
+                gate.release()
+            }
+            await sequence?.value
+            let catchUp = self.store.codexCostCatchUpTask
+            self.store.cancelCodexCostCatchUp()
+            await catchUp?.value
+            await self.store.widgetSnapshotPersistTask?.value
+            let memoryRelief = self.store.memoryPressureReliefTask
+            memoryRelief?.cancel()
+            await memoryRelief?.value
+            self.store.tokenRefreshRetryProviders.removeAll()
+            self.store._test_tokenUsageSnapshotLoaderOverride = nil
+            try? FileManager.default.removeItem(at: self.root)
+        }
+    }
+}

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -165,6 +165,8 @@ Example:
   - By default, a selected managed account keeps its own `CODEX_HOME` session history.
   - **Local session cost estimates** is a Codex-only opt-in that instead scans this Mac's ambient `$CODEX_HOME`
     (or `~/.codex`) independently of quota, OAuth, web-dashboard, and administrator access.
+  - Regular menu cost refreshes publish local session estimates even when global cost tracking is off. This does not
+    enable other providers' cost scans; results still require the same provider configuration and history/account scope.
   - The local-only mode never makes a network request or uploads session content. It uses an existing local models.dev
     cache when available, then the bundled `CostUsagePricing` rates.
 - Source files:


### PR DESCRIPTION
## Summary

Codex local session estimates are an independent opt-in, but the regular cost refresh admitted that mode and then rejected its completed result whenever global cost tracking was off. Successful scans were repeatedly retried as stale instead of updating the menu.

Use the existing per-provider effective-enable predicate at the publication boundary. Generation, provider configuration, enabled state, history, account/home scope and cancellation checks remain intact. Other providers do not become enabled. Add production-refresh regression coverage and tighten the related test fixtures' credential-file/catch-up isolation.

Thanks @vinschger for the report that prompted this investigation. Related: #3209, which remains open: its broader Claude/ChatGPT chart-freeze report is not established as this Codex-only configuration bug.

## Verification

All local test/check commands used `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1`, `CODEXBAR_TEST_CODEX_FILE_ISOLATION=1`, with `CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS` unset.

- Before the production fix, the new bounded regression failed with 81 assertions against the unchanged publication guard; after the one-line fix, the regression passed.
- Focused Swift tests: 264 tests across 11 suites, including 28 new cases covering success, empty data, failure/recovery, both-off/unrelated providers, cancellation, and suspended stale-result scope changes.
- `make check`: passed, zero violations.
- Independent review: no actionable findings.
- Full `make test`: 939 selections across 79 groups, all first-pass; zero failures, retries or timeouts (897.0 seconds).
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33047878869): all checks passed, including macOS shards (30m43s/24m6s), Linux x64/ARM/musl, plugin-engine goldens, GitGuardian and the aggregate gate. No reruns.

Fixtures exercise the actual refresh/publication path with injected loaders and isolated settings/account stores. No live accounts, credential files, provider APIs or app UI were probed. An initial mixed-suite run exposed a wall-clock test-wait timeout while the architecture suite occupied the main actor; bounded observation turns fixed the test contention without weakening assertions.

Maintainer review decision: retain the user-facing changelog entry. The automated request to remove it does not apply to this maintainer-authored fix; repository policy requires a changelog for user-visible fixes. The bot found no functional/security defect, and its execution attempt stopped in package setup before running Swift tests.
