### PR TITLE
fix(grok): bind usage to captured account credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.55.2 — Unreleased
 
 ### Fixed
+- Grok: keep OAuth usage, identity, and plan bound to the same credentials when a native login changes during billing, while keeping successful cookie usage separate from auth-file metadata.
 - Cursor: estimate omitted API-rate costs from cached or bundled pricing, preserve invalid-cost coverage and compatible history caches, and separate Overview history coverage from missing subscriptions (#3129). Thanks @Yuxin-Qiao!
 - OpenRouter: label the API key spending limit consistently and clarify that it is a cap, not the separate account balance (#3158). Thanks @vinschger!
 - Codex: refresh local session cost estimates when global cost tracking is off, without repeatedly rejecting successful scans as stale. Thanks @vinschger!

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -209,9 +209,27 @@ struct GrokOAuthFetchStrategy: ProviderFetchStrategy {
 
     let mode: Mode
     let kind: ProviderFetchKind = .oauth
+    let proxyBilling: GrokWebFetchStrategy.ProxyBillingFetch
+    let grpcBilling: GrokWebFetchStrategy.ProxyBillingFetch
+    let webStrategy: GrokWebFetchStrategy
+    let settingsTier: GrokWebFetchStrategy.SettingsTierFetch?
 
-    init(mode: Mode = .proxyThenGrpc) {
+    init(
+        mode: Mode = .proxyThenGrpc,
+        proxyBilling: @escaping GrokWebFetchStrategy.ProxyBillingFetch = {
+            try await GrokCreditsProxyFetcher.fetch(credentials: $0)
+        },
+        grpcBilling: @escaping GrokWebFetchStrategy.ProxyBillingFetch = {
+            try await GrokWebBillingFetcher.fetch(credentials: $0)
+        },
+        webStrategy: GrokWebFetchStrategy = .init(),
+        settingsTier: GrokWebFetchStrategy.SettingsTierFetch? = nil)
+    {
         self.mode = mode
+        self.proxyBilling = proxyBilling
+        self.grpcBilling = grpcBilling
+        self.webStrategy = webStrategy
+        self.settingsTier = settingsTier
     }
 
     var id: String {
@@ -228,31 +246,38 @@ struct GrokOAuthFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        try await GrokWebFetchStrategy().fetch(context) {
-            let credentials = try GrokWebFetchStrategy.resolvedCredentialsResult(context: context).get()
+        try await self.webStrategy.fetch(context) { capturedCredentials in
+            let credentials = try capturedCredentials.get()
             guard !credentials.isExpired else {
                 throw GrokWebBillingError.missingCredentials
             }
             switch self.mode {
             case .grpc:
-                let snapshot = try await GrokWebBillingFetcher.fetch(credentials: credentials)
+                let snapshot = try await self.grpcBilling(credentials)
                 return (snapshot, "grok-web", true)
             case .proxy:
-                let snapshot = try await GrokCreditsProxyFetcher.fetch(credentials: credentials)
-                return try await Self.resolvingUnknownUsage(snapshot, credentials: credentials)
+                let snapshot = try await self.proxyBilling(credentials)
+                return try await Self.resolvingUnknownUsage(
+                    snapshot, credentials: credentials, grpcBilling: self.grpcBilling)
             case .proxyThenGrpc:
                 do {
-                    let snapshot = try await GrokCreditsProxyFetcher.fetch(credentials: credentials)
-                    return try await Self.resolvingUnknownUsage(snapshot, credentials: credentials)
+                    let snapshot = try await self.proxyBilling(credentials)
+                    return try await Self.resolvingUnknownUsage(
+                        snapshot, credentials: credentials, grpcBilling: self.grpcBilling)
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as URLError where error.code == .cancelled {
                     throw error
                 } catch {
-                    let snapshot = try await GrokWebBillingFetcher.fetch(credentials: credentials)
+                    let snapshot = try await self.grpcBilling(credentials)
                     return (snapshot, "grok-web", true)
                 }
             }
+        } settingsTier: { credentials in
+            if let settingsTier = self.settingsTier {
+                return try await settingsTier(credentials)
+            }
+            return try await GrokStatusProbe.loadSettingsTier(credentials: credentials)
         }
     }
 
@@ -315,9 +340,18 @@ struct GrokOAuthFetchStrategy: ProviderFetchStrategy {
 struct GrokWebFetchStrategy: ProviderFetchStrategy {
     let id: String = "grok.web"
     let kind: ProviderFetchKind = .web
+    var loadCredentials: @Sendable (ProviderFetchContext) -> Result<GrokCredentials, Error> = {
+        Self.resolvedCredentialsResult(context: $0)
+    }
+
+    var localSummary: @Sendable ([String: String]) async throws -> GrokLocalSessionSummary? = {
+        try await GrokLocalSessionScanner.summarizeOffMainThread(env: $0)
+    }
+
+    var cliVersion: @Sendable ([String: String]) -> String? = { GrokStatusProbe.detectVersion(env: $0) }
     typealias ProxyBillingFetch = @Sendable (GrokCredentials) async throws -> GrokWebBillingSnapshot
     typealias WebBillingFetch =
-        @Sendable () async throws -> (
+        @Sendable (Result<GrokCredentials, Error>) async throws -> (
             snapshot: GrokWebBillingSnapshot,
             sourceLabel: String,
             authenticatedByAuthFile: Bool)
@@ -357,7 +391,7 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         try await self.fetch(
             context,
-            webBilling: { [self] in
+            webBilling: { [self] _ in
                 try await self.fetchWebBilling(context: context)
             })
     }
@@ -367,7 +401,9 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
         webBilling fetchWebBilling: @escaping WebBillingFetch,
         settingsTier loadSettingsTier: SettingsTierFetch? = nil) async throws -> ProviderFetchResult
     {
-        let authCredentials = GrokSettingsReader.resolvedCredentials(environment: context.env).flatMap { credentials in
+        // Billing and enrichment share one capture even if `grok login` replaces auth.json during an await.
+        let capturedCredentials = self.loadCredentials(context)
+        let authCredentials = (try? capturedCredentials.get()).flatMap { credentials in
             credentials.isExpired ? nil : credentials
         }
         let resolveSettingsTier =
@@ -379,7 +415,7 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
         let sourceLabel: String
         let authenticatedByAuthFile: Bool
         do {
-            (webBilling, sourceLabel, authenticatedByAuthFile) = try await fetchWebBilling()
+            (webBilling, sourceLabel, authenticatedByAuthFile) = try await fetchWebBilling(capturedCredentials)
         } catch GrokWebBillingError.teamUsageUnsupported {
             guard let authState = authCredentials, authState.isTeamPrincipal else {
                 throw GrokWebBillingError.teamUsageUnsupported
@@ -387,8 +423,8 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
             let subscriptionTier = try await resolveSettingsTier(authState)
             let identitySnapshot = try await GrokStatusProbe.identityOnlySnapshot(
                 credentials: authState,
-                localSummary: GrokLocalSessionScanner.summarizeOffMainThread(env: context.env),
-                cliVersion: GrokStatusProbe.detectVersion(env: context.env),
+                localSummary: self.localSummary(context.env),
+                cliVersion: self.cliVersion(context.env),
                 subscriptionTier: subscriptionTier)
             return self.makeResult(
                 usage: identitySnapshot.toUsageSnapshot(),
@@ -396,7 +432,7 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
                 diagnostic: identitySnapshot.diagnostic)
         }
         let credentials = Self.credentialsForWebBillingSnapshot(
-            credentials: GrokSettingsReader.resolvedCredentials(environment: context.env),
+            credentials: try? capturedCredentials.get(),
             authenticatedByAuthFile: authenticatedByAuthFile)
         // Cookie/gRPC fallback is a different browser session. Never attach the
         // auth.json account's settings tier onto that usage.
@@ -414,8 +450,8 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
                 credentials: credentials,
                 billing: nil,
                 webBilling: enrichedBilling),
-            localSummary: GrokLocalSessionScanner.summarizeOffMainThread(env: context.env),
-            cliVersion: GrokStatusProbe.detectVersion(env: context.env),
+            localSummary: self.localSummary(context.env),
+            cliVersion: self.cliVersion(context.env),
             updatedAt: Date(),
             subscriptionTier: subscriptionTier ?? enrichedBilling.subscriptionTier)
         return self.makeResult(
@@ -533,7 +569,7 @@ struct GrokWebFetchStrategy: ProviderFetchStrategy {
     static func resolvedCredentialsResult(context: ProviderFetchContext) -> Result<
         GrokCredentials, Error,
     > {
-        if let credentials = GrokSettingsReader.resolvedCredentials(environment: context.env) {
+        if let credentials = GrokSettingsReader.pastedCredentials(environment: context.env) {
             return .success(credentials)
         }
         return Result {

--- a/Tests/CodexBarTests/GrokAccountContextTests.swift
+++ b/Tests/CodexBarTests/GrokAccountContextTests.swift
@@ -1,0 +1,364 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct GrokAccountContextTests {
+    @Test
+    func `billing retains account A when auth is replaced while suspended`() async throws {
+        let fixture = try GrokAccountFixture()
+        defer { fixture.remove() }
+        try fixture.write(account: "a")
+        let gate = GrokBillingGate()
+        let context = fixture.context()
+        let task = Task {
+            try await GrokWebFetchStrategy.isolated.fetch(context) { capturedCredentials in
+                let credentials = try capturedCredentials.get()
+                #expect(credentials.accessToken == "fake-token-a")
+                await gate.suspend()
+                return (GrokWebBillingSnapshot(usedPercent: 37, resetsAt: nil), "grok-cli-proxy", true)
+            } settingsTier: { credentials in
+                #expect(credentials?.accessToken == "fake-token-a")
+                #expect(credentials?.email == "a@example.com")
+                return "SuperGrok Heavy"
+            }
+        }
+        await gate.waitUntilSuspended()
+        let replacement = Result { try fixture.write(account: "b") }
+        await gate.resume()
+        let result = try await task.value
+        try replacement.get()
+
+        #expect(result.usage.primary?.usedPercent == 37)
+        #expect(result.usage.accountEmail(for: .grok) == "a@example.com")
+        #expect(result.usage.accountOrganization(for: .grok) == "team-a")
+        #expect(result.usage.loginMethod(for: .grok) == "SuperGrok Heavy")
+    }
+
+    @Test(arguments: [GrokOAuthFetchStrategy.Mode.proxyThenGrpc, .proxy, .grpc])
+    func `oauth modes share exactly one raw capture across billing identity and tier`(
+        mode: GrokOAuthFetchStrategy.Mode) async throws
+    {
+        let fixture = try GrokAccountFixture()
+        defer { fixture.remove() }
+        try fixture.write(account: "a")
+        let reads = LockIsolated(0)
+        let gate = GrokBillingGate()
+        var webStrategy = GrokWebFetchStrategy.isolated
+        webStrategy.loadCredentials = { context in
+            reads.setValue(reads.value + 1)
+            return Result {
+                let credentials = try GrokWebFetchStrategy.resolvedCredentialsResult(context: context).get()
+                // A second ambient capture at either owner boundary would now select B.
+                try fixture.write(account: "b")
+                return credentials
+            }
+        }
+        let billing: GrokWebFetchStrategy.ProxyBillingFetch = { credentials in
+            Self.expectAccountA(credentials)
+            await gate.suspend()
+            return GrokWebBillingSnapshot(usedPercent: 37, resetsAt: nil)
+        }
+        let strategy = GrokOAuthFetchStrategy(
+            mode: mode,
+            proxyBilling: billing,
+            grpcBilling: billing,
+            webStrategy: webStrategy,
+            settingsTier: { credentials in
+                Self.expectAccountA(credentials)
+                return "SuperGrok Heavy"
+            })
+        let task = Task { try await strategy.fetch(fixture.context()) }
+        await gate.waitUntilSuspended()
+        let replacement = Result { try fixture.write(account: "c") }
+        await gate.resume()
+        let result = try await task.value
+        try replacement.get()
+
+        #expect(reads.value == 1)
+        #expect(result.usage.primary?.usedPercent == 37)
+        #expect(result.usage.accountEmail(for: .grok) == "a@example.com")
+        #expect(result.usage.accountOrganization(for: .grok) == "team-a")
+        #expect(result.usage.loginMethod(for: .grok) == "SuperGrok Heavy")
+        #expect(result.sourceLabel == (mode == .grpc ? "grok-web" : "grok-cli-proxy"))
+    }
+
+    @Test(arguments: [false, true])
+    func `cookie success stays siloed while team rejection retains only captured metadata`(
+        teamRejection: Bool) async throws
+    {
+        let fixture = try GrokAccountFixture()
+        defer { fixture.remove() }
+        try fixture.write(account: "a", principal: "Team")
+        let gate = GrokBillingGate()
+        let tierCalls = LockIsolated(0)
+        let task = Task {
+            try await GrokWebFetchStrategy.isolated.fetch(fixture.context(sourceMode: .web)) { _ in
+                await gate.suspend()
+                if teamRejection { throw GrokWebBillingError.teamUsageUnsupported }
+                return (
+                    GrokWebBillingSnapshot(usedPercent: 23, resetsAt: nil, subscriptionTier: "Cookie Plan"),
+                    "manual-cookie", false)
+            } settingsTier: { credentials in
+                tierCalls.setValue(tierCalls.value + 1)
+                Self.expectAccountA(credentials)
+                return "SuperGrok Heavy"
+            }
+        }
+        await gate.waitUntilSuspended()
+        let replacement = Result { try fixture.write(account: "b", principal: "Team") }
+        await gate.resume()
+        let result = try await task.value
+        try replacement.get()
+
+        #expect(tierCalls.value == (teamRejection ? 1 : 0))
+        #expect(result.usage.primary?.usedPercent == (teamRejection ? nil : 23))
+        #expect(result.usage.accountEmail(for: .grok) == (teamRejection ? "a@example.com" : nil))
+        #expect(result.usage.accountOrganization(for: .grok) == (teamRejection ? "team-a" : nil))
+        #expect(result.usage.loginMethod(for: .grok) == (teamRejection ? "SuperGrok Heavy" : "Cookie Plan"))
+        #expect(result.diagnostic == (teamRejection ? GrokStatusProbe.teamUsageUnavailableMessage : nil))
+        #expect(result.sourceLabel == (teamRejection ? "grok-web" : "manual-cookie"))
+    }
+
+    @Test(arguments: ["proxy-failure", "known-usage", "unknown-usage", "enrichment-failure"])
+    func `bearer fallback and unknown usage enrichment retain the original account`(route: String) async throws {
+        let fixture = try GrokAccountFixture()
+        defer { fixture.remove() }
+        try fixture.write(account: "a")
+        let calls = LockIsolated<[String]>([])
+        let reset = Date(timeIntervalSince1970: 1_900_000_000)
+        let strategy = GrokOAuthFetchStrategy(
+            proxyBilling: { credentials in
+                calls.setValue(calls.value + ["proxy"])
+                Self.expectAccountA(credentials)
+                try fixture.write(account: "b")
+                if route == "proxy-failure" { throw GrokWebBillingError.invalidResponse }
+                return GrokWebBillingSnapshot(usedPercent: nil, resetsAt: reset, subscriptionTier: "SuperGrok Heavy")
+            },
+            grpcBilling: { credentials in
+                calls.setValue(calls.value + ["grpc"])
+                Self.expectAccountA(credentials)
+                if route == "enrichment-failure" { throw GrokWebBillingError.invalidResponse }
+                return GrokWebBillingSnapshot(
+                    usedPercent: route == "unknown-usage" ? nil : 42,
+                    resetsAt: reset.addingTimeInterval(60))
+            },
+            webStrategy: .isolated,
+            settingsTier: { credentials in
+                calls.setValue(calls.value + ["tier"])
+                Self.expectAccountA(credentials)
+                return nil
+            })
+        let result = try await strategy.fetch(fixture.context())
+        let knownUsage = route == "known-usage" || route == "proxy-failure"
+
+        #expect(calls.value == ["proxy", "grpc", "tier"])
+        #expect(result.usage.primary?.usedPercent == (knownUsage ? 42 : nil))
+        if knownUsage {
+            #expect(result.usage.primary?.resetsAt == (route == "proxy-failure" ? reset.addingTimeInterval(60) : reset))
+        }
+        #expect(result.usage.accountEmail(for: .grok) == "a@example.com")
+        #expect(result.usage.accountOrganization(for: .grok) == "team-a")
+        #expect(result.usage.loginMethod(for: .grok) == (route == "proxy-failure" ? "SuperGrok" : "SuperGrok Heavy"))
+        #expect(result.sourceLabel == (knownUsage ? "grok-web" : "grok-cli-proxy"))
+        #expect(result.diagnostic == (knownUsage ? nil : GrokStatusProbe.usageUnavailableMessage))
+    }
+
+    @Test(arguments: ["expired", "missing", "malformed", "empty"], [
+        GrokOAuthFetchStrategy.Mode.proxyThenGrpc, .proxy, .grpc,
+    ])
+    func `oauth rejects unavailable credentials before billing or enrichment`(
+        authState: String, mode: GrokOAuthFetchStrategy.Mode) async throws
+    {
+        let fixture = try GrokAccountFixture()
+        defer { fixture.remove() }
+        switch authState {
+        case "expired": try fixture.write(account: "a", expired: true)
+        case "malformed": try Data("not-json".utf8).write(to: fixture.home.appendingPathComponent("auth.json"))
+        case "empty": try Data("{}".utf8).write(to: fixture.home.appendingPathComponent("auth.json"))
+        default: break
+        }
+        let unexpectedBilling: GrokWebFetchStrategy.ProxyBillingFetch = { _ in
+            Issue.record("Unavailable credentials must not reach billing")
+            throw GrokWebBillingError.invalidResponse
+        }
+        let strategy = GrokOAuthFetchStrategy(
+            mode: mode,
+            proxyBilling: unexpectedBilling,
+            grpcBilling: unexpectedBilling,
+            webStrategy: .isolated,
+            settingsTier: { _ in
+                Issue.record("Unavailable credentials must not reach tier enrichment")
+                return nil
+            })
+        let context = fixture.context()
+        #expect(await strategy.isAvailable(context) == (authState != "missing"))
+        await #expect {
+            _ = try await strategy.fetch(context)
+        } throws: { error in
+            switch (authState, error) {
+            case ("expired", GrokWebBillingError.missingCredentials),
+                 ("missing", GrokCredentialsError.notFound),
+                 ("malformed", GrokCredentialsError.decodeFailed),
+                 ("empty", GrokCredentialsError.missingTokens): true
+            default: false
+            }
+        }
+    }
+
+    @Test(arguments: ["missing", "expired", "personal"])
+    func `team rejection does not invent a team identity`(authState: String) async throws {
+        let fixture = try GrokAccountFixture()
+        defer { fixture.remove() }
+        if authState != "missing" {
+            try fixture.write(
+                account: "a", principal: authState == "personal" ? "Personal" : "Team", expired: authState == "expired")
+        }
+        await #expect {
+            _ = try await GrokWebFetchStrategy.isolated.fetch(fixture.context(sourceMode: .web)) { _ in
+                throw GrokWebBillingError.teamUsageUnsupported
+            } settingsTier: { _ in
+                Issue.record("Team fallback requires a valid team credential")
+                return nil
+            }
+        } throws: { error in
+            guard case GrokWebBillingError.teamUsageUnsupported = error else { return false }
+            return true
+        }
+    }
+
+    @Test(arguments: ["proxy", "grpc", "tier"], [false, true])
+    func `cancellation stays cancellation across oauth billing and enrichment`(
+        stage: String, urlCancellation: Bool) async throws
+    {
+        let fixture = try GrokAccountFixture()
+        defer { fixture.remove() }
+        try fixture.write(account: "a")
+        let cancellation: any Error = urlCancellation ? URLError(.cancelled) : CancellationError()
+        let calls = LockIsolated<[String]>([])
+        let strategy = GrokOAuthFetchStrategy(
+            proxyBilling: { _ in
+                calls.setValue(calls.value + ["proxy"])
+                if stage == "proxy" { throw cancellation }
+                return GrokWebBillingSnapshot(usedPercent: stage == "grpc" ? nil : 37, resetsAt: nil)
+            },
+            grpcBilling: { _ in
+                calls.setValue(calls.value + ["grpc"])
+                throw cancellation
+            },
+            webStrategy: .isolated,
+            settingsTier: { _ in
+                calls.setValue(calls.value + ["tier"])
+                throw cancellation
+            })
+        await #expect {
+            _ = try await strategy.fetch(fixture.context())
+        } throws: { error in
+            urlCancellation ? (error as? URLError)?.code == .cancelled : error is CancellationError
+        }
+        #expect(calls.value == (stage == "proxy" ? ["proxy"] : ["proxy", stage]))
+    }
+
+    private static func expectAccountA(_ credentials: GrokCredentials?) {
+        #expect(credentials?.accessToken == "fake-token-a")
+        #expect(credentials?.refreshToken == "fake-refresh-a")
+        #expect(credentials?.email == "a@example.com")
+        #expect(credentials?.teamId == "team-a")
+        #expect(credentials?.userId == "user-a")
+        #expect(credentials?.scope == "https://auth.x.ai::fake-client")
+        #expect(credentials?.authMode == "oidc")
+        #expect(credentials?.isExpired == false)
+    }
+}
+
+extension GrokWebFetchStrategy {
+    static var isolated: Self {
+        Self(localSummary: { _ in nil }, cliVersion: { _ in nil })
+    }
+}
+
+private struct GrokAccountFixture: Sendable {
+    let home: URL
+
+    init() throws {
+        self.home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBar-GrokAccountContext-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: self.home, withIntermediateDirectories: true)
+    }
+
+    func write(account: String, principal: String = "Personal", expired: Bool = false) throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "https://auth.x.ai::fake-client": [
+                "key": "fake-token-\(account)",
+                "refresh_token": "fake-refresh-\(account)",
+                "email": "\(account)@example.com",
+                "team_id": "team-\(account)",
+                "user_id": "user-\(account)",
+                "auth_mode": "oidc",
+                "principal_type": principal,
+                "expires_at": expired ? "2000-01-01T00:00:00Z" : "2099-01-01T00:00:00Z",
+            ],
+        ])
+        try data.write(to: self.home.appendingPathComponent("auth.json"), options: .atomic)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: self.home)
+    }
+
+    func context(sourceMode: ProviderSourceMode = .oauth) -> ProviderFetchContext {
+        #if os(macOS)
+        let browserDetection = BrowserDetection(
+            homeDirectory: self.home.path,
+            cacheTTL: 0,
+            now: Date.init,
+            fileExists: { _ in false },
+            directoryContents: { _ in nil },
+            applicationURLs: { _ in [] },
+            profileAccessIssue: { _ in nil })
+        #else
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        #endif
+        let environment = [
+            "GROK_HOME": self.home.path,
+            "GROK_CLI_PATH": self.home.appendingPathComponent("missing-grok").path,
+            "PATH": self.home.path,
+        ]
+        return ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: sourceMode,
+            includeCredits: true,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: environment,
+            settings: nil,
+            fetcher: UsageFetcher(environment: environment),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+}
+
+private actor GrokBillingGate {
+    private var suspended = false
+    private var observer: CheckedContinuation<Void, Never>?
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            self.suspended = true
+            self.observer?.resume()
+            self.observer = nil
+        }
+    }
+
+    func waitUntilSuspended() async {
+        guard !self.suspended else { return }
+        await withCheckedContinuation { self.observer = $0 }
+    }
+
+    func resume() {
+        self.continuation?.resume()
+        self.continuation = nil
+    }
+}

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -383,7 +383,7 @@ struct GrokWebBillingFetcherTests {
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
             browserDetection: browserDetection)
 
-        let result = try await GrokWebFetchStrategy().fetch(context) {
+        let result = try await GrokWebFetchStrategy.isolated.fetch(context) { _ in
             throw GrokWebBillingError.teamUsageUnsupported
         } settingsTier: { _ in
             "SuperGrok Heavy"
@@ -400,9 +400,9 @@ struct GrokWebBillingFetcherTests {
     @Test
     func `web strategy does not attach auth-file settings tier to cookie billing`() async throws {
         let asked = LockIsolated(false)
-        let result = try await GrokWebFetchStrategy().fetch(
+        let result = try await GrokWebFetchStrategy.isolated.fetch(
             Self.webContext(grokHome: nil),
-            webBilling: {
+            webBilling: { _ in
                 (
                     GrokWebBillingSnapshot(
                         usedPercent: 0,
@@ -423,9 +423,9 @@ struct GrokWebBillingFetcherTests {
 
     @Test
     func `web strategy applies settings tier when billing used the auth file`() async throws {
-        let result = try await GrokWebFetchStrategy().fetch(
+        let result = try await GrokWebFetchStrategy.isolated.fetch(
             Self.webContext(grokHome: nil),
-            webBilling: {
+            webBilling: { _ in
                 (
                     GrokWebBillingSnapshot(
                         usedPercent: 0,
@@ -459,9 +459,9 @@ struct GrokWebBillingFetcherTests {
         """#
         try Data(auth.utf8).write(to: grokHome.appendingPathComponent("auth.json"))
 
-        let result = try await GrokWebFetchStrategy().fetch(
+        let result = try await GrokWebFetchStrategy.isolated.fetch(
             Self.webContext(grokHome: grokHome),
-            webBilling: {
+            webBilling: { _ in
                 (
                     GrokWebBillingSnapshot(
                         usedPercent: nil,
@@ -481,9 +481,9 @@ struct GrokWebBillingFetcherTests {
 
     @Test
     func `web strategy keeps credits when settings enrichment fails`() async throws {
-        let result = try await GrokWebFetchStrategy().fetch(
+        let result = try await GrokWebFetchStrategy.isolated.fetch(
             Self.webContext(grokHome: nil),
-            webBilling: {
+            webBilling: { _ in
                 (
                     GrokWebBillingSnapshot(
                         usedPercent: 18,

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -90,9 +90,8 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
      Cookie-only authentication can fail with gRPC status 16 and
      `no-credentials`; signing in through Chrome alone cannot provide that proof
      to CodexBar, so `grok login` is the recommended recovery path.
-   - Uses grok.com browser session cookies. When a non-expired
-     `~/.grok/auth.json` token is available, CodexBar first sends it with each
-     browser session, then retries that session with cookies only.
+   - Uses grok.com browser session cookies. Successful cookie usage never inherits
+     the auth-file account's identity or settings tier.
    - CodexBar imports Chrome only by default to avoid unrelated browser
      Keychain prompts.
    - Ordinary CLI/test runtime does not import browser cookies unless
@@ -103,8 +102,10 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
      re-open the Chromium Keychain gate. The cached cookie is evicted only on
      authentication failures (HTTP 401/403 or gRPC auth statuses); a cached
      team-limited session keeps degrading to identity-only data.
-   - `~/.grok/auth.json` is still used for identity and as a last best-effort
-     bearer-only probe after browser sessions fail. Expired tokens are not sent.
+   - Auto can try a separate bearer-only probe after browser sessions fail.
+     Expired tokens are not sent. A team-usage rejection may still produce the
+     documented identity-only fallback from captured, non-expired team credentials;
+     this does not attach those credentials to successful cookie usage.
    - Parses the returned protobuf enough to recover used percent and
      reset timestamp, accepting both gRPC-web frames and the raw protobuf form
      returned by some successful requests. A current billing period with an
@@ -135,6 +136,10 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
   Chrome only.
 - Credits `subscriptionTier` maps SuperGrok vs SuperGrok Heavy on the plan badge.
   SuperGrok Heavy with no `creditUsagePercent` is unknown usage, not 0%.
+- Each OAuth fetch captures credentials once for billing, bearer retries, identity,
+  and settings enrichment. Replacing `auth.json` during an awaited request cannot
+  relabel the result with the new account. Cookie usage stays separate from this
+  captured account; local session scanning and CLI behavior are unchanged.
 
 
 ## JSON-RPC contract


### PR DESCRIPTION
## Summary

Fix a current-main race where replacing the native Grok auth file during an awaited billing request could label account A's usage with account B's email and team.

The web/OAuth wrapper now captures the credential result once and passes it into billing. Proxy requests, bearer retries, unknown-usage enrichment, identity, and settings tier use that same capture. Pasted-token precedence and auth-file errors are preserved. Successful cookie usage stays separate from auth-file identity and tier; the documented team-only metadata fallback remains intact.

Tests inject billing, tier, local-summary, and version lookup so they cannot launch a real Grok CLI or use saved accounts. Source ordering, CLI behavior, off-thread local scanning, and existing token-snapshot projection are unchanged. Documentation and the Unreleased changelog are updated.

## Verification

Executed the regression before the fix: fake billing suspended with account A, the temporary auth file was atomically replaced by B, and the result incorrectly contained B's email/team while retaining A's usage and tier. The pre-fix production changes were limited to local-summary/version test seams. The same regression passes after the fix.

Exact protected test/check commands:

```sh
env -u CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 CODEXBAR_TEST_CODEX_FILE_ISOLATION=1 swift test --filter Grok
env -u CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 CODEXBAR_TEST_CODEX_FILE_ISOLATION=1 swift test --filter ProviderArchitectureGatekeeperTests
env -u CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 CODEXBAR_TEST_CODEX_FILE_ISOLATION=1 make check
env -u CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 CODEXBAR_TEST_CODEX_FILE_ISOLATION=1 make test
```

- `swift test --filter Grok`: 141 tests in 13 suites passed, including all OAuth modes, a counted single capture, login replacement before/during billing, cookie separation, team-only fallback, unknown usage, expired/missing/malformed auth, and cancellation.
- `swift test --filter ProviderArchitectureGatekeeperTests`: 39 passed.
- `make check`: passed, zero lint violations in 2,014 files.
- Independent Codex review: no actionable findings through P2.
- Full `make test`: all 943 selections across 79 groups passed on the first pass; zero failures, retries, or timeouts (799.1 seconds).
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33066720353): all eight workflow jobs passed at `b8e4ee0a1e93362158bfaf503c21da33207cdd3e`, including both macOS shards and Linux x64/ARM64/musl; no workflow rerun.

The first expanded-test compile used the wrong local lock-helper API, and the first lint run caught a multiline-arguments layout violation; both were corrected and the focused/architecture checks rerun on the final tree. The pre-existing OpenCodeGo test Sendable warning is unchanged.

No live provider, account, browser, Keychain, app, or real CLI probe was performed. This is deterministic credential-selection proof, not live billing proof; transport is unchanged.

Related review context: #3188. This standalone main fix does not implement or approve that PR's reset-coupon feature, or #3236's additional local-log reads, and does not close either proposal.
