### PR TITLE
fix: preserve WebView acquisition ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.55.2 — Unreleased
 
 ### Fixed
-- Codex: keep OpenAI web acquisitions and lease cleanup owned across cache eviction, preventing stale preparation results or timeout retries from displacing replacement views.
+- Codex: keep OpenAI web acquisitions and lease cleanup owned across cache eviction, preventing stale preparation results or timeout retries from displacing replacement views (#3252).
 - Codex: reduce cached cost-read overhead by loading progress metadata separately and leaving raw scanner state out of cached reports, including project and session details (#3247). Thanks @robertoecf!
 - Antigravity: read recognized local SQLite conversations as bounded token-only history, preserving unavailable coverage, session identity, and overflow-safe totals (#3212). Thanks @Yuxin-Qiao!
 - Usage & Spend: refresh outdated independent 365-day histories after regular token publications, preserving older rows and coalescing updates during scans (investigated alongside #3209, #3176). Thanks @vinschger!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.55.2 — Unreleased
 
 ### Fixed
+- Codex: keep OpenAI web acquisitions and lease cleanup owned across cache eviction, preventing stale preparation results or timeout retries from displacing replacement views.
 - Codex: reduce cached cost-read overhead by loading progress metadata separately and leaving raw scanner state out of cached reports, including project and session details (#3247). Thanks @robertoecf!
 - Antigravity: read recognized local SQLite conversations as bounded token-only history, preserving unavailable coverage, session identity, and overflow-safe totals (#3212). Thanks @Yuxin-Qiao!
 - Usage & Spend: refresh outdated independent 365-day histories after regular token publications, preserving older rows and coalescing updates during scans (investigated alongside #3209, #3176). Thanks @vinschger!

--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -104,20 +104,63 @@ if sys.platform == "darwin":
             (name, ctypes.c_uint32) for name in ("files", "group", "jobc", "tdev", "tpgid", "nice")
         ] + [("seconds", ctypes.c_uint64), ("microseconds", ctypes.c_uint64)]
 
+    class ProcUniqueIdentifierInfo(ctypes.Structure):
+        # sys/proc_info_private.h: 56-byte API layout, including unused reserved fields.
+        _fields_ = [
+            ("uuid", ctypes.c_uint8 * 16), ("uniqueid", ctypes.c_uint64),
+            ("parent_uniqueid", ctypes.c_uint64), ("pidversion", ctypes.c_int32),
+            ("reserved", ctypes.c_uint32), ("reserved2", ctypes.c_uint64), ("reserved3", ctypes.c_uint64),
+        ]
+
+    class ProcBSDInfoWithUniqueID(ctypes.Structure):
+        _fields_ = [("bsd", ProcBSDInfo), ("unique", ProcUniqueIdentifierInfo)]
+
+    class AuditToken(ctypes.Structure):
+        _fields_ = [("val", ctypes.c_uint32 * 8)]
+
     _libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
     _libproc.proc_pidinfo.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_int]
     _libproc.proc_pidinfo.restype = ctypes.c_int
+    _proc_signal_with_audittoken = getattr(_libproc, "proc_signal_with_audittoken", None)
+    if _proc_signal_with_audittoken is not None:
+        _proc_signal_with_audittoken.argtypes = [ctypes.POINTER(AuditToken), ctypes.c_int]
+        _proc_signal_with_audittoken.restype = ctypes.c_int
+
+
+def darwin_pidinfo(pid: int, flavor: int, info):
+    ctypes.set_errno(0)
+    size = _libproc.proc_pidinfo(pid, flavor, 0, ctypes.byref(info), ctypes.sizeof(info))
+    if size != ctypes.sizeof(info):
+        error = ctypes.get_errno() if size <= 0 else errno.EIO
+        raise OSError(error or errno.EIO, f"Cannot read process metadata for PID {pid}")
+    return info
+
+
+def darwin_signal_process(info: TestProcess, sig: signal.Signals) -> None:
+    if _proc_signal_with_audittoken is None:
+        raise OSError(errno.ENOSYS, "Darwin process cleanup requires proc_signal_with_audittoken")
+    try:
+        # PROC_PIDT_BSDINFOWITHUNIQID reads birth and generation from one held proc.
+        current = darwin_pidinfo(info.pid, 18, ProcBSDInfoWithUniqueID())
+    except (FileNotFoundError, ProcessLookupError):
+        return
+    if current.bsd.pid != info.pid or (current.bsd.seconds, current.bsd.microseconds) != info.birth:
+        return
+    # Only target PID/pidversion are used; these are not caller credentials. XNU
+    # checks the real caller's permissions and binds the signal to this generation.
+    token = AuditToken()
+    token.val[5], token.val[7] = info.pid, current.unique.pidversion
+    error = _proc_signal_with_audittoken(ctypes.byref(token), sig)
+    # libproc returns errno directly, not -1/errno. An exec can stale this token;
+    # a later cleanup attempt obtains a fresh generation only after matching birth.
+    if error and error != errno.ESRCH:
+        raise OSError(error, f"Cannot signal process identity for PID {info.pid}")
 
 
 def test_process(pid: int) -> TestProcess | None:
     try:
         if sys.platform == "darwin":
-            info = ProcBSDInfo()
-            ctypes.set_errno(0)
-            size = _libproc.proc_pidinfo(pid, 3, 0, ctypes.byref(info), ctypes.sizeof(info))
-            if size != ctypes.sizeof(info):
-                error = ctypes.get_errno() if size <= 0 else errno.EIO
-                raise OSError(error or errno.EIO, f"Cannot read process metadata for PID {pid}")
+            info = darwin_pidinfo(pid, 3, ProcBSDInfo())
             zombie = info.state == 5
             try:
                 session = 0 if zombie else os.getsid(pid)
@@ -237,6 +280,8 @@ class TestProcessOwnership:
                 return
             if descriptor is not None:
                 signal.pidfd_send_signal(descriptor, sig)
+            elif sys.platform == "darwin":
+                darwin_signal_process(info, sig)
             else:
                 os.kill(info.pid, sig)
         except ProcessLookupError:

--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
+import errno
 import os
+from pathlib import Path
 import re
 import signal
 import subprocess
@@ -80,20 +83,290 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run_command(command: list[str], timeout: int | None = None) -> int:
-    print(f"+ {' '.join(command)}", flush=True)
-    process = subprocess.Popen(command, start_new_session=True)
+@dataclass(frozen=True)
+class TestProcess:
+    pid: int
+    parent: int
+    session: int
+    birth: tuple[int, int]
+    zombie: bool = False
+
+
+if sys.platform == "darwin":
+    class ProcBSDInfo(ctypes.Structure):
+        # proc_bsdinfo from sys/proc_info.h; ps lstart loses subsecond PID identity.
+        _fields_ = [
+            (name, ctypes.c_uint32) for name in (
+                "flags", "state", "exit_status", "pid", "parent", "uid", "gid",
+                "ruid", "rgid", "svuid", "svgid", "reserved",
+            )
+        ] + [("comm", ctypes.c_char * 16), ("name", ctypes.c_char * 32)] + [
+            (name, ctypes.c_uint32) for name in ("files", "group", "jobc", "tdev", "tpgid", "nice")
+        ] + [("seconds", ctypes.c_uint64), ("microseconds", ctypes.c_uint64)]
+
+    _libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+    _libproc.proc_pidinfo.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_int]
+    _libproc.proc_pidinfo.restype = ctypes.c_int
+
+
+def test_process(pid: int) -> TestProcess | None:
     try:
-        return process.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        print(f"::warning::Command timed out after {timeout}s: {' '.join(command)}", flush=True)
-        os.killpg(process.pid, signal.SIGTERM)
+        if sys.platform == "darwin":
+            info = ProcBSDInfo()
+            ctypes.set_errno(0)
+            size = _libproc.proc_pidinfo(pid, 3, 0, ctypes.byref(info), ctypes.sizeof(info))
+            if size != ctypes.sizeof(info):
+                error = ctypes.get_errno() if size <= 0 else errno.EIO
+                raise OSError(error or errno.EIO, f"Cannot read process metadata for PID {pid}")
+            zombie = info.state == 5
+            try:
+                session = 0 if zombie else os.getsid(pid)
+            except ProcessLookupError:
+                # getsid excludes exited processes; retain the birth read before that race.
+                session = 0
+            return TestProcess(pid, info.parent, session, (info.seconds, info.microseconds), zombie)
+        if sys.platform.startswith("linux"):
+            fields = Path(f"/proc/{pid}/stat").read_bytes().rsplit(b")", 1)[1].split()
+            # A zombie leader can still have live threads after pthread_exit(). Linux release_task
+            # removes the last nonleader before notifying the parent that the group has exited.
+            zombie = fields[0] == b"Z" and int(fields[17]) == 1
+            return TestProcess(pid, int(fields[1]), int(fields[3]), (int(fields[19]), 0), zombie)
+        raise RuntimeError("Swift test process containment requires macOS or Linux")
+    except (FileNotFoundError, ProcessLookupError):
+        return None
+    except (IndexError, ValueError) as error:
+        raise OSError(errno.EIO, f"Incomplete process metadata for PID {pid}") from error
+
+
+def test_process_snapshot(required: Iterable[int] = ()) -> dict[int, TestProcess]:
+    # Numeric metadata only; never inspect command lines or environments of peer jobs.
+    pids = subprocess.check_output(["ps", "-axo", "pid="], text=True, timeout=2).split()
+    required = set(required)
+    snapshot = {}
+    for pid in {int(pid) for pid in pids} | required:
         try:
-            process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            os.killpg(process.pid, signal.SIGKILL)
-            process.wait()
-        return 124
+            info = test_process(pid)
+        except OSError:
+            if pid in required:
+                raise
+            continue
+        if info is not None:
+            snapshot[pid] = info
+    return snapshot
+
+
+class TestProcessOwnership:
+    def __init__(self, root: TestProcess, process: subprocess.Popen | None = None):
+        self.root = root
+        self.process = process
+        self.known = {root.pid: root.birth}
+        self.sessions = {root.pid: root.birth} if root.session == root.pid else {}
+
+    def refresh(self) -> dict[int, TestProcess]:
+        snapshot = test_process_snapshot(self.known.keys() | self.sessions.keys())
+        if self.process is not None:
+            if self.process.returncode is not None:
+                raise RuntimeError("Test root was reaped before cleanup completed")
+            exited = unreaped_exit_code(self.process) is not None
+            current_root = snapshot.get(self.root.pid)
+            if current_root is not None and self.root.birth == (0, 0):
+                self.root = TestProcess(
+                    current_root.pid, current_root.parent, self.process.pid, current_root.birth, current_root.zombie)
+                self.known[self.root.pid] = current_root.birth
+                self.sessions[self.root.pid] = current_root.birth
+            elif current_root is not None and current_root.birth != self.root.birth:
+                raise RuntimeError("Test root identity changed before cleanup completed")
+            # Darwin can hide metadata before exit becomes waitable. The unreaped child
+            # still anchors its PID/session; only wait status establishes root completion.
+            snapshot[self.root.pid] = TestProcess(
+                self.root.pid, self.root.parent, self.root.session, self.root.birth, exited)
+        owned = {pid: info for pid, info in snapshot.items() if self.known.get(pid) == info.birth}
+        checked_sessions = {}
+        while True:
+            self.known.update({pid: info.birth for pid, info in owned.items()})
+            self.sessions.update({pid: info.birth for pid, info in owned.items() if info.session == pid})
+            for sid, birth in self.sessions.items():
+                if sid in checked_sessions:
+                    continue
+                if self.process is not None and sid == self.root.pid:
+                    checked_sessions[sid] = True
+                    continue
+                anchor = snapshot.get(sid)
+                # Recheck AFTER enumeration: the leader might have been reaped during the snapshot.
+                current = test_process(sid) if anchor is not None and anchor.birth == birth else None
+                checked_sessions[sid] = current is not None and current.birth == birth
+            additions = {
+                pid: info for pid, info in snapshot.items()
+                if pid not in owned and (
+                    (info.parent in owned and info.birth >= owned[info.parent].birth)
+                    or (checked_sessions.get(info.session, False) and info.birth >= self.sessions[info.session])
+                )
+            }
+            if not additions:
+                break
+            owned.update(additions)
+        for sid in list(self.sessions):
+            if checked_sessions[sid]:
+                continue
+            members = {pid for pid, info in snapshot.items() if info.session == sid and not info.zombie}
+            if members - owned.keys():
+                raise RuntimeError(
+                    f"Lost test session continuity for SID {sid}; "
+                    f"cannot attribute PIDs {sorted(members - owned.keys())}")
+            if not members:
+                del self.sessions[sid]
+        # Confirmed exits/replacements retire; unavailable known metadata raises before reaching here.
+        self.known = {pid: info.birth for pid, info in owned.items()}
+        return {pid: info for pid, info in owned.items() if not info.zombie}
+
+    def send(self, info: TestProcess, sig: signal.Signals) -> None:
+        descriptor = None
+        try:
+            if self.process is not None and info.pid == self.process.pid:
+                if self.process.returncode is not None:
+                    raise RuntimeError("Test root was reaped before cleanup completed")
+                # Direct-child signal authority comes from wait ownership, not metadata
+                # which may already be hidden (or a placeholder for an unobserved birth).
+                if unreaped_exit_code(self.process) is None:
+                    os.kill(self.process.pid, sig)
+                return
+            if sys.platform.startswith("linux") and hasattr(os, "pidfd_open"):
+                descriptor = os.pidfd_open(info.pid)
+            current = test_process(info.pid)
+            if current is None or current.birth != self.known.get(info.pid) or current.birth != info.birth:
+                return
+            if descriptor is not None:
+                signal.pidfd_send_signal(descriptor, sig)
+            else:
+                os.kill(info.pid, sig)
+        except ProcessLookupError:
+            pass
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+
+    def drain(self, process: subprocess.Popen) -> None:
+        try:
+            self._drain(process)
+        except BaseException:
+            # If enumeration fails, still stop identities already proven ours, then fail closed.
+            for pid, birth in self.known.items():
+                try:
+                    info = test_process(pid)
+                    if info is not None and info.birth == birth:
+                        self.send(info, signal.SIGKILL)
+                except OSError as error:
+                    print(f"Cannot verify cleanup PID {pid}: errno={error.errno}", file=sys.stderr, flush=True)
+            try:
+                stop_unreaped_child(process)
+            except (OSError, subprocess.TimeoutExpired) as error:
+                print(f"Direct child cleanup failed: {type(error).__name__}", file=sys.stderr, flush=True)
+            raise
+
+    def _drain(self, process: subprocess.Popen) -> None:
+        started = time.monotonic()
+        terminated: set[tuple[int, tuple[int, int]]] = set()
+        while True:
+            owned = self.refresh()
+            if not owned:
+                process.wait(timeout=1)
+                return
+            elapsed = time.monotonic() - started
+            if elapsed >= 5:
+                # Never begin a retry while a known child is still running.
+                raise RuntimeError(f"Could not drain owned test processes within 5s: {sorted(owned)}")
+            for info in owned.values():
+                identity = (info.pid, info.birth)
+                if elapsed >= 3:
+                    self.send(info, signal.SIGKILL)
+                elif identity not in terminated:
+                    self.send(info, signal.SIGTERM)
+                    terminated.add(identity)
+            time.sleep(0.1)
+
+
+def unreaped_exit_code(process: subprocess.Popen) -> int | None:
+    result = os.waitid(os.P_PID, process.pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+    if result is None:
+        return None
+    return result.si_status if result.si_code == os.CLD_EXITED else -result.si_status
+
+
+def stop_unreaped_child(process: subprocess.Popen) -> None:
+    # The direct child is ours even if native metadata initialization failed. Do not use
+    # Popen.terminate/poll: they may reap it and permit its PID/session to be recycled.
+    if process.returncode is not None:
+        return
+    if unreaped_exit_code(process) is not None:
+        process.wait(timeout=2)
+        return
+    try:
+        os.kill(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    deadline = time.monotonic() + 3
+    while unreaped_exit_code(process) is None and time.monotonic() < deadline:
+        time.sleep(0.1)
+    if unreaped_exit_code(process) is None:
+        try:
+            os.kill(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    process.wait(timeout=2)
+
+
+def run_command(command: list[str], timeout: int | None = None) -> int:
+    if sys.platform != "darwin" and not sys.platform.startswith("linux"):
+        raise RuntimeError("Swift test process containment requires macOS or Linux")
+    if not all(hasattr(os, name) for name in ("waitid", "P_PID", "WEXITED", "WNOHANG", "WNOWAIT")):
+        raise RuntimeError("Swift test process containment requires waitid with WNOWAIT")
+    print(f"+ {' '.join(command)}", flush=True)
+    started = time.monotonic()
+    ownership = None
+    process = None
+    try:
+        process = subprocess.Popen(command, start_new_session=True)
+        root = test_process(process.pid)
+        if root is None:
+            exited = unreaped_exit_code(process) is not None
+            # Missing metadata can precede a waitable exit. Zero is only a placeholder
+            # for this unreaped handle; ordinary polling retains the existing deadline.
+            root = TestProcess(process.pid, os.getpid(), process.pid, (0, 0), exited)
+        # Popen established this session even if getsid now races with the command's exit.
+        root = TestProcess(root.pid, root.parent, process.pid, root.birth, root.zombie)
+        ownership = TestProcessOwnership(root, process)
+        next_diagnostic = started + 30
+        while True:
+            owned = ownership.refresh()
+            result = unreaped_exit_code(process)
+            if result is not None:
+                return result
+            now = time.monotonic()
+            if timeout is not None and now - started >= timeout:
+                print(f"::warning::Command timed out after {timeout}s: {' '.join(command)}", flush=True)
+                return 124
+            if now >= next_diagnostic:
+                print(f"Swift test command pid={process.pid} elapsed={now - started:.1f}s owned={sorted(owned)}", flush=True)
+                next_diagnostic = now + 30
+            wait = 0.5 if timeout is None else min(0.5, max(0, timeout - (now - started)))
+            time.sleep(wait)
+    finally:
+        # SwiftPM children can create their own groups; killing only the root group leaks them.
+        propagating_error = sys.exc_info()[0] is not None
+        previous_interrupt = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        try:
+            if process is None:
+                pass
+            elif ownership is None:
+                stop_unreaped_child(process)
+            else:
+                ownership.drain(process)
+        except BaseException as error:
+            if not propagating_error:
+                raise
+            print(f"Cleanup also failed: {type(error).__name__}: {error}", file=sys.stderr, flush=True)
+        finally:
+            signal.signal(signal.SIGINT, previous_interrupt)
 
 
 def swift_test_list(swift_command: list[str]) -> list[TestSelection]:

--- a/Scripts/test_swift_test_process_cleanup.py
+++ b/Scripts/test_swift_test_process_cleanup.py
@@ -261,6 +261,191 @@ class ProcessIdentityTests(unittest.TestCase):
         stop.assert_called_once_with(process)
 
 
+@unittest.skipUnless(sys.platform == "darwin", "requires Darwin audit-token signaling")
+class DarwinSignalTests(unittest.TestCase):
+    child = runner.TestProcess(20, 10, 20, (101, 123))
+
+    def setUp(self):
+        self.ownership = runner.TestProcessOwnership(runner.TestProcess(10, 1, 10, (100, 0)))
+        self.ownership.known[self.child.pid] = self.child.birth
+        self.generation = 41
+
+    def metadata(self, pid, flavor, offset, pointer, size):
+        self.assertEqual((pid, flavor, offset, size), (20, 18, 0, 192))
+        info = pointer._obj
+        info.bsd.pid, info.bsd.parent = pid, self.child.parent
+        info.bsd.seconds, info.bsd.microseconds = self.child.birth
+        info.unique.pidversion = self.generation
+        return size
+
+    def send_with_native(self, native, metadata=None):
+        # Fake PIDs never reach any real signal API, including the pre-fix numeric path.
+        with patch.object(runner, "test_process", return_value=self.child), \
+                patch.object(runner._libproc, "proc_pidinfo", side_effect=metadata or self.metadata), \
+                patch.object(runner, "_proc_signal_with_audittoken", native, create=True), \
+                patch.object(runner.os, "kill") as kill:
+            try:
+                self.ownership.send(self.child, signal.SIGTERM)
+            finally:
+                kill.assert_not_called()
+
+    def test_generation_change_between_metadata_and_signal_never_signals_replacement(self):
+        delivered = []
+        captured = []
+        def native(pointer, sig):
+            token = pointer._obj
+            captured.append((token.val[5], token.val[7], sig))
+            self.generation += 1  # deterministic replacement after the combined read
+            if token.val[7] != self.generation:
+                return errno.ESRCH
+            delivered.append(token.val[5])
+            return 0
+        self.send_with_native(native)
+        self.assertEqual(captured, [(20, 41, signal.SIGTERM)])
+        self.assertEqual(delivered, [])
+
+    def test_same_birth_exec_refreshes_generation_on_later_attempt(self):
+        tokens = []
+        def native(pointer, sig):
+            tokens.append(pointer._obj.val[7])
+            if len(tokens) == 1:
+                self.generation += 1
+                return errno.ESRCH
+            return 0
+        self.send_with_native(native)
+        self.send_with_native(native)
+        self.assertEqual(tokens, [41, 42])
+
+    def test_success_uses_return_value_not_stale_errno_or_numeric_pid(self):
+        def native(pointer, sig):
+            self.assertEqual(list(pointer._obj.val), [0, 0, 0, 0, 0, 20, 0, 41])
+            ctypes.set_errno(errno.EPERM)
+            return 0
+        send = Mock(side_effect=native)
+        self.send_with_native(send)
+        send.assert_called_once()
+
+    def test_native_errno_is_preserved_without_numeric_fallback(self):
+        for error in (errno.EPERM, errno.EACCES, errno.EIO, errno.EINVAL, errno.ENOSYS, errno.ENOENT):
+            with self.subTest(errno=error):
+                ctypes.set_errno(errno.ESRCH)
+                with self.assertRaises(OSError) as raised:
+                    self.send_with_native(Mock(return_value=error))
+                self.assertEqual(raised.exception.errno, error)
+
+    def test_missing_native_api_fails_closed(self):
+        with self.assertRaises(OSError) as raised:
+            self.send_with_native(None)
+        self.assertEqual(raised.exception.errno, errno.ENOSYS)
+
+    def test_combined_birth_mismatch_never_sends(self):
+        def metadata(*args):
+            size = self.metadata(*args)
+            args[3]._obj.bsd.microseconds += 1
+            return size
+        send = Mock(return_value=0)
+        self.send_with_native(send, metadata)
+        send.assert_not_called()
+
+    def test_combined_metadata_errors_do_not_become_success(self):
+        for error in (errno.ESRCH, errno.ENOENT, errno.EPERM, errno.EACCES, errno.EIO, errno.EINVAL, 0):
+            def metadata(*_):
+                ctypes.set_errno(error)
+                return 0
+            send = Mock(return_value=0)
+            with self.subTest(errno=error):
+                if error in (errno.ESRCH, errno.ENOENT):
+                    self.send_with_native(send, metadata)
+                else:
+                    with self.assertRaises(OSError) as raised:
+                        self.send_with_native(send, metadata)
+                    self.assertEqual(raised.exception.errno, error or errno.EIO)
+                send.assert_not_called()
+
+    def test_partial_combined_metadata_is_io_error_even_with_stale_esrch(self):
+        def metadata(*_):
+            ctypes.set_errno(errno.ESRCH)
+            return 136
+        with self.assertRaises(OSError) as raised:
+            self.send_with_native(Mock(return_value=0), metadata)
+        self.assertEqual(raised.exception.errno, errno.EIO)
+
+
+@unittest.skipUnless(sys.platform == "darwin", "requires native Darwin audit-token signaling")
+class DarwinNativeSignalTests(unittest.TestCase):
+    def exercise(self, sig):
+        self.assertEqual(ctypes.sizeof(runner.ProcBSDInfo), 136)
+        self.assertEqual(ctypes.sizeof(runner.ProcUniqueIdentifierInfo), 56)
+        self.assertEqual(runner.ProcUniqueIdentifierInfo.pidversion.offset, 32)
+        self.assertEqual(runner.ProcBSDInfoWithUniqueID.unique.offset, 136)
+        self.assertEqual(ctypes.sizeof(runner.ProcBSDInfoWithUniqueID), 192)
+        self.assertEqual(ctypes.sizeof(runner.AuditToken), 32)
+        native = runner._proc_signal_with_audittoken
+        self.assertIsNotNone(native, "native signal API must be available on supported macOS")
+        with tempfile.TemporaryDirectory(prefix="codexbar-audit-signal-") as directory:
+            root = Path(directory)
+            processes = []
+            def start(name, mode):
+                path = root / name
+                path.mkdir()
+                process = subprocess.Popen([sys.executable, __file__, "--fixture", mode, str(path)],
+                                           start_new_session=True)
+                processes.append(process)
+                wait_until(lambda: (path / "pid").exists())
+                return process
+            def identity(pid):
+                info = runner.darwin_pidinfo(pid, 18, runner.ProcBSDInfoWithUniqueID())
+                return (info.bsd.pid, info.bsd.parent, info.bsd.seconds, info.bsd.microseconds,
+                        info.unique.pidversion & 0xFFFFFFFF)
+            try:
+                sentinel = start("sentinel", "sentinel")
+                child = start("child", "child" if sig == signal.SIGTERM else "stubborn")
+                before, sentinel_before = identity(child.pid), identity(sentinel.pid)
+                tracked = runner.test_process(child.pid)
+                self.assertEqual(before[:4], (child.pid, os.getpid(), *tracked.birth))
+                ownership = runner.TestProcessOwnership(runner.test_process(os.getpid()))
+                ownership.known[child.pid] = tracked.birth
+                wrong = runner.AuditToken()
+                wrong.val[5], wrong.val[7] = child.pid, before[4] ^ 1
+                wrong_result = native(ctypes.byref(wrong), sig)
+                self.assertEqual(wrong_result, errno.ESRCH)
+                time.sleep(0.1)
+                after_wrong = identity(child.pid)
+                self.assertEqual(after_wrong, before)
+                self.assertIsNone(runner.unreaped_exit_code(child), "wrong generation signaled the live fixture")
+                self.assertIsNone(child.returncode, "fixture must remain wait-owned until matching signal")
+                results = []
+                def matching(pointer, requested):
+                    self.assertEqual((pointer._obj.val[5], pointer._obj.val[7], requested),
+                                     (child.pid, before[4], sig))
+                    result = native(pointer, requested)
+                    results.append(result)
+                    return result
+                with patch.object(runner, "_proc_signal_with_audittoken", side_effect=matching), \
+                        patch.object(runner.os, "kill") as kill:
+                    ownership.send(tracked, sig)
+                    kill.assert_not_called()
+                self.assertEqual(results, [0])
+                self.assertEqual(child.wait(timeout=3), -sig)
+                self.assertEqual(identity(sentinel.pid), sentinel_before)
+                self.assertIsNone(runner.unreaped_exit_code(sentinel), "unrelated sentinel was signaled")
+                print(json.dumps(dict(signal=sig.name, before=before, after_wrong=after_wrong,
+                                      wrong_pidversion=wrong.val[7], wrong_result=wrong_result,
+                                      matching_results=results, reaped_status=child.returncode,
+                                      unrelated_sentinel_alive=True)), flush=True)
+            finally:
+                for path in root.iterdir():
+                    (path / "stop").touch()
+                for process in processes:
+                    runner.stop_unreaped_child(process)
+
+    def test_wrong_generation_survives_then_matching_identity_terms_and_reaps(self):
+        self.exercise(signal.SIGTERM)
+
+    def test_wrong_generation_survives_then_matching_identity_kills_and_reaps(self):
+        self.exercise(signal.SIGKILL)
+
+
 class ReviewRegressionTests(unittest.TestCase):
     def test_recycled_sid_without_replacement_leader_is_not_adopted(self):
         root = runner.TestProcess(10, 1, 10, (100, 0))

--- a/Scripts/test_swift_test_process_cleanup.py
+++ b/Scripts/test_swift_test_process_cleanup.py
@@ -1,0 +1,750 @@
+#!/usr/bin/env python3
+"""Synthetic process ownership tests; never launch Swift or inspect provider data."""
+
+import ctypes
+import errno
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from unittest.mock import Mock, patch
+
+import ci_swift_test_by_suite as runner
+
+
+def running(pid: int) -> bool:
+    result = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "stat="], capture_output=True, text=True, timeout=2
+    )
+    return bool(result.stdout.strip()) and not result.stdout.strip().startswith("Z")
+
+
+def wait_until(predicate, timeout=3):
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() >= deadline:
+            raise AssertionError("condition did not become true within its bound")
+        time.sleep(0.05)
+
+
+def fixture(mode, directory):
+    root = Path(directory)
+    if mode == "session-leader":
+        (root / "pid").write_text(str(os.getpid()))
+        grandchild = root / "grandchild"
+        grandchild.mkdir()
+        subprocess.Popen([sys.executable, __file__, "--fixture", "child", str(grandchild)])
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline and not (root / "stop").exists():
+            time.sleep(0.05)
+        return
+    if mode in ("child", "stubborn", "sentinel"):
+        if os.getpgrp() != os.getpid():
+            os.setpgid(0, 0)
+        if mode == "stubborn":
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        (root / "pid").write_text(str(os.getpid()))
+        # Self-expiry and the stop file also contain pre-fix failures without fuzzy process kills.
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline and not (root / "stop").exists():
+            time.sleep(0.05)
+        return
+
+    child_mode = "stubborn" if mode == "timeout-stubborn" else "child"
+    if mode == "success-session-tree":
+        child_mode = "session-leader"
+    (root / "parent-pid").write_text(str(os.getpid()))
+    subprocess.Popen(
+        [sys.executable, __file__, "--fixture", child_mode, str(root)],
+        start_new_session=mode in ("timeout-session", "success-session", "success-session-tree"),
+    )
+    signal.signal(signal.SIGTERM, lambda *_: os._exit(0))
+    wait_until(lambda: (root / "pid").exists())
+    # Keep the ancestry visible before success/failure/interrupt or timeout.
+    time.sleep(1.2)
+    if mode in ("success", "success-session", "success-session-tree"):
+        return
+    if mode == "failure":
+        raise SystemExit(23)
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline and not (root / "stop").exists():
+        time.sleep(0.05)
+
+
+class ProcessCleanupTests(unittest.TestCase):
+    def exercise(self, mode, expected, interrupt=False):
+        with tempfile.TemporaryDirectory(prefix="codexbar-process-cleanup-") as directory:
+            root = Path(directory)
+            child_root = root / "child"
+            sentinel_root = root / "sentinel"
+            child_root.mkdir()
+            sentinel_root.mkdir()
+            sentinel = subprocess.Popen(
+                [sys.executable, __file__, "--fixture", "sentinel", str(sentinel_root)],
+                start_new_session=True,
+            )
+            timer = None
+            try:
+                wait_until(lambda: (sentinel_root / "pid").exists())
+                if interrupt:
+                    timer = threading.Timer(2, lambda: os.kill(os.getpid(), signal.SIGINT))
+                    timer.start()
+                started = time.monotonic()
+                command = [sys.executable, __file__, "--fixture", mode, str(child_root)]
+                original_drain = runner.TestProcessOwnership.drain
+                def drain(ownership, process):
+                    try:
+                        self.assertIsNone(process.returncode, "root was reaped before cleanup")
+                        first = runner.unreaped_exit_code(process)
+                        if first is not None:
+                            self.assertEqual(runner.unreaped_exit_code(process), first)
+                        else:
+                            info = runner.test_process(process.pid)
+                            if info is not None:
+                                self.assertEqual(info.birth, ownership.root.birth)
+                    finally:
+                        original_drain(ownership, process)
+                    self.assertIsNotNone(process.returncode, "root was not reaped after cleanup")
+                with patch.object(runner.TestProcessOwnership, "drain", drain):
+                    if interrupt:
+                        with self.assertRaises(KeyboardInterrupt):
+                            runner.run_command(command, timeout=8)
+                    else:
+                        self.assertEqual(runner.run_command(command, timeout=2), expected)
+                elapsed = time.monotonic() - started
+                child = int((child_root / "pid").read_text())
+                self.assertFalse(running(child), f"owned child {child} survived command completion")
+                for pid_file in child_root.rglob("pid"):
+                    self.assertFalse(running(int(pid_file.read_text())), f"owned helper {pid_file} survived")
+                self.assertFalse(running(int((child_root / "parent-pid").read_text())))
+                self.assertIsNone(sentinel.poll(), "unrelated sentinel was terminated")
+                self.assertLess(elapsed, 9, "cleanup exceeded bounded grace")
+                print(json.dumps(dict(mode=mode, elapsed=round(elapsed, 3), child_terminated=True,
+                                      unrelated_sentinel_alive=True)), flush=True)
+            finally:
+                if timer is not None:
+                    timer.cancel()
+                    timer.join()
+                (child_root / "stop").touch()
+                for pid_file in child_root.rglob("pid"):
+                    (pid_file.parent / "stop").touch()
+                (sentinel_root / "stop").touch()
+                sentinel.wait(timeout=3)
+                for pid_file in child_root.rglob("pid"):
+                    child = int(pid_file.read_text())
+                    wait_until(lambda: not running(child))
+                if (child_root / "parent-pid").exists():
+                    parent = int((child_root / "parent-pid").read_text())
+                    wait_until(lambda: not running(parent))
+
+    def test_timeout_drains_separate_child_group_after_parent_exits_on_term(self):
+        self.exercise("timeout", 124)
+
+    def test_timeout_escalates_for_term_ignoring_child(self):
+        self.exercise("timeout-stubborn", 124)
+
+    def test_timeout_retains_observed_child_after_it_starts_a_separate_session(self):
+        self.exercise("timeout-session", 124)
+
+    def test_success_drains_lingering_child_without_touching_sentinel(self):
+        self.exercise("success", 0)
+
+    def test_success_allows_and_drains_a_separate_session(self):
+        self.exercise("success-session", 0)
+
+    def test_success_drains_observed_child_session_and_its_grandchild(self):
+        self.exercise("success-session-tree", 0)
+
+    def test_signal_exit_status_is_preserved(self):
+        self.assertEqual(runner.run_command(["/bin/sh", "-c", "kill -TERM $$"], timeout=2), -signal.SIGTERM)
+
+    def test_failure_drains_lingering_child_and_preserves_exit_code(self):
+        self.exercise("failure", 23)
+
+    def test_keyboard_interrupt_drains_children_and_propagates(self):
+        self.exercise("timeout", None, interrupt=True)
+
+
+class ProcessIdentityTests(unittest.TestCase):
+    def test_native_identity_matches_own_parent_and_session(self):
+        info = runner.test_process(os.getpid())
+        self.assertIsNotNone(info)
+        self.assertEqual(info.parent, os.getppid())
+        self.assertEqual(info.session, os.getsid(0))
+        self.assertGreater(info.birth[0], 0)
+
+    def test_reparenting_preserves_observed_child_ownership(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        child = runner.TestProcess(20, 10, 20, (101, 0))
+        orphan = runner.TestProcess(20, 1, 20, child.birth)
+        peer = runner.TestProcess(30, 1, 30, (102, 0))
+        ownership = runner.TestProcessOwnership(root)
+        with patch.object(runner, "test_process_snapshot", side_effect=[{10: root, 20: child}, {20: orphan, 30: peer}]):
+            self.assertEqual(set(ownership.refresh()), {10, 20})
+            self.assertEqual(set(ownership.refresh()), {20})
+
+    def test_root_pid_reuse_does_not_claim_the_new_session(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        replacement = runner.TestProcess(10, 1, 10, (200, 0))
+        peer = runner.TestProcess(30, 10, 10, (201, 0))
+        ownership = runner.TestProcessOwnership(root)
+        with patch.object(runner, "test_process_snapshot", return_value={10: replacement, 30: peer}):
+            with self.assertRaisesRegex(RuntimeError, "session continuity"):
+                ownership.refresh()
+        self.assertNotIn(30, ownership.known)
+
+    def test_stale_parent_pid_does_not_claim_a_process_older_than_its_parent(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        stale = runner.TestProcess(20, 10, 20, (99, 0))
+        ownership = runner.TestProcessOwnership(root)
+        with patch.object(runner, "test_process_snapshot", return_value={10: root, 20: stale}):
+            self.assertEqual(set(ownership.refresh()), {10})
+
+    def test_pid_reuse_is_rechecked_immediately_before_signal(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        replacement = runner.TestProcess(10, 1, 10, (200, 0))
+        ownership = runner.TestProcessOwnership(root)
+        with patch.object(runner, "test_process", return_value=replacement), \
+                patch.object(runner.sys, "platform", "darwin"), patch.object(runner.os, "kill") as kill:
+            ownership.send(root, signal.SIGTERM)
+        kill.assert_not_called()
+
+    def test_linux_stat_parser_preserves_birth_ticks_with_parentheses_in_command(self):
+        fields = ["S", "11", "123", "123", *(["0"] * 15), "456", "0"]
+        with patch.object(runner.sys, "platform", "linux"), \
+                patch.object(runner.Path, "read_bytes", return_value=("123 (tool ) name) " + " ".join(fields)).encode()):
+            self.assertEqual(runner.test_process(123), runner.TestProcess(123, 11, 123, (456, 0)))
+
+    def test_linux_signals_the_pinned_identity(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        ownership = runner.TestProcessOwnership(root)
+        with patch.object(runner, "test_process", return_value=root), \
+                patch.object(runner.sys, "platform", "linux"), \
+                patch.object(runner.os, "pidfd_open", return_value=77, create=True), \
+                patch.object(runner.signal, "pidfd_send_signal", create=True) as send, \
+                patch.object(runner.os, "close") as close, patch.object(runner.os, "kill") as kill:
+            ownership.send(root, signal.SIGTERM)
+        send.assert_called_once_with(77, signal.SIGTERM)
+        close.assert_called_once_with(77)
+        kill.assert_not_called()
+
+    def test_undrained_child_fails_closed_after_bounded_grace(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        ownership = runner.TestProcessOwnership(root)
+        process = Mock()
+        with patch.object(ownership, "refresh", return_value={10: root}), \
+                patch.object(ownership, "send") as send, \
+                patch.object(runner, "stop_unreaped_child") as stop, \
+                patch.object(runner.time, "monotonic", side_effect=[0, 0, 3.1, 5.1]), \
+                patch.object(runner.time, "sleep"):
+            with self.assertRaisesRegex(RuntimeError, "Could not drain"):
+                ownership.drain(process)
+        self.assertEqual([call.args[1] for call in send.call_args_list], [signal.SIGTERM, signal.SIGKILL])
+        stop.assert_called_once_with(process)
+
+    def test_enumeration_failure_stops_known_identities_and_does_not_report_success(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        ownership = runner.TestProcessOwnership(root)
+        process = Mock()
+        with patch.object(ownership, "refresh", side_effect=OSError("enumeration unavailable")), \
+                patch.object(runner, "test_process", return_value=root), patch.object(ownership, "send") as send, \
+                patch.object(runner, "stop_unreaped_child") as stop:
+            with self.assertRaisesRegex(OSError, "enumeration unavailable"):
+                ownership.drain(process)
+        send.assert_called_once_with(root, signal.SIGKILL)
+        stop.assert_called_once_with(process)
+
+
+class ReviewRegressionTests(unittest.TestCase):
+    def test_recycled_sid_without_replacement_leader_is_not_adopted(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        peer = runner.TestProcess(30, 1, 10, (201, 0))
+        ownership = runner.TestProcessOwnership(root)
+        with patch.object(runner, "test_process_snapshot", return_value={30: peer}):
+            with self.assertRaisesRegex(RuntimeError, "session continuity"):
+                ownership.refresh()
+        self.assertNotIn(30, ownership.known)
+
+    @unittest.skipUnless(sys.platform == "darwin", "Darwin native race regression")
+    def test_darwin_getsid_exit_race_preserves_birth(self):
+        def live_info(pid, flavor, offset, pointer, size):
+            info = pointer._obj
+            info.pid, info.parent, info.state = pid, 11, 2
+            info.seconds, info.microseconds = 456, 789
+            return size
+        with patch.object(runner._libproc, "proc_pidinfo", side_effect=live_info), \
+                patch.object(runner.os, "getsid", side_effect=ProcessLookupError(errno.ESRCH, "exited")):
+            info = runner.test_process(123)
+        self.assertIsNotNone(info)
+        self.assertEqual(info.birth, (456, 789))
+
+    def test_known_unreadable_linux_metadata_fails_snapshot_but_unrelated_peer_does_not(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        fields = b"10 (root) S 1 10 10 " + b"0 " * 15 + b"100 0"
+        def read(path):
+            if str(path) == "/proc/10/stat":
+                return fields
+            raise PermissionError(errno.EACCES, "denied")
+        ownership = runner.TestProcessOwnership(root)
+        with patch.object(runner.sys, "platform", "linux"), \
+                patch.object(runner.subprocess, "check_output", return_value="10 20"), \
+                patch.object(runner.Path, "read_bytes", autospec=True, side_effect=read):
+            self.assertEqual(set(ownership.refresh()), {10})
+            ownership.known[20] = (101, 0)
+            with self.assertRaises(PermissionError):
+                ownership.refresh()
+
+    @unittest.skipUnless(sys.platform == "darwin", "Darwin native error regression")
+    def test_known_unreadable_darwin_metadata_fails_snapshot_but_unrelated_peer_does_not(self):
+        def denied(*_):
+            ctypes.set_errno(errno.EPERM)
+            return 0
+        with patch.object(runner._libproc, "proc_pidinfo", side_effect=denied), \
+                patch.object(runner.subprocess, "check_output", return_value="123"):
+            self.assertEqual(runner.test_process_snapshot(), {})
+            with self.assertRaises(PermissionError):
+                runner.TestProcessOwnership(runner.TestProcess(123, 1, 123, (100, 0))).refresh()
+
+    def test_linux_metadata_permission_failure_is_not_exit(self):
+        with patch.object(runner.sys, "platform", "linux"), \
+                patch.object(runner.Path, "read_bytes", side_effect=PermissionError(errno.EACCES, "denied")), \
+                patch.object(runner.Path, "read_text", side_effect=PermissionError(errno.EACCES, "denied")):
+            with self.assertRaises(PermissionError):
+                runner.test_process(123)
+
+    def test_linux_stat_does_not_decode_invalid_command_bytes(self):
+        fields = [b"S", b"11", b"123", b"123", *([b"0"] * 15), b"456", b"0"]
+        raw = b"123 (tool ) \xff\xe2) " + b" ".join(fields)
+        with patch.object(runner.sys, "platform", "linux"), \
+                patch.object(runner.Path, "read_bytes", return_value=raw), \
+                patch.object(runner.Path, "read_text", side_effect=UnicodeDecodeError("utf8", b"\xff", 0, 1, "invalid")):
+            self.assertEqual(runner.test_process(123).birth, (456, 0))
+
+    def test_linux_zombie_leader_with_other_threads_is_not_dead(self):
+        fields = [b"Z", b"11", b"123", b"123", *([b"0"] * 15), b"456", b"0"]
+        fields[17] = b"2"
+        raw = b"123 (worker) " + b" ".join(fields)
+        with patch.object(runner.sys, "platform", "linux"), \
+                patch.object(runner.Path, "read_bytes", return_value=raw), \
+                patch.object(runner.Path, "read_text", return_value=raw.decode()):
+            self.assertFalse(runner.test_process(123).zombie)
+
+    def test_linux_zombie_leader_is_dead_only_after_last_thread_exits(self):
+        fields = [b"Z", b"11", b"123", b"123", *([b"0"] * 15), b"456", b"0"]
+        fields[17] = b"1"
+        with patch.object(runner.sys, "platform", "linux"), \
+                patch.object(runner.Path, "read_bytes", return_value=b"123 (worker) " + b" ".join(fields)):
+            self.assertTrue(runner.test_process(123).zombie)
+
+    def test_linux_confirmed_exit_is_absence_but_truncated_stat_is_uncertain(self):
+        with patch.object(runner.sys, "platform", "linux"):
+            with patch.object(runner.Path, "read_bytes", side_effect=FileNotFoundError(errno.ENOENT, "exited")):
+                self.assertIsNone(runner.test_process(123))
+            with patch.object(runner.Path, "read_bytes", return_value=b"123 (truncated"):
+                with self.assertRaises(OSError) as raised:
+                    runner.test_process(123)
+                self.assertEqual(raised.exception.errno, errno.EIO)
+
+    def test_known_metadata_failure_still_cleans_readable_identities_and_preserves_error(self):
+        ownership = runner.TestProcessOwnership(runner.TestProcess(10, 1, 10, (100, 0)))
+        ownership.known[20] = (101, 0)
+        failure = PermissionError(errno.EACCES, "known identity unavailable")
+        def read(path):
+            if str(path) == "/proc/10/stat":
+                raise failure
+            return b"20 (child) S 10 20 20 " + b"0 " * 15 + b"101 0"
+        process = Mock()
+        with patch.object(runner.sys, "platform", "linux"), \
+                patch.object(runner.subprocess, "check_output", return_value="10 20"), \
+                patch.object(runner.Path, "read_bytes", autospec=True, side_effect=read), \
+                patch.object(ownership, "send") as send, \
+                patch.object(runner, "stop_unreaped_child") as stop:
+            with self.assertRaises(PermissionError) as raised:
+                ownership.drain(process)
+        self.assertIs(raised.exception, failure)
+        self.assertEqual([(call.args[0].pid, call.args[1]) for call in send.call_args_list], [(20, signal.SIGKILL)])
+        stop.assert_called_once_with(process)
+
+    @unittest.skipUnless(sys.platform == "darwin", "Darwin native error regression")
+    def test_darwin_permission_failure_is_not_exit(self):
+        def denied(*_):
+            ctypes.set_errno(errno.EPERM)
+            return 0
+        with patch.object(runner._libproc, "proc_pidinfo", side_effect=denied):
+            with self.assertRaises(OSError):
+                runner.test_process(123)
+
+    @unittest.skipUnless(sys.platform == "darwin", "Darwin native error regression")
+    def test_darwin_only_confirmed_exit_is_absence(self):
+        for error in (errno.ESRCH, errno.ENOENT, errno.EIO, 0):
+            def unavailable(*_):
+                ctypes.set_errno(error)
+                return 0
+            with self.subTest(errno=error), patch.object(runner._libproc, "proc_pidinfo", side_effect=unavailable):
+                if error in (errno.ESRCH, errno.ENOENT):
+                    self.assertIsNone(runner.test_process(123))
+                else:
+                    with self.assertRaises(OSError):
+                        runner.test_process(123)
+
+    def exercise_initialization_failure(self, failure):
+        with tempfile.TemporaryDirectory(prefix="codexbar-init-cleanup-") as directory:
+            root = Path(directory)
+            spawned = []
+            original_spawn = subprocess.Popen
+            original_lookup = runner.test_process
+            def spawn(*args, **kwargs):
+                process = original_spawn(*args, **kwargs)
+                if args[0][0] == sys.executable:
+                    spawned.append(process)
+                return process
+            first = True
+            def lookup(pid, *args, **kwargs):
+                nonlocal first
+                if first:
+                    first = False
+                    wait_until(lambda: (root / "pid").exists())
+                    if failure is not None:
+                        raise failure
+                    return None
+                if failure is None and spawned and pid == spawned[0].pid:
+                    return None
+                return original_lookup(pid, *args, **kwargs)
+            started = time.monotonic()
+            sent = []
+            original_kill = os.kill
+            def kill(pid, sig):
+                if spawned and pid == spawned[0].pid:
+                    sent.append((sig, time.monotonic() - started))
+                return original_kill(pid, sig)
+            try:
+                with patch.object(runner.subprocess, "Popen", side_effect=spawn), \
+                        patch.object(runner, "test_process", side_effect=lookup), \
+                        patch.object(runner.os, "kill", side_effect=kill):
+                    if failure is None:
+                        self.assertEqual(runner.run_command(
+                            [sys.executable, __file__, "--fixture", "stubborn", str(root)], timeout=2), 124)
+                    else:
+                        with self.assertRaises(type(failure)) as raised:
+                            runner.run_command([sys.executable, __file__, "--fixture", "stubborn", str(root)], timeout=2)
+                        self.assertIs(raised.exception, failure)
+                self.assertEqual(len(spawned), 1)
+                self.assertIsNotNone(spawned[0].poll(), "initialization failure leaked direct child")
+                if failure is None:
+                    self.assertEqual([sig for sig, _ in sent], [signal.SIGTERM, signal.SIGKILL])
+                    self.assertGreaterEqual(sent[0][1], 2, "missing metadata shortened the command deadline")
+                    self.assertEqual(spawned[0].returncode, -signal.SIGKILL)
+                self.assertLess(time.monotonic() - started, 9)
+            finally:
+                (root / "stop").touch()
+                for process in spawned:
+                    try:
+                        process.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=2)
+
+    def test_initial_metadata_exception_reaps_direct_child(self):
+        self.exercise_initialization_failure(PermissionError(errno.EACCES, "injected initialization failure"))
+
+    def test_initial_keyboard_interrupt_reaps_direct_child(self):
+        self.exercise_initialization_failure(KeyboardInterrupt())
+
+    def test_initial_missing_metadata_times_out_and_reaps_term_ignoring_child(self):
+        self.exercise_initialization_failure(None)
+
+
+class ExitTransitionTests(unittest.TestCase):
+    def exercise_transition(self, initial, result):
+        process = Mock(pid=10, returncode=None)
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        clock = [0.0]
+        sleeps = []
+        def sleep(seconds):
+            sleeps.append(seconds)
+            clock[0] += seconds
+        def wait(timeout):
+            self.assertGreaterEqual(clock[0], 1, "root was reaped before its exit was waitable")
+            process.returncode = result
+            return result
+        process.wait.side_effect = wait
+        lookup = [None if initial else root]
+        def metadata(_pid):
+            return lookup.pop() if lookup else None
+        def waitid(*_args):
+            return None if clock[0] < 1 else Mock(si_code=os.CLD_EXITED, si_status=result)
+        with patch.object(runner.subprocess, "Popen", return_value=process), \
+                patch.object(runner, "test_process", side_effect=metadata), \
+                patch.object(runner, "test_process_snapshot", return_value={}), \
+                patch.object(runner.os, "waitid", side_effect=waitid), \
+                patch.object(runner.os, "kill") as kill, \
+                patch.object(runner.time, "monotonic", side_effect=lambda: clock[0]), \
+                patch.object(runner.time, "sleep", side_effect=sleep):
+            self.assertEqual(runner.run_command(["synthetic-exit-transition"], timeout=2), result)
+        self.assertEqual(sleeps, [0.5, 0.5], "transition must use ordinary polling, without extra grace")
+        kill.assert_not_called()
+        process.wait.assert_called_once_with(timeout=1)
+        self.assertEqual(process.returncode, result)
+
+    def test_initial_missing_metadata_then_pending_wait_then_success(self):
+        self.exercise_transition(True, 0)
+
+    def test_initial_missing_metadata_then_pending_wait_then_nonzero_exit(self):
+        self.exercise_transition(True, 23)
+
+    def test_later_missing_metadata_then_pending_wait_then_success(self):
+        self.exercise_transition(False, 0)
+
+    def test_later_missing_metadata_then_pending_wait_then_nonzero_exit(self):
+        self.exercise_transition(False, 23)
+
+    def test_pending_hidden_root_remains_live_and_anchors_orphan_session(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        orphan = runner.TestProcess(20, 1, 10, (101, 0))
+        ownership = runner.TestProcessOwnership(root, Mock(pid=10, returncode=None))
+        with patch.object(runner, "test_process_snapshot", return_value={20: orphan}), \
+                patch.object(runner.os, "waitid", return_value=None):
+            owned = ownership.refresh()
+        self.assertEqual(set(owned), {10, 20})
+        self.assertFalse(owned[10].zombie)
+        self.assertEqual(owned[10].birth, root.birth)
+
+    def test_hidden_root_signal_requires_wait_ownership_not_placeholder_birth(self):
+        root = runner.TestProcess(10, 1, 10, (0, 0))
+        ownership = runner.TestProcessOwnership(root, Mock(pid=10, returncode=None))
+        with patch.object(runner, "test_process", return_value=None), \
+                patch.object(runner.os, "waitid", side_effect=ChildProcessError()), \
+                patch.object(runner.os, "kill") as kill:
+            with self.assertRaises(ChildProcessError):
+                ownership.send(root, signal.SIGKILL)
+        kill.assert_not_called()
+
+    def test_permanently_pending_transition_times_out_and_fails_undrained_cleanup(self):
+        process = Mock(pid=10, returncode=None)
+        clock = [0.0]
+        signals = []
+        def sleep(seconds):
+            clock[0] += seconds
+        def wait(timeout):
+            clock[0] += timeout
+            raise subprocess.TimeoutExpired("synthetic-pending-transition", timeout)
+        process.wait.side_effect = wait
+        with patch.object(runner.subprocess, "Popen", return_value=process), \
+                patch.object(runner, "test_process", return_value=None), \
+                patch.object(runner, "test_process_snapshot", return_value={}), \
+                patch.object(runner.os, "waitid", return_value=None), \
+                patch.object(runner.os, "kill", side_effect=lambda pid, sig: signals.append((pid, sig, clock[0]))), \
+                patch.object(runner.time, "monotonic", side_effect=lambda: clock[0]), \
+                patch.object(runner.time, "sleep", side_effect=sleep):
+            with self.assertRaisesRegex(RuntimeError, "Could not drain"):
+                runner.run_command(["synthetic-pending-transition"], timeout=2)
+        self.assertEqual(signals[0], (10, signal.SIGTERM, 2.0))
+        self.assertTrue(any(sig == signal.SIGKILL and when >= 5 for _, sig, when in signals))
+        self.assertLess(clock[0], 13, "pending transition must not create an unbounded retry")
+        self.assertIsNone(process.returncode, "unwaitable root must never be reported reaped")
+
+
+class AnchorSemanticsTests(unittest.TestCase):
+    def test_lost_direct_child_wait_ownership_never_signals_numeric_pid(self):
+        process = Mock(pid=10, returncode=None)
+        with patch.object(runner.os, "waitid", side_effect=ChildProcessError()), \
+                patch.object(runner.os, "kill") as kill:
+            with self.assertRaises(ChildProcessError):
+                runner.stop_unreaped_child(process)
+        kill.assert_not_called()
+
+    def test_exited_root_hidden_from_native_metadata_still_anchors_orphan_session(self):
+        root = runner.TestProcess(10, 1, 10, (100, 0))
+        orphan = runner.TestProcess(20, 1, 10, (101, 0))
+        process = Mock(pid=10, returncode=None)
+        ownership = runner.TestProcessOwnership(root, process)
+        with patch.object(runner, "test_process_snapshot", return_value={20: orphan}), \
+                patch.object(runner, "unreaped_exit_code", return_value=0):
+            self.assertEqual(set(ownership.refresh()), {20})
+
+    def test_command_exited_before_initial_native_lookup_preserves_status(self):
+        original_lookup = runner.test_process
+        spawned = []
+        original_spawn = subprocess.Popen
+        def spawn(*args, **kwargs):
+            process = original_spawn(*args, **kwargs)
+            if args[0][0] == "/bin/sh":
+                spawned.append(process)
+            return process
+        def lookup(pid):
+            if spawned and pid == spawned[0].pid:
+                wait_until(lambda: runner.unreaped_exit_code(spawned[0]) is not None)
+                return None
+            return original_lookup(pid)
+        try:
+            with patch.object(runner.subprocess, "Popen", side_effect=spawn), \
+                    patch.object(runner, "test_process", side_effect=lookup):
+                self.assertEqual(runner.run_command(["/bin/sh", "-c", "exit 23"], timeout=2), 23)
+            self.assertEqual(spawned[0].returncode, 23)
+        finally:
+            for process in spawned:
+                runner.stop_unreaped_child(process)
+
+    def test_waitid_observes_exit_repeatedly_without_reaping_session_anchor(self):
+        with tempfile.TemporaryDirectory(prefix="codexbar-waitid-anchor-") as directory:
+            root = Path(directory)
+            process = subprocess.Popen([sys.executable, __file__, "--fixture", "success", directory],
+                                       start_new_session=True)
+            try:
+                options = os.WEXITED | os.WNOHANG | os.WNOWAIT
+                wait_until(lambda: os.waitid(os.P_PID, process.pid, options) is not None)
+                first = os.waitid(os.P_PID, process.pid, options)
+                second = os.waitid(os.P_PID, process.pid, options)
+                self.assertEqual(first.si_pid, process.pid)
+                self.assertEqual(first.si_status, 0)
+                self.assertEqual(first, second)
+                self.assertIsNone(process.returncode)
+                child = int((root / "pid").read_text())
+                self.assertTrue(running(child))
+                self.assertEqual(os.getsid(child), process.pid)
+                (root / "stop").touch()
+                wait_until(lambda: not running(child))
+                self.assertEqual(process.wait(timeout=2), 0)
+                with self.assertRaises(ChildProcessError):
+                    os.waitid(os.P_PID, process.pid, options)
+                print("waitid WNOWAIT: repeated exit observation retained anchor and orphan SID until explicit reap", flush=True)
+            finally:
+                (root / "stop").touch()
+                try:
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=2)
+
+
+class SessionOwnershipTests(unittest.TestCase):
+    root = runner.TestProcess(10, 1, 10, (100, 0))
+    leader = runner.TestProcess(20, 10, 20, (101, 0))
+    helper = runner.TestProcess(30, 1, 20, (102, 0))
+
+    def refresh(self, ownership, *infos):
+        snapshot = {info.pid: info for info in infos}
+        with patch.object(runner, "test_process_snapshot", return_value=snapshot), \
+                patch.object(runner, "test_process", side_effect=snapshot.get):
+            return ownership.refresh()
+
+    def test_live_child_session_anchor_adopts_reparented_grandchild(self):
+        ownership = runner.TestProcessOwnership(self.root)
+        self.refresh(ownership, self.root, self.leader)
+        self.assertEqual(set(self.refresh(ownership, self.root, self.leader, self.helper)), {10, 20, 30})
+        self.assertEqual(set(self.refresh(ownership, self.root, self.helper)), {10, 30})
+        self.assertEqual(set(self.refresh(ownership, self.root)), {10})
+
+    def test_unreaped_child_session_anchor_adopts_reparented_grandchild(self):
+        ownership = runner.TestProcessOwnership(self.root)
+        self.refresh(ownership, self.root, self.leader)
+        zombie = runner.TestProcess(20, 1, 0, self.leader.birth, True)
+        self.assertEqual(set(self.refresh(ownership, self.root, zombie, self.helper)), {10, 30})
+
+    def test_lost_child_session_anchor_fails_without_claiming_unknown_member(self):
+        ownership = runner.TestProcessOwnership(self.root)
+        self.refresh(ownership, self.root, self.leader)
+        with self.assertRaisesRegex(RuntimeError, "session continuity"):
+            self.refresh(ownership, self.root, self.helper)
+        self.assertNotIn(30, ownership.known)
+
+    def test_reused_child_session_anchor_does_not_claim_unrelated_member(self):
+        ownership = runner.TestProcessOwnership(self.root)
+        self.refresh(ownership, self.root, self.leader)
+        replacement = runner.TestProcess(20, 1, 20, (200, 0))
+        with self.assertRaisesRegex(RuntimeError, "session continuity"):
+            self.refresh(ownership, self.root, replacement, self.helper)
+        self.assertEqual(ownership.known[20], self.leader.birth)
+        self.assertNotIn(30, ownership.known)
+
+    def test_completed_empty_child_session_retires_without_rejecting_later_peer(self):
+        ownership = runner.TestProcessOwnership(self.root)
+        self.refresh(ownership, self.root, self.leader)
+        self.assertEqual(set(self.refresh(ownership, self.root)), {10})
+        self.assertEqual(set(self.refresh(ownership, self.root, self.helper)), {10})
+
+    def test_session_anchor_is_rechecked_after_member_enumeration(self):
+        ownership = runner.TestProcessOwnership(self.root)
+        self.refresh(ownership, self.root, self.leader)
+        snapshot = {10: self.root, 20: self.leader, 30: self.helper}
+        with patch.object(runner, "test_process_snapshot", return_value=snapshot), \
+                patch.object(runner, "test_process", side_effect=lambda pid: self.root if pid == 10 else None):
+            with self.assertRaisesRegex(RuntimeError, "session continuity"):
+                ownership.refresh()
+        self.assertNotIn(30, ownership.known)
+
+
+@unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux /proc and pthread_exit semantics")
+class LinuxThreadGroupTests(unittest.TestCase):
+    def test_native_zombie_leader_with_live_worker_is_killed_and_reaped(self):
+        with tempfile.TemporaryDirectory(prefix="codexbar-linux-thread-group-") as directory:
+            root = Path(directory)
+            source = root / "thread.c"
+            binary = root / "thread"
+            stop = root / "stop"
+            source.write_text(r'''
+#include <pthread.h>
+#include <signal.h>
+#include <time.h>
+#include <unistd.h>
+static void *worker(void *stop) {
+    time_t deadline = time(NULL) + 20;
+    while (time(NULL) < deadline && access(stop, F_OK) != 0) usleep(10000);
+    return NULL;
+}
+int main(int argc, char **argv) {
+    if (argc != 2) return 2;
+    signal(SIGTERM, SIG_IGN);
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, worker, argv[1])) return 3;
+    pthread_exit(NULL);
+}
+''')
+            subprocess.run(["cc", "-pthread", str(source), "-o", str(binary)], check=True, timeout=30)
+            spawned = []
+            original_spawn = subprocess.Popen
+            def spawn(*args, **kwargs):
+                process = original_spawn(*args, **kwargs)
+                if args[0][0] == str(binary):
+                    spawned.append(process)
+                return process
+            observed_live_worker = False
+            original_lookup = runner.test_process
+            def lookup(pid):
+                nonlocal observed_live_worker
+                info = original_lookup(pid)
+                if spawned and pid == spawned[0].pid and info is not None:
+                    fields = Path(f"/proc/{pid}/stat").read_bytes().rsplit(b")", 1)[1].split()
+                    if fields[0] == b"Z" and int(fields[17]) > 1:
+                        self.assertFalse(info.zombie)
+                        observed_live_worker = True
+                return info
+            try:
+                with patch.object(runner.subprocess, "Popen", side_effect=spawn), \
+                        patch.object(runner, "test_process", side_effect=lookup):
+                    self.assertEqual(runner.run_command([str(binary), str(stop)], timeout=1), 124)
+                self.assertTrue(observed_live_worker, "fixture did not expose the Linux zombie-leader state")
+                self.assertEqual(len(spawned), 1)
+                self.assertEqual(spawned[0].returncode, -signal.SIGKILL)
+                self.assertFalse(Path(f"/proc/{spawned[0].pid}").exists())
+            finally:
+                stop.touch()
+                for process in spawned:
+                    try:
+                        process.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=2)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--fixture":
+        fixture(sys.argv[2], sys.argv[3])
+    else:
+        unittest.main()

--- a/Scripts/test_swift_test_process_cleanup.py
+++ b/Scripts/test_swift_test_process_cleanup.py
@@ -33,23 +33,47 @@ def wait_until(predicate, timeout=3):
         time.sleep(0.05)
 
 
-def fixture(mode, directory):
+def publish_fixture_identity(root):
+    info = runner.test_process(os.getpid())
+    assert info is not None
+    (root / "pid").write_text(str(info.pid))
+    ready = root / "ready.tmp"
+    ready.write_text(json.dumps(dict(pid=info.pid, birth=info.birth)))
+    ready.replace(root / "ready")
+
+
+def release_observed_fixture(root, owned, include_grandchild=False):
+    paths = [root, root / "grandchild"] if include_grandchild else [root]
+    for path in paths:
+        try:
+            identity = json.loads((path / "ready").read_text())
+        except FileNotFoundError:
+            return False
+        info = owned.get(identity["pid"])
+        if info is None or info.birth != tuple(identity["birth"]):
+            return False
+    (root / "observed").touch()
+    return True
+
+
+def fixture(mode, directory, ready_delay=0):
     root = Path(directory)
     if mode == "session-leader":
-        (root / "pid").write_text(str(os.getpid()))
+        publish_fixture_identity(root)
         grandchild = root / "grandchild"
         grandchild.mkdir()
         subprocess.Popen([sys.executable, __file__, "--fixture", "child", str(grandchild)])
         deadline = time.monotonic() + 20
         while time.monotonic() < deadline and not (root / "stop").exists():
             time.sleep(0.05)
+        (grandchild / "stop").touch()
         return
     if mode in ("child", "stubborn", "sentinel"):
         if os.getpgrp() != os.getpid():
             os.setpgid(0, 0)
         if mode == "stubborn":
             signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        (root / "pid").write_text(str(os.getpid()))
+        publish_fixture_identity(root)
         # Self-expiry and the stop file also contain pre-fix failures without fuzzy process kills.
         deadline = time.monotonic() + 20
         while time.monotonic() < deadline and not (root / "stop").exists():
@@ -60,14 +84,20 @@ def fixture(mode, directory):
     if mode == "success-session-tree":
         child_mode = "session-leader"
     (root / "parent-pid").write_text(str(os.getpid()))
+    signal.signal(signal.SIGTERM, lambda *_: os._exit(0))
+    if ready_delay:
+        ready_at = time.monotonic() + ready_delay
+        wait_until(lambda: time.monotonic() >= ready_at or (root / "stop").exists())
+        if (root / "stop").exists():
+            return
     subprocess.Popen(
         [sys.executable, __file__, "--fixture", child_mode, str(root)],
         start_new_session=mode in ("timeout-session", "success-session", "success-session-tree"),
     )
-    signal.signal(signal.SIGTERM, lambda *_: os._exit(0))
-    wait_until(lambda: (root / "pid").exists())
-    # Keep the ancestry visible before success/failure/interrupt or timeout.
-    time.sleep(1.2)
+    # Preserve ancestry until the real ownership refresh has observed the ready identities.
+    wait_until(lambda: (root / "observed").exists() or (root / "stop").exists())
+    if (root / "stop").exists():
+        return
     if mode in ("success", "success-session", "success-session-tree"):
         return
     if mode == "failure":
@@ -78,7 +108,7 @@ def fixture(mode, directory):
 
 
 class ProcessCleanupTests(unittest.TestCase):
-    def exercise(self, mode, expected, interrupt=False):
+    def exercise(self, mode, expected, interrupt=False, ready_delay=0):
         with tempfile.TemporaryDirectory(prefix="codexbar-process-cleanup-") as directory:
             root = Path(directory)
             child_root = root / "child"
@@ -96,12 +126,26 @@ class ProcessCleanupTests(unittest.TestCase):
                     timer = threading.Timer(2, lambda: os.kill(os.getpid(), signal.SIGINT))
                     timer.start()
                 started = time.monotonic()
-                command = [sys.executable, __file__, "--fixture", mode, str(child_root)]
+                command = [sys.executable, __file__, "--fixture", mode, str(child_root), str(ready_delay)]
+                original_refresh = runner.TestProcessOwnership.refresh
                 original_drain = runner.TestProcessOwnership.drain
+                acknowledged = False
+                draining = False
+                def refresh(ownership):
+                    nonlocal acknowledged
+                    owned = original_refresh(ownership)
+                    if not acknowledged and not draining:
+                        acknowledged = release_observed_fixture(
+                            child_root, owned, include_grandchild=mode == "success-session-tree")
+                    return owned
                 def drain(ownership, process):
+                    nonlocal draining
+                    draining = True
                     try:
                         self.assertIsNone(process.returncode, "root was reaped before cleanup")
                         first = runner.unreaped_exit_code(process)
+                        if expected in (0, 23):
+                            self.assertEqual(first, expected, "fixture must exit before drain begins")
                         if first is not None:
                             self.assertEqual(runner.unreaped_exit_code(process), first)
                         else:
@@ -111,13 +155,15 @@ class ProcessCleanupTests(unittest.TestCase):
                     finally:
                         original_drain(ownership, process)
                     self.assertIsNotNone(process.returncode, "root was not reaped after cleanup")
-                with patch.object(runner.TestProcessOwnership, "drain", drain):
+                with patch.object(runner.TestProcessOwnership, "refresh", refresh), \
+                        patch.object(runner.TestProcessOwnership, "drain", drain):
                     if interrupt:
                         with self.assertRaises(KeyboardInterrupt):
                             runner.run_command(command, timeout=8)
                     else:
                         self.assertEqual(runner.run_command(command, timeout=2), expected)
                 elapsed = time.monotonic() - started
+                self.assertTrue(acknowledged, "fixture identities were not observed before drain")
                 child = int((child_root / "pid").read_text())
                 self.assertFalse(running(child), f"owned child {child} survived command completion")
                 for pid_file in child_root.rglob("pid"):
@@ -125,7 +171,8 @@ class ProcessCleanupTests(unittest.TestCase):
                 self.assertFalse(running(int((child_root / "parent-pid").read_text())))
                 self.assertIsNone(sentinel.poll(), "unrelated sentinel was terminated")
                 self.assertLess(elapsed, 9, "cleanup exceeded bounded grace")
-                print(json.dumps(dict(mode=mode, elapsed=round(elapsed, 3), child_terminated=True,
+                print(json.dumps(dict(mode=mode, ready_delay=ready_delay, elapsed=round(elapsed, 3),
+                                      observed_before_drain=acknowledged, child_terminated=True,
                                       unrelated_sentinel_alive=True)), flush=True)
             finally:
                 if timer is not None:
@@ -154,6 +201,10 @@ class ProcessCleanupTests(unittest.TestCase):
 
     def test_success_drains_lingering_child_without_touching_sentinel(self):
         self.exercise("success", 0)
+
+    def test_success_after_delayed_readiness_keeps_the_two_second_budget(self):
+        # One second of startup plus the former 1.2-second ancestry sleep exceeds the command budget.
+        self.exercise("success", 0, ready_delay=1)
 
     def test_success_allows_and_drains_a_separate_session(self):
         self.exercise("success-session", 0)
@@ -782,6 +833,12 @@ class AnchorSemanticsTests(unittest.TestCase):
             process = subprocess.Popen([sys.executable, __file__, "--fixture", "success", directory],
                                        start_new_session=True)
             try:
+                wait_until(lambda: (root / "ready").exists())
+                self.assertIsNone(runner.unreaped_exit_code(process))
+                identity = runner.test_process(process.pid)
+                self.assertIsNotNone(identity)
+                ownership = runner.TestProcessOwnership(identity, process)
+                wait_until(lambda: release_observed_fixture(root, ownership.refresh()))
                 options = os.WEXITED | os.WNOHANG | os.WNOWAIT
                 wait_until(lambda: os.waitid(os.P_PID, process.pid, options) is not None)
                 first = os.waitid(os.P_PID, process.pid, options)
@@ -806,6 +863,9 @@ class AnchorSemanticsTests(unittest.TestCase):
                 except subprocess.TimeoutExpired:
                     process.kill()
                     process.wait(timeout=2)
+                if (root / "pid").exists():
+                    child = int((root / "pid").read_text())
+                    wait_until(lambda: not running(child))
 
 
 class SessionOwnershipTests(unittest.TestCase):
@@ -930,6 +990,6 @@ int main(int argc, char **argv) {
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "--fixture":
-        fixture(sys.argv[2], sys.argv[3])
+        fixture(sys.argv[2], sys.argv[3], float(sys.argv[4]) if len(sys.argv) > 4 else 0)
     else:
         unittest.main()

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -247,4 +247,6 @@ grep -Fq "test-list stderr marker" "${TEMP_DIR}/list-failure.log"
 grep -Eq -- '- Discovery seconds: 0\.[1-9]' "${TEMP_DIR}/list-failure.log"
 grep -Fq '| Discovered selections | `0` |' "${GITHUB_STEP_SUMMARY}"
 
+python3 "${ROOT_DIR}/Scripts/test_swift_test_process_cleanup.py"
+
 echo "Swift test sharding tests passed."

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -17,15 +17,26 @@ final class OpenAIDashboardWebViewCache {
 
     private final class ReleaseState {
         var preserveLoadedPageOnRelease: Bool
+        var isReleased = false
 
         init(preserveLoadedPageOnRelease: Bool) {
             self.preserveLoadedPageOnRelease = preserveLoadedPageOnRelease
         }
     }
 
-    private struct AcquireOptions {
-        let allowTimeoutRetry: Bool
-        let preserveLoadedPageOnRelease: Bool
+    private final class Acquisition {
+        let key: ObjectIdentifier
+        var entry: Entry?
+        var isInvalidated = false
+
+        init(key: ObjectIdentifier) {
+            self.key = key
+        }
+
+        func checkCancellation() throws {
+            try Task.checkCancellation()
+            if self.isInvalidated { throw CancellationError() }
+        }
     }
 
     @MainActor
@@ -56,6 +67,7 @@ final class OpenAIDashboardWebViewCache {
         }
     }
 
+    @MainActor
     private final class Entry {
         let webView: WKWebView
         let host: OffscreenWebViewHost
@@ -105,9 +117,17 @@ final class OpenAIDashboardWebViewCache {
             guard let preservedPageExpiresAt else { return false }
             return preservedPageExpiresAt <= now
         }
+
+        func close() {
+            self.isBusy = false
+            self.clearPreservedPage()
+            self.host.close()
+        }
     }
 
     private var entries: [ObjectIdentifier: Entry] = [:]
+    /// Explicit invalidation outlives dictionary removal, but only while an acquire is suspended.
+    private var acquisitions: [ObjectIdentifier: Acquisition] = [:]
     /// Keep the WebView alive only long enough for immediate retries/menu reopens.
     /// Long-lived hidden ChatGPT tabs still consume noticeable energy on some setups.
     private let idleTimeout: TimeInterval
@@ -115,6 +135,8 @@ final class OpenAIDashboardWebViewCache {
     private var idlePruneGeneration = 0
     #if DEBUG
     private(set) var idlePruneDeadlineForTesting: Date?
+    var prepareForTesting: ((WKWebView, TimeInterval, Bool) async throws -> Void)?
+    var didCreateWebViewForTesting: ((WKWebView, AnyObject) -> Void)?
     #endif
     /// Reuse the validated analytics page only for the immediate next handoff.
     private let preservedPageHandoffTimeout: TimeInterval = 5
@@ -160,7 +182,11 @@ final class OpenAIDashboardWebViewCache {
         return remaining
     }
 
-    private func releaseCachedEntry(_ entry: Entry, preserveLoadedPage: Bool) {
+    private func releaseCachedEntry(_ entry: Entry, key: ObjectIdentifier, preserveLoadedPage: Bool) {
+        guard self.entries[key] === entry else {
+            entry.close()
+            return
+        }
         entry.isBusy = false
         entry.lastUsedAt = Date()
         if preserveLoadedPage {
@@ -172,13 +198,8 @@ final class OpenAIDashboardWebViewCache {
         self.evictEntry(entry)
     }
 
-    private func releaseNewEntry(_ entry: Entry, webView _: WKWebView, preserveLoadedPage: Bool) {
-        self.releaseCachedEntry(entry, preserveLoadedPage: preserveLoadedPage)
-    }
-
     private func evictEntry(_ entry: Entry) {
-        entry.clearPreservedPage()
-        entry.host.close()
+        entry.close()
         if let key = self.entries.first(where: { $0.value === entry })?.key {
             self.entries.removeValue(forKey: key)
         }
@@ -192,6 +213,18 @@ final class OpenAIDashboardWebViewCache {
     /// Number of cached WebView entries (for testing).
     var entryCount: Int {
         self.entries.count
+    }
+
+    var activeAcquisitionCountForTesting: Int {
+        self.acquisitions.count
+    }
+
+    static func cleanupRequestCountForTesting(_ host: AnyObject) -> Int? {
+        (host as? OffscreenWebViewHost)?.cleanupRequestCountForTesting
+    }
+
+    func cachedWebViewForTesting(for websiteDataStore: WKWebsiteDataStore) -> WKWebView? {
+        self.entries[ObjectIdentifier(websiteDataStore)]?.webView
     }
 
     /// Check if a WebView is cached for the given data store (for testing).
@@ -259,12 +292,7 @@ final class OpenAIDashboardWebViewCache {
 
     /// Clear all cached entries (for test isolation).
     func clearAllForTesting() {
-        self.cancelIdlePrune()
-        for (_, entry) in self.entries {
-            entry.clearPreservedPage()
-            entry.host.close()
-        }
-        self.entries.removeAll()
+        self.evictAll()
     }
 
     func resetReusablePageStateForTesting(_ webView: WKWebView) async -> Bool {
@@ -281,177 +309,124 @@ final class OpenAIDashboardWebViewCache {
         preserveLoadedPageOnRelease: Bool = false) async throws -> OpenAIDashboardWebViewLease
     {
         let deadline = Date().addingTimeInterval(max(navigationTimeout, 0.01))
-        return try await self.acquire(
-            websiteDataStore: websiteDataStore,
-            usageURL: usageURL,
-            logger: logger,
-            deadline: deadline,
-            options: .init(
-                allowTimeoutRetry: allowTimeoutRetry,
-                preserveLoadedPageOnRelease: preserveLoadedPageOnRelease))
-    }
-
-    private func acquire(
-        websiteDataStore: WKWebsiteDataStore,
-        usageURL: URL,
-        logger: ((String) -> Void)?,
-        deadline: Date,
-        options: AcquireOptions) async throws -> OpenAIDashboardWebViewLease
-    {
-        let now = Date()
-        self.prune(now: now)
+        let key = ObjectIdentifier(websiteDataStore)
+        let acquisition = Acquisition(key: key)
+        let acquisitionID = ObjectIdentifier(acquisition)
+        self.acquisitions[acquisitionID] = acquisition
+        defer { self.acquisitions.removeValue(forKey: acquisitionID) }
 
         let log: (String) -> Void = { message in
             logger?("[webview] \(message)")
         }
-        let key = ObjectIdentifier(websiteDataStore)
-        let remainingTimeout = try Self.remainingNavigationTimeout(until: deadline, now: now)
+        self.prune(now: Date())
+        let isTemporary = self.entries[key]?.isBusy == true
+        if isTemporary { log("Cached WebView busy; using a temporary WebView.") }
+        var canRetry = allowTimeoutRetry
 
-        if let entry = self.entries[key] {
-            if entry.isBusy {
-                log("Cached WebView busy; using a temporary WebView.")
+        while true {
+            try acquisition.checkCancellation()
+            let now = Date()
+            let remainingTimeout = try Self.remainingNavigationTimeout(until: deadline, now: now)
+            let entry: Entry
+            let canReuseLoadedPage: Bool
+            if !isTemporary, let cached = self.entries[key] {
+                entry = cached
+                canReuseLoadedPage = entry.consumePreservedPageReuseIfAvailable(now: now)
+            } else {
                 let (webView, host) = self.makeWebView(websiteDataStore: websiteDataStore)
-                host.show()
-                do {
-                    try await self.prepareWebView(
-                        webView,
-                        usageURL: usageURL,
-                        timeout: remainingTimeout,
-                        canReuseLoadedPage: false)
-                } catch {
-                    if options.allowTimeoutRetry, Self.isPrepareTimeout(error) {
-                        host.close()
-                        log("Temporary OpenAI WebView timed out; retrying with a fresh WebView.")
-                        return try await self.acquireTemporaryWebView(
-                            websiteDataStore: websiteDataStore,
-                            usageURL: usageURL,
-                            log: log,
-                            deadline: deadline)
-                    }
-                    host.close()
-                    throw error
-                }
-                return OpenAIDashboardWebViewLease(
-                    webView: webView,
-                    log: log,
-                    setPreserveLoadedPageOnRelease: { _ in },
-                    release: { host.close() })
+                entry = Entry(webView: webView, host: host, lastUsedAt: now, isBusy: true)
+                canReuseLoadedPage = false
+                if !isTemporary { self.entries[key] = entry }
             }
-
+            acquisition.entry = entry
             entry.isBusy = true
             entry.lastUsedAt = now
-            let canReuseLoadedPage = entry.consumePreservedPageReuseIfAvailable(now: now)
-            let releaseState = ReleaseState(preserveLoadedPageOnRelease: options.preserveLoadedPageOnRelease)
             entry.host.show()
+
             do {
                 try await self.prepareWebView(
                     entry.webView,
                     usageURL: usageURL,
                     timeout: remainingTimeout,
                     canReuseLoadedPage: canReuseLoadedPage)
+                try acquisition.checkCancellation()
+                if !isTemporary, self.entries[key] !== entry { throw CancellationError() }
             } catch {
-                if options.allowTimeoutRetry, Self.isPrepareTimeout(error) {
-                    entry.isBusy = false
-                    entry.lastUsedAt = Date()
-                    entry.clearPreservedPage()
-                    entry.host.close()
-                    self.entries.removeValue(forKey: key)
-                    log("Cached OpenAI WebView timed out; recreating it.")
-                    return try await self.acquire(
-                        websiteDataStore: websiteDataStore,
-                        usageURL: usageURL,
-                        logger: logger,
-                        deadline: deadline,
-                        options: .init(
-                            allowTimeoutRetry: false,
-                            preserveLoadedPageOnRelease: options.preserveLoadedPageOnRelease))
+                let stillOwnsEntry = isTemporary || self.entries[key] === entry
+                self.evictEntry(entry)
+                try acquisition.checkCancellation()
+                guard stillOwnsEntry else { throw CancellationError() }
+                guard canRetry, Self.isPrepareTimeout(error) else {
+                    Self.log.warning("OpenAI webview prepare failed")
+                    throw error
                 }
-                entry.isBusy = false
-                entry.lastUsedAt = Date()
-                entry.clearPreservedPage()
-                entry.host.close()
-                self.entries.removeValue(forKey: key)
-                Self.log.warning("OpenAI webview prepare failed")
-                throw error
+                canRetry = false
+                log("OpenAI WebView timed out during prepare; retrying once with a fresh WebView.")
+                continue
             }
 
-            return OpenAIDashboardWebViewLease(
-                webView: entry.webView,
-                log: log,
-                setPreserveLoadedPageOnRelease: { preserveLoadedPageOnRelease in
-                    releaseState.preserveLoadedPageOnRelease = preserveLoadedPageOnRelease
-                },
-                release: { [weak self, weak entry] in
-                    guard let self, let entry else { return }
+            return self.makeLease(
+                entry: entry,
+                key: key,
+                isTemporary: isTemporary,
+                preserveLoadedPageOnRelease: preserveLoadedPageOnRelease,
+                log: log)
+        }
+    }
+
+    private func makeLease(
+        entry: Entry,
+        key: ObjectIdentifier,
+        isTemporary: Bool,
+        preserveLoadedPageOnRelease: Bool,
+        log: @escaping (String) -> Void) -> OpenAIDashboardWebViewLease
+    {
+        let releaseState = ReleaseState(preserveLoadedPageOnRelease: preserveLoadedPageOnRelease)
+        // The lease owns cleanup even after cache eviction; the entry never retains its lease.
+        return OpenAIDashboardWebViewLease(
+            webView: entry.webView,
+            log: log,
+            setPreserveLoadedPageOnRelease: { preserve in
+                guard !releaseState.isReleased else { return }
+                releaseState.preserveLoadedPageOnRelease = preserve
+            },
+            release: { [weak self, entry] in
+                guard !releaseState.isReleased else { return }
+                releaseState.isReleased = true
+                if !isTemporary, let self {
                     self.releaseCachedEntry(
                         entry,
+                        key: key,
                         preserveLoadedPage: releaseState.preserveLoadedPageOnRelease)
-                })
-        }
-
-        let (webView, host) = self.makeWebView(websiteDataStore: websiteDataStore)
-        let entry = Entry(webView: webView, host: host, lastUsedAt: now, isBusy: true)
-        self.entries[key] = entry
-        host.show()
-        let releaseState = ReleaseState(preserveLoadedPageOnRelease: options.preserveLoadedPageOnRelease)
-
-        do {
-            try await self.prepareWebView(
-                webView,
-                usageURL: usageURL,
-                timeout: remainingTimeout,
-                canReuseLoadedPage: false)
-        } catch {
-            if options.allowTimeoutRetry, Self.isPrepareTimeout(error) {
-                self.entries.removeValue(forKey: key)
-                host.close()
-                log("OpenAI WebView timed out during prepare; retrying once.")
-                return try await self.acquire(
-                    websiteDataStore: websiteDataStore,
-                    usageURL: usageURL,
-                    logger: logger,
-                    deadline: deadline,
-                    options: .init(
-                        allowTimeoutRetry: false,
-                        preserveLoadedPageOnRelease: options.preserveLoadedPageOnRelease))
-            }
-            self.entries.removeValue(forKey: key)
-            host.close()
-            Self.log.warning("OpenAI webview prepare failed")
-            throw error
-        }
-
-        return OpenAIDashboardWebViewLease(
-            webView: webView,
-            log: log,
-            setPreserveLoadedPageOnRelease: { preserveLoadedPageOnRelease in
-                releaseState.preserveLoadedPageOnRelease = preserveLoadedPageOnRelease
-            },
-            release: { [weak self, weak entry] in
-                guard let self, let entry else { return }
-                self.releaseNewEntry(
-                    entry,
-                    webView: webView,
-                    preserveLoadedPage: releaseState.preserveLoadedPageOnRelease)
+                } else {
+                    entry.close()
+                }
             })
+    }
+
+    private func invalidateAcquisitions(for key: ObjectIdentifier? = nil) {
+        for acquisition in self.acquisitions.values where key == nil || acquisition.key == key {
+            acquisition.isInvalidated = true
+            acquisition.entry?.close()
+        }
     }
 
     func evict(websiteDataStore: WKWebsiteDataStore) {
         let key = ObjectIdentifier(websiteDataStore)
+        self.invalidateAcquisitions(for: key)
         guard let entry = self.entries.removeValue(forKey: key) else { return }
-        entry.clearPreservedPage()
+        entry.close()
         Self.log.debug("OpenAI webview evicted")
-        entry.host.close()
         self.scheduleNextIdlePrune()
     }
 
     func evictAll() {
+        self.invalidateAcquisitions()
         self.cancelIdlePrune()
         let existing = self.entries
         self.entries.removeAll()
         for (_, entry) in existing {
-            entry.clearPreservedPage()
-            entry.host.close()
+            entry.close()
         }
         if !existing.isEmpty {
             Self.log.debug("OpenAI webview evicted all")
@@ -546,6 +521,9 @@ final class OpenAIDashboardWebViewCache {
 
         let webView = WKWebView(frame: .zero, configuration: config)
         let host = OffscreenWebViewHost(webView: webView)
+        #if DEBUG
+        self.didCreateWebViewForTesting?(webView, host)
+        #endif
         return (webView, host)
     }
 
@@ -556,6 +534,10 @@ final class OpenAIDashboardWebViewCache {
         canReuseLoadedPage: Bool) async throws
     {
         #if DEBUG
+        if let prepareForTesting {
+            try await prepareForTesting(webView, timeout, canReuseLoadedPage)
+            return
+        }
         if usageURL.absoluteString == "about:blank" {
             _ = webView.loadHTMLString("", baseURL: nil)
             return
@@ -594,32 +576,6 @@ final class OpenAIDashboardWebViewCache {
                 cancellationState.cancel()
             }
         }
-    }
-
-    private func acquireTemporaryWebView(
-        websiteDataStore: WKWebsiteDataStore,
-        usageURL: URL,
-        log: @escaping (String) -> Void,
-        deadline: Date) async throws -> OpenAIDashboardWebViewLease
-    {
-        let remainingTimeout = try Self.remainingNavigationTimeout(until: deadline)
-        let (webView, host) = self.makeWebView(websiteDataStore: websiteDataStore)
-        host.show()
-        do {
-            try await self.prepareWebView(
-                webView,
-                usageURL: usageURL,
-                timeout: remainingTimeout,
-                canReuseLoadedPage: false)
-        } catch {
-            host.close()
-            throw error
-        }
-        return OpenAIDashboardWebViewLease(
-            webView: webView,
-            log: log,
-            setPreserveLoadedPageOnRelease: { _ in },
-            release: { host.close() })
     }
 
     private static func isPrepareTimeout(_ error: Error) -> Bool {
@@ -682,6 +638,10 @@ final class OpenAIDashboardWebViewCache {
 private final class OffscreenWebViewHost {
     private let window: NSWindow
     private weak var webView: WKWebView?
+    private var isClosed = false
+    #if DEBUG
+    private(set) var cleanupRequestCountForTesting = 0
+    #endif
 
     init(webView: WKWebView) {
         // WebKit throttles timers/RAF aggressively when a WKWebView is not considered "visible".
@@ -729,6 +689,11 @@ private final class OffscreenWebViewHost {
     }
 
     func close() {
+        guard !self.isClosed else { return }
+        self.isClosed = true
+        #if DEBUG
+        self.cleanupRequestCountForTesting += 1
+        #endif
         OpenAIDashboardWebViewCache.log.debug("OpenAI webview close")
         WebKitTeardown.scheduleCleanup(
             owner: self,

--- a/Tests/CodexBarTests/AdaptiveRefreshHeuristicsTests.swift
+++ b/Tests/CodexBarTests/AdaptiveRefreshHeuristicsTests.swift
@@ -12,6 +12,35 @@ import Testing
 @MainActor
 struct AdaptiveRefreshHeuristicsTests {
     @Test
+    func `heuristics fixture seeds disabled providers without enabling web access`() throws {
+        let store = Self.makeStore(suite: "heuristics-fixture-state", frequency: .adaptive)
+        let metadata = ProviderRegistry.shared.metadata
+        for provider in UsageProvider.allCases where metadata[provider] != nil {
+            let entry = try #require(store.settings.configSnapshot.providerConfig(for: provider.instanceID))
+            #expect(entry.enabled == false)
+        }
+        #expect(store.settings.enabledProvidersOrdered(metadataByProvider: metadata).isEmpty)
+        #expect(store.settings.refreshFrequency == .adaptive)
+        #expect(store.settings.providerDetectionCompleted)
+        #expect(store.settings.backgroundWorkLowPowerModePreference == .off)
+        #expect(!store.settings.openAIWebAccessEnabled)
+        #expect(store.completedRefreshCountForTesting == 0)
+    }
+
+    @Test
+    func `reset boundary fixture enables only stubbed codex`() throws {
+        let store = Self.makeStoreWithStubbedCodex(suite: "heuristics-stub-fixture-state", frequency: .manual)
+        let metadata = ProviderRegistry.shared.metadata
+        for provider in UsageProvider.allCases where metadata[provider] != nil {
+            let entry = try #require(store.settings.configSnapshot.providerConfig(for: provider.instanceID))
+            #expect(entry.enabled == (provider == .codex))
+        }
+        #expect(store.settings.enabledProvidersOrdered(metadataByProvider: metadata) == [.codex])
+        #expect(!store.settings.openAIWebAccessEnabled)
+        #expect(store.completedRefreshCountForTesting == 0)
+    }
+
+    @Test
     func `manual keeps the heuristics interval nil`() {
         let store = Self.makeStore(suite: "heuristics-manual-nil", frequency: .manual)
         #expect(store.normalRefreshIntervalForHeuristics() == nil)
@@ -149,10 +178,15 @@ struct AdaptiveRefreshHeuristicsTests {
     }
 
     private static func makeStore(suite: String, frequency: RefreshFrequency) -> UsageStore {
-        let settings = testSettingsStore(suiteName: "AdaptiveRefreshHeuristicsTests-\(suite)")
+        let settings = testSettingsStore(
+            suiteName: "AdaptiveRefreshHeuristicsTests-\(suite)",
+            config: testConfigWithAllProvidersDisabled(),
+            prepareDefaults: { defaults in
+                // An existing config otherwise opts this fresh fixture into OpenAI web access.
+                defaults.set(false, forKey: "openAIWebAccessEnabled")
+            })
         settings.providerDetectionCompleted = true
         settings.refreshFrequency = frequency
-        Self.disableAllProviders(settings: settings)
         return UsageStore(
             fetcher: UsageFetcher(environment: [:]),
             browserDetection: BrowserDetection(cacheTTL: 0),
@@ -187,16 +221,6 @@ struct AdaptiveRefreshHeuristicsTests {
     }
 
     private nonisolated static let stubbedCodexEmail = "adaptive-heuristics@example.com"
-
-    /// Keeps `refresh()` cheap and deterministic: no provider fetch can replace the snapshot
-    /// injected by the reset-boundary tests or slow the pipeline tests down.
-    private static func disableAllProviders(settings: SettingsStore) {
-        let metadata = ProviderRegistry.shared.metadata
-        for provider in UsageProvider.allCases {
-            guard let providerMetadata = metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: providerMetadata, enabled: false)
-        }
-    }
 
     private nonisolated static func snapshot(updatedAt: Date, primaryResetsAt: Date) -> UsageSnapshot {
         UsageSnapshot(

--- a/Tests/CodexBarTests/AdaptiveRefreshTimerTests.swift
+++ b/Tests/CodexBarTests/AdaptiveRefreshTimerTests.swift
@@ -9,6 +9,21 @@ import Testing
 @MainActor
 struct AdaptiveRefreshTimerTests {
     @Test
+    func `timer fixture seeds disabled providers without enabling web access`() throws {
+        let settings = Self.makeSettingsStore(suite: "AdaptiveRefreshTimerTests-fixture-state", frequency: .oneMinute)
+        let metadata = ProviderRegistry.shared.metadata
+        for provider in UsageProvider.allCases where metadata[provider] != nil {
+            let entry = try #require(settings.configSnapshot.providerConfig(for: provider.instanceID))
+            #expect(entry.enabled == false)
+        }
+        #expect(settings.enabledProvidersOrdered(metadataByProvider: metadata).isEmpty)
+        #expect(settings.refreshFrequency == .oneMinute)
+        #expect(settings.providerDetectionCompleted)
+        #expect(settings.backgroundWorkLowPowerModePreference == .off)
+        #expect(!settings.openAIWebAccessEnabled)
+    }
+
+    @Test
     func `launch with no menu history begins at thirty minutes`() {
         let settings = Self.makeSettingsStore(suite: "AdaptiveRefreshTimerTests-launch", frequency: .adaptive)
         let store = Self.makeUsageStore(settings: settings, startupBehavior: .testing)
@@ -430,41 +445,16 @@ struct AdaptiveRefreshTimerTests {
     }
 
     private static func makeSettingsStore(suite: String, frequency: RefreshFrequency) -> SettingsStore {
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        let configStore = testConfigStore(suiteName: suite)
-
-        let settings = SettingsStore(
-            userDefaults: defaults,
-            configStore: configStore,
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore(),
-            codexCookieStore: InMemoryCookieHeaderStore(),
-            claudeCookieStore: InMemoryCookieHeaderStore(),
-            cursorCookieStore: InMemoryCookieHeaderStore(),
-            opencodeCookieStore: InMemoryCookieHeaderStore(),
-            factoryCookieStore: InMemoryCookieHeaderStore(),
-            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
-            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
-            kimiTokenStore: InMemoryKimiTokenStore(),
-            augmentCookieStore: InMemoryCookieHeaderStore(),
-            ampCookieStore: InMemoryCookieHeaderStore(),
-            copilotTokenStore: InMemoryCopilotTokenStore(),
-            tokenAccountStore: InMemoryTokenAccountStore())
+        let settings = testSettingsStore(
+            suiteName: suite,
+            config: testConfigWithAllProvidersDisabled(),
+            prepareDefaults: { defaults in
+                // An existing config otherwise opts this fresh fixture into OpenAI web access.
+                defaults.set(false, forKey: "openAIWebAccessEnabled")
+            })
         settings.providerDetectionCompleted = true
         settings.refreshFrequency = frequency
-        Self.disableAllProviders(settings: settings)
         return settings
-    }
-
-    /// Codex is enabled by default; disabling every provider (including it) keeps `refresh()` cheap
-    /// and deterministic in these tests, which care about tick cadence, not provider fetch results.
-    private static func disableAllProviders(settings: SettingsStore) {
-        let metadata = ProviderRegistry.shared.metadata
-        for provider in UsageProvider.allCases {
-            guard let providerMetadata = metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: providerMetadata, enabled: false)
-        }
     }
 
     private static func makeUsageStore(

--- a/Tests/CodexBarTests/ClaudeCLISessionTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLISessionTests.swift
@@ -53,15 +53,18 @@ struct ClaudeCLISessionTests {
         #expect(missingFirst != missingSecond)
     }
 
-    @Test
-    func `profile environment launches and identifies the reusable session`() async throws {
+    @Test(arguments: [0.0, 0.5])
+    func `profile environment launches and identifies the reusable session`(responseDelay: TimeInterval) async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-claude-environment-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let logURL = directory.appendingPathComponent("launches.log")
-        let cliURL = try Self.makeEnvironmentEchoingClaudeCLI(in: directory, logURL: logURL)
+        let cliURL = try Self.makeEnvironmentEchoingClaudeCLI(
+            in: directory,
+            logURL: logURL,
+            responseDelay: responseDelay)
         let session = ClaudeCLISession()
         let firstConfig = directory.appendingPathComponent("profile-a", isDirectory: true)
         let firstSecureStorage = directory.appendingPathComponent("secure-a", isDirectory: true)
@@ -84,27 +87,21 @@ struct ClaudeCLISessionTests {
         secondEnvironment["HOME"] = secondHome.path
 
         do {
-            let first = try await session.capture(
-                subcommand: "/status",
+            let first = try await Self.captureProfileStatus(
+                session: session,
                 binary: cliURL.path,
                 timeout: 2,
-                environment: firstEnvironment,
-                idleTimeout: 0.1,
-                settleAfterStop: 0)
-            let second = try await session.capture(
-                subcommand: "/status",
+                environment: firstEnvironment)
+            let second = try await Self.captureProfileStatus(
+                session: session,
                 binary: cliURL.path,
                 timeout: 2,
-                environment: secondEnvironment,
-                idleTimeout: 0.1,
-                settleAfterStop: 0)
-            let reused = try await session.capture(
-                subcommand: "/status",
+                environment: secondEnvironment)
+            let reused = try await Self.captureProfileStatus(
+                session: session,
                 binary: cliURL.path,
                 timeout: 2,
-                environment: secondEnvironment,
-                idleTimeout: 0.1,
-                settleAfterStop: 0)
+                environment: secondEnvironment)
             await session.reset()
 
             #expect(first.contains("Account: \(firstConfig.path)"))
@@ -146,30 +143,27 @@ struct ClaudeCLISessionTests {
         secondEnvironment["CLAUDE_CONFIG_DIR"] = secondConfig.path
 
         let firstTask = Task {
-            try await session.capture(
-                subcommand: "/status",
+            try await Self.captureProfileStatus(
+                session: session,
                 binary: cliURL.path,
                 timeout: 5,
-                environment: firstEnvironment,
-                idleTimeout: 0.1,
-                settleAfterStop: 0)
+                environment: firstEnvironment)
         }
         do {
             try await Self.waitForLaunchCount(1, at: logURL)
         } catch {
             firstTask.cancel()
+            _ = await firstTask.result
             await session.reset()
             throw error
         }
 
         let secondTask = Task {
-            try await session.capture(
-                subcommand: "/status",
+            try await Self.captureProfileStatus(
+                session: session,
                 binary: cliURL.path,
                 timeout: 5,
-                environment: secondEnvironment,
-                idleTimeout: 0.1,
-                settleAfterStop: 0)
+                environment: secondEnvironment)
         }
 
         do {
@@ -183,6 +177,8 @@ struct ClaudeCLISessionTests {
         } catch {
             firstTask.cancel()
             secondTask.cancel()
+            _ = await firstTask.result
+            _ = await secondTask.result
             await session.reset()
             throw error
         }
@@ -250,8 +246,32 @@ struct ClaudeCLISessionTests {
         #expect(first == second)
     }
 
-    private static func makeEnvironmentEchoingClaudeCLI(in directory: URL, logURL: URL) throws -> URL {
+    private static func captureProfileStatus(
+        session: ClaudeCLISession,
+        binary: String,
+        timeout: TimeInterval,
+        environment: [String: String]) async throws -> String
+    {
+        let configDirectory = try #require(environment["CLAUDE_CONFIG_DIR"])
+        // PTY echo is not the fixture response; these tests check profile ownership, not idle latency.
+        return try await session.capture(
+            subcommand: "/status",
+            binary: binary,
+            timeout: timeout,
+            environment: environment,
+            idleTimeout: nil,
+            stopOnSubstrings: ["Account: \(configDirectory)"],
+            settleAfterStop: 0)
+    }
+
+    private static func makeEnvironmentEchoingClaudeCLI(
+        in directory: URL,
+        logURL: URL,
+        responseDelay: TimeInterval = 0) throws -> URL
+    {
         let url = directory.appendingPathComponent("claude")
+        // Delay the response, not startup, so PTY echo arrives before the old 0.1-second idle window expires.
+        let delayCommand = responseDelay > 0 ? "/bin/sleep \(responseDelay)" : ""
         let script = """
         #!/bin/sh
         printf 'start:%s:%s:%s\n' \
@@ -261,6 +281,7 @@ struct ClaudeCLISessionTests {
         while IFS= read -r line; do
           case "$line" in
             *"/status"*)
+              \(delayCommand)
               printf 'Account: %s\n' "$CLAUDE_CONFIG_DIR"
               ;;
           esac

--- a/Tests/CodexBarTests/CostUsageFairSchedulingTests.swift
+++ b/Tests/CodexBarTests/CostUsageFairSchedulingTests.swift
@@ -399,7 +399,7 @@ struct CostUsageFairSchedulingTests {
         mtime: Date) throws -> URL
     {
         let header = #"{"type":"session_meta","payload":{"id":"\#(name)"}}"# + "\n"
-        let url = try env.writeCodexSessionFile(
+        let url = try env.seedCodexSessionFile(
             day: day,
             filename: name + ".jsonl",
             contents: header + Self.rows(env: env, day: day, indices: 1...rows))

--- a/Tests/CodexBarTests/CostUsageFixtureSeedTests.swift
+++ b/Tests/CodexBarTests/CostUsageFixtureSeedTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+import Testing
+
+struct CostUsageFixtureSeedTests {
+    @Test
+    func `initial seeds match atomic fixture bytes paths and file counts`() throws {
+        let env = try CostUsageTestEnvironment()
+        let reference = try CostUsageTestEnvironment()
+        defer {
+            env.cleanup()
+            reference.cleanup()
+        }
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 10)
+        let contents = ["", "{\"message\":\"café 🦞\"}\n", "first\u{0}second\nlast\n"]
+        var urls: [URL] = []
+        for (index, body) in contents.enumerated() {
+            let filename = "session-\(index).jsonl"
+            let seeded = try env.seedCodexSessionFile(day: day, filename: filename, contents: body)
+            let atomic = try reference.writeCodexSessionFile(day: day, filename: filename, contents: body)
+            #expect(seeded.path == env.codexSessionsRoot.appendingPathComponent("2026/05/10/\(filename)").path)
+            #expect(try Data(contentsOf: seeded) == Data(body.utf8))
+            #expect(try Data(contentsOf: seeded) == Data(contentsOf: atomic))
+            urls.append(seeded)
+        }
+        let directory = try #require(urls.first).deletingLastPathComponent()
+        let files = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        #expect(Set(files.map(\.lastPathComponent)) == Set(urls.map(\.lastPathComponent)))
+        #expect(files.count == contents.count)
+    }
+
+    @Test(arguments: ["file", "directory", "symlink"])
+    func `initial seeds reject existing paths without overwriting them`(kind: String) throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 10)
+        let original = try env.writeCodexSessionFile(day: day, filename: "original.jsonl", contents: "original\n")
+        let destination = original.deletingLastPathComponent().appendingPathComponent("existing.jsonl")
+        switch kind {
+        case "file":
+            try FileManager.default.copyItem(at: original, to: destination)
+        case "directory":
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: false)
+        default:
+            try FileManager.default.createSymbolicLink(at: destination, withDestinationURL: original)
+        }
+        do {
+            _ = try env.seedCodexSessionFile(day: day, filename: destination.lastPathComponent, contents: "replacement")
+            Issue.record("Initial corpus seeding must reject an existing path")
+        } catch {
+            #expect((error as NSError).domain == NSPOSIXErrorDomain)
+            #expect((error as NSError).code == Int(EEXIST))
+        }
+        #expect(try Data(contentsOf: original) == Data("original\n".utf8))
+        if kind == "file" || kind == "symlink" {
+            #expect(try Data(contentsOf: destination) == Data("original\n".utf8))
+        }
+        if kind == "symlink" {
+            #expect(try FileManager.default.destinationOfSymbolicLink(atPath: destination.path) == original.path)
+        }
+    }
+
+    @Test
+    func `initial seed and atomic writer propagate the same day directory errors`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 10)
+        let blocker = env.codexSessionsRoot.appendingPathComponent("2026")
+        #expect(FileManager.default.createFile(atPath: blocker.path, contents: Data("blocker".utf8)))
+        let writers: [(Date, String, String) throws -> URL] = [env.writeCodexSessionFile, env.seedCodexSessionFile]
+        var errors: [NSError] = []
+        for writer in writers {
+            do {
+                _ = try writer(day, "session.jsonl", "body")
+                Issue.record("Creating a day directory beneath a file must fail")
+            } catch {
+                errors.append(error as NSError)
+            }
+        }
+        #expect(errors.count == 2)
+        #expect(errors.first?.domain == errors.last?.domain)
+        #expect(errors.first?.code == errors.last?.code)
+        #expect(try Data(contentsOf: blocker) == Data("blocker".utf8))
+    }
+
+    @Test
+    func `shared atomic fixture writer still replaces an existing file`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 10)
+        let original = try env.writeCodexSessionFile(day: day, filename: "session.jsonl", contents: "before")
+        let inode = try FileManager.default.attributesOfItem(atPath: original.path)[.systemFileNumber] as? NSNumber
+        let replacement = try env.writeCodexSessionFile(day: day, filename: "session.jsonl", contents: "after")
+        #expect(replacement == original)
+        #expect(try Data(contentsOf: replacement) == Data("after".utf8))
+        let attributes = try FileManager.default.attributesOfItem(atPath: replacement.path)
+        #expect(attributes[.systemFileNumber] as? NSNumber != inode)
+    }
+}

--- a/Tests/CodexBarTests/CostUsagePerformanceGateTests.swift
+++ b/Tests/CodexBarTests/CostUsagePerformanceGateTests.swift
@@ -1918,7 +1918,7 @@ extension CostUsagePerformanceGateTests {
                             + #""model":"\#(model)"}}}"#)
                 }
             }
-            let fileURL = try env.writeCodexSessionFile(
+            let fileURL = try env.seedCodexSessionFile(
                 day: day,
                 filename: "session-\(fileIndex).jsonl",
                 contents: lines.joined(separator: "\n") + "\n")

--- a/Tests/CodexBarTests/CostUsageScannerTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerTests.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 import Testing
 @testable import CodexBarCore
 
@@ -1248,6 +1253,31 @@ struct CostUsageTestEnvironment {
     }
 
     func writeCodexSessionFile(day: Date, filename: String, contents: String) throws -> URL {
+        let url = try self.codexSessionFileURL(day: day, filename: filename)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    func seedCodexSessionFile(day: Date, filename: String, contents: String) throws -> URL {
+        let url = try self.codexSessionFileURL(day: day, filename: filename)
+        // Initial corpus files have no readers until setup returns; no atomic publication or fsync is needed.
+        let descriptor = open(url.path, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0o666)
+        guard descriptor >= 0 else {
+            let code = errno
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(code))
+        }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        do {
+            try handle.write(contentsOf: Data(contents.utf8))
+            try handle.close()
+        } catch {
+            try? handle.close()
+            throw error
+        }
+        return url
+    }
+
+    private func codexSessionFileURL(day: Date, filename: String) throws -> URL {
         let comps = Calendar.current.dateComponents([.year, .month, .day], from: day)
         let y = String(format: "%04d", comps.year ?? 1970)
         let m = String(format: "%02d", comps.month ?? 1)
@@ -1259,9 +1289,7 @@ struct CostUsageTestEnvironment {
             .appendingPathComponent(d, isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
 
-        let url = dir.appendingPathComponent(filename, isDirectory: false)
-        try contents.write(to: url, atomically: true, encoding: .utf8)
-        return url
+        return dir.appendingPathComponent(filename, isDirectory: false)
     }
 
     func writeClaudeProjectFile(relativePath: String, contents: String) throws -> URL {

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -19,6 +19,41 @@ struct OpenAIDashboardWebViewCacheTests {
 
     // MARK: - Data Store Identity Tests
 
+    @Test(arguments: [false, true], WebViewPreparationCompletion.allCases)
+    func `suspended acquire completion keeps replacement owned`(
+        reuse: Bool,
+        completion: WebViewPreparationCompletion) async throws
+    {
+        if self.shouldSkipOnCI() { return }
+        for _ in 0..<3 {
+            let fixture = WebViewAcquisitionFixture(path: reuse ? .reused : .new)
+            defer { fixture.cache.clearAllForTesting() }
+            let acquireA = fixture.start()
+            let pausedA = await fixture.preparation.next()
+            fixture.cache.evict(websiteDataStore: fixture.store)
+            let acquireB = fixture.start()
+            let pausedB = await fixture.preparation.next()
+            #expect(pausedA.webView !== pausedB.webView)
+            fixture.preparation.rejectFurtherPreparations = true
+            if completion == .cancelledTask { acquireA.task?.cancel() }
+            pausedA.finish(completion.result)
+            await acquireA.wait()
+            acquireA.expectCancellation()
+            #expect(fixture.cache.cachedWebViewForTesting(for: fixture.store) === pausedB.webView)
+            #expect(fixture.preparation.callCount == 2, "Invalidated work must not retry")
+            #expect(fixture.cache.activeAcquisitionCountForTesting == 1)
+            fixture.expectCleanup(pausedA.webView)
+            pausedB.finish(.success(()))
+            await acquireB.wait()
+            let leaseB = try #require(acquireB.lease)
+            leaseB.release()
+            leaseB.release()
+            fixture.expectCleanup(pausedB.webView)
+            #expect(fixture.cache.entryCount == 0)
+            #expect(fixture.cache.activeAcquisitionCountForTesting == 0)
+        }
+    }
+
     @Test
     func `navigation retry uses only remaining shared deadline`() throws {
         let start = Date(timeIntervalSinceReferenceDate: 1000)
@@ -600,6 +635,421 @@ struct OpenAIDashboardWebViewCacheTests {
 
         cache.clearAllForTesting()
         OpenAIDashboardWebsiteDataStore.clearCacheForTesting()
+    }
+}
+
+extension OpenAIDashboardWebViewCacheTests {
+    @Test(arguments: WebViewAcquisitionPath.allCases, [false, true])
+    func `task cancellation rejects successful preparation and timeout retry`(
+        path: WebViewAcquisitionPath,
+        timeout: Bool) async
+    {
+        if self.shouldSkipOnCI() { return }
+        let fixture = WebViewAcquisitionFixture(path: path)
+        defer { fixture.cache.clearAllForTesting() }
+        let acquire = fixture.start()
+        let paused = await fixture.preparation.next()
+        fixture.preparation.rejectFurtherPreparations = true
+        acquire.task?.cancel()
+        paused.finish(timeout ? .failure(URLError(.timedOut)) : .success(()))
+        await acquire.wait()
+        acquire.expectCancellation()
+        #expect(fixture.preparation.callCount == 1)
+        #expect(fixture.cache.activeAcquisitionCountForTesting == 0)
+        fixture.expectCleanup(paused.webView)
+        if path == .temporary {
+            #expect(fixture.cache.cachedWebViewForTesting(for: fixture.store) === fixture.seededWebView)
+        } else {
+            #expect(!fixture.cache.hasCachedEntry(for: fixture.store))
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `temporary preparation survives normal cached lease release including retry`(retry: Bool) async throws {
+        if self.shouldSkipOnCI() { return }
+        let fixture = WebViewAcquisitionFixture()
+        defer { fixture.cache.clearAllForTesting() }
+        let cached = fixture.start()
+        let cachedPreparation = await fixture.preparation.next()
+        let temporary = fixture.start()
+        var paused = await fixture.preparation.next()
+        cachedPreparation.finish(.success(()))
+        await cached.wait()
+        let cachedLease = try #require(cached.lease)
+        cachedLease.release()
+        #expect(!fixture.cache.hasCachedEntry(for: fixture.store))
+        if retry {
+            paused.finish(.failure(URLError(.timedOut)))
+            let retried = await fixture.preparation.next()
+            fixture.expectCleanup(paused.webView)
+            #expect(retried.webView !== paused.webView)
+            #expect(retried.timeout <= paused.timeout)
+            paused = retried
+        }
+        fixture.preparation.rejectFurtherPreparations = true
+        paused.finish(.success(()))
+        await temporary.wait()
+        let temporaryLease = try #require(temporary.lease)
+        #expect(!fixture.cache.hasCachedEntry(for: fixture.store), "Temporary retry must stay temporary")
+        temporaryLease.setPreserveLoadedPageOnRelease(true)
+        temporaryLease.release()
+        temporaryLease.release()
+        fixture.expectCleanup(cachedPreparation.webView)
+        fixture.expectCleanup(paused.webView)
+        #expect(fixture.cache.activeAcquisitionCountForTesting == 0)
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func `explicit invalidation reaches temporary preparation after cached lease release`(
+        evictAll: Bool,
+        timeout: Bool) async throws
+    {
+        if self.shouldSkipOnCI() { return }
+        let fixture = WebViewAcquisitionFixture()
+        defer { fixture.cache.clearAllForTesting() }
+        let cached = fixture.start()
+        let cachedPreparation = await fixture.preparation.next()
+        cachedPreparation.finish(.success(()))
+        await cached.wait()
+        let cachedLease = try #require(cached.lease)
+        let temporary = fixture.start()
+        let paused = await fixture.preparation.next()
+        cachedLease.release()
+        if evictAll {
+            fixture.cache.evictAll()
+        } else {
+            fixture.cache.evict(websiteDataStore: fixture.store)
+        }
+        fixture.expectCleanup(paused.webView)
+        fixture.preparation.rejectFurtherPreparations = true
+        paused.finish(timeout ? .failure(URLError(.timedOut)) : .success(()))
+        await temporary.wait()
+        temporary.expectCancellation()
+        #expect(fixture.preparation.callCount == 2)
+        #expect(fixture.cache.entryCount == 0)
+        #expect(fixture.cache.activeAcquisitionCountForTesting == 0)
+        fixture.expectCleanup(paused.webView)
+    }
+
+    @Test(arguments: [false, true])
+    func `explicit invalidation is scoped to its store unless evicting all`(evictAll: Bool) async throws {
+        if self.shouldSkipOnCI() { return }
+        let fixture = WebViewAcquisitionFixture()
+        defer { fixture.cache.clearAllForTesting() }
+        let otherStore = WKWebsiteDataStore.nonPersistent()
+        let acquireA = fixture.start()
+        let pausedA = await fixture.preparation.next()
+        let acquireOther = fixture.start(store: otherStore)
+        let pausedOther = await fixture.preparation.next()
+        if evictAll {
+            fixture.cache.evictAll()
+        } else {
+            fixture.cache.evict(websiteDataStore: fixture.store)
+        }
+        fixture.preparation.rejectFurtherPreparations = true
+        pausedA.finish(.success(()))
+        pausedOther.finish(.success(()))
+        await acquireA.wait()
+        await acquireOther.wait()
+        acquireA.expectCancellation()
+        if evictAll {
+            acquireOther.expectCancellation()
+        } else {
+            let lease = try #require(acquireOther.lease)
+            #expect(fixture.cache.cachedWebViewForTesting(for: otherStore) === lease.webView)
+            lease.release()
+        }
+        fixture.expectCleanup(pausedA.webView)
+        fixture.expectCleanup(pausedOther.webView)
+        #expect(fixture.cache.entryCount == 0)
+        #expect(fixture.cache.activeAcquisitionCountForTesting == 0)
+    }
+
+    @Test(arguments: WebViewAcquisitionPath.allCases, [false, true])
+    func `active timeout retries once within original deadline`(
+        path: WebViewAcquisitionPath,
+        success: Bool) async throws
+    {
+        if self.shouldSkipOnCI() { return }
+        let fixture = WebViewAcquisitionFixture(path: path)
+        defer { fixture.cache.clearAllForTesting() }
+        let acquire = fixture.start()
+        let first = await fixture.preparation.next()
+        first.finish(.failure(URLError(.timedOut)))
+        let retry = await fixture.preparation.next()
+        #expect(first.webView !== retry.webView)
+        #expect(retry.timeout > 0 && retry.timeout <= first.timeout)
+        #expect(!retry.canReuseLoadedPage)
+        fixture.expectCleanup(first.webView)
+        fixture.preparation.rejectFurtherPreparations = true
+        retry.finish(success ? .success(()) : .failure(URLError(.timedOut)))
+        await acquire.wait()
+        if success {
+            let lease = try #require(acquire.lease)
+            lease.release()
+        } else {
+            #expect((acquire.error as? URLError)?.code == .timedOut)
+        }
+        #expect(fixture.preparation.callCount == 2)
+        #expect(fixture.cache.activeAcquisitionCountForTesting == 0)
+        fixture.expectCleanup(retry.webView)
+    }
+
+    @Test(arguments: WebViewAcquisitionPath.allCases)
+    func `disabled timeout retry does not prepare another view`(path: WebViewAcquisitionPath) async {
+        if self.shouldSkipOnCI() { return }
+        let fixture = WebViewAcquisitionFixture(path: path)
+        defer { fixture.cache.clearAllForTesting() }
+        let acquire = fixture.start(allowTimeoutRetry: false)
+        let paused = await fixture.preparation.next()
+        fixture.preparation.rejectFurtherPreparations = true
+        paused.finish(.failure(URLError(.timedOut)))
+        await acquire.wait()
+        #expect((acquire.error as? URLError)?.code == .timedOut)
+        #expect(fixture.preparation.callCount == 1)
+        #expect(fixture.cache.activeAcquisitionCountForTesting == 0)
+        fixture.expectCleanup(paused.webView)
+    }
+
+    @Test(arguments: WebViewAcquisitionPath.allCases, [false, true])
+    func `ordinary preparation failure and cancellation never retry`(
+        path: WebViewAcquisitionPath,
+        cancellation: Bool) async
+    {
+        if self.shouldSkipOnCI() { return }
+        let fixture = WebViewAcquisitionFixture(path: path)
+        defer { fixture.cache.clearAllForTesting() }
+        let acquire = fixture.start()
+        let paused = await fixture.preparation.next()
+        fixture.preparation.rejectFurtherPreparations = true
+        paused.finish(cancellation ? .failure(CancellationError()) : .failure(URLError(.cannotConnectToHost)))
+        await acquire.wait()
+        if cancellation {
+            acquire.expectCancellation()
+        } else {
+            #expect((acquire.error as? URLError)?.code == .cannotConnectToHost)
+        }
+        #expect(fixture.preparation.callCount == 1)
+        #expect(fixture.cache.activeAcquisitionCountForTesting == 0)
+        fixture.expectCleanup(paused.webView)
+    }
+
+    @Test(arguments: WebViewAcquisitionPath.allCases)
+    func `invalidation during timeout retry preserves replacement`(path: WebViewAcquisitionPath) async throws {
+        if self.shouldSkipOnCI() { return }
+        let fixture = WebViewAcquisitionFixture(path: path)
+        defer { fixture.cache.clearAllForTesting() }
+        let acquire = fixture.start()
+        let first = await fixture.preparation.next()
+        first.finish(.failure(URLError(.timedOut)))
+        let retry = await fixture.preparation.next()
+        fixture.cache.evict(websiteDataStore: fixture.store)
+        let replacement = fixture.start()
+        let pausedReplacement = await fixture.preparation.next()
+        fixture.preparation.rejectFurtherPreparations = true
+        retry.finish(.success(()))
+        await acquire.wait()
+        acquire.expectCancellation()
+        #expect(fixture.cache.cachedWebViewForTesting(for: fixture.store) === pausedReplacement.webView)
+        pausedReplacement.finish(.success(()))
+        await replacement.wait()
+        let lease = try #require(replacement.lease)
+        lease.release()
+        fixture.expectCleanup(first.webView)
+        fixture.expectCleanup(retry.webView)
+        fixture.expectCleanup(pausedReplacement.webView)
+        #expect(fixture.preparation.callCount == 3)
+        #expect(fixture.cache.activeAcquisitionCountForTesting == 0)
+    }
+
+    @Test(arguments: WebViewAcquisitionPath.allCases)
+    func `lease owns cleanup after cache deallocation`(path: WebViewAcquisitionPath) async throws {
+        if self.shouldSkipOnCI() { return }
+        var cache: OpenAIDashboardWebViewCache? = OpenAIDashboardWebViewCache()
+        let cacheIsAlive = { [weak cache] in cache != nil }
+        let store = WKWebsiteDataStore.nonPersistent()
+        var hosts: [ObjectIdentifier: AnyObject] = [:]
+        cache?.prepareForTesting = { _, _, _ in }
+        cache?.didCreateWebViewForTesting = { webView, host in hosts[ObjectIdentifier(webView)] = host }
+        if path != .new {
+            cache?.cacheEntryForTesting(websiteDataStore: store, isBusy: path == .temporary)
+        }
+        let url = try #require(URL(string: "https://example.invalid/usage"))
+        let lease = try #require(try await cache?.acquire(
+            websiteDataStore: store,
+            usageURL: url,
+            logger: nil,
+            preserveLoadedPageOnRelease: true))
+        if path == .temporary { cache?.evict(websiteDataStore: store) }
+        cache = nil
+        #expect(!cacheIsAlive(), "Lease must not retain its cache")
+        let host = try #require(hosts[ObjectIdentifier(lease.webView)])
+        #expect(!WebKitTeardown.isScheduledForTesting(host))
+        lease.release()
+        lease.release()
+        #expect(WebKitTeardown.isScheduledForTesting(host))
+        #expect(OpenAIDashboardWebViewCache.cleanupRequestCountForTesting(host) == 1)
+    }
+
+    @Test(arguments: [false, true])
+    func `released or evicted lease cannot change replacement ownership`(evict: Bool) async throws {
+        if self.shouldSkipOnCI() { return }
+        let fixture = WebViewAcquisitionFixture()
+        defer { fixture.cache.clearAllForTesting() }
+        let first = fixture.start(preserveLoadedPage: true)
+        let firstPreparation = await fixture.preparation.next()
+        firstPreparation.finish(.success(()))
+        await first.wait()
+        let firstLease = try #require(first.lease)
+        if evict {
+            fixture.cache.evict(websiteDataStore: fixture.store)
+        } else {
+            firstLease.release()
+            #expect(fixture.cache.hasPreservedPageForTesting(for: fixture.store))
+        }
+        let second = fixture.start()
+        let secondPreparation = await fixture.preparation.next()
+        #expect(secondPreparation.canReuseLoadedPage == !evict)
+        #expect((firstPreparation.webView === secondPreparation.webView) == !evict)
+        if !evict { firstLease.setPreserveLoadedPageOnRelease(false) }
+        firstLease.release()
+        firstLease.release()
+        #expect(fixture.cache.cachedWebViewForTesting(for: fixture.store) === secondPreparation.webView)
+        let secondHost = try #require(fixture.hosts[ObjectIdentifier(secondPreparation.webView)])
+        #expect(!WebKitTeardown.isScheduledForTesting(secondHost))
+        secondPreparation.finish(.success(()))
+        await second.wait()
+        let secondLease = try #require(second.lease)
+        secondLease.release()
+        fixture.expectCleanup(firstPreparation.webView)
+        fixture.expectCleanup(secondPreparation.webView)
+        #expect(fixture.cache.entryCount == 0)
+    }
+}
+
+enum WebViewAcquisitionPath: CaseIterable {
+    case new, reused, temporary
+}
+
+enum WebViewPreparationCompletion: CaseIterable {
+    case failure, cancellation, timeout, success, cancelledTask
+
+    var result: Result<Void, Error> {
+        switch self {
+        case .failure: .failure(URLError(.cannotConnectToHost))
+        case .cancellation: .failure(CancellationError())
+        case .timeout: .failure(URLError(.timedOut))
+        case .success, .cancelledTask: .success(())
+        }
+    }
+}
+
+@MainActor
+private final class WebViewAcquisitionFixture {
+    let cache = OpenAIDashboardWebViewCache()
+    let store = WKWebsiteDataStore.nonPersistent()
+    let preparation = WebViewPreparationGate()
+    var hosts: [ObjectIdentifier: AnyObject] = [:]
+    var seededWebView: WKWebView?
+
+    init(path: WebViewAcquisitionPath = .new) {
+        self.cache.prepareForTesting = self.preparation.prepare
+        self.cache.didCreateWebViewForTesting = { [weak self] webView, host in
+            self?.hosts[ObjectIdentifier(webView)] = host
+        }
+        if path != .new {
+            self.seededWebView = self.cache.cacheEntryForTesting(
+                websiteDataStore: self.store,
+                isBusy: path == .temporary)
+        }
+    }
+
+    func start(
+        store: WKWebsiteDataStore? = nil,
+        allowTimeoutRetry: Bool = true,
+        preserveLoadedPage: Bool = false) -> WebViewAcquireResult
+    {
+        let result = WebViewAcquireResult()
+        let store = store ?? self.store
+        result.task = Task { @MainActor [cache] in
+            do {
+                result.lease = try await cache.acquire(
+                    websiteDataStore: store,
+                    usageURL: URL(string: "https://example.invalid/usage")!,
+                    logger: nil,
+                    allowTimeoutRetry: allowTimeoutRetry,
+                    preserveLoadedPageOnRelease: preserveLoadedPage)
+            } catch {
+                result.error = error
+            }
+        }
+        return result
+    }
+
+    func expectCleanup(_ webView: WKWebView, sourceLocation: SourceLocation = #_sourceLocation) {
+        guard let host = self.hosts[ObjectIdentifier(webView)] else {
+            Issue.record("Missing host", sourceLocation: sourceLocation)
+            return
+        }
+        #expect(WebKitTeardown.isScheduledForTesting(host), sourceLocation: sourceLocation)
+        #expect(OpenAIDashboardWebViewCache.cleanupRequestCountForTesting(host) == 1, sourceLocation: sourceLocation)
+    }
+}
+
+@MainActor
+private final class WebViewAcquireResult {
+    var lease: OpenAIDashboardWebViewLease?
+    var error: Error?
+    var task: Task<Void, Never>?
+
+    func wait() async {
+        await self.task?.value
+        self.task = nil
+    }
+
+    func expectCancellation(sourceLocation: SourceLocation = #_sourceLocation) {
+        #expect(self.lease == nil, sourceLocation: sourceLocation)
+        #expect(self.error is CancellationError, sourceLocation: sourceLocation)
+        self.lease?.release()
+    }
+}
+
+@MainActor
+private final class WebViewPreparationGate {
+    @MainActor
+    struct Preparation {
+        let webView: WKWebView
+        let timeout: TimeInterval
+        let canReuseLoadedPage: Bool
+        let finish: (Result<Void, Error>) -> Void
+    }
+
+    var rejectFurtherPreparations = false
+    private(set) var callCount = 0
+    private var pending: [Preparation] = []
+    private var waiter: CheckedContinuation<Preparation, Never>?
+
+    func prepare(_ webView: WKWebView, timeout: TimeInterval, canReuseLoadedPage: Bool) async throws {
+        self.callCount += 1
+        if self.rejectFurtherPreparations { throw URLError(.cannotConnectToHost) }
+        try await withCheckedThrowingContinuation { continuation in
+            let preparation = Preparation(
+                webView: webView,
+                timeout: timeout,
+                canReuseLoadedPage: canReuseLoadedPage,
+                finish: { continuation.resume(with: $0) })
+            if let waiter = self.waiter {
+                self.waiter = nil
+                waiter.resume(returning: preparation)
+            } else {
+                self.pending.append(preparation)
+            }
+        }
+    }
+
+    func next() async -> Preparation {
+        if !self.pending.isEmpty { return self.pending.removeFirst() }
+        return await withCheckedContinuation { self.waiter = $0 }
     }
 }
 

--- a/Tests/CodexBarTests/SpendDashboardSourceConcurrencyTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardSourceConcurrencyTests.swift
@@ -1,10 +1,28 @@
 import CodexBarCore
 import Foundation
+import Observation
 import Testing
 @testable import CodexBar
 
 @MainActor
 struct SpendDashboardSourceConcurrencyTests {
+    @Test
+    func `gate readiness tolerates a delayed producer`() async throws {
+        let gate = SpendDashboardPendingLoads<CostUsageTokenSnapshot>()
+        defer { gate.close() }
+        let producer = Task {
+            try await Task.sleep(for: .seconds(2))
+            return try await gate.load()
+        }
+
+        defer { producer.cancel() }
+        try await gate.waitForPendingCount(1)
+        #expect(gate.isSuspended)
+        gate.resume(returning: Self.input(cost: 5).snapshot)
+        let snapshot = try await producer.value
+        #expect(snapshot.last30DaysCostUSD == 5)
+    }
+
     @Test(CodexCredentialFixtures())
     func `Codex batch revalidates completed and failed accounts after later scans`() async throws {
         let root = CodexCredentialFixtures.root
@@ -17,7 +35,8 @@ struct SpendDashboardSourceConcurrencyTests {
         let later = try Self.makeAccount(id: "later", root: root)
         let completedSnapshot = Self.input(cost: 1).snapshot
         let laterSnapshot = Self.input(cost: 2).snapshot
-        let gate = SpendDashboardCodexBatchGate()
+        let gate = SpendDashboardPendingLoads<CostUsageTokenSnapshot>()
+        defer { gate.close() }
         let request = SpendDashboardLoadRequest(
             configuration: SpendDashboardConfiguration(
                 costUsageEnabled: true,
@@ -37,11 +56,12 @@ struct SpendDashboardSourceConcurrencyTests {
                 case failed.id:
                     throw SpendDashboardSyntheticError.failed
                 default:
-                    await gate.load()
+                    try await gate.load()
                 }
             })
         }
-        await Self.waitForCodexGate(gate)
+        defer { loadTask.cancel() }
+        try await gate.waitForPendingCount(1)
         let replacementAuth = Data("{\"profile\":\"replacement-owner\"}".utf8)
         try replacementAuth.write(
             to: CodexAuthFingerprint.authFileURL(homePath: completed.homePath),
@@ -49,7 +69,7 @@ struct SpendDashboardSourceConcurrencyTests {
         try replacementAuth.write(
             to: CodexAuthFingerprint.authFileURL(homePath: failed.homePath),
             options: .atomic)
-        await gate.resume(snapshot: laterSnapshot)
+        gate.resume(returning: laterSnapshot)
 
         let result = await loadTask.value
         #expect(result.inputs.map(\.id) == ["codex:later"])
@@ -58,8 +78,9 @@ struct SpendDashboardSourceConcurrencyTests {
     }
 
     @Test
-    func `Codex ownership change retains failed unchanged sibling only`() async {
+    func `Codex ownership change retains failed unchanged sibling only`() async throws {
         let gate = SpendDashboardResultBatchGate()
+        defer { gate.close() }
         let initial = SpendDashboardConfiguration(
             costUsageEnabled: true,
             providerIDs: [UsageProvider.codex.rawValue],
@@ -77,24 +98,24 @@ struct SpendDashboardSourceConcurrencyTests {
             loader: { request in await gate.load(request) })
 
         controller.update(configuration: initial)
-        await Self.waitForResultGate(gate)
-        await gate.resume(result: SpendDashboardLoadResult(
+        try await gate.waitForPendingCount(1)
+        gate.resume(result: SpendDashboardLoadResult(
             inputs: [
                 Self.input(id: "codex:a", cost: 3),
                 Self.input(id: "codex:b", cost: 5),
             ],
             failedSourceIDs: []))
-        await Self.waitUntil { !controller.isRefreshing }
+        try await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.model.groups.first?.totalCost == 8)
 
         controller.update(configuration: replacement)
-        await Self.waitForResultGate(gate)
+        try await gate.waitForPendingCount(1)
         #expect(controller.model.groups.first?.totalCost == 5)
         #expect(Set(controller.model.groups.flatMap(\.providers).map(\.id)) == ["codex:b"])
-        await gate.resume(result: SpendDashboardLoadResult(
+        gate.resume(result: SpendDashboardLoadResult(
             inputs: [],
             failedSourceIDs: ["codex:a", "codex:b"]))
-        await Self.waitUntil { !controller.isRefreshing }
+        try await Self.waitUntil { !controller.isRefreshing }
 
         #expect(controller.model.groups.first?.totalCost == 5)
         #expect(Set(controller.model.groups.flatMap(\.providers).map(\.id)) == ["codex:b"])
@@ -104,7 +125,9 @@ struct SpendDashboardSourceConcurrencyTests {
     @Test
     func `Codex removal relabels retained failed account from second to first`() async throws {
         let gate = SpendDashboardResultBatchGate()
-        let requestGate = SpendDashboardProviderBatchGate()
+        defer { gate.close() }
+        let requestGate = SpendDashboardPendingLoads<Void>()
+        defer { requestGate.close() }
         let initialRequests = [
             Self.scanRequest(id: "a", displayName: "Codex · #1"),
             Self.scanRequest(id: "b", displayName: "Codex · #2"),
@@ -143,15 +166,15 @@ struct SpendDashboardSourceConcurrencyTests {
             loader: { request in await gate.load(request) })
 
         controller.update(configuration: initial)
-        await Self.waitForResultGate(gate)
-        await gate.resume(result: SpendDashboardLoadResult(
+        try await gate.waitForPendingCount(1)
+        gate.resume(result: SpendDashboardLoadResult(
             inputs: [
                 Self.input(id: "codex:a", cost: 3, displayName: "Codex · #1"),
                 Self.input(id: "codex:b", cost: 5, displayName: "Codex · #2"),
                 Self.input(id: "codex:c", cost: 7, displayName: "Codex · #3"),
             ],
             failedSourceIDs: []))
-        await Self.waitUntil { !controller.isRefreshing }
+        try await Self.waitUntil { !controller.isRefreshing }
 
         controller.update(configuration: replacement)
         let pendingRows = try #require(controller.model.groups.first?.providers)
@@ -159,14 +182,14 @@ struct SpendDashboardSourceConcurrencyTests {
             "codex:b": "Codex · #1",
             "codex:c": "Codex · #2",
         ])
-        await Self.waitForProviderGate(requestGate)
-        #expect(await gate.pendingCount == 0)
-        await requestGate.resume()
-        await Self.waitForResultGate(gate)
-        await gate.resume(result: SpendDashboardLoadResult(
+        try await requestGate.waitForPendingCount(1)
+        #expect(gate.pendingCount == 0)
+        requestGate.resume()
+        try await gate.waitForPendingCount(1)
+        gate.resume(result: SpendDashboardLoadResult(
             inputs: [Self.input(id: "codex:c", cost: 8, displayName: "Codex · #2")],
             failedSourceIDs: ["codex:b"]))
-        await Self.waitUntil { !controller.isRefreshing }
+        try await Self.waitUntil { !controller.isRefreshing }
 
         let finalRows = try #require(controller.model.groups.first?.providers)
         #expect(Dictionary(uniqueKeysWithValues: finalRows.map { ($0.id, $0.displayName) }) == [
@@ -178,8 +201,9 @@ struct SpendDashboardSourceConcurrencyTests {
     }
 
     @Test
-    func `request revision captured before coalesced update cannot publish stale inputs`() async {
-        let requestGate = SpendDashboardProviderBatchGate()
+    func `request revision captured before coalesced update cannot publish stale inputs`() async throws {
+        let requestGate = SpendDashboardPendingLoads<Void>()
+        defer { requestGate.close() }
         let recorder = SpendDashboardRequestRecorder()
         let initial = SpendDashboardConfiguration(
             costUsageEnabled: true,
@@ -209,10 +233,10 @@ struct SpendDashboardSourceConcurrencyTests {
             })
 
         controller.update(configuration: initial, force: true)
-        await Self.waitForProviderGate(requestGate)
+        try await requestGate.waitForPendingCount(1)
         controller.update(configuration: replacement)
-        await requestGate.resume()
-        await Self.waitUntil { !controller.isRefreshing }
+        requestGate.resume()
+        try await Self.waitUntil { !controller.isRefreshing }
 
         #expect(controller.configuration == replacement)
         #expect(controller.generation == 2)
@@ -223,7 +247,7 @@ struct SpendDashboardSourceConcurrencyTests {
     }
 
     @Test
-    func `force adopts builder published revision without losing Codex scan intent`() async {
+    func `force adopts builder published revision without losing Codex scan intent`() async throws {
         let recorder = SpendDashboardRequestRecorder()
         let initial = SpendDashboardConfiguration(
             costUsageEnabled: true,
@@ -249,7 +273,7 @@ struct SpendDashboardSourceConcurrencyTests {
             })
 
         controller.update(configuration: initial, force: true)
-        await Self.waitUntil { !controller.isRefreshing }
+        try await Self.waitUntil { !controller.isRefreshing }
 
         #expect(controller.configuration == replacement)
         #expect(controller.generation == 2)
@@ -259,8 +283,9 @@ struct SpendDashboardSourceConcurrencyTests {
     }
 
     @Test
-    func `forced builder owner mismatch reruns replacement builder and rejects cached request`() async {
-        let requestGate = SpendDashboardProviderBatchGate()
+    func `forced builder owner mismatch reruns replacement builder and rejects cached request`() async throws {
+        let requestGate = SpendDashboardPendingLoads<Void>()
+        defer { requestGate.close() }
         let recorder = SpendDashboardRequestRecorder()
         let initial = SpendDashboardConfiguration(
             costUsageEnabled: true,
@@ -292,7 +317,7 @@ struct SpendDashboardSourceConcurrencyTests {
             })
 
         controller.update(configuration: initial, force: true)
-        await Self.waitForProviderGate(requestGate)
+        try await requestGate.waitForPendingCount(1)
 
         #expect(controller.configuration == replacement)
         #expect(controller.generation == 2)
@@ -300,8 +325,8 @@ struct SpendDashboardSourceConcurrencyTests {
         #expect(requestSequence.modes == [.forceRefresh, .forceRefresh])
         #expect(await recorder.configurations.isEmpty)
 
-        await requestGate.resume()
-        await Self.waitUntil { !controller.isRefreshing }
+        requestGate.resume()
+        try await Self.waitUntil { !controller.isRefreshing }
 
         #expect(controller.configuration == replacement)
         #expect(controller.generation == 3)
@@ -312,8 +337,9 @@ struct SpendDashboardSourceConcurrencyTests {
     }
 
     @Test
-    func `ownership replacement while force builder is pending reruns builder and loader forced`() async {
-        let requestGate = SpendDashboardProviderBatchGate()
+    func `ownership replacement while force builder is pending reruns builder and loader forced`() async throws {
+        let requestGate = SpendDashboardPendingLoads<Void>()
+        defer { requestGate.close() }
         let recorder = SpendDashboardRequestRecorder()
         let initial = SpendDashboardConfiguration(
             costUsageEnabled: true,
@@ -344,10 +370,10 @@ struct SpendDashboardSourceConcurrencyTests {
             })
 
         controller.update(configuration: initial, force: true)
-        await Self.waitForProviderGate(requestGate)
+        try await requestGate.waitForPendingCount(1)
         controller.update(configuration: replacement)
-        await Self.waitUntil { !controller.isRefreshing }
-        await requestGate.resume()
+        try await Self.waitUntil { !controller.isRefreshing }
+        requestGate.resume()
         await Task.yield()
 
         #expect(controller.configuration == replacement)
@@ -359,8 +385,9 @@ struct SpendDashboardSourceConcurrencyTests {
     }
 
     @Test
-    func `ownership replacement after force builder completes reruns builder and loader forced`() async {
-        let loaderGate = SpendDashboardRecordedResultGate()
+    func `ownership replacement after force builder completes reruns builder and loader forced`() async throws {
+        let loaderGate = SpendDashboardResultBatchGate()
+        defer { loaderGate.close() }
         let initial = SpendDashboardConfiguration(
             costUsageEnabled: true,
             providerIDs: [UsageProvider.codex.rawValue, UsageProvider.claude.rawValue],
@@ -385,21 +412,21 @@ struct SpendDashboardSourceConcurrencyTests {
             loader: { request in await loaderGate.load(request) })
 
         controller.update(configuration: initial, force: true)
-        await Self.waitForRecordedResultGate(loaderGate, pendingCount: 1)
+        try await loaderGate.waitForPendingCount(1)
         controller.update(configuration: replacement)
-        await Self.waitForRecordedResultGate(loaderGate, pendingCount: 2)
+        try await loaderGate.waitForPendingCount(2)
 
         #expect(requestSequence.modes == [.forceRefresh, .forceRefresh])
-        #expect(await loaderGate.configurations == [initial, replacement])
-        #expect(await loaderGate.forces == [true, true])
+        #expect(loaderGate.configurations == [initial, replacement])
+        #expect(loaderGate.forces == [true, true])
 
-        await loaderGate.resume(
+        loaderGate.resume(
             at: 1,
             result: SpendDashboardLoadResult(
                 inputs: [Self.input(provider: .codex, cost: 5)],
                 failedSourceIDs: []))
-        await Self.waitUntil { !controller.isRefreshing }
-        await loaderGate.resume(
+        try await Self.waitUntil { !controller.isRefreshing }
+        loaderGate.resume(
             at: 0,
             result: SpendDashboardLoadResult(
                 inputs: [Self.input(provider: .codex, cost: 99)],
@@ -412,8 +439,9 @@ struct SpendDashboardSourceConcurrencyTests {
     }
 
     @Test
-    func `ordinary in flight same owner revision churn does not restart load`() async {
+    func `ordinary in flight same owner revision churn does not restart load`() async throws {
         let loaderGate = SpendDashboardResultBatchGate()
+        defer { loaderGate.close() }
         let initial = SpendDashboardConfiguration(
             costUsageEnabled: true,
             providerIDs: [UsageProvider.codex.rawValue],
@@ -440,7 +468,7 @@ struct SpendDashboardSourceConcurrencyTests {
         controllerBox.controller = controller
 
         controller.update(configuration: initial)
-        await Self.waitForResultGate(loaderGate)
+        try await loaderGate.waitForPendingCount(1)
         let inFlightGeneration = controller.generation
         #expect(controller.isRefreshing)
 
@@ -450,16 +478,16 @@ struct SpendDashboardSourceConcurrencyTests {
         #expect(controller.publication.configuration == replacement)
         #expect(controller.publication.isRefreshing)
 
-        await loaderGate.resume(
+        loaderGate.resume(
             result: SpendDashboardLoadResult(
                 inputs: [Self.input(provider: .codex, cost: 7)],
                 failedSourceIDs: []))
-        await Self.waitForResultGate(loaderGate)
-        await loaderGate.resume(
+        try await loaderGate.waitForPendingCount(1)
+        loaderGate.resume(
             result: SpendDashboardLoadResult(
                 inputs: [Self.input(provider: .codex, cost: 7)],
                 failedSourceIDs: []))
-        await Self.waitUntil { !controller.isRefreshing }
+        try await Self.waitUntil { !controller.isRefreshing }
 
         #expect(controller.generation == inFlightGeneration + 1)
         #expect(controller.configuration == replacement)
@@ -467,9 +495,13 @@ struct SpendDashboardSourceConcurrencyTests {
     }
 
     @Test
-    func `ordinary in flight same owner revision churn preserves live load after suspended cached prefill`() async {
+    func `ordinary in flight same owner revision churn preserves live load after suspended cached prefill`()
+        async throws
+    {
         let cachedGate = SpendDashboardResultBatchGate()
+        defer { cachedGate.close() }
         let loaderGate = SpendDashboardResultBatchGate()
+        defer { loaderGate.close() }
         let initial = SpendDashboardConfiguration(
             costUsageEnabled: true,
             providerIDs: [UsageProvider.codex.rawValue],
@@ -497,7 +529,7 @@ struct SpendDashboardSourceConcurrencyTests {
         controllerBox.controller = controller
 
         controller.update(configuration: initial)
-        await Self.waitForResultGate(cachedGate)
+        try await cachedGate.waitForPendingCount(1)
         let inFlightGeneration = controller.generation
         #expect(controller.isRefreshing)
 
@@ -507,27 +539,28 @@ struct SpendDashboardSourceConcurrencyTests {
         #expect(controller.configuration == replacement)
 
         // Resume cached prefill with stale initial configuration result.
-        await cachedGate.resume(
+        cachedGate.resume(
             result: SpendDashboardLoadResult(
                 inputs: [Self.input(id: "codex:same", cost: 3)],
                 failedSourceIDs: []))
 
         // Ensure live load is still executed rather than aborting the task early.
-        await Self.waitForResultGate(loaderGate)
-        await loaderGate.resume(
+        try await loaderGate.waitForPendingCount(1)
+        loaderGate.resume(
             result: SpendDashboardLoadResult(
                 inputs: [Self.input(id: "codex:same", cost: 12)],
                 failedSourceIDs: []))
 
         // Reconciliation pass for remaining drift if needed.
-        if await loaderGate.pendingCount > 0 {
-            await loaderGate.resume(
+        try await Self.waitUntil { !controller.isRefreshing || loaderGate.pendingCount > 0 }
+        if loaderGate.pendingCount > 0 {
+            loaderGate.resume(
                 result: SpendDashboardLoadResult(
                     inputs: [Self.input(id: "codex:same", cost: 12)],
                     failedSourceIDs: []))
         }
 
-        await Self.waitUntil { !controller.isRefreshing }
+        try await Self.waitUntil { !controller.isRefreshing }
         #expect(controller.configuration == replacement)
         #expect(controller.model.groups.first?.totalCost == 12)
     }
@@ -557,28 +590,40 @@ struct SpendDashboardSourceConcurrencyTests {
             now: Date(timeIntervalSince1970: 1_784_179_200),
             force: true)
 
-        let gateFirst = SpendDashboardCodexBatchGate()
-        let gateSecond = SpendDashboardCodexBatchGate()
+        let secondSnapshotLoaded = SpendDashboardTestSignal<Void>()
+        let gateFirst = SpendDashboardPendingLoads<CostUsageTokenSnapshot>()
+        defer { gateFirst.close() }
+        let gateSecond = SpendDashboardPendingLoads<CostUsageTokenSnapshot>()
+        defer { gateSecond.close() }
         let loadTask = Task {
             await SpendDashboardSource.load(
                 request,
                 codexSnapshotLoader: { context in
                     switch context.account.id {
                     case first.id:
-                        await gateFirst.load()
+                        try await gateFirst.load()
                     case second.id:
-                        await gateSecond.load()
+                        try await gateSecond.load()
                     default:
                         fatalError("unexpected account \(context.account.id)")
                     }
                 },
-                codexActivityLoader: { _ in nil })
+                codexActivityLoader: { context in
+                    if context.account.id == second.id {
+                        await secondSnapshotLoaded.resolve(.success(()))
+                    }
+                    return nil
+                })
         }
+        defer { loadTask.cancel() }
         // Wait until both gates are suspended, then resume second before first.
-        await Self.waitForCodexGate(gateFirst)
-        await Self.waitForCodexGate(gateSecond)
-        await gateSecond.resume(snapshot: secondSnapshot)
-        await gateFirst.resume(snapshot: firstSnapshot)
+        try await gateFirst.waitForPendingCount(1)
+        try await gateSecond.waitForPendingCount(1)
+        gateSecond.resume(returning: secondSnapshot)
+        // Activity loading follows snapshot loading; first must still be blocked at that boundary.
+        try await secondSnapshotLoaded.wait()
+        #expect(gateFirst.isSuspended)
+        gateFirst.resume(returning: firstSnapshot)
         let final = await loadTask.value
         // Inputs should be in configured order [first, second], not completion order.
         #expect(final.inputs.map(\.id) == ["codex:first", "codex:second"])
@@ -612,7 +657,8 @@ struct SpendDashboardSourceConcurrencyTests {
             Self.input(provider: laterProvider, cost: 2).snapshot,
             provider: laterProvider)
 
-        let gate = SpendDashboardProviderBatchGate()
+        let gate = SpendDashboardPendingLoads<Void>()
+        defer { gate.close() }
         store._test_tokenUsageRefreshOverride = { provider, _ in
             #expect(provider == firstProvider)
             store._setTokenSnapshotForTesting(
@@ -630,11 +676,12 @@ struct SpendDashboardSourceConcurrencyTests {
         let requestTask = Task { @MainActor in
             await SpendDashboardSource.makeRequest(settings: settings, store: store, mode: .forceRefresh)
         }
-        await Self.waitForProviderGate(gate)
+        defer { requestTask.cancel() }
+        try await gate.waitForPendingCount(1)
         store._setTokenSnapshotForTesting(
             Self.input(provider: firstProvider, cost: 11).snapshot,
             provider: firstProvider)
-        await gate.resume()
+        gate.resume()
 
         let request = await requestTask.value
         let firstInput = try #require(request.capturedInputs.first { $0.provider == firstProvider })
@@ -700,61 +747,122 @@ struct SpendDashboardSourceConcurrencyTests {
             snapshot: snapshot)
     }
 
-    private static func waitForCodexGate(_ gate: SpendDashboardCodexBatchGate) async {
-        for _ in 0..<1000 {
-            if await gate.isSuspended {
-                return
-            }
-            await Task.yield()
-        }
-        Issue.record("Timed out waiting for pending Codex load")
-    }
-
-    private static func waitForProviderGate(_ gate: SpendDashboardProviderBatchGate) async {
-        for _ in 0..<1000 {
-            if await gate.isSuspended {
-                return
-            }
-            await Task.yield()
-        }
-        Issue.record("Timed out waiting for pending provider refresh")
-    }
-
-    private static func waitForResultGate(_ gate: SpendDashboardResultBatchGate) async {
-        for _ in 0..<1000 {
-            if await gate.pendingCount == 1 {
-                return
-            }
-            await Task.yield()
-        }
-        Issue.record("Timed out waiting for pending dashboard load")
-    }
-
-    private static func waitForRecordedResultGate(
-        _ gate: SpendDashboardRecordedResultGate,
-        pendingCount: Int) async
-    {
-        for _ in 0..<1000 {
-            if await gate.pendingCount == pendingCount {
-                return
-            }
-            await Task.yield()
-        }
-        Issue.record("Timed out waiting for \(pendingCount) recorded dashboard loads")
-    }
-
-    private static func waitUntil(_ condition: @MainActor () -> Bool) async {
-        for _ in 0..<1000 {
-            if condition() {
-                return
-            }
-            await Task.yield()
-        }
-        Issue.record("Timed out waiting for dashboard state")
+    private static func waitUntil(_ condition: @escaping @MainActor () -> Bool) async throws {
+        try await SpendDashboardStateWait.until(condition)
     }
 }
 
-private enum SpendDashboardSyntheticError: Error {
+extension SpendDashboardSourceConcurrencyTests {
+    @Test
+    func `gate readiness observes an already pending producer and can be reused`() async throws {
+        let gate = SpendDashboardPendingLoads<Int>()
+        defer { gate.close() }
+        for value in [1, 2] {
+            let producer = Task { try await gate.load() }
+            try await Self.waitUntil { gate.pendingCount == 1 }
+            try await gate.waitForPendingCount(1)
+            #expect(gate.readinessWaiterCount == 0)
+            gate.resume(returning: value)
+            #expect(try await producer.value == value)
+            #expect(gate.pendingCount == 0)
+        }
+    }
+
+    @Test
+    func `gate readiness timeout drains pending loads and rejects late arrivals`() async throws {
+        let gate = SpendDashboardPendingLoads<Int>()
+        defer { gate.close() }
+        let producer = Task { try await gate.load() }
+        try await gate.waitForPendingCount(1)
+
+        let started = ContinuousClock.now
+        await #expect(throws: SpendDashboardWaitError.timedOut) {
+            try await gate.waitForPendingCount(2, timeout: .milliseconds(20))
+        }
+        #expect(ContinuousClock.now - started >= .milliseconds(20))
+        await #expect(throws: SpendDashboardWaitError.closed) { try await producer.value }
+        await #expect(throws: SpendDashboardWaitError.closed) { try await gate.load() }
+        #expect(gate.isClosed)
+        #expect(gate.pendingCount == 0)
+        #expect(gate.readinessWaiterCount == 0)
+    }
+
+    @Test
+    func `cancelling a registered readiness wait drains its producer`() async throws {
+        let gate = SpendDashboardPendingLoads<Int>()
+        defer { gate.close() }
+        let producer = Task { try await gate.load() }
+        try await gate.waitForPendingCount(1)
+        let waiter = Task { try await gate.waitForPendingCount(2) }
+        try await Self.waitUntil { gate.readinessWaiterCount == 1 }
+        waiter.cancel()
+
+        await #expect(throws: CancellationError.self) { try await waiter.value }
+        await #expect(throws: SpendDashboardWaitError.closed) { try await producer.value }
+        #expect(gate.isClosed)
+        #expect(gate.pendingCount == 0)
+        #expect(gate.readinessWaiterCount == 0)
+    }
+
+    @Test
+    func `readiness cancellation before registration closes the gate`() async {
+        let gate = SpendDashboardPendingLoads<Int>()
+        defer { gate.close() }
+        let waiter = Task { try await gate.waitForPendingCount(1) }
+        waiter.cancel()
+
+        await #expect(throws: CancellationError.self) { try await waiter.value }
+        await #expect(throws: SpendDashboardWaitError.closed) { try await gate.load() }
+        #expect(gate.pendingCount == 0)
+        #expect(gate.readinessWaiterCount == 0)
+    }
+
+    @Test
+    func `producer cancellation preserves the deliberate stale completion gate`() async throws {
+        let gate = SpendDashboardPendingLoads<Int>()
+        defer { gate.close() }
+        let producer = Task { try await gate.load() }
+        try await gate.waitForPendingCount(1)
+        producer.cancel()
+        #expect(gate.pendingCount == 1)
+        gate.resume(returning: 42)
+        #expect(try await producer.value == 42)
+        #expect(gate.pendingCount == 0)
+    }
+
+    @Test
+    func `throwing test scope drains multiple pending loads`() async throws {
+        let gate = SpendDashboardPendingLoads<Int>()
+        let first = Task { try await gate.load() }
+        let second = Task { try await gate.load() }
+        await #expect(throws: SpendDashboardSyntheticError.failed) {
+            defer { gate.close() }
+            try await gate.waitForPendingCount(2)
+            throw SpendDashboardSyntheticError.failed
+        }
+
+        await #expect(throws: SpendDashboardWaitError.closed) { try await first.value }
+        await #expect(throws: SpendDashboardWaitError.closed) { try await second.value }
+        gate.close()
+        #expect(gate.pendingCount == 0)
+        #expect(gate.readinessWaiterCount == 0)
+    }
+
+    @Test
+    func `state observation timeout releases its captured state`() async {
+        weak var released: SpendDashboardPendingLoads<Int>?
+        await #expect(throws: SpendDashboardWaitError.timedOut) {
+            let gate = SpendDashboardPendingLoads<Int>()
+            released = gate
+            try await SpendDashboardStateWait.until(timeout: .milliseconds(20)) {
+                gate.isClosed
+            }
+        }
+        #expect(released == nil)
+    }
+}
+
+private enum SpendDashboardSyntheticError: Error, Equatable {
     case failed
 }
 
@@ -778,14 +886,14 @@ private final class SpendDashboardRequestSequence {
 
     private var items: [Item]
     private let suspendAt: Int?
-    private let gate: SpendDashboardProviderBatchGate?
+    private let gate: SpendDashboardPendingLoads<Void>?
     private var index = 0
     private(set) var modes: [SpendDashboardRequestBuildMode] = []
 
     init(
         _ items: [Item],
         suspendAt: Int? = nil,
-        gate: SpendDashboardProviderBatchGate? = nil)
+        gate: SpendDashboardPendingLoads<Void>? = nil)
     {
         self.items = items
         self.suspendAt = suspendAt
@@ -820,12 +928,158 @@ private actor SpendDashboardRequestRecorder {
     }
 }
 
-private actor SpendDashboardRecordedResultGate {
-    private var requests: [SpendDashboardLoadRequest] = []
-    private var continuations: [CheckedContinuation<SpendDashboardLoadResult, Never>] = []
+private enum SpendDashboardWaitError: Error, Equatable {
+    case timedOut
+    case closed
+}
+
+@MainActor
+private final class SpendDashboardTestSignal<Value: Sendable> {
+    private var result: Result<Value, any Error>?
+    private var continuation: CheckedContinuation<Value, any Error>?
+    private var watchdog: Task<Void, Never>?
+
+    func resolve(_ result: Result<Value, any Error>) {
+        guard self.result == nil else { return }
+        self.result = result
+        self.watchdog?.cancel()
+        self.watchdog = nil
+        let continuation = self.continuation
+        self.continuation = nil
+        continuation?.resume(with: result)
+    }
+
+    func wait(timeout: Duration = .seconds(5), ignoringCancellation: Bool = false) async throws -> Value {
+        try await withTaskCancellationHandler {
+            if !ignoringCancellation { try Task.checkCancellation() }
+            if let result = self.result { return try result.get() }
+            let deadline = ContinuousClock.now + timeout
+            return try await withCheckedThrowingContinuation { continuation in
+                precondition(self.continuation == nil)
+                self.continuation = continuation
+                self.watchdog = Task { @MainActor [weak self] in
+                    do { try await Task.sleep(until: deadline, clock: .continuous) } catch { return }
+                    self?.resolve(.failure(SpendDashboardWaitError.timedOut))
+                }
+            }
+        } onCancel: {
+            if !ignoringCancellation {
+                Task { @MainActor in self.resolve(.failure(CancellationError())) }
+            }
+        }
+    }
+}
+
+@MainActor
+private final class SpendDashboardStateWait {
+    private var condition: (@MainActor () -> Bool)?
+    private let signal = SpendDashboardTestSignal<Void>()
+
+    private init(_ condition: @escaping @MainActor () -> Bool) {
+        self.condition = condition
+    }
+
+    static func until(
+        timeout: Duration = .seconds(5),
+        _ condition: @escaping @MainActor () -> Bool) async throws
+    {
+        let wait = Self(condition)
+        defer { wait.condition = nil }
+        wait.observe()
+        try await wait.signal.wait(timeout: timeout)
+    }
+
+    private func observe() {
+        guard let condition = self.condition else { return }
+        if withObservationTracking(condition, onChange: { [weak self] in
+            Task { @MainActor [weak self] in self?.observe() }
+        }) {
+            self.signal.resolve(.success(()))
+        }
+    }
+}
+
+@MainActor
+@Observable
+private final class SpendDashboardPendingLoads<Value: Sendable> {
+    private var pending: [SpendDashboardTestSignal<Value>] = []
+    private(set) var isClosed = false
+    private(set) var readinessWaiterCount = 0
 
     var pendingCount: Int {
-        self.continuations.count
+        self.pending.count
+    }
+
+    var isSuspended: Bool {
+        !self.pending.isEmpty
+    }
+
+    func load() async throws -> Value {
+        guard !self.isClosed else { throw SpendDashboardWaitError.closed }
+        let signal = SpendDashboardTestSignal<Value>()
+        self.pending.append(signal)
+        defer { self.pending.removeAll { $0 === signal } }
+        do {
+            // Stale-owner tests deliberately complete cancelled producers. Only the test owns their release.
+            return try await signal.wait(ignoringCancellation: true)
+        } catch {
+            if case SpendDashboardWaitError.timedOut = error {
+                Issue.record("Timed out waiting for the test to release a dashboard load")
+            }
+            self.close()
+            throw error
+        }
+    }
+
+    func waitForPendingCount(_ count: Int, timeout: Duration = .seconds(5)) async throws {
+        self.readinessWaiterCount += 1
+        defer { self.readinessWaiterCount -= 1 }
+        do {
+            try await SpendDashboardStateWait.until(timeout: timeout) {
+                self.pendingCount == count || self.isClosed
+            }
+            guard !self.isClosed else { throw SpendDashboardWaitError.closed }
+        } catch {
+            self.close()
+            throw error
+        }
+    }
+
+    func resume(at index: Int = 0, returning value: Value) {
+        guard self.pending.indices.contains(index) else {
+            Issue.record("Cannot resume a dashboard load before it is pending")
+            return
+        }
+        self.pending.remove(at: index).resolve(.success(value))
+    }
+
+    func close() {
+        self.isClosed = true
+        let pending = self.pending
+        self.pending.removeAll()
+        for signal in pending {
+            signal.resolve(.failure(SpendDashboardWaitError.closed))
+        }
+    }
+}
+
+extension SpendDashboardPendingLoads where Value == Void {
+    func suspend() async {
+        _ = try? await self.load()
+    }
+
+    func resume() {
+        self.resume(returning: ())
+    }
+}
+
+@MainActor
+private final class SpendDashboardResultBatchGate {
+    private var requests: [SpendDashboardLoadRequest] = []
+    private let pending = SpendDashboardPendingLoads<SpendDashboardLoadResult>()
+
+    var pendingCount: Int {
+        self.pending.pendingCount
     }
 
     var configurations: [SpendDashboardConfiguration] {
@@ -838,70 +1092,24 @@ private actor SpendDashboardRecordedResultGate {
 
     func load(_ request: SpendDashboardLoadRequest) async -> SpendDashboardLoadResult {
         self.requests.append(request)
-        return await withCheckedContinuation { continuation in
-            self.continuations.append(continuation)
+        do {
+            return try await self.pending.load()
+        } catch {
+            // A readiness failure already fails the test; closing its scope must still drain controller tasks.
+            return SpendDashboardLoadResult(inputs: [], failedSourceIDs: [])
         }
     }
 
-    func resume(at index: Int, result: SpendDashboardLoadResult) {
-        self.continuations.remove(at: index).resume(returning: result)
-    }
-}
-
-private actor SpendDashboardCodexBatchGate {
-    private var continuation: CheckedContinuation<CostUsageTokenSnapshot, Never>?
-
-    var isSuspended: Bool {
-        self.continuation != nil
+    func waitForPendingCount(_ count: Int) async throws {
+        try await self.pending.waitForPendingCount(count)
     }
 
-    func load() async -> CostUsageTokenSnapshot {
-        await withCheckedContinuation { continuation in
-            self.continuation = continuation
-        }
+    func resume(at index: Int = 0, result: SpendDashboardLoadResult) {
+        self.pending.resume(at: index, returning: result)
     }
 
-    func resume(snapshot: CostUsageTokenSnapshot) {
-        self.continuation?.resume(returning: snapshot)
-        self.continuation = nil
-    }
-}
-
-private actor SpendDashboardProviderBatchGate {
-    private var continuation: CheckedContinuation<Void, Never>?
-
-    var isSuspended: Bool {
-        self.continuation != nil
-    }
-
-    func suspend() async {
-        await withCheckedContinuation { continuation in
-            self.continuation = continuation
-        }
-    }
-
-    func resume() {
-        self.continuation?.resume()
-        self.continuation = nil
-    }
-}
-
-private actor SpendDashboardResultBatchGate {
-    private var continuations: [CheckedContinuation<SpendDashboardLoadResult, Never>] = []
-
-    var pendingCount: Int {
-        self.continuations.count
-    }
-
-    func load(_ request: SpendDashboardLoadRequest) async -> SpendDashboardLoadResult {
-        _ = request
-        return await withCheckedContinuation { continuation in
-            self.continuations.append(continuation)
-        }
-    }
-
-    func resume(result: SpendDashboardLoadResult) {
-        self.continuations.removeFirst().resume(returning: result)
+    func close() {
+        self.pending.close()
     }
 }
 

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -121,6 +121,18 @@ func testConfigStore(suiteName: String, reset: Bool = true) -> CodexBarConfigSto
 }
 
 @MainActor
+func testConfigWithAllProvidersDisabled() -> CodexBarConfig {
+    let metadata = ProviderRegistry.shared.metadata
+    var config = CodexBarConfig.makeDefault(metadata: metadata)
+    for index in config.providers.indices {
+        guard let provider = config.providers[index].id.firstPartyProvider,
+              metadata[provider] != nil else { continue }
+        config.providers[index].enabled = false
+    }
+    return config
+}
+
+@MainActor
 func testSettingsStore(
     suiteName: String,
     tokenAccountStore: any ProviderTokenAccountStoring = InMemoryTokenAccountStore(),

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -154,7 +154,11 @@ owned set to drain within five seconds. Error paths make a final bounded attempt
 identities and reap the direct child, then propagate failure instead of starting another suite/retry.
 Initialization failures similarly TERM/KILL/reap the still-owned direct child. Linux treats a zombie
 leader with other threads as running. Other PIDs require birth checks before signals, with pidfds used
-on Linux when available. macOS birth checking and signaling remain separate system calls.
+on Linux when available. macOS descendant signals use `proc_signal_with_audittoken`: a combined native
+BSD/unique-identity read must match the tracked birth, then the kernel binds the signal to that PID's
+generation while checking the caller's normal signal permissions. A stale generation (including an
+exec race) is not signaled; later cleanup attempts can refresh it after matching birth again. Missing
+native signal support, permission failures, and I/O errors fail cleanup without a numeric-PID fallback.
 
 This is a bounded metadata polling tracker, not a daemon sandbox. A new session whose leader and attached
 ancestry both disappear entirely between observations cannot be discovered reliably. Snapshot enumeration
@@ -163,6 +167,9 @@ discovery/build path is unchanged; the 180-second bound applies to each suite/gr
 startup. `Scripts/test_swift_test_sharding.sh` includes synthetic containment tests; they do not launch
 Swift, the app, or provider probes. Its native pthread regression runs only on Linux and uses the system C
 compiler; macOS runs the corresponding metadata unit tests and reports the native case as skipped.
+macOS also runs native audit-token fixtures: deliberately wrong generations leave owned children alive,
+matching identities TERM/KILL and reap them, and unrelated sentinels survive. These fixtures use stop
+files and self-expiry, with final cleanup restricted to their unreaped direct children.
 
 Cost performance and fair-scheduling corpora use exclusive initial fixture creation: the scanner only
 reads after setup has closed each file. This avoids per-file atomic publication and durability work

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -182,6 +182,14 @@ reads after setup has closed each file. This avoids per-file atomic publication 
 without changing corpus contents or scan budgets. The shared atomic fixture writer remains available
 for replacement and publication tests.
 
+### Adaptive refresh fixtures
+
+Heuristics and timer tests seed disabled providers through `testSettingsStore(config:)`, which saves the
+file-backed config before settings initialization. They do not replay a synchronous config write for each
+provider toggle during setup. The seed preserves provider defaults and explicitly keeps OpenAI web access
+off; an existing config would otherwise enable it. Reset-boundary tests then enable only the stubbed Codex
+provider. Timer intervals, polling deadlines, and production persistence behavior remain unchanged.
+
 ### Claude session fixtures
 
 Profile/reuse and overlapping-capture tests wait for the fixture's expected `Account:` response with idle

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -132,6 +132,43 @@ See the canonical [provider authoring guide](provider.md#adding-a-new-provider) 
 make test
 ```
 
+Suite commands retain the default 180-second deadline, including SwiftPM startup and discovery.
+The runner reports elapsed time and owned PIDs every 30 seconds even when test output is buffered.
+It tracks process birth identities and descendants, including helpers that create separate process
+groups or sessions, and drains them before retrying. Separate sessions are allowed: the shell runner
+uses them to protect controlling-terminal ownership. The direct command remains unreaped until cleanup
+finishes (`waitid` with `WNOWAIT`), preventing reuse of its PID/session. Observed descendant session
+leaders can establish ownership of orphaned session members only while a matching live or unreaped
+birth identity still anchors that session. Known descendants retain their identities after reparenting;
+empty completed sessions retire. If an observed session loses its anchor while unaccounted live members
+remain, cleanup fails without adopting or signaling those uncertain PIDs. Unavailable metadata for a
+known identity also fails cleanup; an unreadable unrelated peer does not abort enumeration.
+For the direct child, confirmed metadata absence (ESRCH/ENOENT) can precede a waitable exit on
+Darwin. Its unreaped wait handle retains ownership while ordinary polling continues within the
+original command deadline. Pending wait status is not completion; permission and I/O errors still
+fail. Direct-child cleanup signals require retained wait ownership, even if no birth metadata was
+captured. Other PIDs continue to require verified birth identities.
+
+Cleanup sends TERM to verified individual identities, escalates after three seconds, and requires the
+owned set to drain within five seconds. Error paths make a final bounded attempt against readable known
+identities and reap the direct child, then propagate failure instead of starting another suite/retry.
+Initialization failures similarly TERM/KILL/reap the still-owned direct child. Linux treats a zombie
+leader with other threads as running. Other PIDs require birth checks before signals, with pidfds used
+on Linux when available. macOS birth checking and signaling remain separate system calls.
+
+This is a bounded metadata polling tracker, not a daemon sandbox. A new session whose leader and attached
+ancestry both disappear entirely between observations cannot be discovered reliably. Snapshot enumeration
+is not atomic, and unreadable, never-observed descendants cannot be attributed. The initial `swift test list`
+discovery/build path is unchanged; the 180-second bound applies to each suite/group command, including its
+startup. `Scripts/test_swift_test_sharding.sh` includes synthetic containment tests; they do not launch
+Swift, the app, or provider probes. Its native pthread regression runs only on Linux and uses the system C
+compiler; macOS runs the corresponding metadata unit tests and reports the native case as skipped.
+
+Cost performance and fair-scheduling corpora use exclusive initial fixture creation: the scanner only
+reads after setup has closed each file. This avoids per-file atomic publication and durability work
+without changing corpus contents or scan budgets. The shared atomic fixture writer remains available
+for replacement and publication tests.
+
 ### Codex credential fixtures
 
 Ordinary tests deny Codex credential-file access at the Codex-owned I/O boundaries, before reads,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -171,10 +171,24 @@ macOS also runs native audit-token fixtures: deliberately wrong generations leav
 matching identities TERM/KILL and reap them, and unrelated sentinels survive. These fixtures use stop
 files and self-expiry, with final cleanup restricted to their unreaped direct children.
 
+Process-cleanup fixtures keep ancestry alive until the real ownership refresh observes matching ready
+child identities (and the session-tree grandchild), then acknowledges a private fixture gate before drain.
+The direct `waitid` fixture uses the same handshake without reaping its root. Immediate cases and a controlled
+one-second readiness delay retain the two-second command budget; startup no longer adds a fixed 1.2-second
+ancestry sleep. Gate waits are bounded and stop-file aware; helper self-expiry remains 20 seconds.
+
 Cost performance and fair-scheduling corpora use exclusive initial fixture creation: the scanner only
 reads after setup has closed each file. This avoids per-file atomic publication and durability work
 without changing corpus contents or scan budgets. The shared atomic fixture writer remains available
 for replacement and publication tests.
+
+### Claude session fixtures
+
+Profile/reuse and overlapping-capture tests wait for the fixture's expected `Account:` response with idle
+completion disabled; PTY command echo alone is not functional completion. The profile/reuse test keeps both
+immediate responses and a controlled 0.5-second response delay, beyond the former 0.1-second idle window.
+Capture budgets remain two seconds for profile/reuse and five seconds for overlap. Account, environment,
+launch-count, isolation, and stale-artifact assertions remain independent of the completion condition.
 
 ### Codex credential fixtures
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -165,6 +165,15 @@ compiles the actual policy and detector with optimization and without `DEBUG`, t
 scoped-child, and non-test decisions against synthetic temporary files. It does not build or exercise
 the complete release CLI, refresh a real account, or establish isolation for other providers.
 
+### WebView ownership regressions
+
+`OpenAIDashboardWebViewCacheTests` uses explicit nonpersistent stores and a DEBUG preparation seam to suspend
+acquisitions without navigation. Controlled continuations exercise eviction/replacement, stale completion, timeout
+retry, store-scoped invalidation, and lease cleanup after cache loss. Host assertions check one cleanup request and
+registration with `WebKitTeardown`; they do not establish WebContent process termination or diagnose CPU/RSS incidents.
+The existing headless CI guards remain in place for these AppKit tests. The suite also contains older persistent-store
+factory tests; exclude those when running a nonpersistent-only focused check.
+
 ### CI Aggregate Contract
 
 The `lint-build-test` check in `.github/workflows/ci.yml` keeps its existing name and requires successful lint,

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -93,6 +93,11 @@ Example:
 - Uses an off-screen `WKWebView` with a per-account `WKWebsiteDataStore`.
   - Store key: deterministic UUID from the normalized email.
 - WebKit store can hold multiple accounts concurrently.
+- Each WebView acquisition keeps ownership across asynchronous page preparation. Explicit store eviction invalidates
+  that store's pending preparations, so stale success, failure, or timeout retry cannot displace a replacement view.
+  Evict-all invalidates all pending preparations; ordinary lease release does not invalidate concurrent temporary views.
+- Leases retain their cleanup owner independently of the cache and release only once. Validated pages still support
+  the brief reuse handoff; other releases schedule the existing deferred WebKit cleanup, including temporary views.
 - Cookie import (Automatic mode, when WebKit store has no matching session or login required):
   1) Safari: `~/Library/Cookies/Cookies.binarycookies`
   2) Chrome/Chromium forks: `~/Library/Application Support/Google/Chrome/*/Cookies`


### PR DESCRIPTION
## Summary

Fix a reentrancy race in the OpenAI dashboard WebView cache. An acquire suspended during page preparation could outlive explicit eviction, then remove a newer entry for the same store. The replacement's weakly captured cleanup owner could disappear, making its lease release ineffective.

Cached, reused, and temporary acquisitions now share one preparation/retry loop. Explicit eviction invalidates only active work for the affected store; stale completions cannot remove replacements or retry. Ordinary lease release does not cancel concurrent temporary acquisitions. Leases retain their cleanup owner independently of the cache, and release/host-close operations are one-shot. Existing page handoff, navigation deadlines, single-timeout-retry policy, and deferred WebKit teardown are preserved.

The active-acquisition registry drains on completion and retains no historical store generations. The redundant temporary retry and new-entry release paths are removed. No provider/auth/cookie behavior, persistent data format, or visible UI is changed.

A test-only follow-up replaces dashboard concurrency tests' five scheduler-count readiness loops with Observation-backed pending-load notifications and bounded, one-shot waits. Readiness failures throw; scope cleanup drains fake loads and rejects late arrivals. Cancelled producers can still deliberately finish in stale-owner tests. Duplicate gate aliases and wrappers were removed, all 73 original assertions remain, and eight additional tests cover readiness, timeout, cancellation, and cleanup. This does not change dashboard production code.

## Verification

The executed baseline regression used nonpersistent stores and controlled preparation continuations, without network navigation. Both new and reused acquires failed two assertions: the replacement lost cache ownership, and its release did not register host cleanup. The repaired tests retain those observations and cover cancellation, stale success, invalidation during retry, per-store isolation, temporary survival across normal release, cache deallocation, duplicate release, and preserved-page handoff.

- Final focused run: **32 test functions / 68 invocations across two suites passed**, including 47 parameterized cases. The replacement interleavings repeat three times each.
- `make check`: passed, zero violations.
- Independent Codex autoreview: passed with no actionable P0–P2 findings.
- Initial full `make test` on `d890c3284be142d5c7772edc8f14955bd9deaabb`: failed in the existing `CodexLoginRunnerTests` detached-child output-drain case. Its timeout outcome passed, but expected `login-started` output was missing (`No output captured.`). A bounded diagnostic predecessor-group run reproduced the failure with both fixture milestones absent; it did not establish lost pipe bytes or an underlying startup cause. All temporary instrumentation was removed, with the original assertion and deadlines intact. A fresh restored-source run passed 27 focused login/subprocess/holder tests and `make check`. The login assertion also passed in the subsequent full run; its intermittent failure is not claimed fixed.
- Second full run on the identical original commit: reached group 67/80, then failed the existing dashboard concurrent-account ordering test. Its readiness helper reported a timeout after 80 ms because it budgeted 1,000 `Task.yield()` calls instead of an elapsed deadline or readiness event. The follow-up reproduced that helper failure with a delayed producer (one test, two issues), then passed 104 tests across eight dashboard suites, including 20 tests in the repaired file. Final `make check` and independent Codex autoreview passed. Neither earlier full run is a pass.
- Third full `make test`, on follow-up head `e2554a221a6837d48226bad95347049f83c2d71c`: failed with timeout exit 124. Groups 32 and 33 exceeded the unchanged 180-second group limit. All 12 isolated retries for group 32 passed; group 33 passed six isolated selections, then `CostUsagePerformanceGateTests` exceeded the same limit with no test-start output. Final statistics were 31 first-pass successful groups, two timed-out groups, one recovered group, and 19 isolated retries. The login assertion passed in this run. This is **not a full pass**; merge remains held while the isolated launch/timeout is diagnosed, without weakening assertions or increasing limits.
- Exact-head CI on `e2554a221a6837d48226bad95347049f83c2d71c`: [passed all eight jobs](https://github.com/steipete/CodexBar/actions/runs/33140855552), including both macOS test shards and Linux builds/tests. This does not turn the failed local run into a pass.

A single bounded diagnostic on the unchanged head reproduced the silent 180-second timeout. Stack samples prove the first performance test was executing its 1,500-file fixture creation, waiting in atomic file writes; no completed tests were evidenced. Silence therefore did not establish a startup stall. The test helper also used a separate process group and survived the parent-group timeout signal; a diagnostic watchdog terminated the verified child. The underlying storage slowdown is not claimed diagnosed.

The test-only follow-up in `a54e5bb0d1306a423bb757de2f6ce8e3a5c80232` repairs both demonstrated test infrastructure paths. Initial performance/fair-scheduling corpora now use exclusive creation, without unnecessary atomic publication or durability work before any reader exists. The shared atomic writer remains for replacement tests. File counts, bytes, dates, scanner passes, budgets, and existing assertions are unchanged. The suite runner tracks owned process births and observed sessions, keeps its direct child unreaped until cleanup, and verifies bounded TERM/KILL/drain before retrying. Legitimate separate sessions remain supported. Metadata errors fail closed; a confirmed Darwin metadata disappearance while exit is still pending uses the original deadline rather than failing early. The runner's default 180-second deadline and group size 12 are unchanged.

- Fixture/scanner proof: executed regression failures, then all 64 focused Swift test functions passed (four seed tests, 30 performance gates, eight fair-scheduling tests, and 22 scanner tests). The performance command completed in 148.122 seconds and fair scheduling in 95.455 seconds, both within 180 seconds on their first optimized attempt. This is not a controlled machine-performance benchmark.
- Runner proof: executed RED/GREEN for escaped process groups, separate-session ownership, metadata/initialization failures, and pending exits. Final shell harness: 50 Python tests passed; one native Linux pthread regression skipped on macOS. The unrelated sentinel remained alive, and no observed owned processes remained. All 34 actual Swift shell/subprocess/process-group tests passed under the unchanged 180-second command limit.
- Final `make check`: passed, zero violations in 2,036 files, including the expanded shell harness. Independent Codex autoreview passed with no actionable P0–P2 findings after the accepted ownership and platform-race findings were repaired.
- Full local `make test` on the exact source committed as `a54e5bb0d1306a423bb757de2f6ce8e3a5c80232`: **passed**, 955 selections across 80 groups, all 80 successful on the first attempt, zero failures/timeouts/retries, 1,031.3 seconds total. Both earlier cost-timeout groups and the dashboard concurrency group passed. [Exact-head CI passed all eight jobs](https://github.com/steipete/CodexBar/actions/runs/33147544169).

The subsequent PR review identified a concrete remaining safety gap in macOS descendant signaling: birth validation and `kill(pid)` were separate calls. Follow-up `b2807d81b1e6d18447784f57dd586f41bd37ef05` addresses it using `proc_signal_with_audittoken`. A combined native read supplies birth and generation from the same process, and the kernel binds the signal to that generation while enforcing normal caller permissions. Missing support or permission/I/O failures do not fall back to a numeric signal. Legitimate child sessions remain supported. The [Apple implementation](https://github.com/apple-oss-distributions/xnu/blob/xnu-11215.1.10/libsyscall/wrappers/libproc/libproc.c) is present in the macOS 15 source; runtime proof ran on macOS 26.6.2, not on a macOS 15 VM.

That safety follow-up has executed RED/GREEN for eight deterministic cases and two native tests. Real wrong-generation TERM and KILL calls returned ESRCH and left the owned child alive with unchanged identity; matching calls returned success, terminated and reaped the child, and left the unrelated sentinel alive. Final shell harness: 60 Python tests passed, one Linux-native skip on macOS. All 34 focused Swift process tests and `make check` passed, with zero lint violations and no observed owned-process leftovers. Independent Codex autoreview found no actionable P0–P2 issues in the follow-up. Swift/product/changelog files remained unchanged.

<details>
<summary>Native macOS final-effect test output</summary>

Executed on the same source bytes subsequently committed as `b2807d81b1e6d18447784f57dd586f41bd37ef05`; hashes of all three changed files matched before review, after worker handoff, and after commit. These are self-expiring, task-owned Python fixtures, not application or account processes. The test checks the child's identity and pending wait status after the rejected signal, then uses the production descendant-send path for the matching signal. `os.kill` is mocked during that production send and required not to be called. The actual system audit-token API is not mocked.

```sh
CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 \
CODEXBAR_TEST_CODEX_FILE_ISOLATION=1 \
CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES=0 LIVE_GEMINI_FETCH=0 \
python3 Scripts/test_swift_test_process_cleanup.py DarwinNativeSignalTests -v
```

The actual invocation also unset the Keychain opt-in, external Codex fixture path, spend/Pi proof paths, and `LIVE_TEST`. Extracted native stdout (identity arrays are PID, parent PID, birth seconds, birth microseconds, pidversion):

```text
{"signal": "SIGKILL", "before": [50055, 50037, 1787899462, 778887, 29317839], "after_wrong": [50055, 50037, 1787899462, 778887, 29317839], "wrong_pidversion": 29317838, "wrong_result": 3, "matching_results": [0], "reaped_status": -9, "unrelated_sentinel_alive": true}
{"signal": "SIGTERM", "before": [50078, 50037, 1787899463, 199161, 29317873], "after_wrong": [50078, 50037, 1787899463, 199161, 29317873], "wrong_pidversion": 29317872, "wrong_result": 3, "matching_results": [0], "reaped_status": -15, "unrelated_sentinel_alive": true}
Ran 2 tests in 0.843s
OK
```

Result 3 is ESRCH; zero is native success. Both TERM and KILL fixtures were reaped with their expected signal status. These native cases also passed in the subsequent shell harness and `make check`. No macOS 15 VM execution or forced OS PID wraparound is claimed.

</details>

The first full local `make test` on `b2807d81b1e6d18447784f57dd586f41bd37ef05` **failed** in the unchanged Kiro PTY hard-stop fixture test. Its hard-stop latency was 1.151 seconds (within the original three-second assertion), but the subsequent 20-second wait for all four delayed fixture processes to exit timed out. Group 45 failed after 44 first-pass successful groups; there were zero group timeouts and zero retries, with 851.2 seconds total. The earlier login and cost groups passed; the following Kiro settle-exit case also passed. The failure does not identify which fixture process remained or establish its state.

Exactly two bounded diagnostic attempts followed: 57 Kiro tests passed, then all 148 tests in the original 12-suite group passed, both within the unchanged 180-second command limit. Temporary observations showed all four fixture identities disappear before defer cleanup, with no observed PID reuse or zombie; neither outer-runner drain sent a signal. The original failure did not reproduce, and no Kiro fix, scheduler cause, or lease-expiry cause is claimed. All instrumentation was removed; original source hashes and the restored test binary hash match the pre-diagnostic versions, and all 356 observed owned process identities were absent in the final census. No deadlines or assertions changed.

The fresh full local run on restored `b2807d81b1e6d18447784f57dd586f41bd37ef05` also failed, this time in the unchanged Claude CLI session environment/reuse fixture. Its first capture contained only the PTY `/status` echo, and the launch log contained only the second profile; the second and reused account assertions passed. Group 15 failed after 14 first-pass successful groups, with zero group timeouts/retries and 413.6 seconds total. The functional fixture used a 100 ms idle cutoff, which could complete on input echo before its Account response.

The test-only Claude repair now waits for the expected fixture Account response with idle completion disabled. All 23 original assertions and the two/five-second capture deadlines remain unchanged; production idle policy is untouched. A controlled 0.5-second response delay produced three echo-only Account failures with the old setup, then both immediate/delayed cases and all 22 selected tests across five suites passed. Cancellation error paths now await their owned tasks before fixture teardown. Independent Codex autoreview found no actionable findings.

The subsequent `make check` failed in a separate synthetic process success fixture (`124 != 0`): its fixed 1.2-second ancestry sleep consumed most of a two-second command budget. A test-only follow-up replaces that sleep with acknowledgment after the real runner observes matching ready child identities, including the session-tree grandchild. A controlled one-second startup delay failed the old fixed-wait setup and passed the repaired case; all original cleanup/sentinel/deadline assertions remain. A diagnostic outer wrapper that recursively ran the process harness inside another copy of the runner failed closed on lost nested-session continuity; no test pass is claimed for that attempt, and all recorded fixture identities were subsequently absent. Through the normal direct entry point, 16 of 17 focused tests passed, including the delayed regression and native signal/waitid tests; the first failure-exit fixture still exceeded two seconds. This is not an all-green result. The follow-up has a clean independent review, but a single bounded timing diagnostic and aggregate validation remain in progress. No production runner change or higher deadline is being used to conceal these failures.

[Exact-head CI on b280 passed all eight jobs](https://github.com/steipete/CodexBar/actions/runs/33149390352), including both macOS shards. That does not convert either failed local run into a pass; merge remains held for the focused repair and final validation.

The Claude and process-fixture test repairs are now committed in `78d5909b78c9693b2dfcc9c78aa3ea49494c7b78`. One bounded diagnostic of the remaining failure-exit case passed with status 23 and verified fixture cleanup; it did not reproduce or diagnose the earlier timeout. The next aggregate attempt was interrupted by an external 180-second supervisor, which was an inappropriate cap for the whole `make check`, not a repository deadline. A subsequent normal invocation without that cap stalled inside the sharding shell before test execution. A sample showed Bash 5.3.15 blocked in `heredoc_write`/`write`; after terminating only that verified task-owned shell, it reported a here-document temporary-file space error. The volume still had 190 GiB free, so a full disk or underlying kernel cause is not established. Neither aggregate is a pass, and no test deadline has been increased.

The full local run on `78d5909b78c9693b2dfcc9c78aa3ea49494c7b78` failed with timeout 124: group 5 exceeded 180 seconds, seven isolated selections passed, and the eighth, `AdaptiveRefreshHeuristicsTests`, exceeded the same limit. Final statistics were four first-pass successful groups, one timed-out group, eight isolated selections, zero recovered groups, and 617.5 seconds total. A sample during the isolated run located test setup in `disableAllProviders` repeatedly persisting the config through atomic writes (588 rename and 180 open samples). The underlying storage slowdown is not claimed diagnosed.

Follow-up `797452d9caa852690ac0f5031cdd941475880d5c` uses the existing file-backed settings fixture seed instead of replaying a synchronous mutation for every provider. Both adaptive heuristics and timer fixtures retain provider defaults and explicitly keep OpenAI web access off; merely preloading a config would otherwise change that default. All 29 original test bodies and timer wait helpers remain verbatim, and three new tests check disabled-provider state and Codex-only stubbing. Production persistence, test deadlines, and timer behavior are unchanged. All 49 focused tests across five suites passed; normal `make check` passed, including 61 Python passes and one Linux-native skip, with zero lint violations. Independent Codex autoreview found no actionable P0–P2 findings. A persisted-state audit checked 37 new configs with all 69 entries and web cookies off; only the three intended stub fixtures enabled Codex. Known owned processes and task fixture paths were cleaned up.

The initial combined build/discovery command hit its 180-second wrapper bound after compilation completed in 149.95 seconds. Discovery against the built products then passed in 9.378 seconds; no failing assertion was retried or deadline increased. The final full local run on `797452d9caa852690ac0f5031cdd941475880d5c` **passed**: 955 selections across 80 groups, 79 first-pass successful groups, one 180-second group timeout recovered through all 12 isolated selections, zero full-group retries, and 1,912.4 seconds total. The previously failing adaptive, Claude, login, Kiro, and dashboard cases passed. A sample during the isolated cost-progress suite showed SQLite checkpoint work; no further code change was made for that recovered timeout. [Exact-head CI for 797452](https://github.com/steipete/CodexBar/actions/runs/33157883853) **passed**, including both macOS shards and Linux x64/ARM64/musl. The earlier run history below is retained; those failures are not retroactively passes.

The preceding 78d590 CI run ultimately became cancelled after the new push, but its Linux x64 job had already **failed**; cancellation does not erase that failure. The EMFILE child passed its exhaustion scenario and then crashed with SIGILL during its subsequent 100-capture pipe-release test. The stack entered libdispatch's source-finalization path. Swift 6.3.3's [matching source check](https://github.com/swiftlang/swift-corelibs-libdispatch/blob/swift-6.3.3-RELEASE/src/source.c#L591) rejects double finalization; a Linux hangup/unregistration interleaving is a source-supported lead, not a demonstrated cause. The production capture and Linux test files are unchanged by this branch. The whole child sequence remains intact: narrowing its filter would hide the post-exhaustion work that exposed the crash. No Linux crash fix or successful reproduction is claimed. Two supplemental AWS Crabbox attempts stalled during lease acquisition, before issuing a lease ID or running tests. Their local clients were stopped and subsequent AWS inventory was empty; no extra remote stress-test pass is claimed.

The bounded shell-bootstrap diagnosis completed without a reproduction: the exact 1,667-byte literal passed once under Bash 5.3 default, that same binary's disposable compatibility-50 mode, and system Bash 3.2; a 64 KiB native write/fsync/read/delete probe also passed. All four children were reaped without signals. [GNU Bash's source](https://git.savannah.gnu.org/cgit/bash.git/plain/redir.c?h=bash-5.3) uses a common here-document error path for pipes and temporary files and can synthesize ENOSPC after a short write. This explains why the wording alone does not prove a full disk, not why the original process stalled. No compatibility fallback, runtime swap, or source workaround was added. The later normal `make check` passed its shell bootstrap without those changes.

Process containment is a bounded metadata poller, not a daemon sandbox: it cannot reliably discover a new session whose ancestry and leader both vanish between observations. Unknown ownership fails rather than signaling uncertain PIDs or claiming successful cleanup. The initial `swift test list` discovery/build path is unchanged. These limits and the native Linux regression are documented in `docs/DEVELOPMENT.md`.

The focused command was:

```sh
swift test --no-parallel \
  --filter 'OpenAIDashboardWebViewCacheTests|WebKitTeardownTests' \
  --skip 'OpenAIDashboardWebViewCacheTests/.*(WKWebsiteDataStore should|same email profile|live website data store|Sequential fetches with OpenAIDashboardWebsiteDataStore)'
```

The four excluded tests are unchanged persistent-store factory tests; the focused proof intentionally uses only nonpersistent WebViews. Tests ran with Keychain suppression, isolated Codex fixtures, non-timeout retries disabled, and live Gemini fetching disabled. The initial incorrect RED filter matched no tests and was corrected using actual discovery; only the subsequent executed failure is counted as RED. An intermediate compile error was fixed by making the UI-owned Entry explicitly MainActor-isolated, without adding unsafe Sendable conformance.

## Scope and limits

Cleanup proof checks an actual host's single cleanup request and registration with the existing teardown owner, independently of dictionary counts. It does not prove eventual window cleanup or WebContent process termination. Existing headless CI guards remain unchanged, so the local nonpersistent run supplies the AppKit lifecycle execution proof.

This independent ownership defect was found while investigating #3247, but this PR does **not** reproduce or establish resolution of that report's sustained CPU/RSS growth or older WebContent episode. It must not close that issue. No real account, provider, cookie store, or normal app-bundle launch was used.
