### PR TITLE
test: stabilize Kiro race and streamline architecture scans

### DIFF
--- a/Tests/CodexBarTests/KiroTransportRaceTests.swift
+++ b/Tests/CodexBarTests/KiroTransportRaceTests.swift
@@ -68,12 +68,19 @@ struct KiroTransportRaceTests {
             fi
             if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
               if [ -t 1 ]; then
+                printf '%s\n' "$$" > "${0%/*}/pty.pid"
                 printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
                 printf 'Credits (49 of 50 covered in plan)\n'
                 printf '████████████████████ 98%%\n'
                 exit 91
               fi
-              sleep 1
+              printf '%s\n' "$$" > "${0%/*}/pipe.ready"
+              attempts=0
+              while [ ! -e "${0%/*}/pipe.release" ]; do
+                attempts=$((attempts + 1))
+                [ "$attempts" -lt 2000 ] || exit 92
+                sleep 0.01
+              done
               printf 'Estimated Usage | resets on 2026-06-01 | KIRO FREE\n'
               printf 'Credits (12.50 of 50 covered in plan)\n'
               printf '████████████████████ 25%%\n'
@@ -86,12 +93,40 @@ struct KiroTransportRaceTests {
             """)
         defer { try? FileManager.default.removeItem(at: cliURL.deletingLastPathComponent()) }
 
-        let snapshot = try await KiroStatusProbe(
-            cliBinaryResolver: { cliURL.path },
-            usageProbeTimeout: 2,
-            pipeTimeoutCap: 0.2).fetch()
+        let root = cliURL.deletingLastPathComponent()
+        let registry = KiroTestProcessRegistry()
+        defer { registry.terminateAll() }
+        let probe = KiroProcessTestSupport.makeFunctionalProbe(
+            cliURL: cliURL,
+            pipeTimeoutCap: 0.2,
+            processRegistry: registry)
+        let task = Task { try await probe.fetch() }
 
-        #expect(snapshot.creditsUsed == 12.50)
+        do {
+            let pipePID = try await KiroProcessTestSupport.waitForPID(in: root.appendingPathComponent("pipe.ready"))
+            try #require(registry.isRegistered(pipePID))
+            let ptyPID = try await KiroProcessTestSupport.waitForPID(in: root.appendingPathComponent("pty.pid"))
+            // Observe process exit before releasing the pipe; this does not certify PTY event consumption.
+            try await KiroProcessTestSupport.waitForExit(
+                of: ptyPID,
+                timeout: KiroProcessTestSupport.fixtureSetupTimeout,
+                description: "the failed PTY fixture to exit before releasing valid pipe output")
+            try KiroProcessTestSupport.touch(root.appendingPathComponent("pipe.release"))
+
+            let snapshot = try await task.value
+            #expect(snapshot.creditsUsed == 12.50)
+            #expect(registry.activePIDs().isEmpty)
+            try await KiroProcessTestSupport.waitForExit(
+                of: Array(registry.observedPIDs()),
+                timeout: KiroProcessTestSupport.fixtureSetupTimeout,
+                description: "the owned pipe fixtures to exit")
+        } catch {
+            task.cancel()
+            registry.terminateAll()
+            // Joining fetch also joins the PTY runner's scoped cancellation cleanup before removing the fixture.
+            _ = try? await task.value
+            throw error
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -289,6 +289,18 @@ struct ProviderArchitectureGatekeeperTests {
     }
 
     @Test
+    func `provider reference scanner preserves mixed quoted and executable occurrences`() {
+        let source = #"let values = [".claude", "escaped \".claude\"", "\(choose(.codex))", "# +
+            #".codex, .codex, UsageProvider.cursor, "gemini"]"#
+        let references = Self.providerReferences(in: source, providerIDs: ["claude", "codex", "cursor", "gemini"])
+
+        #expect(references == [ProviderReference(
+            line: 0,
+            providerOccurrences: ["claude", "codex", "codex", "codex", "cursor", "gemini"],
+            newlyRecognizedProviderOccurrences: ["codex", "cursor"])])
+    }
+
+    @Test
     func `provider reference scanner sees through inline block comments`() {
         let assignment = "let provider: UsageProvider = /* fallback */ .claude"
         let labeled = "choose(provider: /* fallback */ .claude)"
@@ -4070,12 +4082,17 @@ struct ProviderArchitectureGatekeeperTests {
         return lines.enumerated().flatMap { index, line -> [ProviderReference] in
             let code = self.codeBeforeLineComment(line)
             guard !code.trimmingCharacters(in: .whitespaces).isEmpty else { return [] }
+            let quotedLiterals = self.quotedStringLiterals(in: code)
+            let plainStringRanges = quotedLiterals.compactMap { literal -> Range<String.Index>? in
+                code[literal.range].contains("\\(") ? nil : literal.range
+            }
             var matches: [String] = []
             var newlyRecognizedMatches: [String] = []
             for providerID in providerIDs {
                 for strength in self.dottedProviderReferenceStrengths(
                     providerID,
                     in: code,
+                    plainStringRanges: plainStringRanges,
                     statement: statementContexts[index])
                 {
                     matches.append(providerID)
@@ -4084,7 +4101,7 @@ struct ProviderArchitectureGatekeeperTests {
                     }
                 }
             }
-            for literal in self.quotedStringLiterals(in: code) {
+            for literal in quotedLiterals {
                 for providerID in providerIDs where self.isProviderIDLiteral(
                     providerID,
                     literal: literal.value,
@@ -4112,12 +4129,10 @@ struct ProviderArchitectureGatekeeperTests {
     private static func dottedProviderReferenceStrengths(
         _ rawValue: String,
         in line: String,
+        plainStringRanges: [Range<String.Index>],
         statement: StatementContext) -> [ProviderReferenceStrength]
     {
         let needle = ".\(rawValue)"
-        let plainStringRanges = self.quotedStringLiterals(in: line).compactMap { literal -> Range<String.Index>? in
-            line[literal.range].contains("\\(") ? nil : literal.range
-        }
         var searchStart = line.startIndex
         var found: [ProviderReferenceStrength] = []
         while let range = line.range(of: needle, range: searchStart..<line.endIndex) {


### PR DESCRIPTION
## Summary

Make two bounded test-only improvements found while validating recent fixes. No production behavior, provider timeout, architecture allowance, or source inventory changes.

- Replace the Kiro functional race's one-second sleep and two-second fixture budget with the existing functional-test budgets, explicit pipe readiness, observed failed-PTY exit, and a release barrier. Preserve the misleading PTY output, successful pipe assertion, and owned-process cleanup. Exact production-deadline tests remain unchanged.
- Parse quoted literals once per source line in the provider architecture scanner instead of reparsing them for every provider ID. Reuse the same immutable exclusion ranges and literals, with a mixed quoted/interpolated/executable regression.

## Verification

All local tests use `CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1` and `CODEXBAR_TEST_CODEX_FILE_ISOLATION=1`, with `CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS` unset. No live accounts, credentials, or app launch were used.

- `swift build --build-tests` — passed.
- `swift test --skip-build --filter 'KiroTransportRaceTests|KiroStatusProbeTests'` — 61 tests passed without retries; repaired race passed in 1.509 seconds.
- `swift test --skip-build --filter ProviderArchitectureGatekeeperTests` — 39 tests passed.
- `make check` — passed, zero violations in 2,009 Swift files.
- Complete before/after scanner captures were byte-identical: 27 files, 27,415,679 bytes, and 3,458 records, covering 1,133 shipped Swift files and 69 provider IDs. Occurrences, line positions, clusters, fingerprints, suppressions, and the adversarial fixtures' expected failures were preserved. Temporary capture instrumentation was removed.
- Same isolated corpus-gate command: 43.512 → 22.762 seconds, a 47.7% reduction in one local paired run. This is not a statistical performance guarantee; no timing assertion was added.
- The unrelated 50-iteration real-PTY stress test is byte-for-byte unchanged.
- Independent Codex review — no actionable findings.
- Full `make test` — all 939 selections / 79 groups passed on the first attempt; zero failed groups, timeouts, or retries; 813.3 seconds total. The repaired Kiro race passed in 1.502 seconds during this run.
- Exact-head [CI](https://github.com/steipete/CodexBar/actions/runs/33056108840) — passed without rerun: both macOS shards, Linux x64/arm64, lint and the aggregate gate passed; musl was correctly skipped for this test-only change. GitGuardian also passed.

The Kiro fixture proves process exit before releasing the pipe, not task-group event-consumption order. Development corrections were a mixed-fixture expectation for an existing raw-ID rule and one overlong test string; final focused tests and lint passed. No changelog entry is needed for this test-only cleanup.
