### PR TITLE
perf: group Codex cost aggregates in one pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Localization: translate missing Catalan iCloud, spend, and Plugins sidebar labels, restore the Projects translation, and align command labels and instructions with their UI roles (#3245). Thanks @pmontp19!
 - Keychain: apply saved disabled-access preferences before startup credential migration, including shared-defaults fallback, and keep deferred migrations retryable (investigated alongside #3249). Thanks @jaychou0642-create!
 
+### Performance
+- Codex: build saved cost aggregates in one pass per file instead of rescanning history for every day/model, preserving costs and token totals (investigated alongside #3247). Thanks @robertoecf!
+
 ## 0.56.0 — 2026-08-28
 
 ### Added

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+CodexCache.swift
@@ -198,7 +198,8 @@ extension CostUsageStore {
             persistedFiles += 1
             Self.saveCycleCheckpointForTesting?(persistedFiles)
         }
-        _ = self.replaceDayAggregates(Self.globalAggregates(cache: cache))
+        _ = self.replaceDayAggregates(Self.globalAggregates(
+            cache: cache, recorder: self.scopedReadWorkRecorderForTesting))
         _ = self.setMetadata(Self.metadata(cache: cache, calendar: calendar))
         _ = self.setDiscoveryState(Self.discoveryState(cache.codexSessionDiscovery))
         _ = self.setLookbackState(Self.lookbackState(cache.codexActiveLookbackState))
@@ -910,7 +911,8 @@ extension CostUsageStore {
         case .replace:
             _ = self.replaceUsageRows(path: path, rows: rows)
         }
-        _ = self.replaceFileDayAggregates(path: path, aggregates: Self.fileAggregates(usage))
+        _ = self.replaceFileDayAggregates(path: path, aggregates: Self.fileAggregates(
+            usage, recorder: self.scopedReadWorkRecorderForTesting))
         _ = self.upsertForkLineage(CostUsageStoreForkLineage(
             path: path,
             sessionID: usage.sessionId,
@@ -991,7 +993,10 @@ extension CostUsageStore {
             reportUntilKey: untilKey)
     }
 
-    private static func fileAggregates(_ usage: CostUsageFileUsage) -> [CostUsageStoreDayAggregate] {
+    private static func fileAggregates(
+        _ usage: CostUsageFileUsage,
+        recorder: CostUsageStoreReadWorkRecorder?) -> [CostUsageStoreDayAggregate]
+    {
         var keys = Set<DayModelKey>()
         func addKeys(_ map: [String: [String: some Any]]?) {
             for (day, models) in map ?? [:] {
@@ -1007,54 +1012,49 @@ extension CostUsageStore {
         addKeys(usage.codexPriorityCostNanos)
         addKeys(usage.codexStandardTokens)
         addKeys(usage.codexPriorityTokens)
+        var values: [DayModelKey: CostUsageStoreDayAggregate] = [:]
         for row in usage.codexRows ?? [] {
-            keys.insert(DayModelKey(day: row.day, model: row.model))
+            recorder?.recordAggregateGroupingRowVisit()
+            let key = DayModelKey(day: row.day, model: row.model)
+            keys.insert(key)
+            var aggregate = values[key] ?? .zero(day: row.day, model: row.model)
+            aggregate.reasoningTokens += Int64(row.reasoning ?? 0)
+            aggregate.requestCount += 1
+            let isPriority = row.pricingMode == "priority"
+            let total = Int64(max(0, row.input) + max(0, row.output))
+            if isPriority {
+                aggregate.priorityTokens += total
+            } else {
+                aggregate.standardTokens += total
+            }
+            if let cost = row.knownCostNanos {
+                aggregate.authoritativeCostNanos += cost
+            } else if isPriority {
+                aggregate.priorityInputTokens += Int64(row.input)
+                aggregate.priorityCachedTokens += Int64(row.cached)
+                aggregate.priorityOutputTokens += Int64(row.output)
+            } else {
+                aggregate.standardInputTokens += Int64(row.input)
+                aggregate.standardCachedTokens += Int64(row.cached)
+                aggregate.standardOutputTokens += Int64(row.output)
+            }
+            values[key] = aggregate
         }
         return keys.map { key in
+            var aggregate = values[key] ?? .zero(day: key.day, model: key.model)
+            // Packed totals remain authoritative; rows supply pricing and request detail only.
             let packed = usage.days[key.day]?[key.model] ?? []
-            let rows = (usage.codexRows ?? []).filter { $0.day == key.day && $0.model == key.model }
-            var aggregate = CostUsageStoreDayAggregate(
-                day: key.day,
-                model: key.model,
-                inputTokens: Int64(packed[safe: 0] ?? 0),
-                cachedTokens: Int64(packed[safe: 1] ?? 0),
-                outputTokens: Int64(packed[safe: 2] ?? 0),
-                reasoningTokens: Int64(rows.compactMap(\.reasoning).reduce(0, +)),
-                requestCount: Int64(rows.count),
-                authoritativeCostNanos: 0,
-                standardInputTokens: 0,
-                standardCachedTokens: 0,
-                standardOutputTokens: 0,
-                priorityInputTokens: 0,
-                priorityCachedTokens: 0,
-                priorityOutputTokens: 0,
-                standardTokens: 0,
-                priorityTokens: 0)
-            for row in rows {
-                let isPriority = row.pricingMode == "priority"
-                let total = Int64(max(0, row.input) + max(0, row.output))
-                if isPriority {
-                    aggregate.priorityTokens += total
-                } else {
-                    aggregate.standardTokens += total
-                }
-                if let cost = row.knownCostNanos {
-                    aggregate.authoritativeCostNanos += cost
-                } else if isPriority {
-                    aggregate.priorityInputTokens += Int64(row.input)
-                    aggregate.priorityCachedTokens += Int64(row.cached)
-                    aggregate.priorityOutputTokens += Int64(row.output)
-                } else {
-                    aggregate.standardInputTokens += Int64(row.input)
-                    aggregate.standardCachedTokens += Int64(row.cached)
-                    aggregate.standardOutputTokens += Int64(row.output)
-                }
-            }
+            aggregate.inputTokens = Int64(packed[safe: 0] ?? 0)
+            aggregate.cachedTokens = Int64(packed[safe: 1] ?? 0)
+            aggregate.outputTokens = Int64(packed[safe: 2] ?? 0)
             return aggregate
         }.sorted { ($0.day, $0.model) < ($1.day, $1.model) }
     }
 
-    private static func globalAggregates(cache: CostUsageCache) -> [CostUsageStoreDayAggregate] {
+    private static func globalAggregates(
+        cache: CostUsageCache,
+        recorder: CostUsageStoreReadWorkRecorder?) -> [CostUsageStoreDayAggregate]
+    {
         var values: [DayModelKey: CostUsageStoreDayAggregate] = [:]
         for (day, models) in cache.days {
             for (model, packed) in models {
@@ -1066,7 +1066,7 @@ extension CostUsageStore {
             }
         }
         for usage in cache.files.values {
-            for aggregate in self.fileAggregates(usage) {
+            for aggregate in self.fileAggregates(usage, recorder: recorder) {
                 let key = DayModelKey(day: aggregate.day, model: aggregate.model)
                 guard var value = values[key] else { continue }
                 value.reasoningTokens += aggregate.reasoningTokens

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+ReadWork.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageStore+ReadWork.swift
@@ -21,6 +21,7 @@ struct CostUsageStoreReadWorkMetrics: Codable, Equatable, Sendable {
     var accumulatorRows = 0
     var readViewConversions = 0
     var readViewConversionsInTransaction = 0
+    var aggregateGroupingRowVisits = 0
 }
 
 /// Opt-in diagnostic counters for one owned database; never installed in production.
@@ -95,6 +96,10 @@ final class CostUsageStoreReadWorkRecorder: @unchecked Sendable {
 
     func recordIntegrityCheck() {
         self.lock.withLock { self.metrics.integrityChecks += 1 }
+    }
+
+    func recordAggregateGroupingRowVisit() {
+        self.lock.withLock { self.metrics.aggregateGroupingRowVisits += 1 }
     }
 }
 

--- a/Tests/CodexBarTests/CostUsageStoreAggregateWorkTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreAggregateWorkTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct CostUsageStoreAggregateWorkTests {
+    @Test(arguments: [1, 32])
+    func `aggregate grouping visits rows independently of key count`(keyCount: Int) async throws {
+        let fixture = try ReadWorkFixture(fileCount: 2, rowsPerFile: 128)
+        defer { fixture.remove() }
+        let store = CostUsageStore(cacheRoot: fixture.env.root.appendingPathComponent("aggregate-proof"))
+        var cache = fixture.canonical
+        cache.days = [:]
+        for path in cache.files.keys.sorted() {
+            var usage = try #require(cache.files[path])
+            usage.days = [:]
+            usage.codexCostNanos = nil
+            usage.codexPrioritySurchargeNanos = nil
+            usage.codexStandardCostNanos = nil
+            usage.codexPriorityCostNanos = nil
+            usage.codexStandardTokens = nil
+            usage.codexPriorityTokens = nil
+            usage.codexRows = (0..<128).map { index in
+                Self.row(model: "fixture-model-\(index % keyCount)", event: index)
+            }
+            for index in 0..<keyCount {
+                let model = "fixture-model-\(index)"
+                usage.days[ReadWorkFixture.day, default: [:]][model] = [1280 / keyCount, 256 / keyCount, 384 / keyCount]
+                cache.days[ReadWorkFixture.day, default: [:]][model] = [2560 / keyCount, 512 / keyCount, 768 / keyCount]
+            }
+            cache.files[path] = usage
+        }
+        let recorder = CostUsageStoreReadWorkRecorder(databaseURL: store.databaseURL)
+        let previousRecorder = CostUsageStore.readWorkRecorderForTesting
+        CostUsageStore.readWorkRecorderForTesting = recorder
+        defer { CostUsageStore.readWorkRecorderForTesting = previousRecorder }
+
+        #expect(!Self.save(cache, store: store, fixture: fixture).catchUpRequired)
+        let visits = recorder.snapshot().aggregateGroupingRowVisits
+        print("[cost-aggregate-proof] rows=256 keys_per_file=\(keyCount) grouping_row_visits=\(visits)")
+        #expect(visits > 0)
+        #expect(visits <= 2 * fixture.rowCount)
+        let aggregates = await store.fetchDayAggregates(sinceDay: ReadWorkFixture.day, untilDay: ReadWorkFixture.day)
+        #expect(aggregates.count == keyCount)
+        #expect(aggregates.allSatisfy { $0.requestCount == Int64(256 / keyCount) })
+        #expect(aggregates.reduce(0) { $0 + $1.authoritativeCostNanos } == 256_000_000)
+
+        var unchanged = store.syncLoadCodexCache(calendar: fixture.calendar)
+        unchanged.lastScanUnixMs += 1000
+        recorder.reset()
+        #expect(!Self.save(unchanged, store: store, fixture: fixture).catchUpRequired)
+        #expect(recorder.snapshot().aggregateGroupingRowVisits == 0)
+
+        var other = fixture.canonical
+        other.codexProjectMetadataVersion = (other.codexProjectMetadataVersion ?? 0) + 1
+        #expect(!fixture.save(other).catchUpRequired)
+        #expect(recorder.snapshot().aggregateGroupingRowVisits == 0)
+    }
+
+    @Test
+    func `aggregate persistence preserves packed totals row pricing and key boundaries`() async throws {
+        let fixture = try ReadWorkFixture(fileCount: 2, rowsPerFile: 4)
+        defer { fixture.remove() }
+        let store = CostUsageStore(cacheRoot: fixture.env.root.appendingPathComponent("aggregate-parity"))
+        var cache = fixture.canonical
+        let day = ReadWorkFixture.day
+        let model = ReadWorkFixture.model
+        for path in cache.files.keys.sorted() {
+            var usage = try #require(cache.files[path])
+            usage.days = [day: [model: [101, 17, 23], "packed-only": [5]]]
+            usage.codexCostNanos = [day: ["cost-only": 11]]
+            usage.codexPrioritySurchargeNanos = [day: ["surcharge-only": 12]]
+            usage.codexStandardCostNanos = [day: ["standard-cost-only": 13]]
+            usage.codexPriorityCostNanos = [day: ["priority-cost-only": 14]]
+            usage.codexStandardTokens = [day: ["standard-tokens-only": 15]]
+            usage.codexPriorityTokens = [day: ["priority-tokens-only": 16]]
+            usage.codexRows = [
+                Self.row(event: 0, input: 10, cached: 2, output: 3, reasoning: 1, cost: 0),
+                Self.row(event: 1, input: 20, cached: 4, output: 5, cost: nil, mode: nil),
+                Self.row(event: 2, input: 30, cached: 6, output: 7, reasoning: 2, cost: 7, mode: "priority"),
+                Self.row(event: 3, input: 40, cached: 8, output: 9, reasoning: 3, cost: nil, mode: "priority"),
+                Self.row(
+                    day: "2026-08-02",
+                    model: model,
+                    event: 4,
+                    input: -3,
+                    cached: -2,
+                    output: 5,
+                    reasoning: 0,
+                    cost: nil,
+                    mode: "other"),
+            ]
+            cache.files[path] = usage
+        }
+        cache.days = [day: [model: [401, 41, 53], "global-only": [7, 2, 1]]]
+        #expect(!Self.save(cache, store: store, fixture: fixture).catchUpRequired)
+
+        var main = CostUsageStoreDayAggregate.zero(day: day, model: model)
+        main.inputTokens = 101
+        main.cachedTokens = 17
+        main.outputTokens = 23
+        main.reasoningTokens = 6
+        main.requestCount = 4
+        main.authoritativeCostNanos = 7
+        main.standardInputTokens = 20
+        main.standardCachedTokens = 4
+        main.standardOutputTokens = 5
+        main.priorityInputTokens = 40
+        main.priorityCachedTokens = 8
+        main.priorityOutputTokens = 9
+        main.standardTokens = 38
+        main.priorityTokens = 86
+        var packedOnly = CostUsageStoreDayAggregate.zero(day: day, model: "packed-only")
+        packedOnly.inputTokens = 5
+        var rowOnly = CostUsageStoreDayAggregate.zero(day: "2026-08-02", model: model)
+        rowOnly.requestCount = 1
+        rowOnly.standardInputTokens = -3
+        rowOnly.standardCachedTokens = -2
+        rowOnly.standardOutputTokens = 5
+        rowOnly.standardTokens = 5
+        let metadataOnly = [
+            "cost-only",
+            "surcharge-only",
+            "standard-cost-only",
+            "priority-cost-only",
+            "standard-tokens-only",
+            "priority-tokens-only",
+        ]
+            .map { CostUsageStoreDayAggregate.zero(day: day, model: $0) }
+        let expectedFiles = (metadataOnly + [main, packedOnly, rowOnly])
+            .sorted { ($0.day, $0.model) < ($1.day, $1.model) }
+
+        var global = main
+        global.inputTokens = 401
+        global.cachedTokens = 41
+        global.outputTokens = 53
+        global.reasoningTokens = 12
+        global.requestCount = 8
+        global.authoritativeCostNanos = 14
+        global.standardInputTokens = 40
+        global.standardCachedTokens = 8
+        global.standardOutputTokens = 10
+        global.priorityInputTokens = 80
+        global.priorityCachedTokens = 16
+        global.priorityOutputTokens = 18
+        global.standardTokens = 76
+        global.priorityTokens = 172
+        var globalOnly = CostUsageStoreDayAggregate.zero(day: day, model: "global-only")
+        globalOnly.inputTokens = 7
+        globalOnly.cachedTokens = 2
+        globalOnly.outputTokens = 1
+        let expectedGlobals = [global, globalOnly].sorted { ($0.day, $0.model) < ($1.day, $1.model) }
+
+        for metadataRefresh in [false, true] {
+            if metadataRefresh {
+                cache.codexProjectMetadataVersion = (cache.codexProjectMetadataVersion ?? 0) + 1
+                #expect(!Self.save(cache, store: store, fixture: fixture).catchUpRequired)
+            }
+            for path in cache.files.keys.sorted() {
+                #expect(await store.fetchFileDayAggregates(path: path) == expectedFiles)
+            }
+            #expect(await store.fetchDayAggregates(sinceDay: day, untilDay: "2026-08-02") == expectedGlobals)
+        }
+    }
+
+    private static func save(
+        _ cache: CostUsageCache,
+        store: CostUsageStore,
+        fixture: ReadWorkFixture) -> CostUsageStoreBudgetResult
+    {
+        store.syncSaveCodexCache(
+            cache,
+            calendar: fixture.calendar,
+            requestedScanWindow: (sinceKey: "2026-08-01", untilKey: "2026-08-02"),
+            skipIdenticalContent: true)
+    }
+
+    private static func row(
+        day: String = ReadWorkFixture.day,
+        model: String = ReadWorkFixture.model,
+        event: Int,
+        input: Int = 10,
+        cached: Int = 2,
+        output: Int = 3,
+        reasoning: Int? = nil,
+        cost: Int64? = 1_000_000,
+        mode: String? = "standard") -> CostUsageScanner.CodexUsageRow
+    {
+        .init(
+            day: day,
+            model: model,
+            turnID: "fixture-\(event)",
+            eventIndex: event,
+            input: input,
+            cached: cached,
+            output: output,
+            reasoning: reasoning,
+            knownCostNanos: cost,
+            pricingModel: model,
+            pricingMode: mode)
+    }
+}

--- a/Tests/CodexBarTests/CostUsageStoreReadWorkTests+Aggregates.swift
+++ b/Tests/CodexBarTests/CostUsageStoreReadWorkTests+Aggregates.swift
@@ -2,8 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
-@Suite(.serialized)
-struct CostUsageStoreAggregateWorkTests {
+extension CostUsageStoreReadWorkTests {
     @Test(arguments: [1, 32])
     func `aggregate grouping visits rows independently of key count`(keyCount: Int) async throws {
         let fixture = try ReadWorkFixture(fileCount: 2, rowsPerFile: 128)

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -198,6 +198,8 @@ Example:
     retain row-level pricing evidence and project/session details, but omit raw token snapshots, accumulator state,
     and replay bodies. File cursor metadata, including JSONL resume state, remains available for progress tracking.
     Scanner and save operations still load the complete state; fresh database opens retain integrity validation.
+  - Saved day/model aggregates group each file's usage rows in one pass per aggregate build. Packed token totals,
+    authoritative costs (including zero), and standard/priority estimation buckets retain their existing meanings.
 - Window: configurable 1-365 day rolling history, with a 60s minimum refresh interval.
 - Inline cost charts preserve a slot for every day in that window, using the selected cost-bucket time zone and the snapshot's date. Missing days are zero only after history coverage is established; unscanned days and entries without prices remain unknown. Long windows fit within the menu width without dropping dates.
 - While a bounded refresh catches up with new session history, established totals remain visible only for the same


### PR DESCRIPTION
## Summary

Build each file's saved Codex day/model aggregates with one pass over its usage rows, replacing a complete row filter for every key. The existing per-file and global builds remain separate; this removes repeated grouping work without changing transaction ownership or persistence behavior.

Preserve packed token totals, authoritative costs including zero, standard/priority estimation buckets, reasoning and request counts, all metadata-only file keys, global `cache.days` key filtering, and deterministic output ordering. Storage schema, cache versions, retention, refresh policy, pricing, and account boundaries are unchanged.

Add database-scoped opt-in row-visit diagnostics and persisted-value regression coverage. The fixed-row-count proof varies key cardinality; separate hand-calculated vectors cover multiple files, the same model on different days, known-zero versus missing costs, nil/other pricing modes, raw estimated buckets, packed totals distinct from row sums, metadata-only keys, and row-only/global-only keys. Unchanged saves do no grouping work, and other databases do not affect the recorder.

Changelog and Codex cache documentation updated. Investigated alongside #3247; this does **not** establish that the reporter's broader CPU/RSS incident is resolved, and that issue should remain open for affected-account confirmation. No code was extracted from the broader overlapping PRs.

## Verification

- Regression baseline retained the original grouping algorithm and instrumented actual loop visits: 256 rows required **1,024 visits at one key** and **16,896 at 32 keys**. Both failed the 512-visit bound while exact persisted-value assertions passed, including same-model/different-day separation.
- Before the test-ownership follow-up, `swift test --jobs 8 --no-parallel --filter 'CostUsageStoreAggregateWorkTests|CostUsageStoreReadWorkTests|CostUsageStoreScaleProofTests'`: **18 tests passed** in 35.046 seconds. Both key counts now require **512 visits** (one pass for each of the two existing aggregate builds). These are grouping-work counts, not an end-to-end runtime speedup claim.
- Addressed the review's parallel-local recorder ownership concern by placing the aggregate tests in an extension of the existing serialized `CostUsageStoreReadWorkTests` suite. Linux CI does not compile this macOS-only test target, but parallel local runs also deserve correct isolation. Final `swift test --skip-build --parallel --filter CostUsageStoreReadWorkTests`: **15 tests passed** in 7.383 seconds, including both new regression cases and all existing recorder tests.
- Broader follow-up runs exposed the unchanged 100 MiB blob-write scale test's 30-second timing limit, at 30.688 seconds in parallel and 41.860 seconds serialized. All recorder/aggregate tests passed in both runs; this blob-write path does not call aggregate construction. These failures are not counted as green, and no timing threshold has been weakened. The final full run passed that test on its first attempt (29.084-second write).
- `make check`: **passed**, strict lint found zero violations in 2,040 files.
- Independent test-contract inspection and Codex autoreview of the implementation and test-ownership follow-up: **no remaining actionable findings**.
- Final `make test` on `ca734812da47ac5734cc7940bc15b77d08c5ebf5`: **passed all 959 selections across 80 groups on the first attempt**, with zero retries and zero group timeouts; 1,421.5 seconds total. The local suite used the existing 600-second outer group watchdog; individual test deadlines were unchanged. Tests suppressed Keychain access and isolated Codex files; no real account/provider probe or app relaunch was involved.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33240395631): **passed** on `ca734812da47ac5734cc7940bc15b77d08c5ebf5`, including both macOS shards, Linux x64/ARM64 builds and tests, musl, lint, and the aggregate gate. GitGuardian also passed. No final-head CI rerun was needed. The earlier run was superseded by the test-ownership correction, not rerun to conceal a failure.
