### PR TITLE
Add remote codexbar serve snapshots

### DIFF
--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -7,6 +7,15 @@ struct AdvancedPane: View {
     @Bindable var store: UsageStore
     @State private var isInstallingCLI = false
     @State private var cliStatus: String?
+    @State private var remoteCodexBarServerURLDraft: String
+    @State private var remoteCodexBarBearerTokenDraft: String
+
+    init(settings: SettingsStore, store: UsageStore) {
+        self.settings = settings
+        self.store = store
+        self._remoteCodexBarServerURLDraft = State(initialValue: settings.remoteCodexBarServerURL)
+        self._remoteCodexBarBearerTokenDraft = State(initialValue: settings.remoteCodexBarBearerToken)
+    }
 
     var body: some View {
         Form {
@@ -30,6 +39,41 @@ struct AdvancedPane: View {
             } footer: {
                 if let status = self.cliStatus {
                     SettingsSectionFooter(status)
+                }
+            }
+
+            Section {
+                TextField("https://codexbar.example", text: self.$remoteCodexBarServerURLDraft)
+                    .textFieldStyle(.roundedBorder)
+                SecureField("Bearer token", text: self.$remoteCodexBarBearerTokenDraft)
+                    .textFieldStyle(.roundedBorder)
+                HStack {
+                    Button("Connect") {
+                        self.settings.applyRemoteCodexBarConfiguration(
+                            serverURL: self.remoteCodexBarServerURLDraft,
+                            bearerToken: self.remoteCodexBarBearerTokenDraft)
+                    }
+                    .disabled(self.remoteCodexBarDraftConfiguration == nil || !self.remoteCodexBarDraftHasChanges)
+
+                    Button("Disconnect", role: .destructive) {
+                        self.settings.applyRemoteCodexBarConfiguration(serverURL: "", bearerToken: "")
+                        self.remoteCodexBarServerURLDraft = ""
+                        self.remoteCodexBarBearerTokenDraft = ""
+                    }
+                    .disabled(self.settings.remoteCodexBarConfiguration == nil)
+                }
+            } header: {
+                Text("Remote CodexBar")
+            } footer: {
+                if let message = self.settings.remoteCodexBarURLValidationMessage(
+                    for: self.remoteCodexBarServerURLDraft) ??
+                    self.settings.remoteCodexBarSecretError ??
+                    self.store.remoteCodexBarError
+                {
+                    SettingsSectionFooter(message)
+                } else {
+                    SettingsSectionFooter(
+                        "Connects to a separately running codexbar serve and shows its provider snapshots in menus.")
                 }
             }
 
@@ -72,6 +116,17 @@ struct AdvancedPane: View {
 }
 
 extension AdvancedPane {
+    private var remoteCodexBarDraftConfiguration: RemoteCodexBarConfiguration? {
+        RemoteCodexBarConfiguration.resolve(
+            serverURL: self.remoteCodexBarServerURLDraft,
+            bearerToken: self.remoteCodexBarBearerTokenDraft)
+    }
+
+    private var remoteCodexBarDraftHasChanges: Bool {
+        self.remoteCodexBarServerURLDraft != self.settings.remoteCodexBarServerURL ||
+            self.remoteCodexBarBearerTokenDraft != self.settings.remoteCodexBarBearerToken
+    }
+
     private func installCLI() async {
         if self.isInstallingCLI {
             return

--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -4,18 +4,8 @@ import SwiftUI
 @MainActor
 struct AdvancedPane: View {
     @Bindable var settings: SettingsStore
-    @Bindable var store: UsageStore
     @State private var isInstallingCLI = false
     @State private var cliStatus: String?
-    @State private var remoteCodexBarServerURLDraft: String
-    @State private var remoteCodexBarBearerTokenDraft: String
-
-    init(settings: SettingsStore, store: UsageStore) {
-        self.settings = settings
-        self.store = store
-        self._remoteCodexBarServerURLDraft = State(initialValue: settings.remoteCodexBarServerURL)
-        self._remoteCodexBarBearerTokenDraft = State(initialValue: settings.remoteCodexBarBearerToken)
-    }
 
     var body: some View {
         Form {
@@ -39,41 +29,6 @@ struct AdvancedPane: View {
             } footer: {
                 if let status = self.cliStatus {
                     SettingsSectionFooter(status)
-                }
-            }
-
-            Section {
-                TextField("https://codexbar.example", text: self.$remoteCodexBarServerURLDraft)
-                    .textFieldStyle(.roundedBorder)
-                SecureField("Bearer token", text: self.$remoteCodexBarBearerTokenDraft)
-                    .textFieldStyle(.roundedBorder)
-                HStack {
-                    Button("Connect") {
-                        self.settings.applyRemoteCodexBarConfiguration(
-                            serverURL: self.remoteCodexBarServerURLDraft,
-                            bearerToken: self.remoteCodexBarBearerTokenDraft)
-                    }
-                    .disabled(self.remoteCodexBarDraftConfiguration == nil || !self.remoteCodexBarDraftHasChanges)
-
-                    Button("Disconnect", role: .destructive) {
-                        self.settings.applyRemoteCodexBarConfiguration(serverURL: "", bearerToken: "")
-                        self.remoteCodexBarServerURLDraft = ""
-                        self.remoteCodexBarBearerTokenDraft = ""
-                    }
-                    .disabled(self.settings.remoteCodexBarConfiguration == nil)
-                }
-            } header: {
-                Text("Remote CodexBar")
-            } footer: {
-                if let message = self.settings.remoteCodexBarURLValidationMessage(
-                    for: self.remoteCodexBarServerURLDraft) ??
-                    self.settings.remoteCodexBarSecretError ??
-                    self.store.remoteCodexBarError
-                {
-                    SettingsSectionFooter(message)
-                } else {
-                    SettingsSectionFooter(
-                        "Connects to a separately running codexbar serve and shows its provider snapshots in menus.")
                 }
             }
 
@@ -116,17 +71,6 @@ struct AdvancedPane: View {
 }
 
 extension AdvancedPane {
-    private var remoteCodexBarDraftConfiguration: RemoteCodexBarConfiguration? {
-        RemoteCodexBarConfiguration.resolve(
-            serverURL: self.remoteCodexBarServerURLDraft,
-            bearerToken: self.remoteCodexBarBearerTokenDraft)
-    }
-
-    private var remoteCodexBarDraftHasChanges: Bool {
-        self.remoteCodexBarServerURLDraft != self.settings.remoteCodexBarServerURL ||
-            self.remoteCodexBarBearerTokenDraft != self.settings.remoteCodexBarBearerToken
-    }
-
     private func installCLI() async {
         if self.isInstallingCLI {
             return

--- a/Sources/CodexBar/PreferencesICloudSyncPane.swift
+++ b/Sources/CodexBar/PreferencesICloudSyncPane.swift
@@ -4,10 +4,21 @@ import SwiftUI
 @MainActor
 struct ICloudSyncPane: View {
     @Bindable var settings: SettingsStore
+    @Bindable var store: UsageStore
     @Bindable var state: CloudSyncState
+    @State private var remoteCodexBarServerURLDraft: String
+    @State private var remoteCodexBarBearerTokenDraft: String
     private static let securityFootnote =
         "Secrets use iCloud end-to-end encryption via encryptedValues. " +
         "Hooks and machine-local paths never sync."
+
+    init(settings: SettingsStore, store: UsageStore, state: CloudSyncState) {
+        self.settings = settings
+        self.store = store
+        self.state = state
+        self._remoteCodexBarServerURLDraft = State(initialValue: settings.remoteCodexBarServerURL)
+        self._remoteCodexBarBearerTokenDraft = State(initialValue: settings.remoteCodexBarBearerToken)
+    }
 
     var body: some View {
         Form {
@@ -49,6 +60,42 @@ struct ICloudSyncPane: View {
             }
 
             Section {
+                TextField("https://codexbar.example", text: self.$remoteCodexBarServerURLDraft)
+                    .textFieldStyle(.roundedBorder)
+                SecureField("Bearer token", text: self.$remoteCodexBarBearerTokenDraft)
+                    .textFieldStyle(.roundedBorder)
+                HStack {
+                    Button("Connect") {
+                        self.settings.applyRemoteCodexBarConfiguration(
+                            serverURL: self.remoteCodexBarServerURLDraft,
+                            bearerToken: self.remoteCodexBarBearerTokenDraft)
+                    }
+                    .disabled(self.remoteCodexBarDraftConfiguration == nil || !self.remoteCodexBarDraftHasChanges)
+
+                    Button("Disconnect", role: .destructive) {
+                        if self.settings.applyRemoteCodexBarConfiguration(serverURL: "", bearerToken: "") {
+                            self.remoteCodexBarServerURLDraft = ""
+                            self.remoteCodexBarBearerTokenDraft = ""
+                        }
+                    }
+                    .disabled(self.settings.remoteCodexBarConfiguration == nil)
+                }
+            } header: {
+                Text("Remote CodexBar")
+            } footer: {
+                if let message = self.settings.remoteCodexBarURLValidationMessage(
+                    for: self.remoteCodexBarServerURLDraft) ??
+                    self.settings.remoteCodexBarSecretError ??
+                    self.store.remoteCodexBarError
+                {
+                    SettingsSectionFooter(message)
+                } else {
+                    SettingsSectionFooter(
+                        "Connects to a separately running codexbar serve and shows its provider snapshots in menus.")
+                }
+            }
+
+            Section {
                 LabeledContent(
                     L("Last successful fetch"),
                     value: self.relativeTime(self.state.status.lastSuccessfulFetchAt))
@@ -82,6 +129,17 @@ struct ICloudSyncPane: View {
 
     private var syncCanBeEnabled: Bool {
         self.state.availability == .available
+    }
+
+    private var remoteCodexBarDraftConfiguration: RemoteCodexBarConfiguration? {
+        RemoteCodexBarConfiguration.resolve(
+            serverURL: self.remoteCodexBarServerURLDraft,
+            bearerToken: self.remoteCodexBarBearerTokenDraft)
+    }
+
+    private var remoteCodexBarDraftHasChanges: Bool {
+        self.remoteCodexBarServerURLDraft != self.settings.remoteCodexBarServerURL ||
+            self.remoteCodexBarBearerTokenDraft != self.settings.remoteCodexBarBearerToken
     }
 
     private var syncCanRun: Bool {

--- a/Sources/CodexBar/PreferencesICloudSyncPane.swift
+++ b/Sources/CodexBar/PreferencesICloudSyncPane.swift
@@ -64,7 +64,7 @@ struct ICloudSyncPane: View {
             }
 
             Section {
-                TextField("https://codexbar.example", text: self.$remoteCodexBarServerURLDraft)
+                TextField("https://codexbar.example", text: self.remoteCodexBarServerURLDraftBinding)
                     .textFieldStyle(.roundedBorder)
                 SecureField("Bearer token", text: self.$remoteCodexBarBearerTokenDraft)
                     .textFieldStyle(.roundedBorder)
@@ -141,6 +141,21 @@ struct ICloudSyncPane: View {
 
     private var syncCanBeEnabled: Bool {
         self.state.availability == .available
+    }
+
+    private var remoteCodexBarServerURLDraftBinding: Binding<String> {
+        Binding(
+            get: { self.remoteCodexBarServerURLDraft },
+            set: { newValue in
+                let committedEndpoint = self.settings.remoteCodexBarServerURL
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let newEndpoint = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                if newEndpoint != committedEndpoint {
+                    self.remoteCodexBarBearerTokenDraft = ""
+                    self.remoteCodexBarPlainHTTPConsentEndpoint = nil
+                }
+                self.remoteCodexBarServerURLDraft = newValue
+            })
     }
 
     private var remoteCodexBarDraftConfiguration: RemoteCodexBarConfiguration? {

--- a/Sources/CodexBar/PreferencesICloudSyncPane.swift
+++ b/Sources/CodexBar/PreferencesICloudSyncPane.swift
@@ -8,6 +8,7 @@ struct ICloudSyncPane: View {
     @Bindable var state: CloudSyncState
     @State private var remoteCodexBarServerURLDraft: String
     @State private var remoteCodexBarBearerTokenDraft: String
+    @State private var remoteCodexBarPlainHTTPConsentEndpoint: String?
     private static let securityFootnote =
         "Secrets use iCloud end-to-end encryption via encryptedValues. " +
         "Hooks and machine-local paths never sync."
@@ -18,6 +19,9 @@ struct ICloudSyncPane: View {
         self.state = state
         self._remoteCodexBarServerURLDraft = State(initialValue: settings.remoteCodexBarServerURL)
         self._remoteCodexBarBearerTokenDraft = State(initialValue: settings.remoteCodexBarBearerToken)
+        self._remoteCodexBarPlainHTTPConsentEndpoint = State(initialValue: settings.remoteCodexBarAllowsPlainHTTP
+            ? settings.remoteCodexBarServerURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            : nil)
     }
 
     var body: some View {
@@ -64,11 +68,18 @@ struct ICloudSyncPane: View {
                     .textFieldStyle(.roundedBorder)
                 SecureField("Bearer token", text: self.$remoteCodexBarBearerTokenDraft)
                     .textFieldStyle(.roundedBorder)
+                if self.remoteCodexBarDraftRequiresPlainHTTPConsent {
+                    Toggle(
+                        "Allow this bearer token over unencrypted private-network HTTP",
+                        isOn: self.remoteCodexBarPlainHTTPConsentBinding)
+                        .toggleStyle(.checkbox)
+                }
                 HStack {
                     Button("Connect") {
                         self.settings.applyRemoteCodexBarConfiguration(
                             serverURL: self.remoteCodexBarServerURLDraft,
-                            bearerToken: self.remoteCodexBarBearerTokenDraft)
+                            bearerToken: self.remoteCodexBarBearerTokenDraft,
+                            allowsPlainHTTP: self.remoteCodexBarDraftAllowsPlainHTTP)
                     }
                     .disabled(self.remoteCodexBarDraftConfiguration == nil || !self.remoteCodexBarDraftHasChanges)
 
@@ -76,6 +87,7 @@ struct ICloudSyncPane: View {
                         if self.settings.applyRemoteCodexBarConfiguration(serverURL: "", bearerToken: "") {
                             self.remoteCodexBarServerURLDraft = ""
                             self.remoteCodexBarBearerTokenDraft = ""
+                            self.remoteCodexBarPlainHTTPConsentEndpoint = nil
                         }
                     }
                     .disabled(self.settings.remoteCodexBarConfiguration == nil)
@@ -134,12 +146,34 @@ struct ICloudSyncPane: View {
     private var remoteCodexBarDraftConfiguration: RemoteCodexBarConfiguration? {
         RemoteCodexBarConfiguration.resolve(
             serverURL: self.remoteCodexBarServerURLDraft,
-            bearerToken: self.remoteCodexBarBearerTokenDraft)
+            bearerToken: self.remoteCodexBarBearerTokenDraft,
+            allowsPlainHTTP: self.remoteCodexBarDraftAllowsPlainHTTP)
     }
 
     private var remoteCodexBarDraftHasChanges: Bool {
         self.remoteCodexBarServerURLDraft != self.settings.remoteCodexBarServerURL ||
-            self.remoteCodexBarBearerTokenDraft != self.settings.remoteCodexBarBearerToken
+            self.remoteCodexBarBearerTokenDraft != self.settings.remoteCodexBarBearerToken ||
+            self.remoteCodexBarDraftAllowsPlainHTTP != self.settings.remoteCodexBarAllowsPlainHTTP
+    }
+
+    private var remoteCodexBarDraftRequiresPlainHTTPConsent: Bool {
+        RemoteCodexBarConfiguration.requiresPlainHTTPConsent(serverURL: self.remoteCodexBarServerURLDraft)
+    }
+
+    private var remoteCodexBarDraftAllowsPlainHTTP: Bool {
+        self.remoteCodexBarDraftRequiresPlainHTTPConsent &&
+            self.remoteCodexBarPlainHTTPConsentEndpoint ==
+            self.remoteCodexBarServerURLDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var remoteCodexBarPlainHTTPConsentBinding: Binding<Bool> {
+        Binding(
+            get: { self.remoteCodexBarDraftAllowsPlainHTTP },
+            set: { isAllowed in
+                self.remoteCodexBarPlainHTTPConsentEndpoint = isAllowed
+                    ? self.remoteCodexBarServerURLDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                    : nil
+            })
     }
 
     private var syncCanRun: Bool {

--- a/Sources/CodexBar/PreferencesSidebar.swift
+++ b/Sources/CodexBar/PreferencesSidebar.swift
@@ -33,7 +33,7 @@ struct SettingsSidebarView: View {
     private var appPanesSection: some View {
         Section {
             SettingsSidebarPaneRow(pane: .general, systemImage: "gearshape.fill", color: .gray)
-            SettingsSidebarPaneRow(pane: .iCloudSync, systemImage: "icloud.fill", color: .blue)
+            SettingsSidebarPaneRow(pane: .iCloudSync, systemImage: "arrow.triangle.2.circlepath", color: .blue)
             SettingsSidebarPaneRow(pane: .usageSpend, systemImage: "chart.bar.fill", color: .green)
             SettingsSidebarPaneRow(pane: .notifications, systemImage: "bell.badge.fill", color: .red)
             SettingsSidebarPaneRow(pane: .menuBar, systemImage: "menubar.rectangle", color: .blue)

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -30,7 +30,7 @@ enum SettingsPane: Hashable {
     var title: String {
         switch self {
         case .general: L("tab_general")
-        case .iCloudSync: L("iCloud Sync")
+        case .iCloudSync: L("Sync")
         case .usageSpend: L("tab_usage_spend")
         case .notifications: L("tab_notifications")
         case .menuBar: L("tab_menu_bar")
@@ -162,7 +162,7 @@ struct PreferencesView: View {
         case .general:
             GeneralPane(settings: self.settings)
         case .iCloudSync:
-            ICloudSyncPane(settings: self.settings, state: self.cloudSyncState)
+            ICloudSyncPane(settings: self.settings, store: self.store, state: self.cloudSyncState)
         case .usageSpend:
             SpendDashboardPane(settings: self.settings, store: self.store)
         case .notifications:
@@ -172,7 +172,7 @@ struct PreferencesView: View {
         case .menu:
             MenuPane(settings: self.settings, store: self.store)
         case .advanced:
-            AdvancedPane(settings: self.settings, store: self.store)
+            AdvancedPane(settings: self.settings)
         case .hooks:
             HooksPane(settings: self.settings)
         case .plugins:

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -54,6 +54,15 @@ enum RemoteCodexBarSnapshotError: LocalizedError, Equatable {
     case unsupportedSchema(Int)
     case invalidSnapshot
 
+    var preservesLastGoodSnapshot: Bool {
+        switch self {
+        case let .httpStatus(status):
+            status == 408 || status == 429 || (500...599).contains(status)
+        case .invalidResponse, .unauthorized, .responseTooLarge, .unsupportedSchema, .invalidSnapshot:
+            false
+        }
+    }
+
     var errorDescription: String? {
         switch self {
         case .invalidResponse: "Remote CodexBar returned an invalid response."

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -442,10 +442,6 @@ struct RemoteCodexBarProjection: Sendable {
                 return email
             }
         }
-        let accountID = account.id.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !accountID.isEmpty {
-            return accountID
-        }
         return "\(serverIdentity)|\(providerID)|\(account.id)"
     }
 

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -125,6 +125,28 @@ final class RemoteCodexBarBoundedHTTPTransport: NSObject, ProviderHTTPTransport,
         let continuation: CheckedContinuation<(Data, URLResponse), Error>
     }
 
+    private final class RequestCancellation: @unchecked Sendable {
+        private let lock = NSLock()
+        private var task: URLSessionDataTask?
+        private var isCancelled = false
+
+        func install(_ task: URLSessionDataTask) -> Bool {
+            self.lock.withLock {
+                guard !self.isCancelled else { return false }
+                self.task = task
+                return true
+            }
+        }
+
+        func cancel() {
+            let task = self.lock.withLock {
+                self.isCancelled = true
+                return self.task
+            }
+            task?.cancel()
+        }
+    }
+
     private let maximumResponseBytes: Int
     private let lock = NSLock()
     private var states: [Int: RequestState] = [:]
@@ -148,12 +170,21 @@ final class RemoteCodexBarBoundedHTTPTransport: NSObject, ProviderHTTPTransport,
     }
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        try await withCheckedThrowingContinuation { continuation in
-            let task = self.session.dataTask(with: request)
-            self.lock.withLock {
-                self.states[task.taskIdentifier] = RequestState(continuation: continuation)
+        let cancellation = RequestCancellation()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = self.session.dataTask(with: request)
+                guard cancellation.install(task) else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                self.lock.withLock {
+                    self.states[task.taskIdentifier] = RequestState(continuation: continuation)
+                }
+                task.resume()
             }
-            task.resume()
+        } onCancel: {
+            cancellation.cancel()
         }
     }
 
@@ -203,7 +234,12 @@ final class RemoteCodexBarBoundedHTTPTransport: NSObject, ProviderHTTPTransport,
 
     func urlSession(_: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         if let error {
-            self.finish(taskIdentifier: task.taskIdentifier, result: .failure(error))
+            let resolvedError: Error = if (error as? URLError)?.code == .cancelled {
+                CancellationError()
+            } else {
+                error
+            }
+            self.finish(taskIdentifier: task.taskIdentifier, result: .failure(resolvedError))
             return
         }
         let result: Result<(Data, URLResponse), Error> = self.lock.withLock {
@@ -343,15 +379,16 @@ struct RemoteCodexBarProjection: Sendable {
             guard let provider = UsageProvider(rawValue: row.id) else { continue }
             let providerIdentity = row.identity?.accountEmail
                 ?? "\(serverIdentity)|\(row.id)|default"
-            if let usage = self.usageSnapshot(
-                provider: provider,
-                windows: row.windows,
-                identity: row.identity,
-                status: row.status,
-                credits: row.credits,
-                cost: row.cost,
-                error: row.error?.message ?? row.accountsError,
-                updatedAt: row.updatedAt ?? snapshot.generatedAt)
+            if row.accounts.isEmpty,
+               let usage = self.usageSnapshot(
+                   provider: provider,
+                   windows: row.windows,
+                   identity: row.identity,
+                   status: row.status,
+                   credits: row.credits,
+                   cost: row.cost,
+                   error: row.error?.message ?? row.accountsError,
+                   updatedAt: row.updatedAt ?? snapshot.generatedAt)
             {
                 projected.append(AccountSnapshotSyncPayload(
                     provider: provider.instanceID,
@@ -375,12 +412,41 @@ struct RemoteCodexBarProjection: Sendable {
                 projected.append(AccountSnapshotSyncPayload(
                     provider: provider.instanceID,
                     deviceID: "remote-codexbar",
-                    accountIdentity: "\(serverIdentity)|\(row.id)|\(account.id)",
+                    accountIdentity: self.accountIdentity(
+                        account,
+                        in: row.accounts,
+                        providerID: row.id,
+                        serverIdentity: serverIdentity),
                     displayLabel: account.label,
                     usage: usage))
             }
         }
         return Self(snapshots: projected)
+    }
+
+    private static func accountIdentity(
+        _ account: RemoteCodexBarSnapshot.Account,
+        in accounts: [RemoteCodexBarSnapshot.Account],
+        providerID: String,
+        serverIdentity: String) -> String
+    {
+        let email = account.identity?.accountEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let emailLocalPart = email.flatMap { $0.split(separator: "@", maxSplits: 1).first.map(String.init) }
+        let isRedactedEmail = emailLocalPart?.caseInsensitiveCompare("redacted") == .orderedSame
+        if let email, !email.isEmpty, !isRedactedEmail {
+            let matchingEmailCount = accounts.count {
+                let candidate = $0.identity?.accountEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
+                return candidate?.caseInsensitiveCompare(email) == .orderedSame
+            }
+            if matchingEmailCount == 1 {
+                return email
+            }
+        }
+        let accountID = account.id.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !accountID.isEmpty {
+            return accountID
+        }
+        return "\(serverIdentity)|\(providerID)|\(account.id)"
     }
 
     // Projection stays explicit because each server field has a distinct display fallback.

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -59,7 +59,11 @@ struct RemoteCodexBarSnapshotClient: Sendable {
 
     let transport: any ProviderHTTPTransport
 
-    init(transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) {
+    init() {
+        self.transport = RemoteCodexBarBoundedHTTPTransport(maximumResponseBytes: Self.maximumResponseBytes)
+    }
+
+    init(transport: any ProviderHTTPTransport) {
         self.transport = transport
     }
 
@@ -97,6 +101,132 @@ struct RemoteCodexBarSnapshotClient: Sendable {
             throw RemoteCodexBarSnapshotError.unsupportedSchema(snapshot.schemaVersion)
         }
         return snapshot
+    }
+}
+
+final class RemoteCodexBarBoundedHTTPTransport: NSObject, ProviderHTTPTransport, URLSessionDataDelegate,
+    @unchecked Sendable
+{
+    private struct RequestState {
+        var data = Data()
+        var response: URLResponse?
+        let continuation: CheckedContinuation<(Data, URLResponse), Error>
+    }
+
+    private let maximumResponseBytes: Int
+    private let lock = NSLock()
+    private var states: [Int: RequestState] = [:]
+    private let configuration: URLSessionConfiguration
+    private lazy var session = URLSession(configuration: self.configuration, delegate: self, delegateQueue: nil)
+
+    init(
+        maximumResponseBytes: Int,
+        configuration: URLSessionConfiguration? = nil)
+    {
+        self.maximumResponseBytes = maximumResponseBytes
+        let resolvedConfiguration = configuration ?? URLSessionConfiguration.ephemeral
+        resolvedConfiguration.httpCookieStorage = nil
+        resolvedConfiguration.httpShouldSetCookies = false
+        resolvedConfiguration.urlCredentialStorage = nil
+        resolvedConfiguration.urlCache = nil
+        resolvedConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        resolvedConfiguration.timeoutIntervalForRequest = 30
+        resolvedConfiguration.timeoutIntervalForResource = 30
+        self.configuration = resolvedConfiguration
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = self.session.dataTask(with: request)
+            self.lock.withLock {
+                self.states[task.taskIdentifier] = RequestState(continuation: continuation)
+            }
+            task.resume()
+        }
+    }
+
+    func urlSession(
+        _: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection _: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping @Sendable (URLRequest?) -> Void)
+    {
+        completionHandler(Self.guardedRedirectRequest(
+            originalURL: task.originalRequest?.url,
+            redirectRequest: request))
+    }
+
+    func urlSession(
+        _: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void)
+    {
+        if response.expectedContentLength > Int64(self.maximumResponseBytes) {
+            completionHandler(.cancel)
+            self.finish(
+                taskIdentifier: dataTask.taskIdentifier,
+                result: .failure(RemoteCodexBarSnapshotError.responseTooLarge))
+            return
+        }
+        self.lock.withLock { self.states[dataTask.taskIdentifier]?.response = response }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        let exceeded = self.lock.withLock {
+            guard var state = self.states[dataTask.taskIdentifier] else { return false }
+            guard data.count <= self.maximumResponseBytes - state.data.count else { return true }
+            state.data.append(data)
+            self.states[dataTask.taskIdentifier] = state
+            return false
+        }
+        guard exceeded else { return }
+        dataTask.cancel()
+        self.finish(
+            taskIdentifier: dataTask.taskIdentifier,
+            result: .failure(RemoteCodexBarSnapshotError.responseTooLarge))
+    }
+
+    func urlSession(_: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error {
+            self.finish(taskIdentifier: task.taskIdentifier, result: .failure(error))
+            return
+        }
+        let result: Result<(Data, URLResponse), Error> = self.lock.withLock {
+            guard let state = self.states[task.taskIdentifier], let response = state.response else {
+                return .failure(URLError(.badServerResponse))
+            }
+            return .success((state.data, response))
+        }
+        self.finish(taskIdentifier: task.taskIdentifier, result: result)
+    }
+
+    private func finish(taskIdentifier: Int, result: Result<(Data, URLResponse), Error>) {
+        let continuation = self.lock.withLock { self.states.removeValue(forKey: taskIdentifier)?.continuation }
+        continuation?.resume(with: result)
+    }
+
+    static func guardedRedirectRequest(originalURL: URL?, redirectRequest request: URLRequest) -> URLRequest? {
+        guard let originalURL, let redirectedURL = request.url else { return nil }
+        guard originalURL.scheme?.caseInsensitiveCompare(redirectedURL.scheme ?? "") == .orderedSame else {
+            return nil
+        }
+        guard originalURL.host?.caseInsensitiveCompare(redirectedURL.host ?? "") == .orderedSame else {
+            return nil
+        }
+        guard self.normalizedPort(originalURL) == self.normalizedPort(redirectedURL) else { return nil }
+        return request
+    }
+
+    private static func normalizedPort(_ url: URL) -> Int? {
+        if let port = url.port { return port }
+        switch url.scheme?.lowercased() {
+        case "http": 80
+        case "https": 443
+        default: nil
+        }
     }
 }
 

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -375,7 +375,7 @@ struct RemoteCodexBarProjection: Sendable {
                 projected.append(AccountSnapshotSyncPayload(
                     provider: provider.instanceID,
                     deviceID: "remote-codexbar",
-                    accountIdentity: account.identity?.accountEmail ?? account.id,
+                    accountIdentity: "\(serverIdentity)|\(row.id)|\(account.id)",
                     displayLabel: account.label,
                     usage: usage))
             }

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -19,9 +19,9 @@ struct RemoteCodexBarConfiguration: Equatable, Sendable {
         let validator = ProviderEndpointOverrideValidator()
         let normalizedServerURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !token.isEmpty,
-              !validator.requiresExplicitPlainHTTPConsent(normalizedServerURL) || allowsPlainHTTP,
+              !validator.requiresExplicitRemoteCodexBarPlainHTTPConsent(normalizedServerURL) || allowsPlainHTTP,
               var components = validator
-                  .validatedURLAllowingPrivateNetworkHTTP(normalizedServerURL)
+                  .validatedURLAllowingRemoteCodexBarHTTP(normalizedServerURL)
                   .flatMap({ URLComponents(url: $0, resolvingAgainstBaseURL: false) }),
                   components.query == nil,
                   components.fragment == nil
@@ -41,7 +41,7 @@ struct RemoteCodexBarConfiguration: Equatable, Sendable {
     }
 
     static func requiresPlainHTTPConsent(serverURL: String) -> Bool {
-        ProviderEndpointOverrideValidator().requiresExplicitPlainHTTPConsent(
+        ProviderEndpointOverrideValidator().requiresExplicitRemoteCodexBarPlainHTTPConsent(
             serverURL.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 }

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -183,12 +183,14 @@ final class RemoteCodexBarBoundedHTTPTransport: NSObject, ProviderHTTPTransport,
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 let task = self.session.dataTask(with: request)
-                guard cancellation.install(task) else {
-                    continuation.resume(throwing: CancellationError())
-                    return
-                }
                 self.lock.withLock {
                     self.states[task.taskIdentifier] = RequestState(continuation: continuation)
+                }
+                guard cancellation.install(task) else {
+                    self.finish(
+                        taskIdentifier: task.taskIdentifier,
+                        result: .failure(CancellationError()))
+                    return
                 }
                 task.resume()
             }

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -223,9 +223,9 @@ final class RemoteCodexBarBoundedHTTPTransport: NSObject, ProviderHTTPTransport,
     private static func normalizedPort(_ url: URL) -> Int? {
         if let port = url.port { return port }
         switch url.scheme?.lowercased() {
-        case "http": 80
-        case "https": 443
-        default: nil
+        case "http": return 80
+        case "https": return 443
+        default: return nil
         }
     }
 }

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -1,0 +1,334 @@
+import CodexBarCore
+import Foundation
+
+struct RemoteCodexBarConfiguration: Equatable, Sendable {
+    let snapshotURL: URL
+    let bearerToken: String
+
+    var configurationID: String {
+        let tokenFingerprint = CanonicalSyncJSON.hash(data: Data(self.bearerToken.utf8))
+        return "\(self.snapshotURL.absoluteString)|\(tokenFingerprint)"
+    }
+
+    static func resolve(serverURL: String, bearerToken: String) -> Self? {
+        let token = bearerToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty,
+              var components = ProviderEndpointOverrideValidator()
+                  .validatedURLAllowingPrivateNetworkHTTP(serverURL.trimmingCharacters(in: .whitespacesAndNewlines))
+                  .flatMap({ URLComponents(url: $0, resolvingAgainstBaseURL: false) }),
+                  components.query == nil,
+                  components.fragment == nil
+        else { return nil }
+
+        let endpointPath = "/dashboard/v1/snapshot"
+        let trimmedPath = components.path.hasSuffix("/")
+            ? String(components.path.dropLast())
+            : components.path
+        if trimmedPath.hasSuffix(endpointPath) {
+            components.path = trimmedPath
+        } else {
+            components.path = trimmedPath + endpointPath
+        }
+        guard let url = components.url else { return nil }
+        return Self(snapshotURL: url, bearerToken: token)
+    }
+}
+
+enum RemoteCodexBarSnapshotError: LocalizedError, Equatable {
+    case invalidResponse
+    case unauthorized
+    case httpStatus(Int)
+    case responseTooLarge
+    case unsupportedSchema(Int)
+    case invalidSnapshot
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse: "Remote CodexBar returned an invalid response."
+        case .unauthorized: "Remote CodexBar rejected the bearer token."
+        case let .httpStatus(status): "Remote CodexBar returned HTTP \(status)."
+        case .responseTooLarge: "Remote CodexBar returned an unexpectedly large snapshot."
+        case let .unsupportedSchema(version): "Remote CodexBar schema \(version) is not supported."
+        case .invalidSnapshot: "Remote CodexBar returned an invalid schema-v1 snapshot."
+        }
+    }
+}
+
+struct RemoteCodexBarSnapshotClient: Sendable {
+    static let maximumResponseBytes = 2 * 1024 * 1024
+
+    let transport: any ProviderHTTPTransport
+
+    init(transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) {
+        self.transport = transport
+    }
+
+    func fetch(configuration: RemoteCodexBarConfiguration) async throws -> RemoteCodexBarSnapshot {
+        var request = URLRequest(
+            url: configuration.snapshotURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 30)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(configuration.bearerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let response = try await self.transport.response(for: request, retryPolicy: .transientIdempotent)
+        guard response.data.count <= Self.maximumResponseBytes else {
+            throw RemoteCodexBarSnapshotError.responseTooLarge
+        }
+        switch response.statusCode {
+        case 200:
+            break
+        case 401, 403:
+            throw RemoteCodexBarSnapshotError.unauthorized
+        default:
+            throw RemoteCodexBarSnapshotError.httpStatus(response.statusCode)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snapshot: RemoteCodexBarSnapshot
+        do {
+            snapshot = try decoder.decode(RemoteCodexBarSnapshot.self, from: response.data)
+        } catch {
+            throw RemoteCodexBarSnapshotError.invalidSnapshot
+        }
+        guard snapshot.schemaVersion == 1 else {
+            throw RemoteCodexBarSnapshotError.unsupportedSchema(snapshot.schemaVersion)
+        }
+        return snapshot
+    }
+}
+
+struct RemoteCodexBarSnapshot: Decodable, Sendable {
+    let schemaVersion: Int
+    let generatedAt: Date
+    let staleAfterSeconds: Int
+    let providers: [Provider]
+
+    struct Provider: Decodable, Sendable {
+        let id: String
+        let name: String
+        let enabled: Bool
+        let source: String?
+        let status: Status?
+        let identity: Identity?
+        let windows: [Window]
+        let credits: Credits?
+        let cost: Cost?
+        let error: RemoteError?
+        let updatedAt: Date?
+        let accounts: [Account]
+        let accountsError: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case id, name, enabled, source, status, identity, windows, credits, cost, error, updatedAt, accounts
+            case accountsError
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.id = try container.decode(String.self, forKey: .id)
+            self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? self.id
+            self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+            self.source = try container.decodeIfPresent(String.self, forKey: .source)
+            self.status = try container.decodeIfPresent(Status.self, forKey: .status)
+            self.identity = try container.decodeIfPresent(Identity.self, forKey: .identity)
+            self.windows = try container.decodeIfPresent([Window].self, forKey: .windows) ?? []
+            self.credits = try container.decodeIfPresent(Credits.self, forKey: .credits)
+            self.cost = try container.decodeIfPresent(Cost.self, forKey: .cost)
+            self.error = try container.decodeIfPresent(RemoteError.self, forKey: .error)
+            self.updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
+            self.accounts = try container.decodeIfPresent([Account].self, forKey: .accounts) ?? []
+            self.accountsError = try container.decodeIfPresent(String.self, forKey: .accountsError)
+        }
+    }
+
+    struct Account: Decodable, Sendable {
+        let id: String
+        let label: String
+        let active: Bool
+        let identity: Identity?
+        let windows: [Window]
+        let error: String?
+        let updatedAt: Date?
+    }
+
+    struct Status: Decodable, Sendable {
+        let level: String
+        let label: String
+        let updatedAt: Date?
+    }
+
+    struct Identity: Decodable, Sendable {
+        let accountEmail: String?
+        let plan: String?
+    }
+
+    struct Window: Decodable, Sendable {
+        let kind: String
+        let label: String
+        let usedPercent: Double
+        let resetAt: Date?
+        let idle: Bool?
+    }
+
+    struct Credits: Decodable, Sendable {
+        let remaining: Double
+        let unit: String
+    }
+
+    struct Cost: Decodable, Sendable {
+        let todayUSD: Double?
+        let last30DaysUSD: Double?
+    }
+
+    struct RemoteError: Decodable, Sendable {
+        let message: String
+    }
+}
+
+struct RemoteCodexBarProjection: Sendable {
+    let snapshots: [AccountSnapshotSyncPayload]
+
+    static func make(
+        snapshot: RemoteCodexBarSnapshot,
+        serverURL: URL) -> Self
+    {
+        let serverIdentity = serverURL.absoluteString
+        var projected: [AccountSnapshotSyncPayload] = []
+        for row in snapshot.providers where row.enabled {
+            guard let provider = UsageProvider(rawValue: row.id) else { continue }
+            let providerIdentity = row.identity?.accountEmail
+                ?? "\(serverIdentity)|\(row.id)|default"
+            if let usage = self.usageSnapshot(
+                provider: provider,
+                windows: row.windows,
+                identity: row.identity,
+                status: row.status,
+                credits: row.credits,
+                cost: row.cost,
+                error: row.error?.message ?? row.accountsError,
+                updatedAt: row.updatedAt ?? snapshot.generatedAt)
+            {
+                projected.append(AccountSnapshotSyncPayload(
+                    provider: provider.instanceID,
+                    deviceID: "remote-codexbar",
+                    accountIdentity: providerIdentity,
+                    displayLabel: row.identity?.accountEmail ?? row.name,
+                    usage: usage))
+            }
+
+            for account in row.accounts {
+                guard let usage = self.usageSnapshot(
+                    provider: provider,
+                    windows: account.windows,
+                    identity: account.identity,
+                    status: nil,
+                    credits: nil,
+                    cost: nil,
+                    error: account.error,
+                    updatedAt: account.updatedAt ?? row.updatedAt ?? snapshot.generatedAt)
+                else { continue }
+                projected.append(AccountSnapshotSyncPayload(
+                    provider: provider.instanceID,
+                    deviceID: "remote-codexbar",
+                    accountIdentity: account.identity?.accountEmail ?? account.id,
+                    displayLabel: account.label,
+                    usage: usage))
+            }
+        }
+        return Self(snapshots: projected)
+    }
+
+    // Projection stays explicit because each server field has a distinct display fallback.
+    // swiftlint:disable:next function_parameter_count
+    private static func usageSnapshot(
+        provider: UsageProvider,
+        windows: [RemoteCodexBarSnapshot.Window],
+        identity: RemoteCodexBarSnapshot.Identity?,
+        status: RemoteCodexBarSnapshot.Status?,
+        credits: RemoteCodexBarSnapshot.Credits?,
+        cost: RemoteCodexBarSnapshot.Cost?,
+        error: String?,
+        updatedAt: Date) -> UsageSnapshot?
+    {
+        let visibleWindows = windows.filter { $0.idle != true && $0.usedPercent.isFinite }
+        let primary = visibleWindows.first(where: { $0.kind == "session" }).map(self.rateWindow)
+        let secondary = visibleWindows.first(where: { $0.kind == "weekly" }).map(self.rateWindow)
+        let tertiary = visibleWindows.first(where: { $0.kind == "tertiary" }).map(self.rateWindow)
+        let standardKinds: Set = ["session", "weekly", "tertiary"]
+        let extras = visibleWindows.filter { !standardKinds.contains($0.kind) }.map { window in
+            NamedRateWindow(id: window.kind, title: window.label, window: self.rateWindow(window))
+        }
+        let details = self.details(status: status, credits: credits, cost: cost, error: error)
+        guard primary != nil || secondary != nil || tertiary != nil || !extras.isEmpty || !details.isEmpty else {
+            return nil
+        }
+        return UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            tertiary: tertiary,
+            extraRateWindows: extras.isEmpty ? nil : extras,
+            details: details,
+            updatedAt: updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: provider.instanceID,
+                accountEmail: identity?.accountEmail,
+                accountOrganization: nil,
+                loginMethod: identity?.plan),
+            dataConfidence: .percentOnly)
+    }
+
+    private static func rateWindow(_ window: RemoteCodexBarSnapshot.Window) -> RateWindow {
+        RateWindow(
+            usedPercent: min(100, max(0, window.usedPercent)),
+            windowMinutes: nil,
+            resetsAt: window.resetAt,
+            resetDescription: nil)
+    }
+
+    private static func details(
+        status: RemoteCodexBarSnapshot.Status?,
+        credits: RemoteCodexBarSnapshot.Credits?,
+        cost: RemoteCodexBarSnapshot.Cost?,
+        error: String?) -> [ProviderDetailSection]
+    {
+        var rows: [ProviderDetailSection.Row] = []
+        if let status, !status.label.isEmpty {
+            if let row = try? ProviderDetailSection.Row(label: "Status", value: status.label) {
+                rows.append(row)
+            }
+        }
+        if let credits, credits.remaining.isFinite {
+            if let row = try? ProviderDetailSection.Row(
+                label: "Credits remaining",
+                value: "\(credits.remaining) \(credits.unit)")
+            {
+                rows.append(row)
+            }
+        }
+        if let today = cost?.todayUSD, today.isFinite {
+            if let row = try? ProviderDetailSection.Row(label: "Today", value: String(format: "$%.2f", today)) {
+                rows.append(row)
+            }
+        }
+        if let month = cost?.last30DaysUSD, month.isFinite {
+            if let row = try? ProviderDetailSection.Row(
+                label: "Last 30 days",
+                value: String(format: "$%.2f", month))
+            {
+                rows.append(row)
+            }
+        }
+        if let error = error?.trimmingCharacters(in: .whitespacesAndNewlines), !error.isEmpty {
+            if let row = try? ProviderDetailSection.Row(label: "Remote error", value: error) {
+                rows.append(row)
+            }
+        }
+        guard !rows.isEmpty, let section = try? ProviderDetailSection(title: "Remote CodexBar", rows: rows) else {
+            return []
+        }
+        return [section]
+    }
+}

--- a/Sources/CodexBar/RemoteCodexBarSnapshot.swift
+++ b/Sources/CodexBar/RemoteCodexBarSnapshot.swift
@@ -10,11 +10,18 @@ struct RemoteCodexBarConfiguration: Equatable, Sendable {
         return "\(self.snapshotURL.absoluteString)|\(tokenFingerprint)"
     }
 
-    static func resolve(serverURL: String, bearerToken: String) -> Self? {
+    static func resolve(
+        serverURL: String,
+        bearerToken: String,
+        allowsPlainHTTP: Bool = false) -> Self?
+    {
         let token = bearerToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        let validator = ProviderEndpointOverrideValidator()
+        let normalizedServerURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !token.isEmpty,
-              var components = ProviderEndpointOverrideValidator()
-                  .validatedURLAllowingPrivateNetworkHTTP(serverURL.trimmingCharacters(in: .whitespacesAndNewlines))
+              !validator.requiresExplicitPlainHTTPConsent(normalizedServerURL) || allowsPlainHTTP,
+              var components = validator
+                  .validatedURLAllowingPrivateNetworkHTTP(normalizedServerURL)
                   .flatMap({ URLComponents(url: $0, resolvingAgainstBaseURL: false) }),
                   components.query == nil,
                   components.fragment == nil
@@ -31,6 +38,11 @@ struct RemoteCodexBarConfiguration: Equatable, Sendable {
         }
         guard let url = components.url else { return nil }
         return Self(snapshotURL: url, bearerToken: token)
+    }
+
+    static func requiresPlainHTTPConsent(serverURL: String) -> Bool {
+        ProviderEndpointOverrideValidator().requiresExplicitPlainHTTPConsent(
+            serverURL.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 }
 

--- a/Sources/CodexBar/RemoteCodexBarTokenStore.swift
+++ b/Sources/CodexBar/RemoteCodexBarTokenStore.swift
@@ -28,7 +28,7 @@ struct KeychainRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring {
                 allowsPlainHTTP: credential.allowsPlainHTTP)
         case .missing:
             return nil
-        case .temporarilyUnavailable:
+        case .interactionRequired, .temporarilyUnavailable:
             throw RemoteCodexBarTokenStoreError.temporarilyUnavailable
         case .invalid:
             throw RemoteCodexBarTokenStoreError.invalidData

--- a/Sources/CodexBar/RemoteCodexBarTokenStore.swift
+++ b/Sources/CodexBar/RemoteCodexBarTokenStore.swift
@@ -1,9 +1,15 @@
 import CodexBarCore
 import Foundation
 
+struct RemoteCodexBarStoredCredential: Codable, Equatable, Sendable {
+    let serverURL: String
+    let bearerToken: String
+    let allowsPlainHTTP: Bool
+}
+
 protocol RemoteCodexBarTokenStoring: Sendable {
-    func loadToken() throws -> String?
-    func storeToken(_ token: String?) throws
+    func loadCredential() throws -> RemoteCodexBarStoredCredential?
+    func storeCredential(_ credential: RemoteCodexBarStoredCredential?) throws
 }
 
 struct KeychainRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring {
@@ -11,11 +17,15 @@ struct KeychainRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring {
         category: "remote-codexbar-secret",
         identifier: "dashboard-bearer-token")
 
-    func loadToken() throws -> String? {
-        switch KeychainCacheStore.load(key: Self.key, as: String.self) {
-        case let .found(token):
-            let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
+    func loadCredential() throws -> RemoteCodexBarStoredCredential? {
+        switch KeychainCacheStore.load(key: Self.key, as: RemoteCodexBarStoredCredential.self) {
+        case let .found(credential):
+            let token = credential.bearerToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !token.isEmpty else { return nil }
+            return RemoteCodexBarStoredCredential(
+                serverURL: credential.serverURL.trimmingCharacters(in: .whitespacesAndNewlines),
+                bearerToken: token,
+                allowsPlainHTTP: credential.allowsPlainHTTP)
         case .missing:
             return nil
         case .temporarilyUnavailable:
@@ -25,10 +35,9 @@ struct KeychainRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring {
         }
     }
 
-    func storeToken(_ token: String?) throws {
-        let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let trimmed, !trimmed.isEmpty {
-            guard KeychainCacheStore.storeResult(key: Self.key, entry: trimmed) else {
+    func storeCredential(_ credential: RemoteCodexBarStoredCredential?) throws {
+        if let credential {
+            guard KeychainCacheStore.storeResult(key: Self.key, entry: credential) else {
                 throw RemoteCodexBarTokenStoreError.writeFailed
             }
         } else {

--- a/Sources/CodexBar/RemoteCodexBarTokenStore.swift
+++ b/Sources/CodexBar/RemoteCodexBarTokenStore.swift
@@ -1,0 +1,57 @@
+import CodexBarCore
+import Foundation
+
+protocol RemoteCodexBarTokenStoring: Sendable {
+    func loadToken() throws -> String?
+    func storeToken(_ token: String?) throws
+}
+
+struct KeychainRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring {
+    private static let key = KeychainCacheStore.Key(
+        category: "remote-codexbar-secret",
+        identifier: "dashboard-bearer-token")
+
+    func loadToken() throws -> String? {
+        switch KeychainCacheStore.load(key: Self.key, as: String.self) {
+        case let .found(token):
+            let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        case .missing:
+            return nil
+        case .temporarilyUnavailable:
+            throw RemoteCodexBarTokenStoreError.temporarilyUnavailable
+        case .invalid:
+            throw RemoteCodexBarTokenStoreError.invalidData
+        }
+    }
+
+    func storeToken(_ token: String?) throws {
+        let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmed, !trimmed.isEmpty {
+            guard KeychainCacheStore.storeResult(key: Self.key, entry: trimmed) else {
+                throw RemoteCodexBarTokenStoreError.writeFailed
+            }
+        } else {
+            switch KeychainCacheStore.clearResult(key: Self.key) {
+            case .removed, .missing:
+                break
+            case .failed:
+                throw RemoteCodexBarTokenStoreError.writeFailed
+            }
+        }
+    }
+}
+
+enum RemoteCodexBarTokenStoreError: LocalizedError, Equatable {
+    case invalidData
+    case temporarilyUnavailable
+    case writeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidData: "The saved remote CodexBar token is invalid."
+        case .temporarilyUnavailable: "The saved remote CodexBar token is temporarily unavailable."
+        case .writeFailed: "The remote CodexBar token could not be saved securely."
+        }
+    }
+}

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -75,12 +75,17 @@ extension SettingsStore {
     var debugDisableKeychainAccess: Bool {
         get { self.defaultsState.debugDisableKeychainAccess }
         set {
+            let wasDisabled = self.defaultsState.debugDisableKeychainAccess
             self.defaultsState.debugDisableKeychainAccess = newValue
             self.userDefaults.set(newValue, forKey: "debugDisableKeychainAccess")
             if Self.shouldBridgeSharedDefaults(for: self.userDefaults) {
                 Self.sharedDefaults?.set(newValue, forKey: "debugDisableKeychainAccess")
             }
             self.keychainAccessPolicy.setDisabled(newValue)
+            if wasDisabled, !newValue {
+                self.remoteCodexBarTokenLoadNeedsRetry = true
+                self.retryRemoteCodexBarTokenLoadIfNeeded()
+            }
             self.noteBackgroundWorkSettingsChanged()
         }
     }

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -10,6 +10,7 @@ extension SettingsStore {
         _ = self.debugMenuEnabled
         _ = self.debugDisableKeychainAccess
         _ = self.debugKeepCLISessionsAlive
+        _ = self.remoteCodexBarConfigurationRevision
         _ = self.statusChecksEnabled
         _ = self.sessionQuotaNotificationsEnabled
         _ = self.quotaWarningNotificationsEnabled

--- a/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
+++ b/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
@@ -29,10 +29,25 @@ extension SettingsStore {
         }
     }
 
+    var remoteCodexBarAllowsPlainHTTP: Bool {
+        self.remoteCodexBarAllowsPlainHTTPStorage
+    }
+
     @discardableResult
-    func applyRemoteCodexBarConfiguration(serverURL: String, bearerToken: String) -> Bool {
+    func applyRemoteCodexBarConfiguration(
+        serverURL: String,
+        bearerToken: String,
+        allowsPlainHTTP: Bool = false) -> Bool
+    {
         let normalizedURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedToken = bearerToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        let requiresPlainHTTPConsent = RemoteCodexBarConfiguration.requiresPlainHTTPConsent(serverURL: normalizedURL)
+        guard !requiresPlainHTTPConsent || allowsPlainHTTP else {
+            self.remoteCodexBarSecretError =
+                "Confirm that the bearer token may be sent over unencrypted private-network HTTP."
+            return false
+        }
+        let storesPlainHTTPConsent = requiresPlainHTTPConsent && allowsPlainHTTP
 
         // Commit the credential before publishing its endpoint. If Keychain rejects the write or clear,
         // the previously matched endpoint/token pair remains active and durable.
@@ -47,7 +62,9 @@ extension SettingsStore {
         // revision after both values change makes the endpoint/token pair atomic to refresh consumers.
         self.remoteCodexBarServerURLStorage = normalizedURL
         self.remoteCodexBarBearerTokenStorage = normalizedToken
+        self.remoteCodexBarAllowsPlainHTTPStorage = storesPlainHTTPConsent
         self.userDefaults.set(normalizedURL, forKey: "remoteCodexBarServerURL")
+        self.userDefaults.set(storesPlainHTTPConsent, forKey: "remoteCodexBarAllowsPlainHTTP")
         self.remoteCodexBarTokenLoadNeedsRetry = false
         self.remoteCodexBarSecretError = nil
         self.remoteCodexBarConfigurationRevision &+= 1
@@ -71,7 +88,8 @@ extension SettingsStore {
     var remoteCodexBarConfiguration: RemoteCodexBarConfiguration? {
         RemoteCodexBarConfiguration.resolve(
             serverURL: self.remoteCodexBarServerURL,
-            bearerToken: self.remoteCodexBarBearerToken)
+            bearerToken: self.remoteCodexBarBearerToken,
+            allowsPlainHTTP: self.remoteCodexBarAllowsPlainHTTP)
     }
 
     func remoteCodexBarURLValidationMessage(for serverURL: String) -> String? {

--- a/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
+++ b/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
@@ -89,6 +89,7 @@ extension SettingsStore {
 
     func retryRemoteCodexBarTokenLoadIfNeeded() {
         guard self.remoteCodexBarTokenLoadNeedsRetry else { return }
+        guard !KeychainAccessGate.isExplicitlyDisabled else { return }
         do {
             if let credential = try self.remoteCodexBarTokenStore.loadCredential() {
                 self.remoteCodexBarServerURLStorage = credential.serverURL

--- a/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
+++ b/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
@@ -121,8 +121,9 @@ extension SettingsStore {
     func remoteCodexBarURLValidationMessage(for serverURL: String) -> String? {
         let raw = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !raw.isEmpty else { return nil }
-        guard ProviderEndpointOverrideValidator().validatedURLAllowingPrivateNetworkHTTP(raw) != nil else {
-            return "Use HTTPS, or HTTP only for loopback/private-network hosts. User info is not allowed."
+        guard ProviderEndpointOverrideValidator().validatedURLAllowingRemoteCodexBarHTTP(raw) != nil else {
+            return "Use HTTPS, or HTTP only for loopback, private-network, or Tailscale/CGNAT hosts. " +
+                "User info is not allowed."
         }
         guard URLComponents(string: raw)?.query == nil, URLComponents(string: raw)?.fragment == nil else {
             return "The server URL cannot include a query or fragment."

--- a/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
+++ b/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
@@ -15,8 +15,16 @@ extension SettingsStore {
         get { self.remoteCodexBarBearerTokenStorage }
         set {
             let normalizedToken = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            let credential = self.remoteCodexBarStoredCredential(
+                serverURL: self.remoteCodexBarServerURLStorage,
+                bearerToken: normalizedToken,
+                allowsPlainHTTP: self.remoteCodexBarAllowsPlainHTTPStorage)
+            guard normalizedToken.isEmpty || credential != nil else {
+                self.remoteCodexBarSecretError = "Save a valid server URL before saving its bearer token."
+                return
+            }
             do {
-                try self.remoteCodexBarTokenStore.storeToken(normalizedToken)
+                try self.remoteCodexBarTokenStore.storeCredential(credential)
                 self.remoteCodexBarBearerTokenStorage = normalizedToken
                 self.remoteCodexBarTokenLoadNeedsRetry = false
                 self.remoteCodexBarSecretError = nil
@@ -48,11 +56,19 @@ extension SettingsStore {
             return false
         }
         let storesPlainHTTPConsent = requiresPlainHTTPConsent && allowsPlainHTTP
+        let credential = self.remoteCodexBarStoredCredential(
+            serverURL: normalizedURL,
+            bearerToken: normalizedToken,
+            allowsPlainHTTP: storesPlainHTTPConsent)
+        guard normalizedToken.isEmpty || credential != nil else {
+            self.remoteCodexBarSecretError = "Save a valid server URL and bearer token together."
+            return false
+        }
 
-        // Commit the credential before publishing its endpoint. If Keychain rejects the write or clear,
-        // the previously matched endpoint/token pair remains active and durable.
+        // The Keychain record binds the endpoint and token in one durable write. UserDefaults keeps only
+        // a display draft, so an interruption can never recombine authority from two different servers.
         do {
-            try self.remoteCodexBarTokenStore.storeToken(normalizedToken)
+            try self.remoteCodexBarTokenStore.storeCredential(credential)
         } catch {
             self.remoteCodexBarSecretError = error.localizedDescription
             return false
@@ -64,7 +80,6 @@ extension SettingsStore {
         self.remoteCodexBarBearerTokenStorage = normalizedToken
         self.remoteCodexBarAllowsPlainHTTPStorage = storesPlainHTTPConsent
         self.userDefaults.set(normalizedURL, forKey: "remoteCodexBarServerURL")
-        self.userDefaults.set(storesPlainHTTPConsent, forKey: "remoteCodexBarAllowsPlainHTTP")
         self.remoteCodexBarTokenLoadNeedsRetry = false
         self.remoteCodexBarSecretError = nil
         self.remoteCodexBarConfigurationRevision &+= 1
@@ -75,9 +90,19 @@ extension SettingsStore {
     func retryRemoteCodexBarTokenLoadIfNeeded() {
         guard self.remoteCodexBarTokenLoadNeedsRetry else { return }
         do {
-            self.remoteCodexBarBearerTokenStorage = try self.remoteCodexBarTokenStore.loadToken() ?? ""
+            if let credential = try self.remoteCodexBarTokenStore.loadCredential() {
+                self.remoteCodexBarServerURLStorage = credential.serverURL
+                self.remoteCodexBarBearerTokenStorage = credential.bearerToken
+                self.remoteCodexBarAllowsPlainHTTPStorage = credential.allowsPlainHTTP
+                self.userDefaults.set(credential.serverURL, forKey: "remoteCodexBarServerURL")
+            } else {
+                self.remoteCodexBarBearerTokenStorage = ""
+                self.remoteCodexBarAllowsPlainHTTPStorage = false
+            }
             self.remoteCodexBarSecretError = nil
             self.remoteCodexBarTokenLoadNeedsRetry = false
+            self.remoteCodexBarConfigurationRevision &+= 1
+            self.noteBackgroundWorkSettingsChanged()
         } catch {
             self.remoteCodexBarSecretError = error.localizedDescription
             self.remoteCodexBarTokenLoadNeedsRetry =
@@ -102,5 +127,21 @@ extension SettingsStore {
             return "The server URL cannot include a query or fragment."
         }
         return nil
+    }
+
+    private func remoteCodexBarStoredCredential(
+        serverURL: String,
+        bearerToken: String,
+        allowsPlainHTTP: Bool) -> RemoteCodexBarStoredCredential?
+    {
+        guard RemoteCodexBarConfiguration.resolve(
+            serverURL: serverURL,
+            bearerToken: bearerToken,
+            allowsPlainHTTP: allowsPlainHTTP) != nil
+        else { return nil }
+        return RemoteCodexBarStoredCredential(
+            serverURL: serverURL.trimmingCharacters(in: .whitespacesAndNewlines),
+            bearerToken: bearerToken.trimmingCharacters(in: .whitespacesAndNewlines),
+            allowsPlainHTTP: allowsPlainHTTP)
     }
 }

--- a/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
+++ b/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
@@ -1,0 +1,80 @@
+import CodexBarCore
+import Foundation
+
+extension SettingsStore {
+    var remoteCodexBarServerURL: String {
+        get { self.remoteCodexBarServerURLStorage }
+        set {
+            // A token is scoped to the configured server. Never retain it across an endpoint edit,
+            // where an observation callback could otherwise send the old server's token to the new host.
+            self.applyRemoteCodexBarConfiguration(serverURL: newValue, bearerToken: "")
+        }
+    }
+
+    var remoteCodexBarBearerToken: String {
+        get { self.remoteCodexBarBearerTokenStorage }
+        set {
+            self.remoteCodexBarBearerTokenStorage = newValue
+            self.remoteCodexBarTokenLoadNeedsRetry = false
+            do {
+                try self.remoteCodexBarTokenStore.storeToken(newValue)
+                self.remoteCodexBarSecretError = nil
+            } catch {
+                self.remoteCodexBarSecretError = error.localizedDescription
+            }
+            self.remoteCodexBarConfigurationRevision &+= 1
+            self.noteBackgroundWorkSettingsChanged()
+        }
+    }
+
+    func applyRemoteCodexBarConfiguration(serverURL: String, bearerToken: String) {
+        let normalizedURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedToken = bearerToken.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // These storage properties are deliberately not part of menu observation. Publishing one
+        // revision after both values change makes the endpoint/token pair atomic to refresh consumers.
+        self.remoteCodexBarServerURLStorage = normalizedURL
+        self.remoteCodexBarBearerTokenStorage = normalizedToken
+        self.userDefaults.set(normalizedURL, forKey: "remoteCodexBarServerURL")
+        self.remoteCodexBarTokenLoadNeedsRetry = false
+        do {
+            try self.remoteCodexBarTokenStore.storeToken(normalizedToken)
+            self.remoteCodexBarSecretError = nil
+        } catch {
+            self.remoteCodexBarSecretError = error.localizedDescription
+        }
+        self.remoteCodexBarConfigurationRevision &+= 1
+        self.noteBackgroundWorkSettingsChanged()
+    }
+
+    func retryRemoteCodexBarTokenLoadIfNeeded() {
+        guard self.remoteCodexBarTokenLoadNeedsRetry else { return }
+        do {
+            self.remoteCodexBarBearerTokenStorage = try self.remoteCodexBarTokenStore.loadToken() ?? ""
+            self.remoteCodexBarSecretError = nil
+            self.remoteCodexBarTokenLoadNeedsRetry = false
+        } catch {
+            self.remoteCodexBarSecretError = error.localizedDescription
+            self.remoteCodexBarTokenLoadNeedsRetry =
+                error as? RemoteCodexBarTokenStoreError == .temporarilyUnavailable
+        }
+    }
+
+    var remoteCodexBarConfiguration: RemoteCodexBarConfiguration? {
+        RemoteCodexBarConfiguration.resolve(
+            serverURL: self.remoteCodexBarServerURL,
+            bearerToken: self.remoteCodexBarBearerToken)
+    }
+
+    func remoteCodexBarURLValidationMessage(for serverURL: String) -> String? {
+        let raw = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return nil }
+        guard ProviderEndpointOverrideValidator().validatedURLAllowingPrivateNetworkHTTP(raw) != nil else {
+            return "Use HTTPS, or HTTP only for loopback/private-network hosts. User info is not allowed."
+        }
+        guard URLComponents(string: raw)?.query == nil, URLComponents(string: raw)?.fragment == nil else {
+            return "The server URL cannot include a query or fragment."
+        }
+        return nil
+    }
+}

--- a/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
+++ b/Sources/CodexBar/SettingsStore+RemoteCodexBar.swift
@@ -14,22 +14,34 @@ extension SettingsStore {
     var remoteCodexBarBearerToken: String {
         get { self.remoteCodexBarBearerTokenStorage }
         set {
-            self.remoteCodexBarBearerTokenStorage = newValue
-            self.remoteCodexBarTokenLoadNeedsRetry = false
+            let normalizedToken = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
             do {
-                try self.remoteCodexBarTokenStore.storeToken(newValue)
+                try self.remoteCodexBarTokenStore.storeToken(normalizedToken)
+                self.remoteCodexBarBearerTokenStorage = normalizedToken
+                self.remoteCodexBarTokenLoadNeedsRetry = false
                 self.remoteCodexBarSecretError = nil
             } catch {
                 self.remoteCodexBarSecretError = error.localizedDescription
+                return
             }
             self.remoteCodexBarConfigurationRevision &+= 1
             self.noteBackgroundWorkSettingsChanged()
         }
     }
 
-    func applyRemoteCodexBarConfiguration(serverURL: String, bearerToken: String) {
+    @discardableResult
+    func applyRemoteCodexBarConfiguration(serverURL: String, bearerToken: String) -> Bool {
         let normalizedURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedToken = bearerToken.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Commit the credential before publishing its endpoint. If Keychain rejects the write or clear,
+        // the previously matched endpoint/token pair remains active and durable.
+        do {
+            try self.remoteCodexBarTokenStore.storeToken(normalizedToken)
+        } catch {
+            self.remoteCodexBarSecretError = error.localizedDescription
+            return false
+        }
 
         // These storage properties are deliberately not part of menu observation. Publishing one
         // revision after both values change makes the endpoint/token pair atomic to refresh consumers.
@@ -37,14 +49,10 @@ extension SettingsStore {
         self.remoteCodexBarBearerTokenStorage = normalizedToken
         self.userDefaults.set(normalizedURL, forKey: "remoteCodexBarServerURL")
         self.remoteCodexBarTokenLoadNeedsRetry = false
-        do {
-            try self.remoteCodexBarTokenStore.storeToken(normalizedToken)
-            self.remoteCodexBarSecretError = nil
-        } catch {
-            self.remoteCodexBarSecretError = error.localizedDescription
-        }
+        self.remoteCodexBarSecretError = nil
         self.remoteCodexBarConfigurationRevision &+= 1
         self.noteBackgroundWorkSettingsChanged()
+        return true
     }
 
     func retryRemoteCodexBarTokenLoadIfNeeded() {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -254,6 +254,7 @@ final class SettingsStore {
     @ObservationIgnored let configStore: CodexBarConfigStore
     @ObservationIgnored let antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore
     @ObservationIgnored let keychainAccessPolicy: SettingsStoreKeychainAccessPolicy
+    @ObservationIgnored let remoteCodexBarTokenStore: any RemoteCodexBarTokenStoring
     @ObservationIgnored var config: CodexBarConfig
     @ObservationIgnored var configPersistTask: Task<Void, Never>?
     @ObservationIgnored var configFileWatcher: ConfigFileWatcher?
@@ -271,6 +272,11 @@ final class SettingsStore {
     @ObservationIgnored var selectedMenuProviderRawStorage: String?
     @ObservationIgnored private nonisolated(unsafe) var lowPowerModeObserver: NSObjectProtocol?
     var defaultsState: SettingsDefaultsState
+    var remoteCodexBarServerURLStorage: String
+    var remoteCodexBarBearerTokenStorage: String
+    var remoteCodexBarSecretError: String?
+    @ObservationIgnored var remoteCodexBarTokenLoadNeedsRetry: Bool
+    var remoteCodexBarConfigurationRevision: Int = 0
     var configRevision: Int = 0
     var providerDetailSettingsRevision: Int = 0
     var backgroundWorkSettingsRevision: Int = 0
@@ -333,6 +339,7 @@ final class SettingsStore {
             account: "amp-cookie",
             promptKind: .ampCookie),
         copilotTokenStore: any CopilotTokenStoring = KeychainCopilotTokenStore(),
+        remoteCodexBarTokenStore: any RemoteCodexBarTokenStoring = KeychainRemoteCodexBarTokenStore(),
         tokenAccountStore: any ProviderTokenAccountStoring = FileTokenAccountStore(),
         antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore = AntigravityOAuthCredentialsStore(),
         keychainAccessPolicy: SettingsStoreKeychainAccessPolicy = .live,
@@ -393,12 +400,24 @@ final class SettingsStore {
         self.configStore = configStore
         self.antigravityOAuthCredentialsStore = antigravityOAuthCredentialsStore
         self.keychainAccessPolicy = keychainAccessPolicy
+        self.remoteCodexBarTokenStore = remoteCodexBarTokenStore
         self.config = config
         self.configLoading = true
         let defaultsState = Self.loadDefaultsState(
             userDefaults: userDefaults,
             hadPreviousInstallationState: hadPreviousInstallationState)
         self.defaultsState = defaultsState
+        self.remoteCodexBarServerURLStorage = userDefaults.string(forKey: "remoteCodexBarServerURL") ?? ""
+        do {
+            self.remoteCodexBarBearerTokenStorage = try remoteCodexBarTokenStore.loadToken() ?? ""
+            self.remoteCodexBarSecretError = nil
+            self.remoteCodexBarTokenLoadNeedsRetry = false
+        } catch {
+            self.remoteCodexBarBearerTokenStorage = ""
+            self.remoteCodexBarSecretError = error.localizedDescription
+            self.remoteCodexBarTokenLoadNeedsRetry =
+                error as? RemoteCodexBarTokenStoreError == .temporarilyUnavailable
+        }
         self.mergedMenuLastSelectedWasOverviewStorage = defaultsState.mergedMenuLastSelectedWasOverview
         self.selectedMenuProviderRawStorage = defaultsState.selectedMenuProviderRaw
         self.updateProviderState(config: config)

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -415,7 +415,7 @@ final class SettingsStore {
             self.remoteCodexBarBearerTokenStorage = credential?.bearerToken ?? ""
             self.remoteCodexBarAllowsPlainHTTPStorage = credential?.allowsPlainHTTP ?? false
             self.remoteCodexBarSecretError = nil
-            self.remoteCodexBarTokenLoadNeedsRetry = false
+            self.remoteCodexBarTokenLoadNeedsRetry = KeychainAccessGate.isExplicitlyDisabled
             if let credential {
                 userDefaults.set(credential.serverURL, forKey: "remoteCodexBarServerURL")
             }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -274,6 +274,7 @@ final class SettingsStore {
     var defaultsState: SettingsDefaultsState
     var remoteCodexBarServerURLStorage: String
     var remoteCodexBarBearerTokenStorage: String
+    var remoteCodexBarAllowsPlainHTTPStorage: Bool
     var remoteCodexBarSecretError: String?
     @ObservationIgnored var remoteCodexBarTokenLoadNeedsRetry: Bool
     var remoteCodexBarConfigurationRevision: Int = 0
@@ -408,6 +409,7 @@ final class SettingsStore {
             hadPreviousInstallationState: hadPreviousInstallationState)
         self.defaultsState = defaultsState
         self.remoteCodexBarServerURLStorage = userDefaults.string(forKey: "remoteCodexBarServerURL") ?? ""
+        self.remoteCodexBarAllowsPlainHTTPStorage = userDefaults.bool(forKey: "remoteCodexBarAllowsPlainHTTP")
         do {
             self.remoteCodexBarBearerTokenStorage = try remoteCodexBarTokenStore.loadToken() ?? ""
             self.remoteCodexBarSecretError = nil

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -408,14 +408,21 @@ final class SettingsStore {
             userDefaults: userDefaults,
             hadPreviousInstallationState: hadPreviousInstallationState)
         self.defaultsState = defaultsState
-        self.remoteCodexBarServerURLStorage = userDefaults.string(forKey: "remoteCodexBarServerURL") ?? ""
-        self.remoteCodexBarAllowsPlainHTTPStorage = userDefaults.bool(forKey: "remoteCodexBarAllowsPlainHTTP")
+        let remoteCodexBarServerURLDraft = userDefaults.string(forKey: "remoteCodexBarServerURL") ?? ""
         do {
-            self.remoteCodexBarBearerTokenStorage = try remoteCodexBarTokenStore.loadToken() ?? ""
+            let credential = try remoteCodexBarTokenStore.loadCredential()
+            self.remoteCodexBarServerURLStorage = credential?.serverURL ?? remoteCodexBarServerURLDraft
+            self.remoteCodexBarBearerTokenStorage = credential?.bearerToken ?? ""
+            self.remoteCodexBarAllowsPlainHTTPStorage = credential?.allowsPlainHTTP ?? false
             self.remoteCodexBarSecretError = nil
             self.remoteCodexBarTokenLoadNeedsRetry = false
+            if let credential {
+                userDefaults.set(credential.serverURL, forKey: "remoteCodexBarServerURL")
+            }
         } catch {
+            self.remoteCodexBarServerURLStorage = remoteCodexBarServerURLDraft
             self.remoteCodexBarBearerTokenStorage = ""
+            self.remoteCodexBarAllowsPlainHTTPStorage = false
             self.remoteCodexBarSecretError = error.localizedDescription
             self.remoteCodexBarTokenLoadNeedsRetry =
                 error as? RemoteCodexBarTokenStoreError == .temporarilyUnavailable

--- a/Sources/CodexBar/StatusItemController+FleetAccounts.swift
+++ b/Sources/CodexBar/StatusItemController+FleetAccounts.swift
@@ -17,16 +17,22 @@ extension StatusItemController {
     }
 
     func fleetAccountProjection(for provider: UsageProvider) -> FleetAccountMenuProjection {
-        guard self.settings.iCloudSyncEnabled,
-              self.settings.iCloudSyncSnapshotsEnabled,
-              self.settings.iCloudSyncShowFleetAccounts
-        else {
+        let iCloudSnapshots: [AccountSnapshotSyncPayload] = if self.settings.iCloudSyncEnabled,
+                                                               self.settings.iCloudSyncSnapshotsEnabled,
+                                                               self.settings.iCloudSyncShowFleetAccounts
+        {
+            Array(self.cloudSyncState.fleetSnapshots.values)
+        } else {
+            []
+        }
+        let remoteSnapshots = self.store.remoteCodexBarSnapshots
+        guard !iCloudSnapshots.isEmpty || !remoteSnapshots.isEmpty else {
             return FleetAccountMenuProjection(fallback: nil, additionalAccounts: [])
         }
         let localSnapshots = self.store.cloudSyncAccountSnapshots()
         return FleetAccountMenuPlanner.projection(
             provider: provider,
-            snapshots: self.cloudSyncState.fleetSnapshots.values,
+            snapshots: iCloudSnapshots + remoteSnapshots,
             currentDeviceID: self.settings.iCloudSyncDeviceID,
             localAccountKeys: self.store.cloudSyncLocalAccountKeys(for: provider),
             hasLocalUsage: localSnapshots.contains(where: { $0.provider == provider.instanceID }))
@@ -76,9 +82,13 @@ extension StatusItemController {
         _ snapshot: AccountSnapshotSyncPayload) -> UsageMenuCardView.Model?
     {
         guard let provider = snapshot.provider.firstPartyProvider else { return nil }
-        let deviceName = self.cloudSyncState.fleetDevices.values
-            .first(where: { $0.deviceID == snapshot.deviceID })?
-            .hostName ?? L("another Mac")
+        let deviceName = if snapshot.deviceID == "remote-codexbar" {
+            L("remote CodexBar")
+        } else {
+            self.cloudSyncState.fleetDevices.values
+                .first(where: { $0.deviceID == snapshot.deviceID })?
+                .hostName ?? L("another Mac")
+        }
         let badge = FleetAccountMenuPlanner.badge(deviceName: deviceName, fetchedAt: snapshot.fetchedAt)
         let label = snapshot.displayLabel.trimmingCharacters(in: .whitespacesAndNewlines)
         return self.menuCardModel(

--- a/Sources/CodexBar/StatusItemController+FleetAccounts.swift
+++ b/Sources/CodexBar/StatusItemController+FleetAccounts.swift
@@ -25,7 +25,14 @@ extension StatusItemController {
         } else {
             []
         }
-        let remoteSnapshots = self.store.remoteCodexBarSnapshots
+        let remoteSnapshots: [AccountSnapshotSyncPayload] = if let activeConfigurationID = self.settings
+            .remoteCodexBarConfiguration?.configurationID,
+            self.store.remoteCodexBarSnapshotConfigurationID == activeConfigurationID
+        {
+            self.store.remoteCodexBarSnapshots
+        } else {
+            []
+        }
         guard !iCloudSnapshots.isEmpty || !remoteSnapshots.isEmpty else {
             return FleetAccountMenuProjection(fallback: nil, additionalAccounts: [])
         }

--- a/Sources/CodexBar/StatusItemController+FleetAccounts.swift
+++ b/Sources/CodexBar/StatusItemController+FleetAccounts.swift
@@ -91,11 +91,32 @@ extension StatusItemController {
         }
         let badge = FleetAccountMenuPlanner.badge(deviceName: deviceName, fetchedAt: snapshot.fetchedAt)
         let label = snapshot.displayLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displaySnapshot = self.fleetAccountDisplaySnapshot(
+            snapshot.usage,
+            provider: provider,
+            label: label)
         return self.menuCardModel(
             for: provider,
-            snapshotOverride: snapshot.usage,
+            snapshotOverride: displaySnapshot,
             forceOverrideCard: true,
             accountOverride: AccountInfo(email: label.isEmpty ? nil : label, plan: nil),
             subtitleOverride: badge)
+    }
+
+    private func fleetAccountDisplaySnapshot(
+        _ snapshot: UsageSnapshot,
+        provider: UsageProvider,
+        label: String) -> UsageSnapshot
+    {
+        guard !label.isEmpty,
+              snapshot.accountEmail(for: provider)?.caseInsensitiveCompare(label) != .orderedSame
+        else { return snapshot }
+        let identity = snapshot.identity
+        return snapshot.withIdentity(ProviderIdentitySnapshot(
+            providerID: identity?.providerID ?? provider.instanceID,
+            accountEmail: label,
+            accountOrganization: identity?.accountOrganization,
+            loginMethod: identity?.loginMethod,
+            accountID: identity?.accountID))
     }
 }

--- a/Sources/CodexBar/UsageStore+RemoteCodexBar.swift
+++ b/Sources/CodexBar/UsageStore+RemoteCodexBar.swift
@@ -65,6 +65,11 @@ extension UsageStore {
             return
         } catch {
             guard self.settings.remoteCodexBarConfiguration?.configurationID == configurationID else { return }
+            if let snapshotError = error as? RemoteCodexBarSnapshotError,
+               !snapshotError.preservesLastGoodSnapshot
+            {
+                self.remoteCodexBarSnapshots = []
+            }
             // Preserve the last successful cards only for a transient failure of this exact configuration.
             self.remoteCodexBarError = error.localizedDescription
         }

--- a/Sources/CodexBar/UsageStore+RemoteCodexBar.swift
+++ b/Sources/CodexBar/UsageStore+RemoteCodexBar.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+extension UsageStore {
+    func scheduleRemoteCodexBarRefresh() {
+        self.settings.retryRemoteCodexBarTokenLoadIfNeeded()
+        guard let configuration = self.settings.remoteCodexBarConfiguration else {
+            self.remoteCodexBarRefreshTask?.cancel()
+            self.remoteCodexBarRefreshTask = nil
+            self.remoteCodexBarRefreshTaskConfigurationID = nil
+            self.clearRemoteCodexBarState()
+            return
+        }
+
+        let configurationID = configuration.configurationID
+        guard self.remoteCodexBarRefreshTask == nil ||
+            self.remoteCodexBarRefreshTaskConfigurationID != configurationID
+        else { return }
+
+        self.remoteCodexBarRefreshTask?.cancel()
+        self.prepareRemoteCodexBarRefresh(configurationID: configurationID)
+        self.remoteCodexBarRefreshTaskConfigurationID = configurationID
+        self.remoteCodexBarRefreshInFlight = true
+        self.remoteCodexBarRefreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performRemoteCodexBarRefresh(
+                configuration: configuration,
+                configurationID: configurationID)
+            guard self.remoteCodexBarRefreshTaskConfigurationID == configurationID else { return }
+            self.remoteCodexBarRefreshTask = nil
+            self.remoteCodexBarRefreshTaskConfigurationID = nil
+            self.remoteCodexBarRefreshInFlight = false
+        }
+    }
+
+    func refreshRemoteCodexBarSnapshot() async {
+        self.settings.retryRemoteCodexBarTokenLoadIfNeeded()
+        guard let configuration = self.settings.remoteCodexBarConfiguration else {
+            self.clearRemoteCodexBarState()
+            return
+        }
+
+        let configurationID = configuration.configurationID
+        self.prepareRemoteCodexBarRefresh(configurationID: configurationID)
+        self.remoteCodexBarRefreshInFlight = true
+        defer { self.remoteCodexBarRefreshInFlight = false }
+        await self.performRemoteCodexBarRefresh(
+            configuration: configuration,
+            configurationID: configurationID)
+    }
+
+    private func performRemoteCodexBarRefresh(
+        configuration: RemoteCodexBarConfiguration,
+        configurationID: String) async
+    {
+        do {
+            let snapshot = try await self.remoteCodexBarClient.fetch(configuration: configuration)
+            guard !Task.isCancelled,
+                  self.settings.remoteCodexBarConfiguration?.configurationID == configurationID
+            else { return }
+            self.remoteCodexBarSnapshots = RemoteCodexBarProjection.make(
+                snapshot: snapshot,
+                serverURL: configuration.snapshotURL).snapshots
+            self.remoteCodexBarError = nil
+        } catch is CancellationError {
+            return
+        } catch {
+            guard self.settings.remoteCodexBarConfiguration?.configurationID == configurationID else { return }
+            // Preserve the last successful cards only for a transient failure of this exact configuration.
+            self.remoteCodexBarError = error.localizedDescription
+        }
+    }
+
+    private func prepareRemoteCodexBarRefresh(configurationID: String) {
+        if let previousConfigurationID = self.remoteCodexBarSnapshotConfigurationID,
+           previousConfigurationID != configurationID
+        {
+            self.remoteCodexBarSnapshots = []
+        }
+        self.remoteCodexBarSnapshotConfigurationID = configurationID
+    }
+
+    private func clearRemoteCodexBarState() {
+        self.remoteCodexBarSnapshots = []
+        self.remoteCodexBarError = nil
+        self.remoteCodexBarRefreshInFlight = false
+        self.remoteCodexBarSnapshotConfigurationID = nil
+    }
+}

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -9,12 +9,8 @@ import SweetCookieKit
 @MainActor
 extension UsageStore {
     var menuObservationToken: Int {
-        _ = self.snapshots
-        _ = self.remoteCodexBarSnapshots
-        _ = self.remoteCodexBarError
-        _ = self.remoteCodexBarRefreshInFlight
-        _ = self.errors
-        _ = self.diagnostics
+        _ = (self.snapshots, self.remoteCodexBarSnapshots, self.remoteCodexBarError, self.remoteCodexBarRefreshInFlight)
+        _ = (self.errors, self.diagnostics)
         _ = self.knownLimitsAvailabilityByProvider
         _ = self.lastSourceLabels
         _ = self.lastFetchAttempts

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -10,6 +10,9 @@ import SweetCookieKit
 extension UsageStore {
     var menuObservationToken: Int {
         _ = self.snapshots
+        _ = self.remoteCodexBarSnapshots
+        _ = self.remoteCodexBarError
+        _ = self.remoteCodexBarRefreshInFlight
         _ = self.errors
         _ = self.diagnostics
         _ = self.knownLimitsAvailabilityByProvider
@@ -166,6 +169,12 @@ final class UsageStore {
     }
 
     var snapshots: [ProviderInstanceID: UsageSnapshot] = [:]
+    var remoteCodexBarSnapshots: [AccountSnapshotSyncPayload] = []
+    var remoteCodexBarError: String?
+    var remoteCodexBarRefreshInFlight = false
+    @ObservationIgnored var remoteCodexBarSnapshotConfigurationID: String?
+    @ObservationIgnored var remoteCodexBarRefreshTask: Task<Void, Never>?
+    @ObservationIgnored var remoteCodexBarRefreshTaskConfigurationID: String?
     var errors: [ProviderInstanceID: String] = [:]
     var diagnostics: [ProviderInstanceID: String] = [:]
     var geminiMigrationObservation: GeminiMigrationObservation = .none
@@ -475,6 +484,7 @@ final class UsageStore {
     }
 
     @ObservationIgnored let tokenFetchTimeout: TimeInterval = 10 * 60
+    @ObservationIgnored let remoteCodexBarClient: RemoteCodexBarSnapshotClient
     @ObservationIgnored let startupBehavior: StartupBehavior
     @ObservationIgnored let planUtilizationPersistenceCoordinator: PlanUtilizationHistoryPersistenceCoordinator
 
@@ -493,6 +503,7 @@ final class UsageStore {
         environmentBase: [String: String] = ProcessInfo.processInfo.environment,
         widgetSnapshotURL: URL? = nil,
         widgetTimelineReloader: @escaping @MainActor () -> Void = UsageStore.reloadWidgetTimelines,
+        remoteCodexBarClient: RemoteCodexBarSnapshotClient = RemoteCodexBarSnapshotClient(),
         planUtilizationHistoryLoadGateForTesting: PlanUtilizationHistoryLoadGate? = nil)
     {
         self.codexFetcher = fetcher
@@ -504,6 +515,7 @@ final class UsageStore {
         self.environmentBase = environmentBase
         self.widgetSnapshotURL = widgetSnapshotURL
         self.widgetTimelineReloader = widgetTimelineReloader
+        self.remoteCodexBarClient = remoteCodexBarClient
         self.historicalUsageHistoryStore = historicalUsageHistoryStore
         self.startupBehavior = startupBehavior.resolved(isRunningTests: Self.isRunningTestsProcess())
         let planHistoryStore = Self.resolvedPlanHistoryStore(planUtilizationHistoryStore, startup: self.startupBehavior)
@@ -785,6 +797,8 @@ final class UsageStore {
                 displayEnabledProviders: enabledProviderSet,
                 availableProviders: availableRefreshProviders)
             self.scheduleStorageFootprintRefresh(for: displayEnabledProviders.compactMap(\.firstPartyProvider))
+            // Remote CodexBar is best-effort and must never hold local provider refreshes open.
+            self.scheduleRemoteCodexBarRefresh()
 
             await withTaskGroup(of: Void.self) { group in
                 for instanceID in refreshProviders {
@@ -957,6 +971,7 @@ final class UsageStore {
 
     deinit {
         self.timerTask?.cancel()
+        self.remoteCodexBarRefreshTask?.cancel()
         self.tokenRefreshSequenceTask?.cancel()
         self.codexCostCatchUpTask?.cancel()
         self.forcedRefreshEnrichmentTask?.cancel()

--- a/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
+++ b/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
@@ -57,6 +57,13 @@ public struct ProviderEndpointOverrideValidator: Sendable {
         self.validatedURL(raw, allowingHTTPFor: Self.isPrivateNetworkHost)
     }
 
+    public func requiresExplicitPlainHTTPConsent(_ raw: String?) -> Bool {
+        guard let url = self.validatedURLAllowingPrivateNetworkHTTP(raw),
+              url.scheme?.lowercased() == "http"
+        else { return false }
+        return self.validatedURLAllowingLoopbackHTTP(raw) == nil
+    }
+
     private func validatedURL(_ raw: String?, allowingHTTPFor isAllowedHTTPHost: (String) -> Bool) -> URL? {
         guard let raw,
               Self.hasExplicitURLScheme(raw),

--- a/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
+++ b/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
@@ -147,6 +147,7 @@ public struct ProviderEndpointOverrideValidator: Sendable {
 
         if let octets = Self.ipv4Octets(host) {
             return octets[0] == 10 ||
+                (octets[0] == 100 && (64...127).contains(octets[1])) ||
                 (octets[0] == 172 && (16...31).contains(octets[1])) ||
                 (octets[0] == 192 && octets[1] == 168) ||
                 (octets[0] == 169 && octets[1] == 254)

--- a/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
+++ b/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
@@ -175,7 +175,7 @@ public struct ProviderEndpointOverrideValidator: Sendable {
     }
 
     private static func isSharedAddressSpaceHost(_ host: String) -> Bool {
-        guard let octets = Self.ipv4Octets(host) else { return false }
+        guard let octets = ipv4Octets(host) else { return false }
         return octets[0] == 100 && (64...127).contains(octets[1])
     }
 

--- a/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
+++ b/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
@@ -57,8 +57,21 @@ public struct ProviderEndpointOverrideValidator: Sendable {
         self.validatedURL(raw, allowingHTTPFor: Self.isPrivateNetworkHost)
     }
 
+    public func validatedURLAllowingRemoteCodexBarHTTP(_ raw: String?) -> URL? {
+        self.validatedURL(raw, allowingHTTPFor: { host in
+            Self.isPrivateNetworkHost(host) || Self.isSharedAddressSpaceHost(host)
+        })
+    }
+
     public func requiresExplicitPlainHTTPConsent(_ raw: String?) -> Bool {
         guard let url = self.validatedURLAllowingPrivateNetworkHTTP(raw),
+              url.scheme?.lowercased() == "http"
+        else { return false }
+        return self.validatedURLAllowingLoopbackHTTP(raw) == nil
+    }
+
+    public func requiresExplicitRemoteCodexBarPlainHTTPConsent(_ raw: String?) -> Bool {
+        guard let url = self.validatedURLAllowingRemoteCodexBarHTTP(raw),
               url.scheme?.lowercased() == "http"
         else { return false }
         return self.validatedURLAllowingLoopbackHTTP(raw) == nil
@@ -147,7 +160,6 @@ public struct ProviderEndpointOverrideValidator: Sendable {
 
         if let octets = Self.ipv4Octets(host) {
             return octets[0] == 10 ||
-                (octets[0] == 100 && (64...127).contains(octets[1])) ||
                 (octets[0] == 172 && (16...31).contains(octets[1])) ||
                 (octets[0] == 192 && octets[1] == 168) ||
                 (octets[0] == 169 && octets[1] == 254)
@@ -160,6 +172,11 @@ public struct ProviderEndpointOverrideValidator: Sendable {
         else { return false }
 
         return firstValue & 0xFE00 == 0xFC00 || firstValue & 0xFFC0 == 0xFE80
+    }
+
+    private static func isSharedAddressSpaceHost(_ host: String) -> Bool {
+        guard let octets = Self.ipv4Octets(host) else { return false }
+        return octets[0] == 100 && (64...127).contains(octets[1])
     }
 
     private static func ipv4Octets(_ host: String) -> [UInt8]? {

--- a/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
+++ b/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
@@ -19,7 +19,7 @@ enum ProviderEndpointOverrideError: LocalizedError, Equatable {
     }
 }
 
-struct ProviderEndpointOverrideValidator {
+public struct ProviderEndpointOverrideValidator: Sendable {
     enum HostPolicy {
         case allowAnyHTTPSHost
         case providerOwnedOnly
@@ -28,7 +28,7 @@ struct ProviderEndpointOverrideValidator {
     private let allowedHosts: Set<String>
     private let allowedDomainSuffixes: Set<String>
 
-    init(allowedHosts: [String] = [], allowedDomainSuffixes: [String] = []) {
+    public init(allowedHosts: [String] = [], allowedDomainSuffixes: [String] = []) {
         self.allowedHosts = Set(allowedHosts.map { $0.lowercased() })
         self.allowedDomainSuffixes = Set(allowedDomainSuffixes.map { $0.lowercased() })
     }
@@ -53,7 +53,7 @@ struct ProviderEndpointOverrideValidator {
         self.validatedURL(raw, allowingHTTPFor: Self.isLoopbackHost)
     }
 
-    func validatedURLAllowingPrivateNetworkHTTP(_ raw: String?) -> URL? {
+    public func validatedURLAllowingPrivateNetworkHTTP(_ raw: String?) -> URL? {
         self.validatedURL(raw, allowingHTTPFor: Self.isPrivateNetworkHost)
     }
 

--- a/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
+++ b/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
@@ -69,7 +69,7 @@ final class MenuLayoutScreenshotRenderTests: XCTestCase {
                         ("sidebar", AnyView(SettingsSidebarView(
                             settings: settings, store: store, selection: .constant(.plugins))
                             .frame(width: SettingsPane.sidebarMinWidth, height: 620)), []),
-                        ("icloud", AnyView(ICloudSyncPane(settings: settings, state: state)
+                        ("icloud", AnyView(ICloudSyncPane(settings: settings, store: store, state: state)
                                 .frame(width: 560, height: 600)), []),
                         ("hooks", AnyView(HooksPane(settings: settings)
                                 .frame(width: 560, height: 350)), []),

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -12,11 +12,11 @@ struct PreferencesPaneSmokeTests {
         let store = Self.makeUsageStore(settings: settings)
 
         _ = GeneralPane(settings: settings).body
-        _ = ICloudSyncPane(settings: settings, state: CloudSyncState()).body
+        _ = ICloudSyncPane(settings: settings, store: store, state: CloudSyncState()).body
         _ = NotificationsPane(settings: settings).body
         _ = MenuBarPane(settings: settings, store: store).body
         _ = MenuPane(settings: settings, store: store).body
-        _ = AdvancedPane(settings: settings, store: store).body
+        _ = AdvancedPane(settings: settings).body
         _ = HooksPane(settings: settings).body
         _ = ProvidersPane(settings: settings, store: store).body
         _ = DebugPane(settings: settings, store: store).body
@@ -46,11 +46,11 @@ struct PreferencesPaneSmokeTests {
         store._setErrorForTesting("Example error", provider: .codex)
 
         _ = GeneralPane(settings: settings).body
-        _ = ICloudSyncPane(settings: settings, state: CloudSyncState()).body
+        _ = ICloudSyncPane(settings: settings, store: store, state: CloudSyncState()).body
         _ = NotificationsPane(settings: settings).body
         _ = MenuBarPane(settings: settings, store: store).body
         _ = MenuPane(settings: settings, store: store).body
-        _ = AdvancedPane(settings: settings, store: store).body
+        _ = AdvancedPane(settings: settings).body
         _ = ProvidersPane(provider: .claude, settings: settings, store: store).body
         _ = DebugPane(settings: settings, store: store).body
         _ = AboutPane(updater: DisabledUpdaterController()).body

--- a/Tests/CodexBarTests/PreferencesSelectionTests.swift
+++ b/Tests/CodexBarTests/PreferencesSelectionTests.swift
@@ -32,6 +32,11 @@ struct PreferencesSelectionTests {
     }
 
     @Test
+    func `sync pane has a provider neutral title`() {
+        #expect(SettingsPane.iCloudSync.title == "Sync")
+    }
+
+    @Test
     func `selection restores persisted pane and saves changes`() throws {
         let suite = "PreferencesSelectionTests-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suite))

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2385,7 +2385,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1224,
+            line: 1231,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -947,13 +947,13 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact provider-owned construct passes a fixed identity to shared infrastructure."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/SettingsStore+MenuObservation.swift",
-            line: 103,
+            line: 104,
             anchor: "_ = self[providerConfig: .synthetic, field: .apiKey]",
             expectedProviderIDs: ["synthetic"],
             reason: "This observation touchpoint reads a fixed provider field so UI invalidation tracks that setting."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/SettingsStore+MenuObservation.swift",
-            line: 122,
+            line: 123,
             anchor: "_ = self[providerConfig: .warp, field: .apiKey]",
             expectedProviderIDs: ["warp"],
             reason: "This observation touchpoint reads a fixed provider field so UI invalidation tracks that setting."),
@@ -1344,19 +1344,19 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Claude widget quota ownership uses the selected Claude account's isolated snapshot key."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1074,
+            line: 1089,
             anchor: "provider: .deepseek,",
             expectedProviderIDs: ["deepseek"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1176,
+            line: 1191,
             anchor: "let sourceMode = self.sourceMode(for: .claude)",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1180,
+            line: 1195,
             anchor: "provider: .claude,",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -2385,7 +2385,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1203,
+            line: 1222,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,
@@ -3400,7 +3400,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 615,
+            line: 627,
             anchor: "self.metadata(for: .codex).browserCookieOrder ?? Browser.defaultImportOrder",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3408,7 +3408,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 667,
+            line: 679,
             anchor: "self.providerSpecs[provider]?.style ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3416,7 +3416,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 700,
+            line: 712,
             anchor: "guard provider != .codex else { return true }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3424,7 +3424,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1048,
+            line: 1063,
             anchor: "let claudeDebugConfiguration: ClaudeDebugLogConfiguration? = if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3432,7 +3432,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1071,
+            line: 1086,
             anchor: "let deepSeekHasTokenAccount = self.settings.selectedTokenAccount(for: .deepseek) != nil",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3440,7 +3440,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1128,
+            line: 1143,
             anchor: "case .amp:",
             expectedProviderIDs: ["amp", "deepseek", "notion", "ollama", "warp"],
             expectedReferenceCount: 7,
@@ -3456,7 +3456,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1183,
+            line: 1198,
             anchor: "let claudeSettings = snapshot.claude ?? ProviderSettingsSnapshot.ClaudeProviderSettings(",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2385,7 +2385,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1222,
+            line: 1224,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1344,19 +1344,19 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Claude widget quota ownership uses the selected Claude account's isolated snapshot key."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1089,
+            line: 1085,
             anchor: "provider: .deepseek,",
             expectedProviderIDs: ["deepseek"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1191,
+            line: 1187,
             anchor: "let sourceMode = self.sourceMode(for: .claude)",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1195,
+            line: 1191,
             anchor: "provider: .claude,",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -3400,7 +3400,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 627,
+            line: 623,
             anchor: "self.metadata(for: .codex).browserCookieOrder ?? Browser.defaultImportOrder",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3408,7 +3408,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 679,
+            line: 675,
             anchor: "self.providerSpecs[provider]?.style ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3416,7 +3416,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 712,
+            line: 708,
             anchor: "guard provider != .codex else { return true }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3424,7 +3424,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1063,
+            line: 1059,
             anchor: "let claudeDebugConfiguration: ClaudeDebugLogConfiguration? = if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3432,7 +3432,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1086,
+            line: 1082,
             anchor: "let deepSeekHasTokenAccount = self.settings.selectedTokenAccount(for: .deepseek) != nil",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3440,7 +3440,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1143,
+            line: 1139,
             anchor: "case .amp:",
             expectedProviderIDs: ["amp", "deepseek", "notion", "ollama", "warp"],
             expectedReferenceCount: 7,
@@ -3456,7 +3456,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1198,
+            line: 1194,
             anchor: "let claudeSettings = snapshot.claude ?? ProviderSettingsSnapshot.ClaudeProviderSettings(",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -116,6 +116,74 @@ struct RemoteCodexBarSnapshotTests {
 
     @MainActor
     @Test
+    func `failed token replacement preserves the prior durable authority pair`() async throws {
+        let tokens = FailingRemoteCodexBarTokenStore()
+        let settings = testSettingsStore(
+            suiteName: "RemoteCodexBarSnapshotTests-failed-token-replacement",
+            remoteCodexBarTokenStore: tokens)
+        #expect(settings.applyRemoteCodexBarConfiguration(
+            serverURL: "https://server-a.example.com",
+            bearerToken: "server-a-token"))
+        tokens.failWrites = true
+
+        #expect(!settings.applyRemoteCodexBarConfiguration(
+            serverURL: "https://server-b.example.com",
+            bearerToken: "server-b-token"))
+        #expect(settings.remoteCodexBarServerURL == "https://server-a.example.com")
+        #expect(settings.remoteCodexBarBearerToken == "server-a-token")
+        #expect(settings.userDefaults.string(forKey: "remoteCodexBarServerURL") ==
+            "https://server-a.example.com")
+        #expect(try tokens.loadToken() == "server-a-token")
+
+        let persisted = try #require(RemoteCodexBarConfiguration.resolve(
+            serverURL: settings.userDefaults.string(forKey: "remoteCodexBarServerURL") ?? "",
+            bearerToken: try tokens.loadToken() ?? ""))
+        let requests = LockIsolated<[URLRequest]>([])
+        let transport = ProviderHTTPTransportHandler { request in
+            requests.setValue(requests.value + [request])
+            let response = try #require(HTTPURLResponse(
+                url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil))
+            return (Data(), response)
+        }
+
+        await #expect(throws: RemoteCodexBarSnapshotError.unauthorized) {
+            try await RemoteCodexBarSnapshotClient(transport: transport).fetch(configuration: persisted)
+        }
+        #expect(requests.value.map(\.url?.host) == ["server-a.example.com"])
+        #expect(requests.value.map { $0.value(forHTTPHeaderField: "Authorization") } ==
+            ["Bearer server-a-token"])
+    }
+
+    @Test
+    func `production transport aborts oversized retryable responses without retrying`() async throws {
+        RemoteCodexBarOversizedURLProtocol.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RemoteCodexBarOversizedURLProtocol.self]
+        let transport = RemoteCodexBarBoundedHTTPTransport(
+            maximumResponseBytes: 32,
+            configuration: configuration)
+        let remoteConfiguration = try #require(RemoteCodexBarConfiguration.resolve(
+            serverURL: "https://example.com",
+            bearerToken: "secret-value"))
+
+        await #expect(throws: RemoteCodexBarSnapshotError.responseTooLarge) {
+            try await RemoteCodexBarSnapshotClient(transport: transport).fetch(configuration: remoteConfiguration)
+        }
+        #expect(RemoteCodexBarOversizedURLProtocol.requestCount == 1)
+    }
+
+    @Test
+    func `production transport blocks bearer redirects to another origin`() throws {
+        var redirect = try URLRequest(url: #require(URL(string: "https://attacker.example/capture")))
+        redirect.setValue("Bearer secret-value", forHTTPHeaderField: "Authorization")
+
+        #expect(RemoteCodexBarBoundedHTTPTransport.guardedRedirectRequest(
+            originalURL: URL(string: "https://server.example/dashboard/v1/snapshot"),
+            redirectRequest: redirect) == nil)
+    }
+
+    @MainActor
+    @Test
     func `editing the endpoint clears the token before publishing the new server`() {
         let tokens = InMemoryRemoteCodexBarTokenStore()
         let settings = testSettingsStore(
@@ -284,4 +352,44 @@ struct RemoteCodexBarSnapshotTests {
       }]
     }
     """
+}
+
+private final class RemoteCodexBarOversizedURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var requestCountStorage = 0
+
+    static var requestCount: Int {
+        self.lock.withLock { self.requestCountStorage }
+    }
+
+    static func reset() {
+        self.lock.withLock { self.requestCountStorage = 0 }
+    }
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.lock.withLock { Self.requestCountStorage += 1 }
+        guard let url = self.request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: 503,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: nil)
+        else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        self.client?.urlProtocol(self, didLoad: Data(repeating: 0x41, count: 64))
+        self.client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -40,7 +40,7 @@ struct RemoteCodexBarSnapshotTests {
     }
 
     @Test
-    func `client sends bearer auth decodes schema v1 and projects provider cards`() async throws {
+    func `client sends bearer auth decodes schema v1 and projects account cards over ambient provider`() async throws {
         let body = Data(Self.snapshotJSON.utf8)
         let transport = ProviderHTTPTransportHandler { request in
             #expect(request.url?.absoluteString == "https://example.com/dashboard/v1/snapshot")
@@ -62,19 +62,12 @@ struct RemoteCodexBarSnapshotTests {
         #expect(snapshot.providers.count == 1)
 
         let projection = RemoteCodexBarProjection.make(snapshot: snapshot, serverURL: configuration.snapshotURL)
-        #expect(projection.snapshots.count == 2)
-        let provider = try #require(projection.snapshots.first)
-        #expect(provider.provider == UsageProvider.codex.instanceID)
-        #expect(provider.accountKey == AccountSnapshotSyncPayload.accountKey(for: "person@example.com"))
-        #expect(projection.snapshots[1].accountKey ==
-            AccountSnapshotSyncPayload.accountKey(
-                for: "https://example.com/dashboard/v1/snapshot|codex|slot:1"))
-        #expect(provider.displayLabel == "person@example.com")
-        #expect(provider.usage.primary?.usedPercent == 25)
-        #expect(provider.usage.secondary?.usedPercent == 60)
-        #expect(provider.usage.extraRateWindows?.first?.title == "Spark")
-        #expect(provider.usage.identity?.loginMethod == "Plus")
-        #expect(provider.usage.details.first?.rows.contains(where: { $0.label == "Today" }) == true)
+        #expect(projection.snapshots.count == 1)
+        let account = try #require(projection.snapshots.first)
+        #expect(account.provider == UsageProvider.codex.instanceID)
+        #expect(account.accountKey == AccountSnapshotSyncPayload.accountKey(for: "work@example.com"))
+        #expect(account.displayLabel == "Work")
+        #expect(account.usage.primary?.usedPercent == 15)
     }
 
     @Test
@@ -245,6 +238,35 @@ struct RemoteCodexBarSnapshotTests {
             redirectRequest: redirect) == nil)
     }
 
+    @Test
+    func `production transport propagates task cancellation to the URL session request`() async throws {
+        RemoteCodexBarCancellableURLProtocol.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RemoteCodexBarCancellableURLProtocol.self]
+        let transport = RemoteCodexBarBoundedHTTPTransport(
+            maximumResponseBytes: 32,
+            configuration: configuration)
+        let request = try URLRequest(url: #require(URL(string: "https://example.com/dashboard/v1/snapshot")))
+        let task = Task { try await transport.data(for: request) }
+
+        let deadline = ContinuousClock.now + .seconds(1)
+        while RemoteCodexBarCancellableURLProtocol.requestCount == 0, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(RemoteCodexBarCancellableURLProtocol.requestCount == 1)
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        let cancellationDeadline = ContinuousClock.now + .seconds(1)
+        while RemoteCodexBarCancellableURLProtocol.cancelCount == 0,
+              ContinuousClock.now < cancellationDeadline
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(RemoteCodexBarCancellableURLProtocol.cancelCount == 1)
+    }
+
     @MainActor
     @Test
     func `editing the endpoint clears the token before publishing the new server`() {
@@ -393,6 +415,10 @@ struct RemoteCodexBarSnapshotTests {
         let projection = RemoteCodexBarProjection.make(snapshot: snapshot, serverURL: serverURL)
         #expect(projection.snapshots.count == 2)
         #expect(Set(projection.snapshots.map(\.accountKey)).count == 2)
+        #expect(Set(projection.snapshots.map(\.accountKey)) == Set([
+            AccountSnapshotSyncPayload.accountKey(for: "slot:1"),
+            AccountSnapshotSyncPayload.accountKey(for: "slot:2"),
+        ]))
         #expect(Set(projection.snapshots.map(\.displayLabel)) == Set(["Personal", "Work"]))
     }
 
@@ -506,4 +532,41 @@ private final class RemoteCodexBarOversizedURLProtocol: URLProtocol {
     }
 
     override func stopLoading() {}
+}
+
+private final class RemoteCodexBarCancellableURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var requestCountStorage = 0
+    private nonisolated(unsafe) static var cancelCountStorage = 0
+
+    static var requestCount: Int {
+        self.lock.withLock { self.requestCountStorage }
+    }
+
+    static var cancelCount: Int {
+        self.lock.withLock { self.cancelCountStorage }
+    }
+
+    static func reset() {
+        self.lock.withLock {
+            self.requestCountStorage = 0
+            self.cancelCountStorage = 0
+        }
+    }
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.lock.withLock { Self.requestCountStorage += 1 }
+    }
+
+    override func stopLoading() {
+        Self.lock.withLock { Self.cancelCountStorage += 1 }
+    }
 }

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -333,6 +333,42 @@ struct RemoteCodexBarSnapshotTests {
 
     @MainActor
     @Test
+    func `permanent remote failure clears same-server last-good data`() async {
+        let settings = testSettingsStore(suiteName: "RemoteCodexBarSnapshotTests-permanent-failure")
+        settings.remoteCodexBarServerURL = "https://example.com"
+        settings.remoteCodexBarBearerToken = "revoked-token"
+        let unauthorizedTransport = ProviderHTTPTransportHandler { request in
+            let response = try #require(HTTPURLResponse(
+                url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil))
+            return (Data(), response)
+        }
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            remoteCodexBarClient: RemoteCodexBarSnapshotClient(transport: unauthorizedTransport))
+        store.remoteCodexBarSnapshots = [AccountSnapshotSyncPayload(
+            provider: UsageProvider.codex.instanceID,
+            deviceID: "remote-codexbar",
+            accountIdentity: "person@example.com",
+            displayLabel: "Stale remote account",
+            usage: UsageSnapshot(
+                primary: RateWindow(usedPercent: 40, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: .now))]
+        store.remoteCodexBarSnapshotConfigurationID = settings.remoteCodexBarConfiguration?.configurationID
+
+        await store.refreshRemoteCodexBarSnapshot()
+
+        #expect(store.remoteCodexBarSnapshots.isEmpty)
+        #expect(store.remoteCodexBarError == RemoteCodexBarSnapshotError.unauthorized.localizedDescription)
+        #expect(RemoteCodexBarSnapshotError.httpStatus(503).preservesLastGoodSnapshot)
+        #expect(!RemoteCodexBarSnapshotError.unsupportedSchema(2).preservesLastGoodSnapshot)
+    }
+
+    @MainActor
+    @Test
     func `temporarily unavailable token retries without restarting the app`() {
         let tokens = RetryingRemoteCodexBarTokenStore(value: RemoteCodexBarStoredCredential(
             serverURL: "https://saved.example.com",
@@ -348,6 +384,37 @@ struct RemoteCodexBarSnapshotTests {
         #expect(settings.remoteCodexBarServerURL == "https://saved.example.com")
         #expect(settings.remoteCodexBarBearerToken == "saved-token")
         #expect(settings.remoteCodexBarSecretError == nil)
+        #expect(tokens.loadAttempts == 2)
+    }
+
+    @MainActor
+    @Test
+    func `re-enabling Keychain access reloads the saved remote credential`() {
+        let previousOverride = KeychainAccessGate.currentOverrideForTesting
+        defer {
+            if let previousOverride {
+                KeychainAccessGate.isDisabled = previousOverride
+            } else {
+                KeychainAccessGate.resetOverrideForTesting()
+            }
+        }
+        let tokens = KeychainGateAwareRemoteCodexBarTokenStore(value: RemoteCodexBarStoredCredential(
+            serverURL: "https://saved.example.com",
+            bearerToken: "saved-token",
+            allowsPlainHTTP: false))
+        let settings = testSettingsStore(
+            suiteName: "RemoteCodexBarSnapshotTests-keychain-reenabled",
+            remoteCodexBarTokenStore: tokens,
+            prepareDefaults: { $0.set(true, forKey: "debugDisableKeychainAccess") })
+        #expect(settings.remoteCodexBarBearerToken.isEmpty)
+        #expect(tokens.loadAttempts == 1)
+
+        settings.retryRemoteCodexBarTokenLoadIfNeeded()
+        #expect(tokens.loadAttempts == 1)
+        settings.debugDisableKeychainAccess = false
+
+        #expect(settings.remoteCodexBarServerURL == "https://saved.example.com")
+        #expect(settings.remoteCodexBarBearerToken == "saved-token")
         #expect(tokens.loadAttempts == 2)
     }
 

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -137,7 +137,7 @@ struct RemoteCodexBarSnapshotTests {
 
         let persisted = try #require(RemoteCodexBarConfiguration.resolve(
             serverURL: settings.userDefaults.string(forKey: "remoteCodexBarServerURL") ?? "",
-            bearerToken: try tokens.loadToken() ?? ""))
+            bearerToken: tokens.loadToken() ?? ""))
         let requests = LockIsolated<[URLRequest]>([])
         let transport = ProviderHTTPTransportHandler { request in
             requests.setValue(requests.value + [request])

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -1,0 +1,287 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite(.serialized)
+struct RemoteCodexBarSnapshotTests {
+    @Test
+    func `URL validation accepts secure and private transports`() throws {
+        let secure = try #require(RemoteCodexBarConfiguration.resolve(
+            serverURL: "https://example.com/codexbar/",
+            bearerToken: " token "))
+        #expect(secure.snapshotURL.absoluteString == "https://example.com/codexbar/dashboard/v1/snapshot")
+        #expect(secure.bearerToken == "token")
+
+        let existingEndpoint = try #require(RemoteCodexBarConfiguration.resolve(
+            serverURL: "https://example.com/codexbar/dashboard/v1/snapshot",
+            bearerToken: "token"))
+        #expect(existingEndpoint.snapshotURL.absoluteString ==
+            "https://example.com/codexbar/dashboard/v1/snapshot")
+
+        let privateHTTP = try #require(RemoteCodexBarConfiguration.resolve(
+            serverURL: "http://192.168.1.20:9876",
+            bearerToken: "token"))
+        #expect(privateHTTP.snapshotURL.absoluteString == "http://192.168.1.20:9876/dashboard/v1/snapshot")
+
+        #expect(RemoteCodexBarConfiguration.resolve(serverURL: "http://example.com", bearerToken: "token") == nil)
+        #expect(RemoteCodexBarConfiguration.resolve(
+            serverURL: "https://user@example.com", bearerToken: "token") == nil)
+        #expect(RemoteCodexBarConfiguration.resolve(
+            serverURL: "https://example.com?token=bad", bearerToken: "token") == nil)
+        #expect(RemoteCodexBarConfiguration.resolve(serverURL: "https://example.com", bearerToken: "  ") == nil)
+    }
+
+    @Test
+    func `client sends bearer auth decodes schema v1 and projects provider cards`() async throws {
+        let body = Data(Self.snapshotJSON.utf8)
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.url?.absoluteString == "https://example.com/dashboard/v1/snapshot")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer secret-value")
+            #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+            let response = try #require(HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]))
+            return (body, response)
+        }
+        let configuration = try #require(RemoteCodexBarConfiguration.resolve(
+            serverURL: "https://example.com",
+            bearerToken: "secret-value"))
+        let snapshot = try await RemoteCodexBarSnapshotClient(transport: transport)
+            .fetch(configuration: configuration)
+        #expect(snapshot.schemaVersion == 1)
+        #expect(snapshot.providers.count == 1)
+
+        let projection = RemoteCodexBarProjection.make(snapshot: snapshot, serverURL: configuration.snapshotURL)
+        #expect(projection.snapshots.count == 2)
+        let provider = try #require(projection.snapshots.first)
+        #expect(provider.provider == UsageProvider.codex.instanceID)
+        #expect(provider.accountKey == AccountSnapshotSyncPayload.accountKey(for: "person@example.com"))
+        #expect(projection.snapshots[1].accountKey ==
+            AccountSnapshotSyncPayload.accountKey(for: "work@example.com"))
+        #expect(provider.displayLabel == "person@example.com")
+        #expect(provider.usage.primary?.usedPercent == 25)
+        #expect(provider.usage.secondary?.usedPercent == 60)
+        #expect(provider.usage.extraRateWindows?.first?.title == "Spark")
+        #expect(provider.usage.identity?.loginMethod == "Plus")
+        #expect(provider.usage.details.first?.rows.contains(where: { $0.label == "Today" }) == true)
+    }
+
+    @Test
+    func `client rejects auth failures and unsupported schemas`() async throws {
+        let configuration = try #require(RemoteCodexBarConfiguration.resolve(
+            serverURL: "https://example.com",
+            bearerToken: "secret-value"))
+        let unauthorized = ProviderHTTPTransportHandler { request in
+            let response = try #require(HTTPURLResponse(
+                url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil))
+            return (Data(), response)
+        }
+        await #expect(throws: RemoteCodexBarSnapshotError.unauthorized) {
+            try await RemoteCodexBarSnapshotClient(transport: unauthorized).fetch(configuration: configuration)
+        }
+
+        let unsupported = ProviderHTTPTransportHandler { request in
+            let response = try #require(HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil))
+            let body = Self.snapshotJSON.replacingOccurrences(
+                of: "\"schemaVersion\": 1",
+                with: "\"schemaVersion\": 2")
+            return (Data(body.utf8), response)
+        }
+        await #expect(throws: RemoteCodexBarSnapshotError.unsupportedSchema(2)) {
+            try await RemoteCodexBarSnapshotClient(transport: unsupported).fetch(configuration: configuration)
+        }
+    }
+
+    @MainActor
+    @Test
+    func `settings persist URL and keep bearer token in secure store`() {
+        let tokens = InMemoryRemoteCodexBarTokenStore(value: "saved-token")
+        let settings = testSettingsStore(
+            suiteName: "RemoteCodexBarSnapshotTests-settings",
+            remoteCodexBarTokenStore: tokens)
+        #expect(settings.remoteCodexBarBearerToken == "saved-token")
+
+        settings.applyRemoteCodexBarConfiguration(
+            serverURL: "https://example.com",
+            bearerToken: "new-token")
+        #expect(settings.userDefaults.string(forKey: "remoteCodexBarServerURL") == "https://example.com")
+        #expect(settings.userDefaults.string(forKey: "remoteCodexBarBearerToken") == nil)
+        #expect(tokens.storedValues == ["new-token"])
+        #expect(settings.remoteCodexBarConfiguration?.bearerToken == "new-token")
+    }
+
+    @MainActor
+    @Test
+    func `editing the endpoint clears the token before publishing the new server`() {
+        let tokens = InMemoryRemoteCodexBarTokenStore()
+        let settings = testSettingsStore(
+            suiteName: "RemoteCodexBarSnapshotTests-endpoint-token-scope",
+            remoteCodexBarTokenStore: tokens)
+        settings.applyRemoteCodexBarConfiguration(
+            serverURL: "https://server-a.example.com",
+            bearerToken: "server-a-token")
+
+        settings.remoteCodexBarServerURL = "https://server-b.example.com"
+
+        #expect(settings.remoteCodexBarBearerToken.isEmpty)
+        #expect(settings.remoteCodexBarConfiguration == nil)
+        #expect(tokens.storedValues == ["server-a-token", ""])
+    }
+
+    @MainActor
+    @Test
+    func `refresh preserves same-server data but clears data from a replaced endpoint`() async {
+        let settings = testSettingsStore(suiteName: "RemoteCodexBarSnapshotTests-refresh-failure")
+        settings.remoteCodexBarServerURL = "https://new.example.com"
+        settings.remoteCodexBarBearerToken = "token"
+        let failingTransport = ProviderHTTPTransportHandler { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            remoteCodexBarClient: RemoteCodexBarSnapshotClient(transport: failingTransport))
+        let retained = AccountSnapshotSyncPayload(
+            provider: UsageProvider.codex.instanceID,
+            deviceID: "remote-codexbar",
+            accountIdentity: "person@example.com",
+            displayLabel: "Remote account",
+            usage: UsageSnapshot(
+                primary: RateWindow(usedPercent: 40, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: .now))
+        let newConfigurationID = settings.remoteCodexBarConfiguration?.configurationID
+
+        store.remoteCodexBarSnapshots = [retained]
+        store.remoteCodexBarSnapshotConfigurationID = newConfigurationID
+        await store.refreshRemoteCodexBarSnapshot()
+        #expect(store.remoteCodexBarSnapshots.map(\.recordName) == [retained.recordName])
+        #expect(store.remoteCodexBarError != nil)
+
+        store.remoteCodexBarSnapshots = [retained]
+        settings.remoteCodexBarBearerToken = "replacement-token"
+        await store.refreshRemoteCodexBarSnapshot()
+        #expect(store.remoteCodexBarSnapshots.isEmpty)
+        #expect(store.remoteCodexBarSnapshotConfigurationID != newConfigurationID)
+
+        store.remoteCodexBarSnapshots = [retained]
+        settings.remoteCodexBarServerURL = "https://replacement.example.com"
+        await store.refreshRemoteCodexBarSnapshot()
+        #expect(store.remoteCodexBarSnapshots.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func `temporarily unavailable token retries without restarting the app`() {
+        let tokens = RetryingRemoteCodexBarTokenStore(value: "saved-token")
+        let settings = testSettingsStore(
+            suiteName: "RemoteCodexBarSnapshotTests-token-retry",
+            remoteCodexBarTokenStore: tokens)
+        #expect(settings.remoteCodexBarBearerToken.isEmpty)
+        #expect(settings.remoteCodexBarSecretError != nil)
+
+        settings.retryRemoteCodexBarTokenLoadIfNeeded()
+        #expect(settings.remoteCodexBarBearerToken == "saved-token")
+        #expect(settings.remoteCodexBarSecretError == nil)
+        #expect(tokens.loadAttempts == 2)
+    }
+
+    @MainActor
+    @Test
+    func `scheduled remote refresh starts without joining the local refresh wait`() async {
+        let settings = testSettingsStore(suiteName: "RemoteCodexBarSnapshotTests-scheduled-refresh")
+        settings.remoteCodexBarServerURL = "https://example.com"
+        settings.remoteCodexBarBearerToken = "token"
+        let slowTransport = ProviderHTTPTransportHandler { _ in
+            try await Task.sleep(for: .seconds(30))
+            throw URLError(.timedOut)
+        }
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            remoteCodexBarClient: RemoteCodexBarSnapshotClient(transport: slowTransport))
+
+        store.scheduleRemoteCodexBarRefresh()
+        #expect(store.remoteCodexBarRefreshInFlight)
+        let task = store.remoteCodexBarRefreshTask
+        #expect(task != nil)
+        task?.cancel()
+        await task?.value
+    }
+
+    @MainActor
+    @Test
+    func `remote projection enters the existing fleet card display seam`() throws {
+        let settings = testSettingsStore(suiteName: "RemoteCodexBarSnapshotTests-display")
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+        let usage = UsageSnapshot(
+            primary: RateWindow(usedPercent: 40, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: .now)
+        store.remoteCodexBarSnapshots = [AccountSnapshotSyncPayload(
+            provider: UsageProvider.codex.instanceID,
+            deviceID: "remote-codexbar",
+            accountIdentity: "remote|codex|default",
+            displayLabel: "Remote account",
+            usage: usage)]
+
+        try withStatusItemControllerForTesting(store: store, settings: settings, fetcher: fetcher) { controller in
+            let projection = controller.fleetAccountProjection(for: .codex)
+            let remote = try #require(projection.fallback ?? projection.additionalAccounts.first)
+            let model = try #require(controller.fleetAccountMenuCardModel(remote))
+            #expect(model.subtitleText.contains("remote CodexBar"))
+        }
+    }
+
+    private static let snapshotJSON = """
+    {
+      "schemaVersion": 1,
+      "generatedAt": "2026-08-28T20:00:00Z",
+      "staleAfterSeconds": 180,
+      "unknownTopLevel": true,
+      "providers": [{
+        "id": "codex",
+        "name": "Codex",
+        "enabled": true,
+        "source": "oauth",
+        "identity": {"accountEmail": "person@example.com", "plan": "Plus"},
+        "windows": [
+          {"kind": "session", "label": "Session", "usedPercent": 25, "remainingPercent": 75, "resetAt": null},
+          {"kind": "weekly", "label": "Weekly", "usedPercent": 60, "remainingPercent": 40,
+           "resetAt": "2026-09-01T00:00:00Z"},
+          {"kind": "spark", "label": "Spark", "usedPercent": 10, "remainingPercent": 90, "resetAt": null},
+          {"kind": "idle", "label": "Idle", "usedPercent": 0, "remainingPercent": 100, "resetAt": null, "idle": true}
+        ],
+        "credits": {"remaining": 12.5, "unit": "credits"},
+        "cost": {"todayUSD": 1.25, "last30DaysUSD": 18.75},
+        "display": {"accentColor": "#000000", "sortKey": 0, "priority": "normal"},
+        "error": null,
+        "updatedAt": "2026-08-28T20:00:00Z",
+        "accounts": [{
+          "id": "slot:1",
+          "label": "Work",
+          "active": true,
+          "identity": {"accountEmail": "work@example.com", "plan": null},
+          "windows": [{"kind": "session", "label": "Session", "usedPercent": 15,
+                       "remainingPercent": 85, "resetAt": null}],
+          "pace": null,
+          "error": null,
+          "updatedAt": "2026-08-28T19:59:00Z"
+        }]
+      }]
+    }
+    """
+}

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -122,7 +122,7 @@ struct RemoteCodexBarSnapshotTests {
             bearerToken: "new-token")
         #expect(settings.userDefaults.string(forKey: "remoteCodexBarServerURL") == "https://example.com")
         #expect(settings.userDefaults.string(forKey: "remoteCodexBarBearerToken") == nil)
-        #expect(tokens.storedValues.compactMap { $0 }.map(\.bearerToken) == ["new-token"])
+        #expect(tokens.storedValues.compactMap(\.self).map(\.bearerToken) == ["new-token"])
         #expect(settings.remoteCodexBarConfiguration?.bearerToken == "new-token")
     }
 

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -265,6 +265,12 @@ struct RemoteCodexBarSnapshotTests {
             try await Task.sleep(for: .milliseconds(10))
         }
         #expect(RemoteCodexBarCancellableURLProtocol.cancelCount == 1)
+
+        let cancelledBeforeStart = Task { try await transport.data(for: request) }
+        cancelledBeforeStart.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await cancelledBeforeStart.value
+        }
     }
 
     @MainActor
@@ -447,6 +453,8 @@ struct RemoteCodexBarSnapshotTests {
     @Test
     func `remote projection enters the existing fleet card display seam`() throws {
         let settings = testSettingsStore(suiteName: "RemoteCodexBarSnapshotTests-display")
+        settings.remoteCodexBarServerURL = "https://example.com"
+        settings.remoteCodexBarBearerToken = "token"
         let fetcher = UsageFetcher()
         let store = UsageStore(
             fetcher: fetcher,
@@ -468,6 +476,7 @@ struct RemoteCodexBarSnapshotTests {
             accountIdentity: "remote|codex|default",
             displayLabel: "Remote account",
             usage: usage)]
+        store.remoteCodexBarSnapshotConfigurationID = settings.remoteCodexBarConfiguration?.configurationID
 
         try withStatusItemControllerForTesting(store: store, settings: settings, fetcher: fetcher) { controller in
             let projection = controller.fleetAccountProjection(for: .codex)
@@ -475,6 +484,11 @@ struct RemoteCodexBarSnapshotTests {
             let model = try #require(controller.fleetAccountMenuCardModel(remote))
             #expect(model.subtitleText.contains("remote CodexBar"))
             #expect(model.email == "Remote account")
+
+            #expect(settings.applyRemoteCodexBarConfiguration(serverURL: "", bearerToken: ""))
+            let disconnected = controller.fleetAccountProjection(for: .codex)
+            #expect(disconnected.fallback == nil)
+            #expect(disconnected.additionalAccounts.isEmpty)
         }
     }
 

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -21,8 +21,15 @@ struct RemoteCodexBarSnapshotTests {
 
         let privateHTTP = try #require(RemoteCodexBarConfiguration.resolve(
             serverURL: "http://192.168.1.20:9876",
-            bearerToken: "token"))
+            bearerToken: "token",
+            allowsPlainHTTP: true))
         #expect(privateHTTP.snapshotURL.absoluteString == "http://192.168.1.20:9876/dashboard/v1/snapshot")
+        #expect(RemoteCodexBarConfiguration.resolve(
+            serverURL: "http://192.168.1.20:9876",
+            bearerToken: "token") == nil)
+        #expect(RemoteCodexBarConfiguration.resolve(
+            serverURL: "http://127.0.0.1:9876",
+            bearerToken: "token") != nil)
 
         #expect(RemoteCodexBarConfiguration.resolve(serverURL: "http://example.com", bearerToken: "token") == nil)
         #expect(RemoteCodexBarConfiguration.resolve(
@@ -112,6 +119,33 @@ struct RemoteCodexBarSnapshotTests {
         #expect(settings.userDefaults.string(forKey: "remoteCodexBarBearerToken") == nil)
         #expect(tokens.storedValues == ["new-token"])
         #expect(settings.remoteCodexBarConfiguration?.bearerToken == "new-token")
+    }
+
+    @MainActor
+    @Test
+    func `private HTTP requires endpoint-bound consent before connecting`() {
+        let settings = testSettingsStore(suiteName: "RemoteCodexBarSnapshotTests-private-http-consent")
+        #expect(settings.applyRemoteCodexBarConfiguration(
+            serverURL: "https://server-a.example.com",
+            bearerToken: "server-a-token"))
+
+        #expect(!settings.applyRemoteCodexBarConfiguration(
+            serverURL: "http://192.168.1.20:9876",
+            bearerToken: "token"))
+        #expect(settings.remoteCodexBarServerURL == "https://server-a.example.com")
+        #expect(settings.remoteCodexBarBearerToken == "server-a-token")
+
+        #expect(settings.applyRemoteCodexBarConfiguration(
+            serverURL: "http://192.168.1.20:9876",
+            bearerToken: "token",
+            allowsPlainHTTP: true))
+        #expect(settings.remoteCodexBarConfiguration != nil)
+        #expect(settings.remoteCodexBarAllowsPlainHTTP)
+        #expect(settings.userDefaults.bool(forKey: "remoteCodexBarAllowsPlainHTTP"))
+
+        settings.remoteCodexBarServerURL = "http://192.168.1.21:9876"
+        #expect(settings.remoteCodexBarServerURL == "http://192.168.1.20:9876")
+        #expect(settings.remoteCodexBarConfiguration != nil)
     }
 
     @MainActor

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -192,7 +192,8 @@ struct RemoteCodexBarSnapshotTests {
         #expect(settings.remoteCodexBarBearerToken == "server-a-token")
         #expect(settings.userDefaults.string(forKey: "remoteCodexBarServerURL") ==
             "https://server-a.example.com")
-        let durableCredential = try #require(tokens.loadCredential())
+        let loadedCredential = try tokens.loadCredential()
+        let durableCredential = try #require(loadedCredential)
         #expect(durableCredential.serverURL == "https://server-a.example.com")
         #expect(durableCredential.bearerToken == "server-a-token")
 
@@ -259,7 +260,9 @@ struct RemoteCodexBarSnapshotTests {
 
         #expect(settings.remoteCodexBarBearerToken.isEmpty)
         #expect(settings.remoteCodexBarConfiguration == nil)
-        #expect(tokens.storedValues == ["server-a-token", ""])
+        #expect(tokens.storedValues.count == 2)
+        #expect(tokens.storedValues[0]?.bearerToken == "server-a-token")
+        #expect(tokens.storedValues[1] == nil)
     }
 
     @MainActor

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -33,6 +33,8 @@ struct RemoteCodexBarSnapshotTests {
             bearerToken: "token",
             allowsPlainHTTP: true))
         #expect(tailscaleHTTP.snapshotURL.absoluteString == "http://100.100.10.20:9876/dashboard/v1/snapshot")
+        #expect(ProviderEndpointOverrideValidator().validatedURLAllowingPrivateNetworkHTTP(
+            "http://100.100.10.20:9876") == nil)
         #expect(RemoteCodexBarConfiguration.requiresPlainHTTPConsent(
             serverURL: "http://100.100.10.20:9876"))
         #expect(RemoteCodexBarConfiguration.resolve(

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -27,6 +27,18 @@ struct RemoteCodexBarSnapshotTests {
         #expect(RemoteCodexBarConfiguration.resolve(
             serverURL: "http://192.168.1.20:9876",
             bearerToken: "token") == nil)
+
+        let tailscaleHTTP = try #require(RemoteCodexBarConfiguration.resolve(
+            serverURL: "http://100.100.10.20:9876",
+            bearerToken: "token",
+            allowsPlainHTTP: true))
+        #expect(tailscaleHTTP.snapshotURL.absoluteString == "http://100.100.10.20:9876/dashboard/v1/snapshot")
+        #expect(RemoteCodexBarConfiguration.requiresPlainHTTPConsent(
+            serverURL: "http://100.100.10.20:9876"))
+        #expect(RemoteCodexBarConfiguration.resolve(
+            serverURL: "http://100.100.10.20:9876",
+            bearerToken: "token") == nil)
+
         #expect(RemoteCodexBarConfiguration.resolve(
             serverURL: "http://127.0.0.1:9876",
             bearerToken: "token") != nil)

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -416,8 +416,10 @@ struct RemoteCodexBarSnapshotTests {
         #expect(projection.snapshots.count == 2)
         #expect(Set(projection.snapshots.map(\.accountKey)).count == 2)
         #expect(Set(projection.snapshots.map(\.accountKey)) == Set([
-            AccountSnapshotSyncPayload.accountKey(for: "slot:1"),
-            AccountSnapshotSyncPayload.accountKey(for: "slot:2"),
+            AccountSnapshotSyncPayload.accountKey(
+                for: "https://server.example/dashboard/v1/snapshot|codex|slot:1"),
+            AccountSnapshotSyncPayload.accountKey(
+                for: "https://server.example/dashboard/v1/snapshot|codex|slot:2"),
         ]))
         #expect(Set(projection.snapshots.map(\.displayLabel)) == Set(["Personal", "Work"]))
     }

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -1,7 +1,7 @@
-import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
 @Suite(.serialized)
 struct RemoteCodexBarSnapshotTests {

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -67,7 +67,8 @@ struct RemoteCodexBarSnapshotTests {
         #expect(provider.provider == UsageProvider.codex.instanceID)
         #expect(provider.accountKey == AccountSnapshotSyncPayload.accountKey(for: "person@example.com"))
         #expect(projection.snapshots[1].accountKey ==
-            AccountSnapshotSyncPayload.accountKey(for: "work@example.com"))
+            AccountSnapshotSyncPayload.accountKey(
+                for: "https://example.com/dashboard/v1/snapshot|codex|slot:1"))
         #expect(provider.displayLabel == "person@example.com")
         #expect(provider.usage.primary?.usedPercent == 25)
         #expect(provider.usage.secondary?.usedPercent == 60)
@@ -106,10 +107,14 @@ struct RemoteCodexBarSnapshotTests {
     @MainActor
     @Test
     func `settings persist URL and keep bearer token in secure store`() {
-        let tokens = InMemoryRemoteCodexBarTokenStore(value: "saved-token")
+        let tokens = InMemoryRemoteCodexBarTokenStore(value: RemoteCodexBarStoredCredential(
+            serverURL: "https://saved.example.com",
+            bearerToken: "saved-token",
+            allowsPlainHTTP: false))
         let settings = testSettingsStore(
             suiteName: "RemoteCodexBarSnapshotTests-settings",
             remoteCodexBarTokenStore: tokens)
+        #expect(settings.remoteCodexBarServerURL == "https://saved.example.com")
         #expect(settings.remoteCodexBarBearerToken == "saved-token")
 
         settings.applyRemoteCodexBarConfiguration(
@@ -117,8 +122,29 @@ struct RemoteCodexBarSnapshotTests {
             bearerToken: "new-token")
         #expect(settings.userDefaults.string(forKey: "remoteCodexBarServerURL") == "https://example.com")
         #expect(settings.userDefaults.string(forKey: "remoteCodexBarBearerToken") == nil)
-        #expect(tokens.storedValues == ["new-token"])
+        #expect(tokens.storedValues.compactMap { $0 }.map(\.bearerToken) == ["new-token"])
         #expect(settings.remoteCodexBarConfiguration?.bearerToken == "new-token")
+    }
+
+    @MainActor
+    @Test
+    func `startup trusts the endpoint bound to the Keychain credential`() {
+        let tokens = InMemoryRemoteCodexBarTokenStore(value: RemoteCodexBarStoredCredential(
+            serverURL: "https://server-b.example.com",
+            bearerToken: "server-b-token",
+            allowsPlainHTTP: false))
+        let settings = testSettingsStore(
+            suiteName: "RemoteCodexBarSnapshotTests-interrupted-replacement",
+            remoteCodexBarTokenStore: tokens,
+            prepareDefaults: { defaults in
+                defaults.set("https://server-a.example.com", forKey: "remoteCodexBarServerURL")
+            })
+
+        #expect(settings.remoteCodexBarServerURL == "https://server-b.example.com")
+        #expect(settings.remoteCodexBarBearerToken == "server-b-token")
+        #expect(settings.remoteCodexBarConfiguration?.snapshotURL.host == "server-b.example.com")
+        #expect(settings.userDefaults.string(forKey: "remoteCodexBarServerURL") ==
+            "https://server-b.example.com")
     }
 
     @MainActor
@@ -141,7 +167,6 @@ struct RemoteCodexBarSnapshotTests {
             allowsPlainHTTP: true))
         #expect(settings.remoteCodexBarConfiguration != nil)
         #expect(settings.remoteCodexBarAllowsPlainHTTP)
-        #expect(settings.userDefaults.bool(forKey: "remoteCodexBarAllowsPlainHTTP"))
 
         settings.remoteCodexBarServerURL = "http://192.168.1.21:9876"
         #expect(settings.remoteCodexBarServerURL == "http://192.168.1.20:9876")
@@ -167,11 +192,14 @@ struct RemoteCodexBarSnapshotTests {
         #expect(settings.remoteCodexBarBearerToken == "server-a-token")
         #expect(settings.userDefaults.string(forKey: "remoteCodexBarServerURL") ==
             "https://server-a.example.com")
-        #expect(try tokens.loadToken() == "server-a-token")
+        let durableCredential = try #require(tokens.loadCredential())
+        #expect(durableCredential.serverURL == "https://server-a.example.com")
+        #expect(durableCredential.bearerToken == "server-a-token")
 
         let persisted = try #require(RemoteCodexBarConfiguration.resolve(
-            serverURL: settings.userDefaults.string(forKey: "remoteCodexBarServerURL") ?? "",
-            bearerToken: tokens.loadToken() ?? ""))
+            serverURL: durableCredential.serverURL,
+            bearerToken: durableCredential.bearerToken,
+            allowsPlainHTTP: durableCredential.allowsPlainHTTP))
         let requests = LockIsolated<[URLRequest]>([])
         let transport = ProviderHTTPTransportHandler { request in
             requests.setValue(requests.value + [request])
@@ -281,7 +309,10 @@ struct RemoteCodexBarSnapshotTests {
     @MainActor
     @Test
     func `temporarily unavailable token retries without restarting the app`() {
-        let tokens = RetryingRemoteCodexBarTokenStore(value: "saved-token")
+        let tokens = RetryingRemoteCodexBarTokenStore(value: RemoteCodexBarStoredCredential(
+            serverURL: "https://saved.example.com",
+            bearerToken: "saved-token",
+            allowsPlainHTTP: false))
         let settings = testSettingsStore(
             suiteName: "RemoteCodexBarSnapshotTests-token-retry",
             remoteCodexBarTokenStore: tokens)
@@ -289,6 +320,7 @@ struct RemoteCodexBarSnapshotTests {
         #expect(settings.remoteCodexBarSecretError != nil)
 
         settings.retryRemoteCodexBarTokenLoadIfNeeded()
+        #expect(settings.remoteCodexBarServerURL == "https://saved.example.com")
         #expect(settings.remoteCodexBarBearerToken == "saved-token")
         #expect(settings.remoteCodexBarSecretError == nil)
         #expect(tokens.loadAttempts == 2)
@@ -348,6 +380,19 @@ struct RemoteCodexBarSnapshotTests {
         }
     }
 
+    @Test
+    func `redacted accounts use stable server scoped ids`() throws {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snapshot = try decoder.decode(RemoteCodexBarSnapshot.self, from: Data(Self.redactedAccountsJSON.utf8))
+        let serverURL = try #require(URL(string: "https://server.example/dashboard/v1/snapshot"))
+
+        let projection = RemoteCodexBarProjection.make(snapshot: snapshot, serverURL: serverURL)
+        #expect(projection.snapshots.count == 2)
+        #expect(Set(projection.snapshots.map(\.accountKey)).count == 2)
+        #expect(Set(projection.snapshots.map(\.displayLabel)) == Set(["Personal", "Work"]))
+    }
+
     private static let snapshotJSON = """
     {
       "schemaVersion": 1,
@@ -383,6 +428,38 @@ struct RemoteCodexBarSnapshotTests {
           "error": null,
           "updatedAt": "2026-08-28T19:59:00Z"
         }]
+      }]
+    }
+    """
+
+    private static let redactedAccountsJSON = """
+    {
+      "schemaVersion": 1,
+      "generatedAt": "2026-08-28T20:00:00Z",
+      "staleAfterSeconds": 180,
+      "providers": [{
+        "id": "codex",
+        "name": "Codex",
+        "enabled": true,
+        "windows": [],
+        "accounts": [
+          {
+            "id": "slot:1",
+            "label": "Personal",
+            "active": true,
+            "identity": {"accountEmail": "redacted@example.com", "plan": null},
+            "windows": [{"kind": "session", "label": "Session", "usedPercent": 15,
+                         "remainingPercent": 85, "resetAt": null}]
+          },
+          {
+            "id": "slot:2",
+            "label": "Work",
+            "active": false,
+            "identity": {"accountEmail": "redacted@example.com", "plan": null},
+            "windows": [{"kind": "session", "label": "Session", "usedPercent": 35,
+                         "remainingPercent": 65, "resetAt": null}]
+          }
+        ]
       }]
     }
     """

--- a/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexBarSnapshotTests.swift
@@ -456,7 +456,12 @@ struct RemoteCodexBarSnapshotTests {
         let usage = UsageSnapshot(
             primary: RateWindow(usedPercent: 40, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
             secondary: nil,
-            updatedAt: .now)
+            updatedAt: .now,
+            identity: ProviderIdentitySnapshot(
+                providerID: UsageProvider.codex.instanceID,
+                accountEmail: "person@example.com",
+                accountOrganization: nil,
+                loginMethod: "Plus"))
         store.remoteCodexBarSnapshots = [AccountSnapshotSyncPayload(
             provider: UsageProvider.codex.instanceID,
             deviceID: "remote-codexbar",
@@ -469,6 +474,7 @@ struct RemoteCodexBarSnapshotTests {
             let remote = try #require(projection.fallback ?? projection.additionalAccounts.first)
             let model = try #require(controller.fleetAccountMenuCardModel(remote))
             #expect(model.subtitleText.contains("remote CodexBar"))
+            #expect(model.email == "Remote account")
         }
     }
 

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -172,6 +172,45 @@ final class InMemoryCopilotTokenStore: CopilotTokenStoring, @unchecked Sendable 
     }
 }
 
+final class InMemoryRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unchecked Sendable {
+    var value: String?
+    var storedValues: [String?] = []
+
+    init(value: String? = nil) {
+        self.value = value
+    }
+
+    func loadToken() throws -> String? {
+        self.value
+    }
+
+    func storeToken(_ token: String?) throws {
+        self.value = token
+        self.storedValues.append(token)
+    }
+}
+
+final class RetryingRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unchecked Sendable {
+    var value: String?
+    var loadAttempts = 0
+
+    init(value: String?) {
+        self.value = value
+    }
+
+    func loadToken() throws -> String? {
+        self.loadAttempts += 1
+        if self.loadAttempts == 1 {
+            throw RemoteCodexBarTokenStoreError.temporarilyUnavailable
+        }
+        return self.value
+    }
+
+    func storeToken(_ token: String?) throws {
+        self.value = token
+    }
+}
+
 final class InMemoryTokenAccountStore: ProviderTokenAccountStoring, @unchecked Sendable {
     var accounts: [UsageProvider: ProviderTokenAccountData] = [:]
     private let fileURL: URL
@@ -223,6 +262,7 @@ func testConfigWithAllProvidersDisabled() -> CodexBarConfig {
 func testSettingsStore(
     suiteName: String,
     tokenAccountStore: any ProviderTokenAccountStoring = InMemoryTokenAccountStore(),
+    remoteCodexBarTokenStore: any RemoteCodexBarTokenStoring = InMemoryRemoteCodexBarTokenStore(),
     config: CodexBarConfig? = nil,
     prepareDefaults: ((UserDefaults) -> Void)? = nil) -> SettingsStore
 {
@@ -256,6 +296,7 @@ func testSettingsStore(
         augmentCookieStore: InMemoryCookieHeaderStore(),
         ampCookieStore: InMemoryCookieHeaderStore(),
         copilotTokenStore: InMemoryCopilotTokenStore(),
+        remoteCodexBarTokenStore: remoteCodexBarTokenStore,
         tokenAccountStore: tokenAccountStore)
 }
 

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -173,50 +173,50 @@ final class InMemoryCopilotTokenStore: CopilotTokenStoring, @unchecked Sendable 
 }
 
 final class InMemoryRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unchecked Sendable {
-    var value: String?
-    var storedValues: [String?] = []
+    var value: RemoteCodexBarStoredCredential?
+    var storedValues: [RemoteCodexBarStoredCredential?] = []
 
-    init(value: String? = nil) {
+    init(value: RemoteCodexBarStoredCredential? = nil) {
         self.value = value
     }
 
-    func loadToken() throws -> String? {
+    func loadCredential() throws -> RemoteCodexBarStoredCredential? {
         self.value
     }
 
-    func storeToken(_ token: String?) throws {
-        self.value = token
-        self.storedValues.append(token)
+    func storeCredential(_ credential: RemoteCodexBarStoredCredential?) throws {
+        self.value = credential
+        self.storedValues.append(credential)
     }
 }
 
 final class FailingRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unchecked Sendable {
-    var value: String?
+    var value: RemoteCodexBarStoredCredential?
     var failWrites = false
 
-    init(value: String? = nil) {
+    init(value: RemoteCodexBarStoredCredential? = nil) {
         self.value = value
     }
 
-    func loadToken() throws -> String? {
+    func loadCredential() throws -> RemoteCodexBarStoredCredential? {
         self.value
     }
 
-    func storeToken(_ token: String?) throws {
+    func storeCredential(_ credential: RemoteCodexBarStoredCredential?) throws {
         guard !self.failWrites else { throw RemoteCodexBarTokenStoreError.writeFailed }
-        self.value = token
+        self.value = credential
     }
 }
 
 final class RetryingRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unchecked Sendable {
-    var value: String?
+    var value: RemoteCodexBarStoredCredential?
     var loadAttempts = 0
 
-    init(value: String?) {
+    init(value: RemoteCodexBarStoredCredential?) {
         self.value = value
     }
 
-    func loadToken() throws -> String? {
+    func loadCredential() throws -> RemoteCodexBarStoredCredential? {
         self.loadAttempts += 1
         if self.loadAttempts == 1 {
             throw RemoteCodexBarTokenStoreError.temporarilyUnavailable
@@ -224,8 +224,8 @@ final class RetryingRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unche
         return self.value
     }
 
-    func storeToken(_ token: String?) throws {
-        self.value = token
+    func storeCredential(_ credential: RemoteCodexBarStoredCredential?) throws {
+        self.value = credential
     }
 }
 

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -190,6 +190,24 @@ final class InMemoryRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unche
     }
 }
 
+final class FailingRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unchecked Sendable {
+    var value: String?
+    var failWrites = false
+
+    init(value: String? = nil) {
+        self.value = value
+    }
+
+    func loadToken() throws -> String? {
+        self.value
+    }
+
+    func storeToken(_ token: String?) throws {
+        guard !self.failWrites else { throw RemoteCodexBarTokenStoreError.writeFailed }
+        self.value = token
+    }
+}
+
 final class RetryingRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unchecked Sendable {
     var value: String?
     var loadAttempts = 0

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -190,6 +190,24 @@ final class InMemoryRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unche
     }
 }
 
+final class KeychainGateAwareRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unchecked Sendable {
+    var value: RemoteCodexBarStoredCredential?
+    var loadAttempts = 0
+
+    init(value: RemoteCodexBarStoredCredential? = nil) {
+        self.value = value
+    }
+
+    func loadCredential() throws -> RemoteCodexBarStoredCredential? {
+        self.loadAttempts += 1
+        return KeychainAccessGate.isExplicitlyDisabled ? nil : self.value
+    }
+
+    func storeCredential(_ credential: RemoteCodexBarStoredCredential?) throws {
+        self.value = credential
+    }
+}
+
 final class FailingRemoteCodexBarTokenStore: RemoteCodexBarTokenStoring, @unchecked Sendable {
     var value: RemoteCodexBarStoredCredential?
     var failWrites = false


### PR DESCRIPTION
## Summary

- add a provider-neutral **Sync** settings pane that keeps the existing iCloud controls and adds a Remote CodexBar connection for a `codexbar serve` base URL and dashboard bearer token
- store the token in Keychain, validate HTTPS/private-network/Tailscale HTTP endpoints, require explicit consent before sending it over non-loopback HTTP, and fetch `/dashboard/v1/snapshot` with bounded schema-v1 decoding
- project remote provider and account snapshots into the existing fleet-account card UI while preserving local provider behavior
- refresh remote data alongside normal app refreshes, retain last-good cards only for transient same-connection failures, and clear them after permanent auth/schema failures or connection changes
- persist the endpoint, token, and cleartext consent as one Keychain credential record, so failed or interrupted replacements cannot recombine authority from different hosts
- clear the staged token and private-HTTP consent as soon as an existing endpoint draft changes, requiring explicit token re-entry for the new host
- stop reading oversized snapshot responses at 2 MiB and do not retry an oversized retryable response
- prefer unique unredacted account identity for local/remote deduplication, then use server-scoped stable IDs for redacted or ambiguous identities so unrelated local accounts do not collide
- replace ambient provider cards with account cards for multi-account snapshots, and propagate refresh cancellation to the underlying URLSession request
- hide cached cards synchronously when their bound configuration no longer matches the active endpoint/token pair
- render the server-provided multi-account label as the authoritative card title while retaining plan and stable identity metadata

This is the display-client counterpart to the authenticated snapshot endpoint added in #2227 and the remote-monitoring request in #319.

## Verification

- focused RemoteCodexBar settings, transport, projection, and menu tests, including failed and interrupted credential replacement, Keychain re-enablement, private-HTTP consent, transient/permanent failure state, local/remote account deduplication, redacted-account identity, streaming response limits, and request cancellation
- full hosted macOS test shards, Linux CLI builds/tests, static-musl build, SwiftFormat/SwiftLint, and GitGuardian on the exact PR head
- independent final diff review

## Notes

- public endpoints require HTTPS; loopback HTTP works directly, while private-network and Tailscale/CGNAT HTTP require an explicit cleartext-bearer acknowledgment before the connection can be saved
- the app never writes the bearer token to UserDefaults
- the response-limit transport rejects cross-origin redirects so bearer authorization cannot follow a redirect to another host
