### PR TITLE
docs: clarify automatic Codex cost refresh cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.1 — Unreleased
 
 ### Fixed
+- Docs: clarify the Codex app's automatic cost-history refresh floor separately from quota refreshes and the scanner debounce.
 - Codex: preserve calendar spacing in inline cost charts, keep unscanned and unpriced days unknown, honor the selected bucket time zone, and fit year-long histories within the menu (#3232). Thanks @findwangdi!
 - Claude: price the documented Kimi `k3[1m]` context alias in local usage reports, including freshly downloaded prices, without changing model names or mixing provider catalogs; refresh affected Pi costs while preserving native Codex caches (investigated alongside #2374). Thanks @joeVenner!
 - Localization: translate missing Catalan iCloud, spend, and Plugins sidebar labels, restore the Projects translation, and align command labels and instructions with their UI roles (#3245). Thanks @pmontp19!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.56.1 — Unreleased
 
 ### Fixed
-- Docs: clarify the Codex app's automatic cost-history refresh floor separately from quota refreshes and the scanner debounce.
+- Docs: clarify the Codex cost-history refresh floor and explain that Manual stops recurring refreshes, not startup or pending catch-up scans.
 - Codex: preserve calendar spacing in inline cost charts, keep unscanned and unpriced days unknown, honor the selected bucket time zone, and fit year-long histories within the menu (#3232). Thanks @findwangdi!
 - Claude: price the documented Kimi `k3[1m]` context alias in local usage reports, including freshly downloaded prices, without changing model names or mixing provider catalogs; refresh affected Pi costs while preserving native Codex caches (investigated alongside #2374). Thanks @joeVenner!
 - Localization: translate missing Catalan iCloud, spend, and Plugins sidebar labels, restore the Projects translation, and align command labels and instructions with their UI roles (#3245). Thanks @pmontp19!

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -201,9 +201,10 @@ Example:
   - Saved day/model aggregates group each file's usage rows in one pass per aggregate build. Packed token totals,
     authoritative costs (including zero), and standard/priority estimation buckets retain their existing meanings.
 - Window: configurable 1-365 day rolling history.
-- App cadence: automatic local-history scans have a 15-minute minimum (30 minutes in Low Power Mode); Manual disables
-  automatic scans. Faster provider refreshes still update quota/status. The scanner's default 60-second debounce is a
-  separate internal limit, bypassed by forced scans and catch-up passes; it is not the app's automatic refresh cadence.
+- App cadence: regular timer-driven local-history refreshes have a 15-minute minimum (30 minutes in Low Power Mode).
+  Manual disables the recurring refresh timer, not all scan activity: startup refreshes and pending Codex catch-up can
+  still scan local history. Faster provider refreshes still update quota/status. The scanner's default 60-second
+  debounce is a separate internal limit, bypassed by forced scans and catch-up passes; it is not the app's refresh cadence.
 - Inline cost charts preserve a slot for every day in that window, using the selected cost-bucket time zone and the snapshot's date. Missing days are zero only after history coverage is established; unscanned days and entries without prices remain unknown. Long windows fit within the menu width without dropping dates.
 - While a bounded refresh catches up with new session history, established totals remain visible only for the same
   account, history window, and bucket time zone. An incomplete first scan never borrows another account's totals.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -200,7 +200,10 @@ Example:
     Scanner and save operations still load the complete state; fresh database opens retain integrity validation.
   - Saved day/model aggregates group each file's usage rows in one pass per aggregate build. Packed token totals,
     authoritative costs (including zero), and standard/priority estimation buckets retain their existing meanings.
-- Window: configurable 1-365 day rolling history, with a 60s minimum refresh interval.
+- Window: configurable 1-365 day rolling history.
+- App cadence: automatic local-history scans have a 15-minute minimum (30 minutes in Low Power Mode); Manual disables
+  automatic scans. Faster provider refreshes still update quota/status. The scanner's default 60-second debounce is a
+  separate internal limit, bypassed by forced scans and catch-up passes; it is not the app's automatic refresh cadence.
 - Inline cost charts preserve a slot for every day in that window, using the selected cost-bucket time zone and the snapshot's date. Missing days are zero only after history coverage is established; unscanned days and entries without prices remain unknown. Long windows fit within the menu width without dropping dates.
 - While a bounded refresh catches up with new session history, established totals remain visible only for the same
   account, history window, and bucket time zone. An incomplete first scan never borrows another account's totals.

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -12,9 +12,10 @@ read_when:
 - `WidgetSnapshotStore` writes compact JSON snapshots to the app-group container.
 - Widgets read the snapshot and render usage/credits/history states.
 - The app writes snapshots after the main refresh pipeline and token-usage refreshes; narrow single-provider refresh paths may wait for the next snapshot write.
-- Automatic provider refresh is the sole periodic trigger for token/cost refreshes; the token/cost TTL only determines
-  eligibility when that refresh runs. Automatic local-history scans have a 15-minute minimum (30 minutes in low-power
-  mode), while Manual disables automatic scans. The floor limits repeated local-history work and extra WidgetKit reload
+- Scheduled provider refreshes trigger regular token/cost refreshes; the token/cost TTL determines eligibility when
+  that refresh runs. Timer-driven local-history refreshes have a 15-minute minimum (30 minutes in low-power mode).
+  Manual disables the recurring refresh timer, not all scan activity: startup refreshes and pending Codex catch-up can
+  still scan local history. The floor limits repeated local-history work and extra WidgetKit reload
   requests without changing provider usage/status freshness or the user-selected provider refresh cadence.
 - Claude local cost/token history remains eligible for widget snapshots when its account does not expose numeric
   session or weekly quota data.


### PR DESCRIPTION
## Summary

Clarify the existing Codex cost-history cadence in the provider and widget documentation: regular timer-driven local-history refreshes have a 15-minute floor, or 30 minutes in Low Power Mode, while faster quota/status refreshes remain independent. The scanner's separate default 60-second debounce can be bypassed by forced scans and catch-up and should not be presented as the app's cadence.

Address the review's Manual-mode correction on both pages: Manual disables the recurring refresh timer, not all scan activity. The independent startup refresh and pending Codex catch-up can still scan local history. This documents existing behavior; it does not change scheduling policy.

Documentation and changelog only. This clarifies the timing discussed in #3243; it does not fix or close that issue's separate growing-file publication starvation.

## Verification

- Source-checked against `UsageStore.tokenFetchTTL`, `BackgroundWorkPowerPolicy.automaticInterval`, `CostUsageScanner.Options.refreshMinIntervalSeconds`, and the fetcher's forced/catch-up overrides. Manual/startup behavior was additionally traced through `UsageStore` initialization, `startTimer`, `scheduleTokenRefresh`, cached hydration, and catch-up startup.
- Final `swift test --skip-build --no-parallel --filter 'UsageStoreTokenRefreshCadenceTests|UsageStoreCodexCostCatchUpTests|UsageStoreCachedTokenHydrationTests'`: 22 tests passed in 7.016 seconds, covering cadence, catch-up, and cache hydration. The Manual wording is additionally verified by the startup/timer source trace above; the nil-TTL test alone does not prove that all automatic scans stop.
- Codex autoreview: clean. `git diff --check`: passed.
- Runtime sources, tests, scripts, and package files are byte-identical to the verified #3264 candidate. Its immediately preceding full `make test` passed all 959 selections in 80 groups with no retries or timeouts, and [its exact-head CI passed](https://github.com/steipete/CodexBar/actions/runs/33240395631). The full runtime suite is not rerun for these documentation-only changes.
- `make check`: passed, including strict lint with zero violations in 2,040 files. [Final exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33242192663) passed on `9b2c29a9e2761d545194a63080d68c84439d7956`: Linux x64/ARM64 builds and tests, lint, and aggregate gate; GitGuardian also passed. Existing docs-only path gates intentionally skipped macOS and musl. Tests suppress Keychain access and isolate Codex files; no real provider probe or app relaunch was used.
