### PR TITLE
fix: honor disabled Keychain access during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.56.1 — Unreleased
 
+### Fixed
+- Keychain: apply saved disabled-access preferences before startup credential migration, including shared-defaults fallback, and keep deferred migrations retryable (investigated alongside #3249). Thanks @jaychou0642-create!
+
 ## 0.56.0 — 2026-08-28
 
 ### Added

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -64,7 +64,7 @@ struct CodexBarApp: App {
                 "built": buildTimestamp,
             ])
 
-        KeychainAccessGate.isDisabled = UserDefaults.standard.bool(forKey: "debugDisableKeychainAccess")
+        KeychainAccessGate.isDisabled = SettingsStore.loadDebugDisableKeychainAccess(userDefaults: .standard)
         KeychainPromptCoordinator.install()
         if MainThreadHangWatchdog.isEnabledForCurrentProcess {
             MainThreadHangWatchdog.shared.start()

--- a/Sources/CodexBar/Config/CodexBarConfigMigrator.swift
+++ b/Sources/CodexBar/Config/CodexBarConfigMigrator.swift
@@ -31,6 +31,7 @@ struct CodexBarConfigMigrator {
     static func loadOrMigrate(
         configStore: CodexBarConfigStore,
         userDefaults: UserDefaults,
+        keychainAccessDisabled: Bool,
         stores: LegacyStores) -> CodexBarConfig
     {
         let log = CodexBarLog.logger(LogCategories.configMigration)
@@ -71,6 +72,12 @@ struct CodexBarConfigMigrator {
         }
 
         guard didPersistUpdates else {
+            return config.normalized()
+        }
+
+        // A disabled Keychain read looks empty to legacy stores, not successfully migrated.
+        // Keep permitted file/default imports, but preserve cleanup and completion for a later retry.
+        guard !keychainAccessDisabled else {
             return config.normalized()
         }
 

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -324,6 +324,8 @@ final class SettingsStore {
         antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore = AntigravityOAuthCredentialsStore(),
         performInitialProviderDetection: Bool = !SettingsStore.isRunningTests)
     {
+        // Legacy credential migration must see the saved policy, including shared-defaults fallback.
+        KeychainAccessGate.isDisabled = Self.loadDebugDisableKeychainAccess(userDefaults: userDefaults)
         if !Self.isRunningTests {
             _ = UserProviderPluginRegistry.refresh()
         }
@@ -375,6 +377,7 @@ final class SettingsStore {
         let config = CodexBarConfigMigrator.loadOrMigrate(
             configStore: configStore,
             userDefaults: userDefaults,
+            keychainAccessDisabled: KeychainAccessGate.isExplicitlyDisabled,
             stores: legacyStores)
         self.userDefaults = userDefaults
         self.configStore = configStore
@@ -925,13 +928,17 @@ extension SettingsStore {
         userDefaults.string(forKey: "copilotIconSecondaryWindowID") ?? CopilotIconSecondaryWindowSelection.chat
     }
 
-    private static func loadDebugDisableKeychainAccess(userDefaults: UserDefaults) -> Bool {
+    static func loadDebugDisableKeychainAccess(userDefaults: UserDefaults) -> Bool {
+        self.loadDebugDisableKeychainAccess(
+            userDefaults: userDefaults,
+            sharedDefaults: self.shouldBridgeSharedDefaults(for: userDefaults) ? self.sharedDefaults : nil)
+    }
+
+    static func loadDebugDisableKeychainAccess(userDefaults: UserDefaults, sharedDefaults: UserDefaults?) -> Bool {
         if let stored = userDefaults.object(forKey: "debugDisableKeychainAccess") as? Bool {
             return stored
         }
-        if Self.shouldBridgeSharedDefaults(for: userDefaults),
-           let shared = Self.sharedDefaults?.object(forKey: "debugDisableKeychainAccess") as? Bool
-        {
+        if let shared = sharedDefaults?.object(forKey: "debugDisableKeychainAccess") as? Bool {
             if Self.isRunningTests {
                 userDefaults.set(shared, forKey: "debugDisableKeychainAccess")
             }

--- a/Tests/CodexBarTests/CodexBarConfigMigratorTests.swift
+++ b/Tests/CodexBarTests/CodexBarConfigMigratorTests.swift
@@ -1,10 +1,52 @@
-import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
 @Suite(.serialized)
 struct CodexBarConfigMigratorTests {
+    @Test(arguments: [false, true])
+    @MainActor
+    func `settings applies stored keychain policy before legacy migration`(disabled: Bool) throws {
+        let suite = "CodexBarConfigMigratorTests-keychain-startup-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(disabled, forKey: "debugDisableKeychainAccess")
+
+        let previousOverride = KeychainAccessGate.currentOverrideForTesting
+        defer {
+            if let previousOverride {
+                KeychainAccessGate.isDisabled = previousOverride
+            } else {
+                KeychainAccessGate.resetOverrideForTesting()
+            }
+        }
+        KeychainAccessGate.isDisabled = !disabled
+        let secrets = CountingLegacySecretStore()
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: secrets,
+            syntheticTokenStore: secrets,
+            codexCookieStore: secrets,
+            claudeCookieStore: secrets,
+            cursorCookieStore: secrets,
+            opencodeCookieStore: secrets,
+            factoryCookieStore: secrets,
+            minimaxCookieStore: secrets,
+            minimaxAPITokenStore: secrets,
+            kimiTokenStore: secrets,
+            augmentCookieStore: secrets,
+            ampCookieStore: secrets,
+            copilotTokenStore: secrets,
+            tokenAccountStore: CountingTokenAccountStore(),
+            performInitialProviderDetection: false)
+
+        #expect(store.debugDisableKeychainAccess == disabled)
+        #expect(!secrets.keychainAccessOverridesAtLoad.isEmpty)
+        #expect(secrets.keychainAccessOverridesAtLoad.allSatisfy { $0 == disabled })
+    }
+
     @Test
     func `legacy Moonshot key is bound to its selected region`() throws {
         let suite = "CodexBarConfigMigratorTests-moonshot-\(UUID().uuidString)"
@@ -22,6 +64,7 @@ struct CodexBarConfigMigratorTests {
         let migrated = CodexBarConfigMigrator.loadOrMigrate(
             configStore: configStore,
             userDefaults: defaults,
+            keychainAccessDisabled: false,
             stores: Self.legacyStores(
                 secrets: CountingLegacySecretStore(),
                 accountStore: CountingTokenAccountStore()))
@@ -42,7 +85,7 @@ struct CodexBarConfigMigratorTests {
         let stores = Self.legacyStores(secrets: secrets, accountStore: accountStore)
         let configStore = testConfigStore(suiteName: suite)
 
-        _ = CodexBarConfigMigrator.loadOrMigrate(configStore: configStore, userDefaults: defaults, stores: stores)
+        _ = Self.migrate(configStore: configStore, defaults: defaults, stores: stores)
 
         let firstSecretLoads = secrets.loadCount
         let firstAccountLoads = accountStore.loadCount
@@ -50,7 +93,7 @@ struct CodexBarConfigMigratorTests {
         #expect(firstAccountLoads == 1)
         #expect(defaults.bool(forKey: Self.legacyMigrationCompletedKey) == true)
 
-        _ = CodexBarConfigMigrator.loadOrMigrate(configStore: configStore, userDefaults: defaults, stores: stores)
+        _ = Self.migrate(configStore: configStore, defaults: defaults, stores: stores)
 
         #expect(secrets.loadCount == firstSecretLoads)
         #expect(accountStore.loadCount == firstAccountLoads)
@@ -68,7 +111,7 @@ struct CodexBarConfigMigratorTests {
         let stores = Self.legacyStores(secrets: secrets, accountStore: accountStore)
         let configStore = testConfigStore(suiteName: suite)
 
-        _ = CodexBarConfigMigrator.loadOrMigrate(configStore: configStore, userDefaults: defaults, stores: stores)
+        _ = Self.migrate(configStore: configStore, defaults: defaults, stores: stores)
 
         let firstSecretLoads = secrets.loadCount
         #expect(firstSecretLoads > 0)
@@ -76,7 +119,7 @@ struct CodexBarConfigMigratorTests {
         #expect(defaults.bool(forKey: Self.legacyMigrationCompletedKey) == false)
 
         secrets.throwOnStore = false
-        _ = CodexBarConfigMigrator.loadOrMigrate(configStore: configStore, userDefaults: defaults, stores: stores)
+        _ = Self.migrate(configStore: configStore, defaults: defaults, stores: stores)
 
         #expect(secrets.loadCount > firstSecretLoads)
         #expect(defaults.bool(forKey: Self.legacyMigrationCompletedKey) == true)
@@ -104,14 +147,14 @@ struct CodexBarConfigMigratorTests {
         let configStore = CodexBarConfigStore(
             fileURL: blockedDirectory.appendingPathComponent("config.json"))
 
-        _ = CodexBarConfigMigrator.loadOrMigrate(configStore: configStore, userDefaults: defaults, stores: stores)
+        _ = Self.migrate(configStore: configStore, defaults: defaults, stores: stores)
 
         #expect(secrets.clearAttempts == 0)
         #expect(try secrets.loadToken() == "legacy-token")
         #expect(defaults.bool(forKey: Self.legacyMigrationCompletedKey) == false)
 
         try FileManager.default.removeItem(at: blockedDirectory)
-        _ = CodexBarConfigMigrator.loadOrMigrate(configStore: configStore, userDefaults: defaults, stores: stores)
+        _ = Self.migrate(configStore: configStore, defaults: defaults, stores: stores)
 
         #expect(secrets.clearAttempts > 0)
         #expect(try secrets.loadToken() == nil)
@@ -133,6 +176,7 @@ struct CodexBarConfigMigratorTests {
         _ = CodexBarConfigMigrator.loadOrMigrate(
             configStore: configStore,
             userDefaults: defaults,
+            keychainAccessDisabled: false,
             stores: stores)
 
         let failedSecretLoads = secrets.loadCount
@@ -147,6 +191,7 @@ struct CodexBarConfigMigratorTests {
         _ = CodexBarConfigMigrator.loadOrMigrate(
             configStore: configStore,
             userDefaults: defaults,
+            keychainAccessDisabled: false,
             stores: stores)
 
         #expect(secrets.loadCount > failedSecretLoads)
@@ -173,6 +218,7 @@ struct CodexBarConfigMigratorTests {
         let first = CodexBarConfigMigrator.loadOrMigrate(
             configStore: configStore,
             userDefaults: defaults,
+            keychainAccessDisabled: false,
             stores: stores)
 
         #expect(first.providerConfig(for: .zai)?.apiKey == "legacy-token")
@@ -186,6 +232,7 @@ struct CodexBarConfigMigratorTests {
         _ = CodexBarConfigMigrator.loadOrMigrate(
             configStore: configStore,
             userDefaults: defaults,
+            keychainAccessDisabled: false,
             stores: stores)
 
         #expect(unreadableSecrets.loadCount > firstUnreadableLoadCount)
@@ -195,6 +242,52 @@ struct CodexBarConfigMigratorTests {
     }
 
     private static let legacyMigrationCompletedKey = "codexbar.legacySecretsMigrationCompleted"
+
+    @Test(arguments: [false, true])
+    func `disabled keychain migration preserves sources and retries after access returns`(
+        hidesToken: Bool) throws
+    {
+        let suite = "CodexBarConfigMigratorTests-deferred-keychain-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set("fixture-cookie=manual", forKey: "kimiManualCookieHeader")
+        let configStore = testConfigStore(suiteName: suite)
+        let secrets = CountingLegacySecretStore(token: "legacy-fixture-token")
+        secrets.hideTokenOnLoad = hidesToken
+        let stores = Self.legacyStores(secrets: secrets, accountStore: CountingTokenAccountStore())
+
+        let deferred = CodexBarConfigMigrator.loadOrMigrate(
+            configStore: configStore,
+            userDefaults: defaults,
+            keychainAccessDisabled: true,
+            stores: stores)
+
+        #expect(deferred.providerConfig(for: .kimi)?.cookieHeader != nil)
+        #expect(try configStore.load()?.providerConfig(for: .kimi)?.cookieHeader != nil)
+        #expect(!defaults.bool(forKey: Self.legacyMigrationCompletedKey))
+        #expect(secrets.clearAttempts == 0)
+
+        secrets.hideTokenOnLoad = false
+        let recovered = Self.migrate(configStore: configStore, defaults: defaults, stores: stores)
+
+        #expect(recovered.providerConfig(for: .zai)?.apiKey == "legacy-fixture-token")
+        #expect(try configStore.load()?.providerConfig(for: .zai)?.apiKey == "legacy-fixture-token")
+        #expect(secrets.clearAttempts > 0)
+        #expect(try secrets.loadToken() == nil)
+        #expect(defaults.bool(forKey: Self.legacyMigrationCompletedKey))
+    }
+
+    private static func migrate(
+        configStore: CodexBarConfigStore,
+        defaults: UserDefaults,
+        stores: CodexBarConfigMigrator.LegacyStores) -> CodexBarConfig
+    {
+        CodexBarConfigMigrator.loadOrMigrate(
+            configStore: configStore,
+            userDefaults: defaults,
+            keychainAccessDisabled: false,
+            stores: stores)
+    }
 
     private static func legacyStores(
         secrets: CountingLegacySecretStore,
@@ -227,8 +320,10 @@ private final class CountingLegacySecretStore: ZaiTokenStoring, SyntheticTokenSt
     private var token: String?
     var throwOnLoad: Bool
     var throwOnStore: Bool
+    var hideTokenOnLoad = false
     private(set) var loadCount = 0
     private(set) var clearAttempts = 0
+    private(set) var keychainAccessOverridesAtLoad: [Bool?] = []
 
     init(token: String? = nil, throwOnLoad: Bool = false, throwOnStore: Bool = false) {
         self.token = token
@@ -240,10 +335,11 @@ private final class CountingLegacySecretStore: ZaiTokenStoring, SyntheticTokenSt
         self.lock.lock()
         defer { self.lock.unlock() }
         self.loadCount += 1
+        self.keychainAccessOverridesAtLoad.append(KeychainAccessGate.currentOverrideForTesting)
         if self.throwOnLoad {
             throw TestStoreError.loadFailed
         }
-        return self.token
+        return self.hideTokenOnLoad ? nil : self.token
     }
 
     func storeToken(_ token: String?) throws {
@@ -254,10 +350,11 @@ private final class CountingLegacySecretStore: ZaiTokenStoring, SyntheticTokenSt
         self.lock.lock()
         defer { self.lock.unlock() }
         self.loadCount += 1
+        self.keychainAccessOverridesAtLoad.append(KeychainAccessGate.currentOverrideForTesting)
         if self.throwOnLoad {
             throw TestStoreError.loadFailed
         }
-        return self.token
+        return self.hideTokenOnLoad ? nil : self.token
     }
 
     func storeCookieHeader(_ header: String?) throws {

--- a/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
@@ -3,6 +3,15 @@ import Testing
 
 struct KeychainPromptSafetyAuditTests {
     @Test
+    func `app startup resolves shared keychain preferences before constructing settings`() throws {
+        let source = try Self.readRepoFile("Sources/CodexBar/CodexbarApp.swift")
+        let policy = try #require(source.range(of:
+            "KeychainAccessGate.isDisabled = SettingsStore.loadDebugDisableKeychainAccess(userDefaults: .standard)"))
+        let settings = try #require(source.range(of: "let settings = SettingsStore()"))
+        #expect(policy.upperBound < settings.lowerBound)
+    }
+
+    @Test
     func `agent instructions forbid keychain prompt validation`() throws {
         let agents = try Self.readRepoFile("AGENTS.md")
 

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2330,7 +2330,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1185,
+            line: 1192,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,

--- a/Tests/CodexBarTests/SettingsStoreKeychainPreferenceTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreKeychainPreferenceTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct SettingsStoreKeychainPreferenceTests {
+    @Test(arguments: [nil, false, true] as [Bool?], [nil, false, true] as [Bool?])
+    func `local keychain preference wins and shared defaults fill only an absent value`(
+        localValue: Bool?, sharedValue: Bool?) throws
+    {
+        let localSuite = "SettingsStoreKeychainPreferenceTests-local-\(UUID().uuidString)"
+        let sharedSuite = "SettingsStoreKeychainPreferenceTests-shared-\(UUID().uuidString)"
+        let local = try #require(UserDefaults(suiteName: localSuite))
+        let shared = try #require(UserDefaults(suiteName: sharedSuite))
+        defer {
+            local.removePersistentDomain(forName: localSuite)
+            shared.removePersistentDomain(forName: sharedSuite)
+        }
+        if let localValue {
+            local.set(localValue, forKey: "debugDisableKeychainAccess")
+        }
+        if let sharedValue {
+            shared.set(sharedValue, forKey: "debugDisableKeychainAccess")
+        }
+
+        let disabled = SettingsStore.loadDebugDisableKeychainAccess(userDefaults: local, sharedDefaults: shared)
+
+        #expect(disabled == (localValue ?? sharedValue ?? false))
+        #expect(shared.object(forKey: "debugDisableKeychainAccess") as? Bool == sharedValue)
+    }
+}

--- a/docs/keychain-prompts.md
+++ b/docs/keychain-prompts.md
@@ -57,6 +57,11 @@ applications.” In Keychain Access, adding only the installed, stably signed `C
 Open **CodexBar → Settings → Advanced** and enable **Disable Keychain access**. The stored setting is applied
 immediately; relaunching is useful when diagnosing another already-running copy.
 
+Startup resolves the local preference, falling back to the current shared app-group preference only when no local
+value is stored, before legacy credential migration. While access is disabled, permitted file-backed and manual-default
+imports can still be saved, but legacy credential cleanup and migration completion remain pending for a later launch
+with access enabled.
+
 This setting blocks CodexBar-owned Security.framework item reads and writes, including foreign-item readers such as
 Zed, and disables Chromium Safe Storage decryption. Browser-cookie import that needs Keychain is skipped. It does not
 promise that a provider-owned CLI launched by CodexBar will avoid its own credential store; Claude's owner-CLI policy


### PR DESCRIPTION
## Summary

Apply the saved “Disable Keychain access” preference before startup credential migration, using the same local/current-shared defaults resolution as Settings. An explicit local value still wins, including `false`; environment/process disabling remains enforced by the existing gate.

Keep cleanup and the legacy-migration completion marker pending while Keychain access is disabled. A skipped credential read must not permanently mark still-present credentials as migrated. Permitted manual-default and file-backed imports can still be saved, and a later enabled launch retries normally.

Update the changelog and Keychain troubleshooting documentation. This is a narrower startup hardening found while investigating #3249, **not** a demonstrated explanation of that reporter’s all-provider post-update failure; the issue should remain open.

## Verification

- Added fake-store startup regression: failed on the previous implementation for both stored `true` and `false`, and passes after the fix without reading credential stores.
- Added all nine local/shared preference combinations and a two-launch deferred-migration/recovery regression.
- Startup, preference and Keychain safety suites passed. The first combined run found only an existing provider-ownership source anchor shifted by seven lines; its unchanged eight-reference fingerprint was checked, its line relocated, and the guard passed in the full run.
- `make check` passed, including strict SwiftLint with zero violations.
- Codex autoreview passed at its configured P0 threshold; independent source review also checked the initialization and migration boundary.
- Full `make test` passed: 956 selections across 80 groups, all successful on the first pass, zero retries/timeouts (25m05s total).
- [Exact-head hosted CI passed](https://github.com/steipete/CodexBar/actions/runs/33209935551): lint, Linux x64/arm64/musl builds, both macOS shards, plugin golden tests, and the final gate. Tests suppress real Keychain item access and use isolated defaults/config fixtures. No live credentials, ACL changes, or user settings changes were used as proof.
