### PR TITLE
test: isolate RPC fixtures and prove hung requests

### DIFF
--- a/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
@@ -152,12 +152,13 @@ struct CodexUsageFetcherFallbackTests {
     @Test
     func `hung CLI RPC rate limits request times out within budget`() async throws {
         let stubCLIPath = try self.makeHungRateLimitsStubCodexCLI()
-        defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
+        let requestPath = stubCLIPath + ".requests"
+        defer {
+            try? FileManager.default.removeItem(atPath: stubCLIPath)
+            try? FileManager.default.removeItem(atPath: requestPath)
+        }
 
-        let fetcher = UsageFetcher(
-            environment: ["CODEX_CLI_PATH": stubCLIPath],
-            initializeTimeoutSeconds: 20.0,
-            requestTimeoutSeconds: 0.2)
+        let fetcher = self.makeStubUsageFetcher(stubCLIPath, requestTimeoutSeconds: 0.2)
 
         let started = Date()
         do {
@@ -175,17 +176,19 @@ struct CodexUsageFetcherFallbackTests {
 
         let elapsed = Date().timeIntervalSince(started)
         #expect(elapsed < 5.0, "Hung RPC request must fail fast, took \(elapsed)s")
+        #expect(try String(contentsOfFile: requestPath, encoding: .utf8) == "account/rateLimits/read\n")
     }
 
     @Test
     func `repeated hung CLI RPC requests stay bounded`() async throws {
         let stubCLIPath = try self.makeHungRateLimitsStubCodexCLI()
-        defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
+        let requestPath = stubCLIPath + ".requests"
+        defer {
+            try? FileManager.default.removeItem(atPath: stubCLIPath)
+            try? FileManager.default.removeItem(atPath: requestPath)
+        }
 
-        let fetcher = UsageFetcher(
-            environment: ["CODEX_CLI_PATH": stubCLIPath],
-            initializeTimeoutSeconds: 20.0,
-            requestTimeoutSeconds: 0.2)
+        let fetcher = self.makeStubUsageFetcher(stubCLIPath, requestTimeoutSeconds: 0.2)
 
         for attempt in 1...2 {
             let started = Date()
@@ -193,17 +196,50 @@ struct CodexUsageFetcherFallbackTests {
                 _ = try await fetcher.loadLatestCredits()
                 Issue.record("Expected hung Codex RPC credits request \(attempt) to time out")
             } catch let error as RPCWireError {
-                guard case .timeout = error else {
+                guard case let .timeout(method) = error else {
                     Issue.record("Expected RPC timeout on attempt \(attempt), got \(error)")
                     return
                 }
+                #expect(method == "account/rateLimits/read")
             } catch {
                 Issue.record("Expected RPCWireError.timeout on attempt \(attempt), got \(type(of: error)): \(error)")
             }
 
             let elapsed = Date().timeIntervalSince(started)
             #expect(elapsed < 5.0, "Hung RPC request \(attempt) must fail fast, took \(elapsed)s")
+            #expect(try String(contentsOfFile: requestPath, encoding: .utf8)
+                == String(repeating: "account/rateLimits/read\n", count: attempt))
         }
+    }
+
+    @Test(arguments: ["account/rateLimits/read", "account\\/rateLimits\\/read"])
+    func `hung fixture recognizes both JSON slash encodings`(method: String) async throws {
+        let stubCLIPath = try self.makeHungRateLimitsStubCodexCLI()
+        let requestPath = stubCLIPath + ".requests"
+        defer {
+            try? FileManager.default.removeItem(atPath: stubCLIPath)
+            try? FileManager.default.removeItem(atPath: requestPath)
+        }
+        let stdin = RPCChildProcessInput()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: stubCLIPath)
+        process.arguments = ["app-server"]
+        process.environment = ["CODEXBAR_TEST_RPC_REQUEST_PATH": requestPath]
+        process.standardInput = stdin.pipe
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        defer { RPCChildProcessTeardown.terminate(process: process, stdin: stdin) }
+        try stdin.write(Data("{\"id\":2,\"method\":\"\(method)\"}\n".utf8))
+
+        let deadline = ContinuousClock.now.advanced(by: .seconds(20))
+        while (try? String(contentsOfFile: requestPath, encoding: .utf8)) != "account/rateLimits/read\n",
+              ContinuousClock.now < deadline
+        {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(try String(contentsOfFile: requestPath, encoding: .utf8) == "account/rateLimits/read\n")
+        #expect(process.isRunning)
     }
 
     private static let decodeMismatchBodyMessage = """
@@ -287,11 +323,22 @@ struct CodexUsageFetcherFallbackTests {
     }
     """
 
-    private func makeStubUsageFetcher(_ stubCLIPath: String) -> UsageFetcher {
+    private func makeStubUsageFetcher(
+        _ stubCLIPath: String,
+        requestTimeoutSeconds: TimeInterval = 3.0) -> UsageFetcher
+    {
         UsageFetcher(
-            environment: ["CODEX_CLI_PATH": stubCLIPath],
+            environment: [
+                "PATH": "/usr/bin:/bin",
+                "CODEX_CLI_PATH": stubCLIPath,
+                "CODEXBAR_TEST_RPC_REQUEST_PATH": stubCLIPath + ".requests",
+            ],
             initializeTimeoutSeconds: 20.0,
-            requestTimeoutSeconds: 3.0)
+            requestTimeoutSeconds: requestTimeoutSeconds,
+            // Absolute-interpreter fixtures must not capture the user's real login-shell PATH.
+            codexExecutableResolver: { _, _ in
+                CodexExecutableResolution(executable: stubCLIPath, loginPATH: [])
+            })
     }
 
     private func makeDecodeMismatchStubCodexCLI(
@@ -495,8 +542,9 @@ struct CodexUsageFetcherFallbackTests {
             *'"method":"initialize"'*|*'"method": "initialize"'*)
               printf '%s\\n' '{"id":1,"result":{}}'
               ;;
-            *'"method":"account/rateLimits/read"'*|*'"method": "account/rateLimits/read"'*)
-              sleep 30
+            *'"account/rateLimits/read"'*|*'"account\\/rateLimits\\/read"'*)
+              printf '%s\\n' 'account/rateLimits/read' >> "$CODEXBAR_TEST_RPC_REQUEST_PATH"
+              exec /bin/sleep 30
               ;;
             *)
               printf '%s\\n' '{"id":1,"result":{}}'

--- a/Tests/CodexBarTests/RPCChildProcessTeardownTests.swift
+++ b/Tests/CodexBarTests/RPCChildProcessTeardownTests.swift
@@ -69,7 +69,10 @@ struct RPCChildProcessTeardownTests {
         let fetcher = UsageFetcher(
             environment: ["CODEX_CLI_PATH": scriptURL.path],
             initializeTimeoutSeconds: 5,
-            requestTimeoutSeconds: 2)
+            requestTimeoutSeconds: 2,
+            codexExecutableResolver: { _, _ in
+                CodexExecutableResolution(executable: scriptURL.path, loginPATH: [])
+            })
 
         let error = await #expect(throws: RPCWireError.self) {
             _ = try await fetcher.loadLatestCLIAccountSnapshot()
@@ -146,7 +149,10 @@ struct RPCChildProcessTeardownTests {
                 "CODEXBAR_PROOF_PID_FILE": pidURL.path,
             ],
             initializeTimeoutSeconds: 20.0,
-            requestTimeoutSeconds: 3.0)
+            requestTimeoutSeconds: 3.0,
+            codexExecutableResolver: { _, _ in
+                CodexExecutableResolution(executable: scriptURL.path, loginPATH: [])
+            })
 
         _ = try await fetcher.loadLatestCLIAccountSnapshot()
 


### PR DESCRIPTION
## Summary

Make the RPC timeout tests verify the intended failure mode, and remove unrelated login-shell discovery from absolute-interpreter Codex fixtures.

The hanging fixture matched only unescaped JSON method names. Foundation can serialize slashes as `\/`, so the fixture could respond with the wrong request ID instead of entering its hanging branch; the client still timed out and the test passed for the wrong reason. The fixture now handles both encodings, records the intended request before hanging, and the tests assert that evidence for every request. A direct fixture regression covers both wire spellings and waits for complete marker contents rather than just file creation.

Absolute-interpreter Codex fixtures inject the existing executable-resolution seam with an empty login PATH, so they do not consult the user's login shell. This applies to the fallback suite and adjacent Codex teardown tests. The hanging shell uses `exec /bin/sleep` so teardown owns the actual hanging PID rather than leaving a separate sleep child.

No production files, RPC deadlines, existing elapsed-time assertions, provider behavior, or credentials changed. This is test-only, so no user-facing changelog entry is needed. It removes an avoidable startup dependency; it does not claim to fix every host dynamic-loader startup stall observed during earlier triage.

## Verification

- Before correcting the matcher, the new evidence checks reproduced missing request markers in both real RPC timeout tests and the explicit escaped-slash case. That run also found a marker-file creation/read race (fixed) and an unrelated Grok initialization timeout while the two suites ran in parallel. None of those failures is counted as green.
- `swift test --jobs 8 --no-parallel --filter 'CodexUsageFetcherFallbackTests|RPCChildProcessTeardownTests'`: **20 tests passed** in 23.823 seconds. This uses the same serialized execution mode as CI, with Keychain access suppressed and Codex file isolation enabled.
- Independent source review and Codex autoreview: **clean**.
- `make check`: **passed**, including strict lint with zero violations in 2,039 files.
- Full `make test`: **passed**, all 959 selections across 80 groups. 78 groups passed first time; two failed first passes recovered on the runner's automatic full-group retries. There were no group watchdog timeouts or isolated-selection retries. Total elapsed time: 2,062.4 seconds.
- Local retry caveats: group 29 hit a Codex fixture initialization stall, correctly rejected by the new method/marker assertions; group 35 exceeded the unchanged cost-storage scale-test write budget. Both full-group retries passed. No test deadline was relaxed. The local run used the existing 600-second outer group watchdog on this loaded host; individual test and production deadlines remained unchanged.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33237563595) for `2a8012533b3db8aa6c003e51d044c5782c9d7442`: **passed**, including both macOS test shards, Linux x64/ARM64 builds and tests, lint, and the aggregate gate. GitGuardian also passed. The existing test-only path gate intentionally skipped the musl build. No CI rerun was requested.
