### PR TITLE
test: isolate cost and Gemini subprocess fixtures

### DIFF
--- a/Tests/CodexBarTests/CostUsageCustomPricingTests.swift
+++ b/Tests/CodexBarTests/CostUsageCustomPricingTests.swift
@@ -81,7 +81,9 @@ struct CostUsageCustomPricingTests {
     }
 
     @Test
-    func `aggregate fallback consults the overlay before bundled rates`() {
+    func `aggregate fallback consults the overlay before bundled rates`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
         let overlay = CostUsageCustomPricing.parse(Data("""
         { "gpt-5.4": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 } }
         """.utf8))
@@ -97,6 +99,7 @@ struct CostUsageCustomPricingTests {
             inputTokens: 1000,
             cachedInputTokens: 0,
             outputTokens: 100,
+            modelsDevCacheRoot: env.cacheRoot,
             customPricing: .empty)
         #expect(bundled != 0)
         #expect(bundled != nil)

--- a/Tests/CodexBarTests/CostUsageFetcherCacheSnapshotTests.swift
+++ b/Tests/CodexBarTests/CostUsageFetcherCacheSnapshotTests.swift
@@ -11,7 +11,8 @@ struct CostUsageFetcherCacheSnapshotTests {
         let now = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         var cache = CostUsageCache()
         cache.scanSinceKey = "2026-04-06"
         cache.scanUntilKey = "2026-04-08"
@@ -55,7 +56,8 @@ struct CostUsageFetcherCacheSnapshotTests {
         let now = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         var cache = CostUsageCache()
         cache.scanSinceKey = "2026-04-08"
         cache.scanUntilKey = "2026-04-08"
@@ -83,7 +85,8 @@ struct CostUsageFetcherCacheSnapshotTests {
         let now = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let scanTime = now.addingTimeInterval(-60)
         var cache = CostUsageCache()
         cache.lastScanUnixMs = Int64(scanTime.timeIntervalSince1970 * 1000)
@@ -129,6 +132,7 @@ struct CostUsageFetcherCacheSnapshotTests {
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
             cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"),
             calendar: calendar)
         var cache = CostUsageCache()
         cache.lastScanUnixMs = Int64(beforeMidnight.timeIntervalSince1970 * 1000)
@@ -165,7 +169,8 @@ struct CostUsageFetcherCacheSnapshotTests {
         let now = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         var cache = CostUsageCache()
         cache.lastScanUnixMs = Int64(now.addingTimeInterval(-60).timeIntervalSince1970 * 1000)
         cache.scanSinceKey = "2026-04-07"
@@ -195,7 +200,8 @@ struct CostUsageFetcherCacheSnapshotTests {
         let now = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let line = CostUsageScanner.CodexBufferedFastLine(
             lineIndex: 1,
             ordinal: nil,
@@ -243,16 +249,20 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         _ = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
 
         let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
             now: day,
             historyDays: 1,
+            includePiSessions: false,
             scannerOptions: options)
 
         #expect(cached?.sessionTokens == 42)
@@ -281,13 +291,15 @@ struct CostUsageFetcherCacheSnapshotTests {
             tokens: 42)
         var options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         options.refreshMinIntervalSeconds = 0
 
         let established = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             historyDays: 365,
+            allowPricingRefresh: false,
             includePiSessions: false,
             scannerOptions: options)
         let establishedCache = CostUsageStoreAccess.read(cacheRoot: env.cacheRoot)
@@ -322,6 +334,7 @@ struct CostUsageFetcherCacheSnapshotTests {
             provider: .codex,
             now: appendedAt,
             historyDays: 30,
+            allowPricingRefresh: false,
             includePiSessions: false,
             scannerOptions: options)
         let pendingCache = CostUsageStoreAccess.read(cacheRoot: env.cacheRoot)
@@ -378,11 +391,14 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         _ = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
 
         let cache = CostUsageStoreAccess.read(cacheRoot: env.cacheRoot)
@@ -393,6 +409,7 @@ struct CostUsageFetcherCacheSnapshotTests {
         let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshotResult(
             now: hydratedAt,
             historyDays: 1,
+            includePiSessions: false,
             scannerOptions: options)
 
         #expect(cached?.snapshot.updatedAt == scanTime)
@@ -416,7 +433,8 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -425,6 +443,7 @@ struct CostUsageFetcherCacheSnapshotTests {
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
             refreshPricingInBackground: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
@@ -459,7 +478,8 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -468,6 +488,7 @@ struct CostUsageFetcherCacheSnapshotTests {
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
             refreshPricingInBackground: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
@@ -502,7 +523,8 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -511,6 +533,7 @@ struct CostUsageFetcherCacheSnapshotTests {
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
             refreshPricingInBackground: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
@@ -550,21 +573,26 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         _ = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
 
         let expanded = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
             now: day,
             historyDays: 7,
+            includePiSessions: false,
             scannerOptions: options)
         let managed = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
             now: day,
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 1,
+            includePiSessions: false,
             scannerOptions: options)
 
         #expect(expanded == nil)
@@ -586,16 +614,20 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         _ = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
 
         let current = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
             now: day,
             historyDays: 1,
+            includePiSessions: false,
             scannerOptions: options)
         #expect(current?.projects.count == 1)
 
@@ -606,6 +638,7 @@ struct CostUsageFetcherCacheSnapshotTests {
         let legacy = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
             now: day,
             historyDays: 1,
+            includePiSessions: false,
             scannerOptions: options)
         #expect(legacy?.sessionTokens == 42)
         #expect(legacy?.projects.isEmpty == true)
@@ -626,11 +659,14 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         _ = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
 
         var cache = CostUsageStoreAccess.read(cacheRoot: env.cacheRoot)
@@ -640,6 +676,7 @@ struct CostUsageFetcherCacheSnapshotTests {
         let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
             now: day,
             historyDays: 1,
+            includePiSessions: false,
             scannerOptions: options)
 
         #expect(cached == nil)
@@ -661,7 +698,8 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -670,6 +708,7 @@ struct CostUsageFetcherCacheSnapshotTests {
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
             refreshPricingInBackground: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
@@ -708,7 +747,8 @@ struct CostUsageFetcherCacheSnapshotTests {
             historyDays: 1,
             scannerOptions: CostUsageScanner.Options(
                 codexSessionsRoot: env.codexSessionsRoot,
-                cacheRoot: env.cacheRoot))
+                cacheRoot: env.cacheRoot,
+                codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite")))
 
         #expect(cached?.sessionTokens == 165)
         #expect(cached?.last30DaysTokens == 165)
@@ -730,7 +770,8 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -739,6 +780,7 @@ struct CostUsageFetcherCacheSnapshotTests {
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
             refreshPricingInBackground: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
@@ -780,14 +822,17 @@ struct CostUsageFetcherCacheSnapshotTests {
 
         var options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         options.calendar = losAngeles
         options.refreshMinIntervalSeconds = 0
         _ = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
             refreshPricingInBackground: false,
+            includePiSessions: false,
             scannerOptions: options)
 
         let fetcher = CostUsageFetcher(scannerOptions: options)
@@ -804,7 +849,9 @@ struct CostUsageFetcherCacheSnapshotTests {
         #expect(pinned?.snapshot.costProvenance == .listPriceEstimate)
         #expect(travelled == nil)
     }
+}
 
+extension CostUsageFetcherCacheSnapshotTests {
     @discardableResult
     private static func writeCodexSessionFile(
         homeRoot: URL,

--- a/Tests/CodexBarTests/CostUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CostUsageFetcherTests.swift
@@ -32,7 +32,8 @@ struct CostUsageFetcherTests {
 
         var options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         options.refreshMinIntervalSeconds = 0
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
@@ -43,6 +44,7 @@ struct CostUsageFetcherTests {
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
             includePiSessions: true,
             scannerOptions: options,
             piScannerOptions: piOptions)
@@ -50,6 +52,7 @@ struct CostUsageFetcherTests {
             provider: .codex,
             now: day.addingTimeInterval(1),
             historyDays: 1,
+            allowPricingRefresh: false,
             includePiSessions: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
@@ -87,7 +90,10 @@ struct CostUsageFetcherTests {
                 ],
             ]]))
 
-        let options = CostUsageScanner.Options(cacheRoot: env.cacheRoot)
+        let options = CostUsageScanner.Options(
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root
+                .appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -96,12 +102,14 @@ struct CostUsageFetcherTests {
             provider: .codex,
             now: day,
             codexHomePath: env.codexHomeRoot.path,
+            allowPricingRefresh: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
         let managed = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             codexHomePath: otherHome.path,
+            allowPricingRefresh: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
 
@@ -119,13 +127,15 @@ extension CostUsageFetcherTests {
         let day = try env.makeLocalNoon(year: 2026, month: 4, day: 8)
         var options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         options.refreshMinIntervalSeconds = 0
 
         let snapshot = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
             includePiSessions: false,
             scannerOptions: options)
 
@@ -162,6 +172,7 @@ extension CostUsageFetcherTests {
             provider: .codex,
             now: day,
             historyDays: 1,
+            allowPricingRefresh: false,
             includePiSessions: false,
             scannerOptions: options)
         #expect(!pending.historyCoverageIsEstablished)
@@ -172,6 +183,7 @@ extension CostUsageFetcherTests {
             provider: .codex,
             now: day.addingTimeInterval(1),
             historyDays: 1,
+            allowPricingRefresh: false,
             includePiSessions: false,
             scannerOptions: options)
         #expect(covered.historyCoverageIsEstablished)
@@ -192,12 +204,17 @@ extension CostUsageFetcherTests {
             tokens: 100)
         try Self.writeCodexSessionFile(homeRoot: managedHome, env: env, day: day, filename: "managed.jsonl", tokens: 10)
 
-        let options = CostUsageScanner.Options(cacheRoot: env.cacheRoot)
+        let options = CostUsageScanner.Options(
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root
+                .appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(piSessionsRoot: env.piSessionsRoot, cacheRoot: env.cacheRoot)
         let ambient = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             codexHomePath: env.codexHomeRoot.path,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
         #expect(ambient.sessionTokens == 100)
@@ -210,6 +227,8 @@ extension CostUsageFetcherTests {
             provider: .codex,
             now: day.addingTimeInterval(1),
             codexHomePath: managedHome.path,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
 
@@ -236,7 +255,10 @@ extension CostUsageFetcherTests {
             filename: "new.jsonl",
             tokens: 30)
 
-        var options = CostUsageScanner.Options(cacheRoot: env.cacheRoot)
+        var options = CostUsageScanner.Options(
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root
+                .appendingPathComponent("missing-traces.sqlite"))
         options.refreshMinIntervalSeconds = 3600
 
         let narrow = try await CostUsageFetcher.loadTokenSnapshot(
@@ -244,6 +266,8 @@ extension CostUsageFetcherTests {
             now: newDay,
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
         #expect(narrow.daily.map(\.date) == ["2026-04-08"])
         #expect(narrow.last30DaysTokens == 30)
@@ -258,6 +282,8 @@ extension CostUsageFetcherTests {
             now: newDay.addingTimeInterval(1),
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 7,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
         #expect(expanded.daily.map(\.date) == ["2026-04-02", "2026-04-08"])
         #expect(expanded.last30DaysTokens == 45)
@@ -329,12 +355,17 @@ extension CostUsageFetcherTests {
                 ],
             ]))
 
-        let options = CostUsageScanner.Options(cacheRoot: env.cacheRoot)
+        let options = CostUsageScanner.Options(
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root
+                .appendingPathComponent("missing-traces.sqlite"))
         let snapshot = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: childDay,
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
 
         #expect(snapshot.daily.map(\.date) == ["2026-04-08"])
@@ -399,6 +430,8 @@ extension CostUsageFetcherTests {
             forceRefresh: true,
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
         let cache = CostUsageStoreAccess.read(cacheRoot: env.cacheRoot)
         let cacheFileExists = FileManager.default.fileExists(
@@ -474,14 +507,18 @@ extension CostUsageFetcherTests {
             now: newDay.addingTimeInterval(1),
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 7,
+            allowPricingRefresh: false,
             refreshPricingInBackground: false,
+            includePiSessions: false,
             scannerOptions: options)
         let narrow = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: newDay.addingTimeInterval(2),
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 1,
+            allowPricingRefresh: false,
             refreshPricingInBackground: false,
+            includePiSessions: false,
             scannerOptions: options)
         let cache = CostUsageStoreAccess.read(cacheRoot: env.cacheRoot)
 
@@ -553,7 +590,9 @@ extension CostUsageFetcherTests {
             now: newDay,
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 7,
+            allowPricingRefresh: false,
             refreshPricingInBackground: false,
+            includePiSessions: false,
             scannerOptions: options)
 
         var rescanOptions = options
@@ -601,13 +640,18 @@ extension CostUsageFetcherTests {
         ])
         let originalURL = try env.writeCodexSessionFile(day: day, filename: "moved.jsonl", contents: contents)
 
-        var options = CostUsageScanner.Options(cacheRoot: env.cacheRoot)
+        var options = CostUsageScanner.Options(
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root
+                .appendingPathComponent("missing-traces.sqlite"))
         options.refreshMinIntervalSeconds = 0
         let first = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
 
         let archivedURL = env.codexArchivedSessionsRoot.appendingPathComponent("moved.jsonl", isDirectory: false)
@@ -618,6 +662,8 @@ extension CostUsageFetcherTests {
             now: day.addingTimeInterval(1),
             codexHomePath: env.codexHomeRoot.path,
             historyDays: 1,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options)
         let cache = CostUsageStoreAccess.read(cacheRoot: env.cacheRoot)
 
@@ -687,7 +733,8 @@ extension CostUsageFetcherTests {
         let nativeOptions = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
             claudeProjectsRoots: [env.claudeProjectsRoot],
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -696,11 +743,13 @@ extension CostUsageFetcherTests {
         let snapshot = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
+            allowPricingRefresh: false,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)
         let withoutPi = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
+            allowPricingRefresh: false,
             includePiSessions: false,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)
@@ -709,12 +758,14 @@ extension CostUsageFetcherTests {
             model: "gpt-5.4",
             inputTokens: 100,
             cachedInputTokens: 20,
-            outputTokens: 10) ?? 0
+            outputTokens: 10,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
         let piCost = CostUsagePricing.codexCostUSD(
             model: "gpt-5.4",
             inputTokens: 55,
             cachedInputTokens: 5,
-            outputTokens: 5) ?? 0
+            outputTokens: 5,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
 
         #expect(snapshot.daily.count == 1)
         #expect(snapshot.daily.first?.date == "2026-04-08")
@@ -793,7 +844,8 @@ extension CostUsageFetcherTests {
         let nativeOptions = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
             claudeProjectsRoots: [env.claudeProjectsRoot],
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -802,6 +854,7 @@ extension CostUsageFetcherTests {
         let snapshot = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .claude,
             now: day,
+            allowPricingRefresh: false,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)
 
@@ -810,13 +863,15 @@ extension CostUsageFetcherTests {
             inputTokens: 100,
             cacheReadInputTokens: 5,
             cacheCreationInputTokens: 10,
-            outputTokens: 20) ?? 0
+            outputTokens: 20,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
         let piCost = CostUsagePricing.claudeCostUSD(
             model: "claude-sonnet-4-6",
             inputTokens: 50,
             cacheReadInputTokens: 4,
             cacheCreationInputTokens: 6,
-            outputTokens: 10) ?? 0
+            outputTokens: 10,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
 
         #expect(snapshot.daily.count == 1)
         #expect(snapshot.daily.first?.date == "2026-04-09")
@@ -869,7 +924,8 @@ extension CostUsageFetcherTests {
         let nativeOptions = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
             claudeProjectsRoots: [env.claudeProjectsRoot],
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -878,13 +934,16 @@ extension CostUsageFetcherTests {
         let snapshot = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
+            allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)
         let cost = CostUsagePricing.codexCostUSD(
             model: "gpt-5.4",
             inputTokens: 100,
             cachedInputTokens: 20,
-            outputTokens: 10) ?? 0
+            outputTokens: 10,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
 
         let breakdown = try #require(snapshot.daily.first?.modelBreakdowns?.first)
         #expect(breakdown.modelName == "gpt-5.4")
@@ -931,7 +990,8 @@ extension CostUsageFetcherTests {
         let nativeOptions = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
             claudeProjectsRoots: [env.claudeProjectsRoot],
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot)
@@ -940,6 +1000,7 @@ extension CostUsageFetcherTests {
             provider: .codex,
             now: day,
             allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)
         #expect(first.daily.first?.totalTokens == 110)
@@ -966,6 +1027,7 @@ extension CostUsageFetcherTests {
             provider: .codex,
             now: day,
             allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)
         #expect(debounced.daily.first?.totalTokens == 110)
@@ -974,6 +1036,7 @@ extension CostUsageFetcherTests {
             provider: .codex,
             now: day,
             allowPricingRefresh: false,
+            includePiSessions: false,
             bypassScannerDebounce: true,
             scannerOptions: nativeOptions,
             piScannerOptions: piOptions)
@@ -1110,7 +1173,8 @@ extension CostUsageFetcherTests {
         let options = CostUsageScanner.Options(
             codexSessionsRoot: env.codexSessionsRoot,
             claudeProjectsRoots: [env.claudeProjectsRoot],
-            cacheRoot: env.cacheRoot)
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"))
         let piOptions = PiSessionCostScanner.Options(
             piSessionsRoot: env.piSessionsRoot,
             cacheRoot: env.cacheRoot,
@@ -1120,6 +1184,7 @@ extension CostUsageFetcherTests {
             now: day,
             historyDays: 1,
             allowPricingRefresh: false,
+            includePiSessions: false,
             scannerOptions: options,
             piScannerOptions: piOptions)
 

--- a/Tests/CodexBarTests/CostUsageFetcherUnknownModelPricingTests.swift
+++ b/Tests/CodexBarTests/CostUsageFetcherUnknownModelPricingTests.swift
@@ -15,6 +15,7 @@ struct CostUsageFetcherUnknownModelPricingTests {
             provider: .codex,
             now: fixture.day,
             refreshPricingInBackground: false,
+            includePiSessions: false,
             scannerOptions: fixture.options,
             modelsDevClient: ModelsDevClient(transport: CostUsageFetcherModelsDevTransport(
                 data: fixture.refreshedCatalog)))
@@ -56,6 +57,7 @@ struct CostUsageFetcherUnknownModelPricingTests {
             provider: .codex,
             now: fixture.day,
             refreshPricingInBackground: false,
+            includePiSessions: false,
             scannerOptions: fixture.options,
             modelsDevClient: ModelsDevClient(transport: CostUsageFetcherModelsDevTransport(
                 data: fixture.refreshedCatalog)))
@@ -90,6 +92,7 @@ struct CostUsageFetcherUnknownModelPricingTests {
             provider: .claude,
             now: fixture.day,
             refreshPricingInBackground: false,
+            includePiSessions: false,
             scannerOptions: fixture.options,
             modelsDevClient: ModelsDevClient(transport: CostUsageFetcherModelsDevTransport(
                 data: fixture.refreshedCatalog)))
@@ -147,6 +150,7 @@ struct CostUsageFetcherUnknownModelPricingTests {
                 provider: .codex,
                 now: fixture.day,
                 refreshPricingInBackground: true,
+                includePiSessions: false,
                 scannerOptions: fixture.options,
                 modelsDevClient: ModelsDevClient(transport: CostUsageFetcherGatedModelsDevTransport(
                     data: fixture.refreshedCatalog,
@@ -224,13 +228,15 @@ struct CostUsageFetcherUnknownModelPricingTests {
         let options = CostUsageScanner.Options(
             codexSessionsRoot: environment.codexSessionsRoot,
             claudeProjectsRoots: [environment.claudeProjectsRoot],
-            cacheRoot: environment.cacheRoot)
+            cacheRoot: environment.cacheRoot,
+            codexTraceDatabaseURL: environment.root.appendingPathComponent("missing-traces.sqlite"))
         let counter = UnknownModelPricingRequestCounter()
 
         let snapshot = try await CostUsageFetcher.loadTokenSnapshot(
             provider: .codex,
             now: day,
             refreshPricingInBackground: false,
+            includePiSessions: false,
             scannerOptions: options,
             modelsDevClient: ModelsDevClient(transport: CostUsageFetcherCountingModelsDevTransport(counter: counter)))
 
@@ -242,10 +248,11 @@ struct CostUsageFetcherUnknownModelPricingTests {
         #expect(requestCount == 0)
     }
 
-    @Test
-    func `local only fetch skips every pricing network refresh`() async throws {
+    @Test(arguments: [false, true])
+    func `local only fetch skips every pricing network refresh`(includePiSessions: Bool) async throws {
         let fixture = try UnknownModelPricingFixture()
         defer { fixture.environment.cleanup() }
+        try fixture.writePiSession()
         let counter = UnknownModelPricingRequestCounter()
 
         let snapshot = try await CostUsageFetcher.loadTokenSnapshot(
@@ -253,14 +260,39 @@ struct CostUsageFetcherUnknownModelPricingTests {
             now: fixture.day,
             allowPricingRefresh: false,
             refreshPricingInBackground: false,
+            includePiSessions: includePiSessions,
             scannerOptions: fixture.options,
+            piScannerOptions: fixture.piOptions,
             modelsDevClient: ModelsDevClient(
                 transport: CostUsageFetcherCountingModelsDevTransport(counter: counter)))
 
         let breakdown = try #require(snapshot.daily.first?.modelBreakdowns?.first)
         #expect(breakdown.modelName == "gpt-new")
         #expect(breakdown.costUSD == nil)
+        #expect(snapshot.sessionTokens == (includePiSessions ? 170 : 110))
+        #expect(snapshot.last30DaysTokens == (includePiSessions ? 170 : 110))
         #expect(await counter.requestCount == 0)
+    }
+
+    @Test
+    func `foreground pricing scheduling still requests a catalog for native plus pi usage`() async throws {
+        let fixture = try UnknownModelPricingFixture()
+        defer { fixture.environment.cleanup() }
+        try fixture.writePiSession()
+        let counter = UnknownModelPricingRequestCounter()
+
+        // This was the timestamp fixtures' old configuration: foreground is not an opt-out.
+        let snapshot = try await CostUsageFetcher.loadTokenSnapshot(
+            provider: .codex,
+            now: fixture.day,
+            refreshPricingInBackground: false,
+            scannerOptions: fixture.options,
+            piScannerOptions: fixture.piOptions,
+            modelsDevClient: ModelsDevClient(
+                transport: CostUsageFetcherCountingModelsDevTransport(counter: counter)))
+
+        #expect(snapshot.sessionTokens == 170)
+        #expect(await counter.requestCount == 1)
     }
 }
 
@@ -269,6 +301,29 @@ private struct UnknownModelPricingFixture {
     let day: Date
     let options: CostUsageScanner.Options
     let refreshedCatalog: Data
+
+    var piOptions: PiSessionCostScanner.Options {
+        PiSessionCostScanner.Options(
+            piSessionsRoot: self.environment.piSessionsRoot,
+            cacheRoot: self.environment.cacheRoot,
+            refreshMinIntervalSeconds: 0)
+    }
+
+    func writePiSession() throws {
+        _ = try self.environment.writePiSessionFile(
+            relativePath: "2026-04-12T12-00-00-000Z_pricing.jsonl",
+            contents: self.environment.jsonl([[
+                "type": "message",
+                "timestamp": self.environment.isoString(for: self.day),
+                "message": [
+                    "role": "assistant",
+                    "provider": "openai-codex",
+                    "model": "gpt-new",
+                    "timestamp": Int(self.day.timeIntervalSince1970 * 1000),
+                    "usage": ["input": 50, "output": 10, "totalTokens": 60],
+                ],
+            ]]))
+    }
 
     init() throws {
         let environment = try CostUsageTestEnvironment()
@@ -347,7 +402,8 @@ private struct UnknownModelPricingFixture {
         self.options = CostUsageScanner.Options(
             codexSessionsRoot: environment.codexSessionsRoot,
             claudeProjectsRoots: [environment.claudeProjectsRoot],
-            cacheRoot: environment.cacheRoot)
+            cacheRoot: environment.cacheRoot,
+            codexTraceDatabaseURL: environment.root.appendingPathComponent("missing-traces.sqlite"))
     }
 }
 

--- a/Tests/CodexBarTests/GeminiFixturePathTests.swift
+++ b/Tests/CodexBarTests/GeminiFixturePathTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+struct GeminiFixturePathTests {
+    @Test
+    func `fnm fixture PATH preserves inherited peer lookup and fixture priority`() throws {
+        let fixture = try GeminiTestEnvironment()
+        defer { fixture.cleanup() }
+        let inheritedBin = fixture.homeURL.appendingPathComponent("peer-bin")
+        try FileManager.default.createDirectory(at: inheritedBin, withIntermediateDirectories: true)
+        try FakeExecutable.install(
+            "printf '%s\\n' 'inherited-peer'\n",
+            at: inheritedBin.appendingPathComponent("codexbar-path-peer"))
+        try FakeExecutable.install("exit 23\n", at: inheritedBin.appendingPathComponent("fnm"))
+        let geminiBinary = try fixture.writeFakeGeminiCLI(layout: .fnmBundle)
+        _ = try fixture.writeFakeFnm(
+            geminiPackageJSONPath: fixture.homeURL.appendingPathComponent("package.json").path)
+
+        let path = fixture.fnmFixturePath(geminiBinary: geminiBinary, inheritedPath: inheritedBin.path)
+        let environment = [
+            "PATH": path,
+            "CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS": "1",
+            "CODEXBAR_TEST_CODEX_FILE_ISOLATION": "1",
+        ]
+        // Model a peer's /usr/bin/env lookup while the same fixture PATH override is active.
+        for (arguments, expected) in [
+            (["codexbar-path-peer"], "inherited-peer"),
+            (["fnm", "current"], "v24.6.0"),
+        ] {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = arguments
+            process.environment = environment
+            process.standardInput = FileHandle.nullDevice
+            let output = Pipe()
+            process.standardOutput = output
+            process.standardError = output
+            try process.run()
+            process.waitUntilExit()
+            let text = try #require(String(
+                bytes: output.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8))
+            try #require(process.terminationStatus == 0, "\(text)")
+            #expect(text.trimmingCharacters(in: .whitespacesAndNewlines) == expected)
+        }
+        #expect(path.components(separatedBy: ":") == [
+            fixture.homeURL.appendingPathComponent("bin").path,
+            geminiBinary.deletingLastPathComponent().path,
+            inheritedBin.path,
+        ])
+    }
+
+    @Test(arguments: [nil, ""] as [String?])
+    func `fnm fixture PATH handles missing or empty inherited PATH`(inheritedPath: String?) throws {
+        let fixture = try GeminiTestEnvironment()
+        defer { fixture.cleanup() }
+        let geminiBinary = try fixture.writeFakeGeminiCLI(layout: .fnmBundle)
+
+        let path = fixture.fnmFixturePath(geminiBinary: geminiBinary, inheritedPath: inheritedPath)
+
+        #expect(path.components(separatedBy: ":") == [
+            fixture.homeURL.appendingPathComponent("bin").path,
+            geminiBinary.deletingLastPathComponent().path,
+        ])
+    }
+}

--- a/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
+++ b/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
@@ -300,8 +300,7 @@ struct GeminiStatusProbeAPITests {
             geminiPackageJSONPath: packageJSONPath.path)
 
         let previousPath = ProcessInfo.processInfo.environment["PATH"]
-        let fakeBinDir = env.homeURL.appendingPathComponent("bin").path
-        setenv("PATH", "\(fakeBinDir):\(binURL.deletingLastPathComponent().path)", 1)
+        setenv("PATH", env.fnmFixturePath(geminiBinary: binURL, inheritedPath: previousPath), 1)
 
         let previousGeminiPath = ProcessInfo.processInfo.environment["GEMINI_CLI_PATH"]
         setenv("GEMINI_CLI_PATH", binURL.path, 1)

--- a/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
+++ b/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
@@ -271,17 +271,9 @@ struct GeminiStatusProbeAPITests {
     }
 
     @Test
-    func `refreshes expired token with fnm bundle layout when fnm keeps stdout open`() async throws {
+    func `refreshes expired token with fnm bundle layout`() async throws {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }
-        let childPIDFile = env.homeURL.appendingPathComponent("fnm-child.pid")
-        defer {
-            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8),
-               let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
-            {
-                _ = kill(childPID, SIGKILL)
-            }
-        }
         try env.writeCredentials(
             accessToken: "old-token",
             refreshToken: "refresh-token",
@@ -305,19 +297,11 @@ struct GeminiStatusProbeAPITests {
             .path
         _ = try env.writeFakeFnm(
             npmRoot: npmRoot,
-            geminiPackageJSONPath: packageJSONPath.path,
-            holdNpmRootStdoutOpen: true)
+            geminiPackageJSONPath: packageJSONPath.path)
 
         let previousPath = ProcessInfo.processInfo.environment["PATH"]
-        let previousPIDFile = ProcessInfo.processInfo.environment["CODEXBAR_TEST_CHILD_PID_FILE"]
         let fakeBinDir = env.homeURL.appendingPathComponent("bin").path
-        let pathValue = if let previousPath, !previousPath.isEmpty {
-            "\(fakeBinDir):\(binURL.deletingLastPathComponent().path):\(previousPath)"
-        } else {
-            "\(fakeBinDir):\(binURL.deletingLastPathComponent().path)"
-        }
-        setenv("PATH", pathValue, 1)
-        setenv("CODEXBAR_TEST_CHILD_PID_FILE", childPIDFile.path, 1)
+        setenv("PATH", "\(fakeBinDir):\(binURL.deletingLastPathComponent().path)", 1)
 
         let previousGeminiPath = ProcessInfo.processInfo.environment["GEMINI_CLI_PATH"]
         setenv("GEMINI_CLI_PATH", binURL.path, 1)
@@ -326,12 +310,6 @@ struct GeminiStatusProbeAPITests {
                 setenv("PATH", previousPath, 1)
             } else {
                 unsetenv("PATH")
-            }
-
-            if let previousPIDFile {
-                setenv("CODEXBAR_TEST_CHILD_PID_FILE", previousPIDFile, 1)
-            } else {
-                unsetenv("CODEXBAR_TEST_CHILD_PID_FILE")
             }
 
             if let previousGeminiPath {
@@ -394,12 +372,43 @@ struct GeminiStatusProbeAPITests {
         let probe = GeminiStatusProbe(timeout: 2, homeDirectory: env.homeURL.path, dataLoader: dataLoader)
         let snapshot = try await probe.fetch()
         #expect(snapshot.accountPlan == "Paid")
-        let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
-        let childPID = try #require(pid_t(childPIDText.trimmingCharacters(in: .whitespacesAndNewlines)))
-        #expect(kill(childPID, 0) == 0, "package discovery should return while the stdout-holding child is alive")
-
         let updated = try env.readCredentials()
         #expect(updated["access_token"] as? String == "new-token")
+    }
+
+    @Test
+    func `fnm helper returns first line while an owned process holds stdout open`() throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        let holder = try GeminiStdoutHolderFixture(root: env.homeURL)
+        defer { holder.cleanup() }
+
+        let result = holder.runProducer()
+        try #require(result == "/tmp/gemini-package", "\(holder.producerDiagnostics)")
+        let publishedPID = try String(contentsOf: holder.pidFile, encoding: .utf8)
+        #expect(pid_t(publishedPID) == holder.process.processIdentifier)
+        #expect(holder.process.isRunning)
+
+        holder.cleanup()
+        #expect(!holder.process.isRunning)
+    }
+
+    @Test
+    func `fnm helper producer failure cleans up without a PID artifact`() throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        let holder = try GeminiStdoutHolderFixture(root: env.homeURL)
+        defer { holder.cleanup() }
+        let missingParent = env.homeURL.appendingPathComponent("missing/holder.pid")
+
+        #expect(holder.runProducer(pidFile: missingParent) == nil)
+        #expect(holder.producerDiagnostics.contains("FileNotFoundError"))
+        #expect(holder.producerDiagnostics.contains(missingParent.path))
+        #expect(!FileManager.default.fileExists(atPath: missingParent.path))
+        #expect(holder.process.isRunning)
+
+        holder.cleanup()
+        #expect(!holder.process.isRunning)
     }
 
     @Test

--- a/Tests/CodexBarTests/GeminiStdoutHolderFixture.swift
+++ b/Tests/CodexBarTests/GeminiStdoutHolderFixture.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+/// The test owns the holder Process before the producer can hand it a stdout descriptor.
+/// No descendant discovery or PID file is needed to clean up a failed producer.
+final class GeminiStdoutHolderFixture {
+    let process = Process()
+    let pidFile: URL
+    private let helper: URL
+    private let socketPath: String
+    private let control = Pipe()
+    private let exited = DispatchSemaphore(value: 0)
+    private var started = false
+    private var cleanedUp = false
+
+    private let environment = [
+        "PATH": "/usr/bin:/bin",
+        "CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS": "1",
+        "CODEXBAR_TEST_CODEX_FILE_ISOLATION": "1",
+    ]
+
+    init(root: URL) throws {
+        self.helper = root.appendingPathComponent("stdout-holder.py")
+        self.socketPath = root.appendingPathComponent("s").path
+        self.pidFile = root.appendingPathComponent("holder.pid")
+        try Self.script.write(to: self.helper, atomically: true, encoding: .utf8)
+
+        let output = Pipe()
+        let capture = ProcessPipeCapture(pipe: output)
+        // Use the system interpreter directly and isolate its module search from user configuration.
+        self.process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        self.process.arguments = ["-I", self.helper.path, "hold", self.socketPath]
+        self.process.environment = self.environment
+        self.process.standardInput = self.control
+        self.process.standardOutput = output
+        self.process.standardError = FileHandle.standardError
+        let exited = self.exited
+        self.process.terminationHandler = { _ in exited.signal() }
+        try self.process.run()
+        self.started = true
+        self.control.fileHandleForReading.closeFile()
+        output.fileHandleForWriting.closeFile()
+        capture.start()
+        do {
+            let ready = capture.finishFirstLineSynchronously(timeout: 2)
+            try #require(String(data: ready, encoding: .utf8) == "ready\n")
+        } catch {
+            self.cleanup()
+            throw error
+        }
+    }
+
+    func runProducer(pidFile: URL? = nil) -> String? {
+        GeminiStatusProbe.runProcess(
+            executable: "/usr/bin/python3",
+            arguments: ["-I", self.helper.path, "produce", self.socketPath, (pidFile ?? self.pidFile).path],
+            environment: self.environment,
+            timeout: 2)
+    }
+
+    var producerDiagnostics: String {
+        (try? String(contentsOfFile: self.socketPath + ".error", encoding: .utf8)) ?? ""
+    }
+
+    func cleanup() {
+        guard !self.cleanedUp else { return }
+        self.cleanedUp = true
+        self.control.fileHandleForWriting.closeFile()
+        guard self.started else { return }
+        if self.exited.wait(timeout: .now() + 2) == .timedOut {
+            Issue.record("Stdout holder did not exit after its owner closed the control pipe")
+            if self.process.isRunning {
+                _ = kill(self.process.processIdentifier, SIGKILL)
+            }
+        }
+        self.process.waitUntilExit()
+        #expect(self.process.terminationStatus == 0)
+    }
+
+    deinit {
+        self.cleanup()
+    }
+
+    private static let script = #"""
+    import array
+    import os
+    import select
+    import socket
+    import stat
+    import sys
+    import traceback
+
+    mode, path = sys.argv[1:3]
+    if mode == "produce":
+        def record_failure(kind, error, stack):
+            with open(path + ".error", "w") as handle:
+                traceback.print_exception(kind, error, stack, file=handle)
+        sys.excepthook = record_failure
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as channel:
+        if mode == "hold":
+            channel.bind(path)
+            print("ready", flush=True)
+            held = []
+            try:
+                while True:
+                    readable, _, _ = select.select([channel, sys.stdin], [], [])
+                    if sys.stdin in readable:
+                        assert os.read(0, 1) == b""
+                        break
+                    _, ancillary, flags, sender = channel.recvmsg(1, socket.CMSG_SPACE(array.array("i").itemsize))
+                    assert flags == 0 and len(ancillary) == 1
+                    level, kind, data = ancillary[0]
+                    assert (level, kind) == (socket.SOL_SOCKET, socket.SCM_RIGHTS)
+                    descriptors = array.array("i")
+                    descriptors.frombytes(data)
+                    held.extend(descriptors)
+                    assert len(descriptors) == 1 and stat.S_ISFIFO(os.fstat(descriptors[0]).st_mode)
+                    channel.sendto(str(os.getpid()).encode(), sender)
+            finally:
+                for descriptor in held:
+                    os.close(descriptor)
+        else:
+            assert mode == "produce"
+            channel.bind(path + ".p")
+            channel.settimeout(2)
+            channel.connect(path)
+            channel.sendmsg([b"x"], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [1]))])
+            holder_pid = channel.recv(32).decode()
+            # The acknowledgement proves the owned holder has the writer before any output is printed.
+            with open(sys.argv[3], "w") as handle:
+                handle.write(holder_pid)
+            print("/tmp/gemini-package", flush=True)
+            print("ignored trailing output", flush=True)
+    """#
+}

--- a/Tests/CodexBarTests/GeminiTestEnvironment.swift
+++ b/Tests/CodexBarTests/GeminiTestEnvironment.swift
@@ -297,6 +297,15 @@ struct GeminiTestEnvironment {
         return geminiBinary
     }
 
+    func fnmFixturePath(geminiBinary: URL, inheritedPath: String?) -> String {
+        let fnmBin = self.homeURL.appendingPathComponent("bin").path
+        let geminiBin = geminiBinary.deletingLastPathComponent().path
+        let fixturePath = "\(fnmBin):\(geminiBin)"
+        // Other suites may inherit the process-wide PATH while this fixture runs.
+        guard let inheritedPath, !inheritedPath.isEmpty else { return fixturePath }
+        return "\(fixturePath):\(inheritedPath)"
+    }
+
     func writeFakeFnm(
         currentVersion: String = "v24.6.0",
         npmRoot: String? = nil,

--- a/Tests/CodexBarTests/GeminiTestEnvironment.swift
+++ b/Tests/CodexBarTests/GeminiTestEnvironment.swift
@@ -300,31 +300,12 @@ struct GeminiTestEnvironment {
     func writeFakeFnm(
         currentVersion: String = "v24.6.0",
         npmRoot: String? = nil,
-        geminiPackageJSONPath: String,
-        holdNpmRootStdoutOpen: Bool = false) throws -> URL
+        geminiPackageJSONPath: String) throws -> URL
     {
         let binDir = self.homeURL.appendingPathComponent("bin")
         try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
 
         let fnmPath = binDir.appendingPathComponent("fnm")
-        let stdoutHolder = holdNpmRootStdoutOpen
-            ? #"""
-            python3 - <<'PY'
-            import os
-            import subprocess
-            import sys
-
-            child = subprocess.Popen(
-                [sys.executable, "-c", "import time; time.sleep(30)"],
-                stdin=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
-            with open(os.environ["CODEXBAR_TEST_CHILD_PID_FILE"], "w") as handle:
-                handle.write(str(child.pid))
-            PY
-            """#
-            : ":"
         let script = if let npmRoot {
             """
             #!/bin/bash
@@ -334,7 +315,6 @@ struct GeminiTestEnvironment {
             fi
 
             if [ "$1" = "exec" ] && [ "$4" = "npm" ] && [ "$5" = "root" ] && [ "$6" = "-g" ]; then
-              \(stdoutHolder)
               printf '%s\n' "\(npmRoot)"
               exit 0
             fi


### PR DESCRIPTION
## Summary

Make the cost and Gemini subprocess fixtures independent of host pricing requests, ambient trace data, and PID-file-dependent cleanup. Production behavior and timeout budgets are unchanged.

The preceding full-suite run passed after recovering two groups. The twelve-suite cost group exceeded its shared 180-second budget; its successful isolated retries totaled 171.148 seconds before process startup. Several non-pricing fixtures used `refreshPricingInBackground: false`, which still permits an awaited pricing request. They also left the trace database path implicit, and some native-only cases permitted ambient Pi discovery. These are source-proven fixture dependencies, not proof of an exact network delay or a production hang.

Non-pricing cost fixtures now explicitly opt out of pricing refresh, use owned temporary trace/cache/session paths, and include Pi only where temporary Pi data is part of the assertion. A fake counting transport preserves the distinction: foreground pricing requests a catalog, while local-only native and native-plus-Pi assembly make zero requests and retain unknown-cost/token assertions.

The Gemini regression now separates fnm bundle discovery from first-line-versus-EOF behavior. The test owns the stdout holder directly, establishes readiness before producing output, and cleans it up even if PID publication fails. The original intermittent failure's exact stage was not observed; this does not claim a new production Gemini fix.

A late review correctly identified that narrowing the fixture's process-wide PATH could interfere with other suites during parallel Swift Testing. The fixture now preserves the inherited suffix while keeping fake fnm/Gemini executables first. A deterministic regression uses an owned temporary peer executable: the old composition fails with exit 127, and the repaired composition preserves peer lookup and fixture precedence. The explicit system-Python stdout holder is unchanged.

## Verification

- 64 focused tests passed across the three fetcher suites and Gemini API suite; the cache-snapshot suite also passed all 19 tests after moving unchanged private helpers into an extension.
- The exact original twelve-suite cost-group filter passed 112 tests in 44.333 seconds wall time under the unchanged 180-second harness deadline, without retries. Earlier same-selection runs had substantial timing variation; this is not a general performance guarantee.
- Three additional complete Gemini API/direct-helper runs passed all 20 tests each, including success while the holder remains alive and cleanup after the intended PID-publication failure. No new holder/producer processes remained.
- Final PATH repair: 22 tests in the Gemini API and PATH suites passed with normal parallel behavior; 14.844 seconds wall time under the unchanged 180-second harness budget. Missing/empty inherited PATH cases also pass.
- `make check`: zero violations across 2,018 files. `git diff --check`: clean.
- Independent Codex reviews of the original complete patch and the accepted PATH repair: no actionable P0–P2 findings after the repair.
- Revised parent `make test`: all 946 selections across 79 groups passed on the first attempt; zero failed groups, timeouts, retries, or recoveries, 787.8 seconds total. The initial pre-PATH-repair run also passed, but did not expose the parallel environment interference; the deterministic peer regression covers that defect.

[Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33085880742) passed: both macOS shards, Linux ARM64/x64 builds, lint, aggregate gate, and GitGuardian. The conditional musl job was skipped. The macOS logs confirm 118/118 and 119/119 first-pass groups, with zero failed groups, timeouts, retries, or recoveries. Initial compile, helper argument-index, and type-length errors were corrected before the passing focused/lint results; no timeout or lint rule was relaxed.

All test/check commands used `env -u CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 CODEXBAR_TEST_CODEX_FILE_ISOLATION=1`. No real provider/account/browser/Keychain or app/CLI runtime proof is claimed. This is test-only and has no user-facing changelog entry.
