### PR TITLE
fix(antigravity): recover newer session history safely

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -101,9 +101,9 @@ extension AntigravityLocalReader {
             if let failure = progress.failure { throw failure }
             return SourceResult(isComplete: false)
         }
-        let tables = try self.supportedSQLiteTables(database, budget: budget)
+        let supported = try self.hasSupportedSQLiteTable(database, budget: budget)
         if let failure = progress.failure { throw failure }
-        guard tables.hasGenMetadata else { return SourceResult(isComplete: false) }
+        guard supported else { return SourceResult(isComplete: false) }
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -121,28 +121,33 @@ extension AntigravityLocalReader {
         sqlite3_bind_int64(activeStatement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
         let session = url.deletingPathExtension().lastPathComponent
         var rows = try self.readRows(activeStatement, session: session, progress: progress)
-        if tables.hasSteps, !rows.pendingTimestampRows.isEmpty {
+        if !rows.pendingTimestampRows.isEmpty {
             // Release the gen_metadata cursor before the optional steps pass reuses the same snapshot.
             sqlite3_finalize(activeStatement)
             statement = nil
-            var neededStepUUIDCounts: [String: Int] = [:]
-            for pending in rows.pendingTimestampRows {
-                neededStepUUIDCounts[pending.stepUUID, default: 0] += 1
-            }
-            let stepTimestamps = try self.readStepTimestamps(
-                database,
-                neededStepUUIDCounts: neededStepUUIDCounts,
-                progress: progress)
-            let recoveredCount = self.appendRecoveredEvents(
-                to: &rows.source,
-                session: session,
-                pendingRows: rows.pendingTimestampRows,
-                stepTimestamps: stepTimestamps)
-            if recoveredCount < rows.pendingTimestampRows.count {
+            let hasSteps = try self.hasSupportedStepsTable(database, budget: budget)
+            if let failure = progress.failure { throw failure }
+            if hasSteps {
+                var neededStepUUIDCounts: [String: Int] = [:]
+                for stepUUID in Set(rows.pendingTimestampRows.map(\.stepUUID)) {
+                    neededStepUUIDCounts[stepUUID] = rows.stepOccurrenceRows[stepUUID]?.count ?? 0
+                }
+                let stepScan = try self.readStepTimestamps(
+                    database,
+                    neededStepUUIDCounts: neededStepUUIDCounts,
+                    progress: progress)
+                let recoveredCount = self.appendRecoveredEvents(
+                    to: &rows.source,
+                    session: session,
+                    pendingRows: rows.pendingTimestampRows,
+                    stepTimestamps: stepScan.timestamps,
+                    stepOccurrenceRows: rows.stepOccurrenceRows)
+                if !stepScan.isComplete || recoveredCount < rows.pendingTimestampRows.count {
+                    rows.source.isComplete = false
+                }
+            } else {
                 rows.source.isComplete = false
             }
-        } else if !rows.pendingTimestampRows.isEmpty {
-            rows.source.isComplete = false
         }
         return rows.source
         #else
@@ -160,37 +165,46 @@ extension AntigravityLocalReader {
     private struct ParsedRows {
         var source: SourceResult
         var pendingTimestampRows: [PendingTimestampRow]
+        var stepOccurrenceRows: [String: [Int64]]
+    }
+
+    private struct StepTimestamp {
+        let row: Int64
+        let timestampMs: Int64?
+    }
+
+    private struct StepTimestampScan {
+        let timestamps: [String: [Int64]]
+        let isComplete: Bool
     }
 
     private final class StepScanProgress {
-        let budget: Budget
-        let rowLimit: Int
-        let byteLimit: Int
-        var rows = 0
-        var bytes = 0
+        let progress: SQLProgress
 
         var payloadLimit: Int {
-            guard self.rows < self.rowLimit else { return 0 }
+            let budget = self.progress.budget
+            guard budget.statistics.rows < budget.limits.rows,
+                  self.progress.databaseBytes < budget.limits.databaseBytes,
+                  budget.statistics.attemptedBytes < budget.limits.bytes
+            else { return 0 }
             return min(
-                self.budget.limits.blobBytes,
-                self.byteLimit - self.bytes,
-                self.budget.limits.bytes - self.budget.statistics.attemptedBytes)
+                budget.limits.blobBytes,
+                budget.limits.databaseBytes - self.progress.databaseBytes,
+                budget.limits.bytes - budget.statistics.attemptedBytes)
         }
 
-        init(budget: Budget) {
-            self.budget = budget
-            self.rowLimit = min(budget.limits.rowsPerDatabase, 10000)
-            self.byteLimit = budget.limits.databaseBytes
+        init(progress: SQLProgress) {
+            self.progress = progress
         }
     }
 
     private static func readStepTimestamps(
         _ database: OpaquePointer,
         neededStepUUIDCounts: [String: Int],
-        progress: SQLProgress) throws -> [String: [Int64]]
+        progress: SQLProgress) throws -> StepTimestampScan
     {
-        guard !neededStepUUIDCounts.isEmpty else { return [:] }
-        let stepProgress = StepScanProgress(budget: progress.budget)
+        guard !neededStepUUIDCounts.isEmpty else { return StepTimestampScan(timestamps: [:], isComplete: true) }
+        let stepProgress = StepScanProgress(progress: progress)
         let registered = sqlite3_create_function_v2(
             database,
             "antigravity_step_payload_limit",
@@ -205,7 +219,7 @@ extension AntigravityLocalReader {
             nil,
             nil,
             nil)
-        guard registered == SQLITE_OK else { return [:] }
+        guard registered == SQLITE_OK else { return StepTimestampScan(timestamps: [:], isComplete: false) }
         var statement: OpaquePointer?
         defer {
             withExtendedLifetime(stepProgress) {
@@ -226,46 +240,77 @@ extension AntigravityLocalReader {
         SELECT idx, CASE WHEN typeof(metadata) = 'blob' THEN length(metadata) END,
             CASE WHEN typeof(metadata) = 'blob'
                 AND length(metadata) <= antigravity_step_payload_limit() THEN metadata END
-        FROM main.steps NOT INDEXED WHERE metadata IS NOT NULL LIMIT ?
+        FROM main.steps NOT INDEXED WHERE metadata IS NOT NULL
         """
         let prepared = sqlite3_prepare_v2(database, query, -1, &statement, nil)
         if let failure = progress.failure { throw failure }
-        guard prepared == SQLITE_OK, let statement else { return [:] }
-        sqlite3_bind_int64(statement, 1, Int64(stepProgress.rowLimit + 1))
-        var stepTimestamps: [String: [Int64]] = [:]
+        guard prepared == SQLITE_OK, let statement else {
+            return StepTimestampScan(timestamps: [:], isComplete: false)
+        }
+        var stepTimestamps: [String: [StepTimestamp]] = [:]
+        var isComplete = false
+        var rowsAreValid = true
         while true {
             try progress.budget.check()
             let step = sqlite3_step(statement)
             if let failure = progress.failure { throw failure }
-            if step == SQLITE_DONE { break }
+            if step == SQLITE_DONE {
+                isComplete = true
+                break
+            }
             guard step == SQLITE_ROW else { break }
             let payload = SQLitePayload(statement: statement)
             progress.budget.statistics.materializedPayloadBytes += payload.byteCount
-            stepProgress.rows += 1
-            // The optional pass keeps its own per-database ceilings, but every row it touches still
-            // belongs to the job-wide budget: charge it before the step limits get a chance to stop.
+            // Every secondary row belongs to the job-wide budget; the separate byte ceiling only
+            // prevents one database's step metadata from consuming the whole job allocation.
             try progress.budget.chargeRow()
             let count = Int(sqlite3_column_int64(statement, 1))
             let attemptedBytes = max(count, payload.byteCount)
             try progress.budget.chargeBytes(attemptedBytes)
-            guard stepProgress.rows <= stepProgress.rowLimit,
-                  attemptedBytes <= stepProgress.byteLimit - stepProgress.bytes
+            guard attemptedBytes <= progress.budget.limits.databaseBytes - progress.databaseBytes
             else { break }
-            stepProgress.bytes += attemptedBytes
+            progress.databaseBytes += attemptedBytes
             guard count > 0, count <= progress.budget.limits.blobBytes,
+                  sqlite3_column_type(statement, 0) == SQLITE_INTEGER,
+                  sqlite3_column_int64(statement, 0) >= 0,
                   let bytes = payload.copy(declaredCount: count, limit: progress.budget.limits.blobBytes)
-            else { continue }
-            if let (stepUUID, timestampMs) = try AntigravityProtoReader.parseStepMetadata(
-                bytes, checkCancellation: progress.budget.check),
-                let stepUUID, neededStepUUIDCounts[stepUUID] != nil, let timestampMs
+            else {
+                rowsAreValid = false
+                continue
+            }
+            guard let parsed = try AntigravityProtoReader.parseStepMetadata(
+                bytes, checkCancellation: progress.budget.check)
+            else {
+                rowsAreValid = false
+                continue
+            }
+            if let stepUUID = parsed.stepUUID, neededStepUUIDCounts[stepUUID] != nil
             {
-                stepTimestamps[stepUUID, default: []].append(timestampMs)
-                if neededStepUUIDCounts.allSatisfy({ (stepTimestamps[$0.key]?.count ?? 0) >= $0.value }) {
-                    break
-                }
+                stepTimestamps[stepUUID, default: []].append(StepTimestamp(
+                    row: sqlite3_column_int64(statement, 0),
+                    timestampMs: parsed.timestampMs))
             }
         }
-        return stepTimestamps
+        var resolved: [String: [Int64]] = [:]
+        for (stepUUID, timestamps) in stepTimestamps {
+            guard let neededCount = neededStepUUIDCounts[stepUUID] else { continue }
+            let sorted = timestamps.sorted { $0.row < $1.row }
+            // The defensive schema does not require idx to be a key. Conflicting duplicate indices
+            // cannot be ordered safely, so withhold that UUID instead of publishing a false date.
+            guard !zip(sorted, sorted.dropFirst()).contains(where: { pair in pair.0.row == pair.1.row }) else {
+                continue
+            }
+            let orderedTimestamps = sorted.map(\.timestampMs)
+            if orderedTimestamps.count == 1, let sharedTimestamp = orderedTimestamps[0] {
+                resolved[stepUUID] = Array(repeating: sharedTimestamp, count: neededCount)
+                continue
+            }
+            guard orderedTimestamps.count >= neededCount else { continue }
+            let selected = orderedTimestamps.prefix(neededCount)
+            guard selected.allSatisfy({ $0 != nil }) else { continue }
+            resolved[stepUUID] = selected.compactMap(\.self)
+        }
+        return StepTimestampScan(timestamps: resolved, isComplete: isComplete && rowsAreValid)
     }
 
     private static func readRows(
@@ -276,6 +321,7 @@ extension AntigravityLocalReader {
         let budget = progress.budget
         var result = SourceResult()
         var pendingTimestampRows: [PendingTimestampRow] = []
+        var stepOccurrenceRows: [String: [Int64]] = [:]
         while true {
             try budget.check()
             let step = sqlite3_step(statement)
@@ -319,6 +365,9 @@ extension AntigravityLocalReader {
                 result.isComplete = false
                 continue
             }
+            if let stepUUID = turn.stepUUID {
+                stepOccurrenceRows[stepUUID, default: []].append(row)
+            }
             if turn.timestampMs == nil, let stepUUID = turn.stepUUID {
                 pendingTimestampRows.append(PendingTimestampRow(row: row, stepUUID: stepUUID, turn: turn))
                 continue
@@ -329,24 +378,36 @@ extension AntigravityLocalReader {
             }
             result.events.append(event)
         }
-        return ParsedRows(source: result, pendingTimestampRows: pendingTimestampRows)
+        return ParsedRows(
+            source: result,
+            pendingTimestampRows: pendingTimestampRows,
+            stepOccurrenceRows: stepOccurrenceRows)
     }
 
     private static func appendRecoveredEvents(
         to source: inout SourceResult,
         session: String,
         pendingRows: [PendingTimestampRow],
-        stepTimestamps: [String: [Int64]]) -> Int
+        stepTimestamps: [String: [Int64]],
+        stepOccurrenceRows: [String: [Int64]]) -> Int
     {
-        var offsets: [String: Int] = [:]
+        var occurrenceOffsets: [String: [Int64: Int]] = [:]
+        for (stepUUID, rows) in stepOccurrenceRows {
+            let sorted = rows.sorted()
+            guard Set(sorted).count == sorted.count else { continue }
+            occurrenceOffsets[stepUUID] = Dictionary(
+                uniqueKeysWithValues: sorted.enumerated().map { ($0.element, $0.offset) })
+        }
         var recoveredCount = 0
-        for pending in pendingRows {
-            guard let timestamps = stepTimestamps[pending.stepUUID], !timestamps.isEmpty else { continue }
-            let offset = offsets[pending.stepUUID, default: 0]
-            offsets[pending.stepUUID] = offset + 1
+        for pending in pendingRows.sorted(by: { $0.row < $1.row }) {
+            guard let timestamps = stepTimestamps[pending.stepUUID],
+                  let offset = occurrenceOffsets[pending.stepUUID]?[pending.row]
+            else {
+                continue
+            }
+            guard timestamps.indices.contains(offset) else { continue }
             var turn = pending.turn
-            turn.timestampMs = timestamps.indices
-                .contains(offset) ? timestamps[offset] : timestamps[timestamps.count - 1]
+            turn.timestampMs = timestamps[offset]
             if let event = Event(session: session, row: pending.row, turn: turn, cacheWrite: 0) {
                 source.events.append(event)
                 recoveredCount += 1

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -445,6 +445,7 @@ extension AntigravityLocalReader {
                 recoveredCount += 1
             }
         }
+        source.events.sort { $0.row < $1.row }
         return recoveredCount
     }
     #endif

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -284,8 +284,7 @@ extension AntigravityLocalReader {
                 rowsAreValid = false
                 continue
             }
-            if let stepUUID = parsed.stepUUID, neededStepUUIDCounts[stepUUID] != nil
-            {
+            if let stepUUID = parsed.stepUUID, neededStepUUIDCounts[stepUUID] != nil {
                 stepTimestamps[stepUUID, default: []].append(StepTimestamp(
                     row: sqlite3_column_int64(statement, 0),
                     timestampMs: parsed.timestampMs))

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -309,7 +309,11 @@ extension AntigravityLocalReader {
                 rowsAreValid = false
                 continue
             }
-            if let stepUUID = parsed.stepUUID, neededStepUUIDCounts[stepUUID] != nil {
+            guard let stepUUID = parsed.stepUUID, !stepUUID.isEmpty else {
+                rowsAreValid = false
+                continue
+            }
+            if neededStepUUIDCounts[stepUUID] != nil {
                 stepTimestamps[stepUUID, default: []].append(StepTimestamp(
                     row: sqlite3_column_int64(statement, 0),
                     timestampMs: parsed.timestampMs))

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -55,13 +55,19 @@ extension AntigravityLocalReader {
         #if canImport(SQLite3) || canImport(CSQLite3)
         var database: OpaquePointer?
         let opened = sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READONLY, nil)
-        if database != nil { budget.statistics.sqliteHandlesOpened += 1 }
+        if database != nil {
+            budget.statistics.sqliteHandlesOpened += 1
+        }
         guard opened == SQLITE_OK, let database else {
-            if let database, sqlite3_close(database) == SQLITE_OK { budget.statistics.sqliteHandlesClosed += 1 }
+            if let database, sqlite3_close(database) == SQLITE_OK {
+                budget.statistics.sqliteHandlesClosed += 1
+            }
             return SourceResult(isComplete: false)
         }
         defer {
-            if sqlite3_close(database) == SQLITE_OK { budget.statistics.sqliteHandlesClosed += 1 }
+            if sqlite3_close(database) == SQLITE_OK {
+                budget.statistics.sqliteHandlesClosed += 1
+            }
         }
         let progress = SQLProgress(budget: budget)
         // Also bound SQLite's own intermediate values, before step can materialize a hostile record/view.
@@ -98,11 +104,15 @@ extension AntigravityLocalReader {
         }
         // Ordinary read-only SQLite permits WAL read-mark coordination; it does not promise unchanged SHM bytes.
         guard sqlite3_exec(database, "BEGIN DEFERRED", nil, nil, nil) == SQLITE_OK else {
-            if let failure = progress.failure { throw failure }
+            if let failure = progress.failure {
+                throw failure
+            }
             return SourceResult(isComplete: false)
         }
         let supported = try self.hasSupportedSQLiteTable(database, budget: budget)
-        if let failure = progress.failure { throw failure }
+        if let failure = progress.failure {
+            throw failure
+        }
         guard supported else { return SourceResult(isComplete: false) }
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
         var statement: OpaquePointer?
@@ -116,17 +126,24 @@ extension AntigravityLocalReader {
         FROM main.gen_metadata NOT INDEXED LIMIT ?
         """
         let prepared = sqlite3_prepare_v2(database, query, -1, &statement, nil)
-        if let failure = progress.failure { throw failure }
+        if let failure = progress.failure {
+            throw failure
+        }
         guard prepared == SQLITE_OK, let activeStatement = statement else { return SourceResult(isComplete: false) }
         sqlite3_bind_int64(activeStatement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
         let session = url.deletingPathExtension().lastPathComponent
         var rows = try self.readRows(activeStatement, session: session, progress: progress)
         if !rows.pendingTimestampRows.isEmpty {
+            // Positional recovery is safe only when every generation row participated in the occurrence list.
+            // A malformed row can still carry a reused step UUID, so partial primary scans must not realign later rows.
+            guard rows.source.isComplete else { return rows.source }
             // Release the gen_metadata cursor before the optional steps pass reuses the same snapshot.
             sqlite3_finalize(activeStatement)
             statement = nil
             let hasSteps = try self.hasSupportedStepsTable(database, budget: budget)
-            if let failure = progress.failure { throw failure }
+            if let failure = progress.failure {
+                throw failure
+            }
             if hasSteps {
                 var neededStepUUIDCounts: [String: Int] = [:]
                 for stepUUID in Set(rows.pendingTimestampRows.map(\.stepUUID)) {
@@ -136,13 +153,17 @@ extension AntigravityLocalReader {
                     database,
                     neededStepUUIDCounts: neededStepUUIDCounts,
                     progress: progress)
+                guard stepScan.isComplete else {
+                    rows.source.isComplete = false
+                    return rows.source
+                }
                 let recoveredCount = self.appendRecoveredEvents(
                     to: &rows.source,
                     session: session,
                     pendingRows: rows.pendingTimestampRows,
                     stepTimestamps: stepScan.timestamps,
                     stepOccurrenceRows: rows.stepOccurrenceRows)
-                if !stepScan.isComplete || recoveredCount < rows.pendingTimestampRows.count {
+                if recoveredCount < rows.pendingTimestampRows.count {
                     rows.source.isComplete = false
                 }
             } else {
@@ -243,7 +264,9 @@ extension AntigravityLocalReader {
         FROM main.steps NOT INDEXED WHERE metadata IS NOT NULL
         """
         let prepared = sqlite3_prepare_v2(database, query, -1, &statement, nil)
-        if let failure = progress.failure { throw failure }
+        if let failure = progress.failure {
+            throw failure
+        }
         guard prepared == SQLITE_OK, let statement else {
             return StepTimestampScan(timestamps: [:], isComplete: false)
         }
@@ -253,7 +276,9 @@ extension AntigravityLocalReader {
         while true {
             try progress.budget.check()
             let step = sqlite3_step(statement)
-            if let failure = progress.failure { throw failure }
+            if let failure = progress.failure {
+                throw failure
+            }
             if step == SQLITE_DONE {
                 isComplete = true
                 break
@@ -324,8 +349,12 @@ extension AntigravityLocalReader {
         while true {
             try budget.check()
             let step = sqlite3_step(statement)
-            if let failure = progress.failure { throw failure }
-            if step == SQLITE_DONE { break }
+            if let failure = progress.failure {
+                throw failure
+            }
+            if step == SQLITE_DONE {
+                break
+            }
             guard step == SQLITE_ROW else {
                 result.isComplete = false
                 break

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -101,9 +101,9 @@ extension AntigravityLocalReader {
             if let failure = progress.failure { throw failure }
             return SourceResult(isComplete: false)
         }
-        let supported = try self.hasSupportedSQLiteTable(database, budget: budget)
+        let tables = try self.supportedSQLiteTables(database, budget: budget)
         if let failure = progress.failure { throw failure }
-        guard supported else { return SourceResult(isComplete: false) }
+        guard tables.hasGenMetadata else { return SourceResult(isComplete: false) }
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -117,23 +117,160 @@ extension AntigravityLocalReader {
         """
         let prepared = sqlite3_prepare_v2(database, query, -1, &statement, nil)
         if let failure = progress.failure { throw failure }
-        guard prepared == SQLITE_OK, let statement else { return SourceResult(isComplete: false) }
-        sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
-        return try self.readRows(
-            statement, session: url.deletingPathExtension().lastPathComponent, progress: progress)
+        guard prepared == SQLITE_OK, let activeStatement = statement else { return SourceResult(isComplete: false) }
+        sqlite3_bind_int64(activeStatement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
+        let session = url.deletingPathExtension().lastPathComponent
+        var rows = try self.readRows(activeStatement, session: session, progress: progress)
+        if tables.hasSteps, !rows.pendingTimestampRows.isEmpty {
+            // Release the gen_metadata cursor before the optional steps pass reuses the same snapshot.
+            sqlite3_finalize(activeStatement)
+            statement = nil
+            let neededStepUUIDs = Set(rows.pendingTimestampRows.map(\.stepUUID))
+            let stepTimestamps = try self.readStepTimestamps(
+                database,
+                neededStepUUIDs: neededStepUUIDs,
+                progress: progress)
+            let recoveredCount = self.appendRecoveredEvents(
+                to: &rows.source,
+                session: session,
+                pendingRows: rows.pendingTimestampRows,
+                stepTimestamps: stepTimestamps)
+            if recoveredCount < rows.pendingTimestampRows.count {
+                rows.source.isComplete = false
+            }
+        } else if !rows.pendingTimestampRows.isEmpty {
+            rows.source.isComplete = false
+        }
+        return rows.source
         #else
         return SourceResult(isComplete: false)
         #endif
     }
 
     #if canImport(SQLite3) || canImport(CSQLite3)
+    private struct PendingTimestampRow {
+        let row: Int64
+        let stepUUID: String
+        let turn: AntigravityProtoReader.ParsedTurn
+    }
+
+    private struct ParsedRows {
+        var source: SourceResult
+        var pendingTimestampRows: [PendingTimestampRow]
+    }
+
+    private final class StepScanProgress {
+        let budget: Budget
+        let rowLimit: Int
+        let byteLimit: Int
+        var rows = 0
+        var bytes = 0
+
+        var payloadLimit: Int {
+            guard self.rows < self.rowLimit else { return 0 }
+            return min(
+                self.budget.limits.blobBytes,
+                self.byteLimit - self.bytes,
+                self.budget.limits.bytes - self.budget.statistics.attemptedBytes)
+        }
+
+        init(budget: Budget, neededStepUUIDCount: Int) {
+            self.budget = budget
+            self.rowLimit = min(budget.limits.rowsPerDatabase, max(neededStepUUIDCount * 32, 256), 10000)
+            self.byteLimit = min(
+                budget.limits.databaseBytes,
+                max(budget.limits.blobBytes, neededStepUUIDCount * 64 * 1024))
+        }
+    }
+
+    private static func readStepTimestamps(
+        _ database: OpaquePointer,
+        neededStepUUIDs: Set<String>,
+        progress: SQLProgress) throws -> [String: [Int64]]
+    {
+        guard !neededStepUUIDs.isEmpty else { return [:] }
+        let stepProgress = StepScanProgress(budget: progress.budget, neededStepUUIDCount: neededStepUUIDs.count)
+        let registered = sqlite3_create_function_v2(
+            database,
+            "antigravity_step_payload_limit",
+            0,
+            SQLITE_UTF8,
+            Unmanaged.passUnretained(stepProgress).toOpaque(),
+            { context, _, _ in
+                guard let context, let pointer = sqlite3_user_data(context) else { return }
+                let progress = Unmanaged<StepScanProgress>.fromOpaque(pointer).takeUnretainedValue()
+                sqlite3_result_int64(context, Int64(progress.payloadLimit))
+            },
+            nil,
+            nil,
+            nil)
+        guard registered == SQLITE_OK else { return [:] }
+        var statement: OpaquePointer?
+        defer {
+            withExtendedLifetime(stepProgress) {
+                sqlite3_finalize(statement)
+                sqlite3_create_function_v2(
+                    database,
+                    "antigravity_step_payload_limit",
+                    0,
+                    SQLITE_UTF8,
+                    nil,
+                    nil,
+                    nil,
+                    nil,
+                    nil)
+            }
+        }
+        let query = """
+        SELECT idx, CASE WHEN typeof(metadata) = 'blob' THEN length(metadata) END,
+            CASE WHEN typeof(metadata) = 'blob'
+                AND length(metadata) <= antigravity_step_payload_limit() THEN metadata END
+        FROM main.steps NOT INDEXED WHERE metadata IS NOT NULL LIMIT ?
+        """
+        let prepared = sqlite3_prepare_v2(database, query, -1, &statement, nil)
+        if let failure = progress.failure { throw failure }
+        guard prepared == SQLITE_OK, let statement else { return [:] }
+        sqlite3_bind_int64(statement, 1, Int64(stepProgress.rowLimit + 1))
+        var stepTimestamps: [String: [Int64]] = [:]
+        while true {
+            try progress.budget.check()
+            let step = sqlite3_step(statement)
+            if let failure = progress.failure { throw failure }
+            if step == SQLITE_DONE { break }
+            guard step == SQLITE_ROW else { break }
+            let payload = SQLitePayload(statement: statement)
+            progress.budget.statistics.materializedPayloadBytes += payload.byteCount
+            stepProgress.rows += 1
+            let count = Int(sqlite3_column_int64(statement, 1))
+            let attemptedBytes = max(count, payload.byteCount)
+            guard stepProgress.rows <= stepProgress.rowLimit,
+                  attemptedBytes <= stepProgress.byteLimit - stepProgress.bytes
+            else { break }
+            stepProgress.bytes += attemptedBytes
+            guard count > 0, count <= progress.budget.limits.blobBytes,
+                  let bytes = payload.copy(declaredCount: count, limit: progress.budget.limits.blobBytes)
+            else { continue }
+            if let (stepUUID, timestampMs) = try AntigravityProtoReader.parseStepMetadata(
+                bytes, checkCancellation: progress.budget.check),
+                let stepUUID, neededStepUUIDs.contains(stepUUID), let timestampMs
+            {
+                stepTimestamps[stepUUID, default: []].append(timestampMs)
+                if stepTimestamps.values.reduce(0, { $0 + $1.count }) >= stepProgress.rowLimit {
+                    break
+                }
+            }
+        }
+        return stepTimestamps
+    }
+
     private static func readRows(
         _ statement: OpaquePointer,
         session: String,
-        progress: SQLProgress) throws -> SourceResult
+        progress: SQLProgress) throws -> ParsedRows
     {
         let budget = progress.budget
         var result = SourceResult()
+        var pendingTimestampRows: [PendingTimestampRow] = []
         while true {
             try budget.check()
             let step = sqlite3_step(statement)
@@ -173,16 +310,45 @@ extension AntigravityLocalReader {
                 continue
             }
             // Validate exactly once while the single SQL snapshot is held; buffer only typed events.
-            guard let turn = try AntigravityProtoReader.parseTurn(bytes, checkCancellation: budget.check),
-                  let event = Event(
-                      session: session, row: row, turn: turn, cacheWrite: 0)
-            else {
+            guard let turn = try AntigravityProtoReader.parseTurn(bytes, checkCancellation: budget.check) else {
+                result.isComplete = false
+                continue
+            }
+            if turn.timestampMs == nil, let stepUUID = turn.stepUUID {
+                pendingTimestampRows.append(PendingTimestampRow(row: row, stepUUID: stepUUID, turn: turn))
+                continue
+            }
+            guard let event = Event(session: session, row: row, turn: turn, cacheWrite: 0) else {
                 result.isComplete = false
                 continue
             }
             result.events.append(event)
         }
-        return result
+        return ParsedRows(source: result, pendingTimestampRows: pendingTimestampRows)
+    }
+
+    private static func appendRecoveredEvents(
+        to source: inout SourceResult,
+        session: String,
+        pendingRows: [PendingTimestampRow],
+        stepTimestamps: [String: [Int64]]) -> Int
+    {
+        var offsets: [String: Int] = [:]
+        var recoveredCount = 0
+        for pending in pendingRows {
+            let offset = offsets[pending.stepUUID, default: 0]
+            guard let timestamps = stepTimestamps[pending.stepUUID],
+                  timestamps.indices.contains(offset)
+            else { continue }
+            offsets[pending.stepUUID] = offset + 1
+            var turn = pending.turn
+            turn.timestampMs = timestamps[offset]
+            if let event = Event(session: session, row: pending.row, turn: turn, cacheWrite: 0) {
+                source.events.append(event)
+                recoveredCount += 1
+            }
+        }
+        return recoveredCount
     }
     #endif
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -241,8 +241,12 @@ extension AntigravityLocalReader {
             let payload = SQLitePayload(statement: statement)
             progress.budget.statistics.materializedPayloadBytes += payload.byteCount
             stepProgress.rows += 1
+            // The optional pass keeps its own per-database ceilings, but every row it touches still
+            // belongs to the job-wide budget: charge it before the step limits get a chance to stop.
+            try progress.budget.chargeRow()
             let count = Int(sqlite3_column_int64(statement, 1))
             let attemptedBytes = max(count, payload.byteCount)
+            try progress.budget.chargeBytes(attemptedBytes)
             guard stepProgress.rows <= stepProgress.rowLimit,
                   attemptedBytes <= stepProgress.byteLimit - stepProgress.bytes
             else { break }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -125,10 +125,13 @@ extension AntigravityLocalReader {
             // Release the gen_metadata cursor before the optional steps pass reuses the same snapshot.
             sqlite3_finalize(activeStatement)
             statement = nil
-            let neededStepUUIDs = Set(rows.pendingTimestampRows.map(\.stepUUID))
+            var neededStepUUIDCounts: [String: Int] = [:]
+            for pending in rows.pendingTimestampRows {
+                neededStepUUIDCounts[pending.stepUUID, default: 0] += 1
+            }
             let stepTimestamps = try self.readStepTimestamps(
                 database,
-                neededStepUUIDs: neededStepUUIDs,
+                neededStepUUIDCounts: neededStepUUIDCounts,
                 progress: progress)
             let recoveredCount = self.appendRecoveredEvents(
                 to: &rows.source,
@@ -174,22 +177,20 @@ extension AntigravityLocalReader {
                 self.budget.limits.bytes - self.budget.statistics.attemptedBytes)
         }
 
-        init(budget: Budget, neededStepUUIDCount: Int) {
+        init(budget: Budget) {
             self.budget = budget
-            self.rowLimit = min(budget.limits.rowsPerDatabase, max(neededStepUUIDCount * 32, 256), 10000)
-            self.byteLimit = min(
-                budget.limits.databaseBytes,
-                max(budget.limits.blobBytes, neededStepUUIDCount * 64 * 1024))
+            self.rowLimit = min(budget.limits.rowsPerDatabase, 10000)
+            self.byteLimit = budget.limits.databaseBytes
         }
     }
 
     private static func readStepTimestamps(
         _ database: OpaquePointer,
-        neededStepUUIDs: Set<String>,
+        neededStepUUIDCounts: [String: Int],
         progress: SQLProgress) throws -> [String: [Int64]]
     {
-        guard !neededStepUUIDs.isEmpty else { return [:] }
-        let stepProgress = StepScanProgress(budget: progress.budget, neededStepUUIDCount: neededStepUUIDs.count)
+        guard !neededStepUUIDCounts.isEmpty else { return [:] }
+        let stepProgress = StepScanProgress(budget: progress.budget)
         let registered = sqlite3_create_function_v2(
             database,
             "antigravity_step_payload_limit",
@@ -256,10 +257,10 @@ extension AntigravityLocalReader {
             else { continue }
             if let (stepUUID, timestampMs) = try AntigravityProtoReader.parseStepMetadata(
                 bytes, checkCancellation: progress.budget.check),
-                let stepUUID, neededStepUUIDs.contains(stepUUID), let timestampMs
+                let stepUUID, neededStepUUIDCounts[stepUUID] != nil, let timestampMs
             {
                 stepTimestamps[stepUUID, default: []].append(timestampMs)
-                if stepTimestamps.values.reduce(0, { $0 + $1.count }) >= stepProgress.rowLimit {
+                if neededStepUUIDCounts.allSatisfy({ (stepTimestamps[$0.key]?.count ?? 0) >= $0.value }) {
                     break
                 }
             }
@@ -340,13 +341,12 @@ extension AntigravityLocalReader {
         var offsets: [String: Int] = [:]
         var recoveredCount = 0
         for pending in pendingRows {
+            guard let timestamps = stepTimestamps[pending.stepUUID], !timestamps.isEmpty else { continue }
             let offset = offsets[pending.stepUUID, default: 0]
-            guard let timestamps = stepTimestamps[pending.stepUUID],
-                  timestamps.indices.contains(offset)
-            else { continue }
             offsets[pending.stepUUID] = offset + 1
             var turn = pending.turn
-            turn.timestampMs = timestamps[offset]
+            turn.timestampMs = timestamps.indices
+                .contains(offset) ? timestamps[offset] : timestamps[timestamps.count - 1]
             if let event = Event(session: session, row: pending.row, turn: turn, cacheWrite: 0) {
                 source.events.append(event)
                 recoveredCount += 1

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -261,7 +261,7 @@ extension AntigravityLocalReader {
         SELECT idx, CASE WHEN typeof(metadata) = 'blob' THEN length(metadata) END,
             CASE WHEN typeof(metadata) = 'blob'
                 AND length(metadata) <= antigravity_step_payload_limit() THEN metadata END
-        FROM main.steps NOT INDEXED WHERE metadata IS NOT NULL
+        FROM main.steps NOT INDEXED
         """
         let prepared = sqlite3_prepare_v2(database, query, -1, &statement, nil)
         if let failure = progress.failure {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
@@ -7,52 +7,53 @@ import CSQLite3
 
 #if canImport(SQLite3) || canImport(CSQLite3)
 extension AntigravityLocalReader {
-    struct SupportedTables {
-        var hasGenMetadata = false
-        var hasSteps = false
-    }
-
-    static func supportedSQLiteTables(_ database: OpaquePointer, budget: Budget) throws -> SupportedTables {
+    static func hasSupportedSQLiteTable(_ database: OpaquePointer, budget: Budget) throws -> Bool {
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
+        // sqlite_master works on older SQLite versions too. Virtual tables and views have no root b-tree page.
         let query = "SELECT name, type, rootpage FROM main.sqlite_master LIMIT ?"
         guard sqlite3_prepare_v2(database, query, -1, &statement, nil) == SQLITE_OK,
-              let statement else { return SupportedTables() }
+              let statement else { return false }
         sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.schemaEntries, 128) + 1))
         var entries = 0
-        var tables = SupportedTables()
         while true {
             try budget.check()
             let step = sqlite3_step(statement)
-            if step == SQLITE_DONE { break }
-            // A SQLITE_CORRUPT/SQLITE_IOERR termination is not an exhaustive listing: fail closed.
-            guard step == SQLITE_ROW else { return SupportedTables() }
+            guard step == SQLITE_ROW else { return false }
             entries += 1
             budget.statistics.schemaEntries += 1
             guard entries <= budget.limits.schemaEntries else { throw ScanFailure.exhausted }
             let name = try self.schemaText(statement, column: 0, budget: budget)
             let type = try self.schemaText(statement, column: 1, budget: budget)
-            if name?.lowercased() == "gen_metadata" {
-                if type == "table", sqlite3_column_type(statement, 2) == SQLITE_INTEGER,
-                   sqlite3_column_int64(statement, 2) > 0,
-                   try self.hasStoredSQLiteColumns(database, budget: budget)
-                {
-                    tables.hasGenMetadata = true
-                }
-            } else if name?.lowercased() == "steps" {
-                if type == "table", sqlite3_column_type(statement, 2) == SQLITE_INTEGER,
-                   sqlite3_column_int64(statement, 2) > 0,
-                   try self.hasStoredStepsColumns(database, budget: budget)
-                {
-                    tables.hasSteps = true
-                }
-            }
+            guard name?.lowercased() == "gen_metadata" else { continue }
+            guard type == "table", sqlite3_column_type(statement, 2) == SQLITE_INTEGER,
+                  sqlite3_column_int64(statement, 2) > 0 else { return false }
+            return try self.hasStoredSQLiteColumns(database, budget: budget)
         }
-        return tables
     }
 
-    static func hasSupportedSQLiteTable(_ database: OpaquePointer, budget: Budget) throws -> Bool {
-        try self.supportedSQLiteTables(database, budget: budget).hasGenMetadata
+    static func hasSupportedStepsTable(_ database: OpaquePointer, budget: Budget) throws -> Bool {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        let query = "SELECT name, type, rootpage FROM main.sqlite_master LIMIT ?"
+        guard sqlite3_prepare_v2(database, query, -1, &statement, nil) == SQLITE_OK,
+              let statement else { return false }
+        sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.schemaEntries, 128) + 1))
+        var entries = 0
+        while true {
+            try budget.check()
+            let step = sqlite3_step(statement)
+            guard step == SQLITE_ROW else { return false }
+            entries += 1
+            budget.statistics.schemaEntries += 1
+            guard entries <= budget.limits.schemaEntries else { throw ScanFailure.exhausted }
+            let name = try self.schemaText(statement, column: 0, budget: budget)
+            let type = try self.schemaText(statement, column: 1, budget: budget)
+            guard name?.lowercased() == "steps" else { continue }
+            guard type == "table", sqlite3_column_type(statement, 2) == SQLITE_INTEGER,
+                  sqlite3_column_int64(statement, 2) > 0 else { return false }
+            return try self.hasStoredStepsColumns(database, budget: budget)
+        }
     }
 
     private static func hasStoredStepsColumns(_ database: OpaquePointer, budget: Budget) throws -> Bool {
@@ -65,7 +66,7 @@ extension AntigravityLocalReader {
         while true {
             try budget.check()
             let step = sqlite3_step(statement)
-            if step == SQLITE_DONE { return columns.isSuperset(of: ["metadata"]) }
+            if step == SQLITE_DONE { return columns.isSuperset(of: ["idx", "metadata"]) }
             guard step == SQLITE_ROW else { return false }
             count += 1
             budget.statistics.schemaColumns += 1

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
@@ -7,27 +7,72 @@ import CSQLite3
 
 #if canImport(SQLite3) || canImport(CSQLite3)
 extension AntigravityLocalReader {
-    static func hasSupportedSQLiteTable(_ database: OpaquePointer, budget: Budget) throws -> Bool {
+    struct SupportedTables {
+        var hasGenMetadata = false
+        var hasSteps = false
+    }
+
+    static func supportedSQLiteTables(_ database: OpaquePointer, budget: Budget) throws -> SupportedTables {
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
-        // sqlite_master works on older SQLite versions too. Virtual tables and views have no root b-tree page.
         let query = "SELECT name, type, rootpage FROM main.sqlite_master LIMIT ?"
         guard sqlite3_prepare_v2(database, query, -1, &statement, nil) == SQLITE_OK,
-              let statement else { return false }
+              let statement else { return SupportedTables() }
         sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.schemaEntries, 128) + 1))
         var entries = 0
+        var tables = SupportedTables()
         while true {
             try budget.check()
-            guard sqlite3_step(statement) == SQLITE_ROW else { return false }
+            guard sqlite3_step(statement) == SQLITE_ROW else { break }
             entries += 1
             budget.statistics.schemaEntries += 1
             guard entries <= budget.limits.schemaEntries else { throw ScanFailure.exhausted }
             let name = try self.schemaText(statement, column: 0, budget: budget)
             let type = try self.schemaText(statement, column: 1, budget: budget)
-            guard name?.lowercased() == "gen_metadata" else { continue }
-            guard type == "table", sqlite3_column_type(statement, 2) == SQLITE_INTEGER,
-                  sqlite3_column_int64(statement, 2) > 0 else { return false }
-            return try self.hasStoredSQLiteColumns(database, budget: budget)
+            if name?.lowercased() == "gen_metadata" {
+                if type == "table", sqlite3_column_type(statement, 2) == SQLITE_INTEGER,
+                   sqlite3_column_int64(statement, 2) > 0,
+                   try self.hasStoredSQLiteColumns(database, budget: budget)
+                {
+                    tables.hasGenMetadata = true
+                }
+            } else if name?.lowercased() == "steps" {
+                if type == "table", sqlite3_column_type(statement, 2) == SQLITE_INTEGER,
+                   sqlite3_column_int64(statement, 2) > 0,
+                   try self.hasStoredStepsColumns(database, budget: budget)
+                {
+                    tables.hasSteps = true
+                }
+            }
+        }
+        return tables
+    }
+
+    static func hasSupportedSQLiteTable(_ database: OpaquePointer, budget: Budget) throws -> Bool {
+        try self.supportedSQLiteTables(database, budget: budget).hasGenMetadata
+    }
+
+    private static func hasStoredStepsColumns(_ database: OpaquePointer, budget: Budget) throws -> Bool {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(database, "PRAGMA main.table_xinfo('steps')", -1, &statement, nil) == SQLITE_OK,
+              let statement, sqlite3_column_count(statement) >= 7 else { return false }
+        var columns = Set<String>()
+        var count = 0
+        while true {
+            try budget.check()
+            let step = sqlite3_step(statement)
+            if step == SQLITE_DONE { return columns.isSuperset(of: ["metadata"]) }
+            guard step == SQLITE_ROW else { return false }
+            count += 1
+            budget.statistics.schemaColumns += 1
+            guard count <= min(budget.limits.schemaColumns, 64) else { throw ScanFailure.exhausted }
+            guard sqlite3_column_type(statement, 6) == SQLITE_INTEGER,
+                  sqlite3_column_int(statement, 6) == 0 else { return false }
+            guard let name = try self.schemaText(statement, column: 1, budget: budget) else { return false }
+            _ = try self.schemaText(statement, column: 2, budget: budget)
+            _ = try self.schemaText(statement, column: 4, budget: budget)
+            columns.insert(name.lowercased())
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
@@ -23,7 +23,10 @@ extension AntigravityLocalReader {
         var tables = SupportedTables()
         while true {
             try budget.check()
-            guard sqlite3_step(statement) == SQLITE_ROW else { break }
+            let step = sqlite3_step(statement)
+            if step == SQLITE_DONE { break }
+            // A SQLITE_CORRUPT/SQLITE_IOERR termination is not an exhaustive listing: fail closed.
+            guard step == SQLITE_ROW else { return SupportedTables() }
             entries += 1
             budget.statistics.schemaEntries += 1
             guard entries <= budget.limits.schemaEntries else { throw ScanFailure.exhausted }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
@@ -168,19 +168,24 @@ struct AntigravityProtoReader {
     {
         var stepUUID: String?
         var time = Timestamp()
+        var timestampIsValid = true
         do {
             try self.fields(bytes[...], checkCancellation: checkCancellation) { field in
                 switch field.number {
                 case 1:
-                    try self.parseTimestampField(
-                        field.message(), time: &time, checkCancellation: checkCancellation)
+                    do {
+                        try self.parseTimestampField(
+                            field.message(), time: &time, checkCancellation: checkCancellation)
+                    } catch AntigravityLocalReader.ScanFailure.invalid {
+                        timestampIsValid = false
+                    }
                 case 12:
                     stepUUID = try field.string()
                 default:
                     break
                 }
             }
-            let ms = try time.milliseconds()
+            let ms = timestampIsValid ? try time.milliseconds() : nil
             return (stepUUID, ms)
         } catch AntigravityLocalReader.ScanFailure.invalid {
             return nil

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
@@ -29,6 +29,7 @@ struct AntigravityProtoReader {
         var timestampMs: Int64?
         var model: String?
         var label: String?
+        var stepUUID: String?
     }
 
     private struct Timestamp {
@@ -142,14 +143,45 @@ struct AntigravityProtoReader {
         do {
             // Repeated singular messages merge, scalars use last-one-wins. Every occurrence is validated.
             try self.fields(rootBytes[...], checkCancellation: checkCancellation) { field in
-                guard field.number == 1 else { return }
-                foundChat = true
-                try self.parseChat(
-                    field.message(), turn: &turn, time: &time, checkCancellation: checkCancellation)
+                switch field.number {
+                case 1:
+                    foundChat = true
+                    try self.parseChat(
+                        field.message(), turn: &turn, time: &time, checkCancellation: checkCancellation)
+                case 4:
+                    turn.stepUUID = try field.string()
+                default:
+                    break
+                }
             }
             guard foundChat else { return nil }
             turn.timestampMs = try time.milliseconds()
             return turn
+        } catch AntigravityLocalReader.ScanFailure.invalid {
+            return nil
+        }
+    }
+
+    static func parseStepMetadata(
+        _ bytes: [UInt8],
+        checkCancellation: () throws -> Void = {}) throws -> (stepUUID: String?, timestampMs: Int64?)?
+    {
+        var stepUUID: String?
+        var time = Timestamp()
+        do {
+            try self.fields(bytes[...], checkCancellation: checkCancellation) { field in
+                switch field.number {
+                case 1:
+                    try self.parseTimestampField(
+                        field.message(), time: &time, checkCancellation: checkCancellation)
+                case 12:
+                    stepUUID = try field.string()
+                default:
+                    break
+                }
+            }
+            let ms = try time.milliseconds()
+            return (stepUUID, ms)
         } catch AntigravityLocalReader.ScanFailure.invalid {
             return nil
         }
@@ -194,6 +226,28 @@ struct AntigravityProtoReader {
         }
     }
 
+    private static func parseTimestampField(
+        _ bytes: ArraySlice<UInt8>,
+        time: inout Timestamp,
+        checkCancellation: () throws -> Void) throws
+    {
+        try self.fields(bytes, checkCancellation: checkCancellation) { stamp in
+            switch stamp.number {
+            case 1:
+                let seconds = try stamp.integer()
+                guard seconds > 0, seconds <= 253_402_300_799 else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                time.seconds = seconds
+            case 2:
+                let nanos = try stamp.integer()
+                guard nanos <= 999_999_999 else { throw AntigravityLocalReader.ScanFailure.invalid }
+                time.nanos = nanos
+            default: break
+            }
+        }
+    }
+
     private static func parseGeneration(
         _ bytes: ArraySlice<UInt8>,
         time: inout Timestamp,
@@ -201,21 +255,7 @@ struct AntigravityProtoReader {
     {
         try self.fields(bytes, checkCancellation: checkCancellation) { field in
             guard field.number == 4 else { return }
-            try self.fields(field.message(), checkCancellation: checkCancellation) { stamp in
-                switch stamp.number {
-                case 1:
-                    let seconds = try stamp.integer()
-                    guard seconds > 0, seconds <= 253_402_300_799 else {
-                        throw AntigravityLocalReader.ScanFailure.invalid
-                    }
-                    time.seconds = seconds
-                case 2:
-                    let nanos = try stamp.integer()
-                    guard nanos <= 999_999_999 else { throw AntigravityLocalReader.ScanFailure.invalid }
-                    time.nanos = nanos
-                default: break
-                }
-            }
+            try self.parseTimestampField(field.message(), time: &time, checkCancellation: checkCancellation)
         }
     }
 }

--- a/Tests/CodexBarTests/AntigravityLocalFixture.swift
+++ b/Tests/CodexBarTests/AntigravityLocalFixture.swift
@@ -64,7 +64,8 @@ final class AntigravityLocalFixture: Sendable {
     func database(
         _ session: String = "session-a",
         rootIndex: Int = 0,
-        blobs: [[UInt8]] = []) throws -> URL
+        blobs: [[UInt8]] = [],
+        stepBlobs: [[UInt8]]? = nil) throws -> URL
     {
         let directory = self.context.databaseRoots[rootIndex]
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -74,6 +75,12 @@ final class AntigravityLocalFixture: Sendable {
         try Self.execute(database, "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB)")
         for (index, blob) in blobs.enumerated() {
             try Self.insert(database, row: Int64(index), blob: blob)
+        }
+        if let stepBlobs {
+            try Self.execute(database, "CREATE TABLE steps (idx INTEGER PRIMARY KEY, metadata BLOB)")
+            for (index, blob) in stepBlobs.enumerated() {
+                try Self.insertStep(database, row: Int64(index), blob: blob)
+            }
         }
         return url
     }
@@ -108,6 +115,20 @@ final class AntigravityLocalFixture: Sendable {
         defer { sqlite3_finalize(statement) }
         guard sqlite3_prepare_v2(
             database, "INSERT INTO gen_metadata (idx, data) VALUES (?, ?)", -1, &statement, nil) == SQLITE_OK
+        else { throw AntigravityLocalReader.ScanFailure.invalid }
+        sqlite3_bind_int64(statement, 1, row)
+        let result = blob.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, 2, bytes.baseAddress, Int32(blob.count), nil)
+            return sqlite3_step(statement)
+        }
+        guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
+    }
+
+    static func insertStep(_ database: OpaquePointer, row: Int64, blob: [UInt8]) throws {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(
+            database, "INSERT INTO steps (idx, metadata) VALUES (?, ?)", -1, &statement, nil) == SQLITE_OK
         else { throw AntigravityLocalReader.ScanFailure.invalid }
         sqlite3_bind_int64(statement, 1, row)
         let result = blob.withUnsafeBytes { bytes in
@@ -157,6 +178,43 @@ final class AntigravityLocalFixture: Sendable {
         if let model { chat += self.message(19, Array(model.utf8)) }
         if let label { chat += self.message(21, Array(label.utf8)) }
         return self.message(1, chat)
+    }
+
+    static func blobWithRootEnvelope(
+        stepUUID: String? = "step-uuid-1",
+        model: String? = "fixture-model-a",
+        label: String? = "Fixture model",
+        system: UInt64 = 11,
+        input: UInt64 = 100,
+        output: UInt64 = 30,
+        cacheRead: UInt64 = 50,
+        reasoning: UInt64 = 7,
+        response: String? = nil,
+        seconds: UInt64? = nil) -> [UInt8]
+    {
+        var root = self.message(2, [0x01, 0x02])
+        if let stepUUID { root += self.message(4, Array(stepUUID.utf8)) }
+        var usage = self.varint(1, system) + self.varint(2, input) + self.varint(5, cacheRead)
+            + self.varint(9, output) + self.varint(10, reasoning)
+        if let response { usage += self.message(11, Array(response.utf8)) }
+        var chat = self.message(4, usage)
+        if let seconds {
+            chat += self.message(9, self.message(4, self.varint(1, seconds) + self.varint(2, 250_000_000)))
+        }
+        if let model { chat += self.message(19, Array(model.utf8)) }
+        if let label { chat += self.message(21, Array(label.utf8)) }
+        root += self.message(1, chat)
+        return root
+    }
+
+    static func stepMetadataBlob(
+        stepUUID: String = "step-uuid-1",
+        seconds: UInt64 = 1_787_832_000,
+        nanos: UInt64 = 250_000_000) -> [UInt8]
+    {
+        var meta = self.message(1, self.varint(1, seconds) + self.varint(2, nanos))
+        meta += self.message(12, Array(stepUUID.utf8))
+        return meta
     }
 
     static let cacheUsage =

--- a/Tests/CodexBarTests/AntigravityLocalFixture.swift
+++ b/Tests/CodexBarTests/AntigravityLocalFixture.swift
@@ -208,12 +208,12 @@ final class AntigravityLocalFixture: Sendable {
     }
 
     static func stepMetadataBlob(
-        stepUUID: String = "step-uuid-1",
+        stepUUID: String? = "step-uuid-1",
         seconds: UInt64 = 1_787_832_000,
         nanos: UInt64 = 250_000_000) -> [UInt8]
     {
         var meta = self.message(1, self.varint(1, seconds) + self.varint(2, nanos))
-        meta += self.message(12, Array(stepUUID.utf8))
+        if let stepUUID { meta += self.message(12, Array(stepUUID.utf8)) }
         return meta
     }
 

--- a/Tests/CodexBarTests/AntigravityLocalIntegrityTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalIntegrityTests.swift
@@ -112,6 +112,23 @@ struct AntigravityLocalIntegrityTests {
     }
 
     @Test
+    func `embedded timestamps do not spend schema budget discovering optional steps`() throws {
+        let fixture = try Fixture()
+        let url = try fixture.database(blobs: [Fixture.blob()])
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "CREATE TABLE unrelated (value INTEGER)")
+        var limits = AntigravityLocalReader.Limits()
+        limits.schemaEntries = 1
+
+        let report = try fixture.report(limits: limits)
+
+        #expect(report.coverage == .complete)
+        #expect(report.statistics.schemaEntries == 1)
+        #expect(report.statistics.rows == 1)
+    }
+
+    @Test
     func `copy guard derives length from the selected BLOB and rejects inconsistent declarations`() throws {
         let fixture = try Fixture()
         let database = try Fixture.open(fixture.database())

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -593,6 +593,40 @@ struct AntigravityLocalReaderTests {
         #expect(report.report.data.isEmpty)
     }
 
+    @Test(arguments: [String?.none, ""])
+    func `unidentified step occurrence cannot turn one timestamp into shared coverage`(
+        unidentifiedStepUUID: String?) throws
+    {
+        let fixture = try Fixture()
+        let stepUUID = "unidentified-shared-step-uuid"
+        let turns = (0..<2).map { _ in Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil) }
+        let unidentified = Fixture.stepMetadataBlob(
+            stepUUID: unidentifiedStepUUID,
+            seconds: 1_787_875_140)
+        let valid = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        try fixture.database(blobs: turns, stepBlobs: [unidentified, valid])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+
+    @Test
+    func `unidentified timestamp-less step occurrence cannot turn one timestamp into shared coverage`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "unidentified-timestamp-less-step-uuid"
+        let turns = (0..<2).map { _ in Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil) }
+        let unidentified = Fixture.varint(99, 1)
+        let valid = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        try fixture.database(blobs: turns, stepBlobs: [unidentified, valid])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+
     @Test
     func `multiple timestamps cannot be guessed across more reused turns`() throws {
         let fixture = try Fixture()

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -575,6 +575,25 @@ struct AntigravityLocalReaderTests {
     }
 
     @Test
+    func `NULL step occurrence cannot turn one timestamp into shared coverage`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "null-shared-step-uuid"
+        let turns = (0..<2).map { _ in Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil) }
+        let valid = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        let url = try fixture.database(blobs: turns)
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "CREATE TABLE steps (idx INTEGER, metadata BLOB)")
+        try Fixture.execute(database, "INSERT INTO steps (idx, metadata) VALUES (10, NULL)")
+        try Fixture.insertStep(database, row: 20, blob: valid)
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+
+    @Test
     func `multiple timestamps cannot be guessed across more reused turns`() throws {
         let fixture = try Fixture()
         let stepUUID = "ambiguous-reused-step-uuid"

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -489,6 +489,23 @@ struct AntigravityLocalReaderTests {
     }
 
     @Test
+    func `field 2 root envelope with multi-turn steps sharing step timestamp aggregates complete coverage`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "shared-step-uuid"
+        let turn1 = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let turn2 = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let turn3 = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let stepBlob = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_832_000)
+        try fixture.database(blobs: [turn1, turn2, turn3], stepBlobs: [stepBlob])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.requestCount == 3)
+        #expect(report.report.data.first?.date == "2026-08-27")
+    }
+
+    @Test
     func `field 2 root envelope with embedded timestamp in field 9 aggregates complete coverage`() async throws {
         let fixture = try Fixture()
         let genBlob = Fixture.blobWithRootEnvelope(

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -472,11 +472,127 @@ struct AntigravityLocalReaderTests {
     }
 
     @Test
-    func `field 2 root envelope with reused step UUID consumes step timestamps in order`() throws {
+    func `field 2 root envelope with reused step UUID follows stored idx order`() throws {
         let fixture = try Fixture()
         let stepUUID = "reused-step-uuid"
         let first = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
-        let second = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let second = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, input: 200, seconds: nil)
+        let beforeMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
+        let afterMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        let url = try fixture.database(blobs: [first, second])
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "CREATE TABLE steps (idx INTEGER, metadata BLOB)")
+        try Fixture.insertStep(database, row: 20, blob: afterMidnight)
+        try Fixture.insertStep(database, row: 10, blob: beforeMidnight)
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27", "2026-08-28"])
+        #expect(report.report.data.map(\.requestCount) == [1, 1])
+        #expect(report.report.data.map(\.inputTokens) == [111, 211])
+    }
+
+    @Test
+    func `step lookup selects the lowest idx even when it was inserted later`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "extra-step-uuid"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let beforeMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
+        let afterMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        let url = try fixture.database(blobs: [turn])
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "CREATE TABLE steps (idx INTEGER, metadata BLOB)")
+        try Fixture.insertStep(database, row: 20, blob: afterMidnight)
+        try Fixture.insertStep(database, row: 10, blob: beforeMidnight)
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27"])
+    }
+
+    @Test
+    func `duplicate step indices fail closed instead of choosing scan order`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "duplicate-step-uuid"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let first = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
+        let second = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        let url = try fixture.database(blobs: [turn])
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "CREATE TABLE steps (idx INTEGER, metadata BLOB)")
+        try Fixture.insertStep(database, row: 10, blob: first)
+        try Fixture.insertStep(database, row: 10, blob: second)
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+
+    @Test
+    func `missing timestamp at the lowest matching step idx fails closed`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "missing-lowest-step-uuid"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let missingTimestamp = Fixture.message(12, Array(stepUUID.utf8))
+        let laterTimestamp = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        let url = try fixture.database(blobs: [turn])
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "CREATE TABLE steps (idx INTEGER, metadata BLOB)")
+        try Fixture.insertStep(database, row: 10, blob: missingTimestamp)
+        try Fixture.insertStep(database, row: 20, blob: laterTimestamp)
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+
+    @Test
+    func `malformed matching step cannot turn one timestamp into shared coverage`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "malformed-shared-step-uuid"
+        let turns = (0..<2).map { _ in Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil) }
+        let valid = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
+        let invalid = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID,
+            seconds: 1_787_875_260,
+            nanos: 1_000_000_000)
+        try fixture.database(blobs: turns, stepBlobs: [valid, invalid])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+
+    @Test
+    func `multiple timestamps cannot be guessed across more reused turns`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "ambiguous-reused-step-uuid"
+        let turns = (0..<3).map { _ in Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil) }
+        let first = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
+        let second = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        try fixture.database(blobs: turns, stepBlobs: [first, second])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+
+    @Test
+    func `embedded reused step occurrence keeps later pending timestamp aligned`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "mixed-timestamp-step-uuid"
+        let first = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: 1_787_875_140)
+        let second = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, input: 200, seconds: nil)
         let beforeMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
         let afterMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
         try fixture.database(blobs: [first, second], stepBlobs: [beforeMidnight, afterMidnight])
@@ -485,7 +601,7 @@ struct AntigravityLocalReaderTests {
 
         #expect(report.coverage == .complete)
         #expect(report.report.data.map(\.date) == ["2026-08-27", "2026-08-28"])
-        #expect(report.report.data.map(\.requestCount) == [1, 1])
+        #expect(report.report.data.map(\.inputTokens) == [111, 211])
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -662,20 +662,29 @@ struct AntigravityLocalReaderTests {
     @Test
     func `recovered rows retain generation order beside embedded rows`() throws {
         let fixture = try Fixture()
-        let recovered = Fixture.blobWithRootEnvelope(stepUUID: "recovered-step", seconds: nil)
+        let response = "shared-order-response"
+        let recovered = Fixture.blobWithRootEnvelope(
+            stepUUID: "recovered-step",
+            response: response,
+            seconds: nil)
         let embedded = Fixture.blobWithRootEnvelope(
             stepUUID: "embedded-step",
             input: 200,
-            seconds: 1_787_875_260)
-        let step = Fixture.stepMetadataBlob(stepUUID: "recovered-step", seconds: 1_787_875_140, nanos: 0)
+            response: response,
+            seconds: 1_787_875_140)
+        let step = Fixture.stepMetadataBlob(stepUUID: "recovered-step", seconds: 1_787_875_260, nanos: 0)
         let url = try fixture.database(blobs: [recovered, embedded], stepBlobs: [step])
         let budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {})
 
         let source = try AntigravityLocalReader.readDatabases([url], budget: budget)
+        let report = try fixture.report()
 
         #expect(source.isComplete)
         #expect(source.events.map(\.row) == [0, 1])
-        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_000, 1_787_875_260_250])
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_260_000, 1_787_875_140_250])
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.map(\.date) == ["2026-08-28"])
+        #expect(report.report.data.map(\.inputTokens) == [111])
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -416,7 +416,9 @@ struct AntigravityLocalReaderTests {
             var checks = 0
             let budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {
                 checks += 1
-                if checks == 2 { throw expected }
+                if checks == 2 {
+                    throw expected
+                }
             })
             do {
                 _ = try AntigravityLocalReader.readJSONL([path], budget: budget)
@@ -602,6 +604,40 @@ struct AntigravityLocalReaderTests {
         #expect(report.coverage == .complete)
         #expect(report.report.data.map(\.date) == ["2026-08-27", "2026-08-28"])
         #expect(report.report.data.map(\.inputTokens) == [111, 211])
+    }
+
+    @Test
+    func `unparseable generation occurrence cannot shift a later reused step timestamp`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "unparseable-generation-step-uuid"
+        let invalidChat = Fixture.message(4, Fixture.varint(2, UInt64.max))
+        let malformed = Fixture.message(4, Array(stepUUID.utf8)) + Fixture.message(1, invalidChat)
+        let validPending = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, input: 200, seconds: nil)
+        let beforeMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
+        let afterMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        try fixture.database(
+            blobs: [malformed, validPending],
+            stepBlobs: [beforeMidnight, afterMidnight])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+
+    @Test
+    func `unparseable step occurrence cannot shift later timestamps`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "unparseable-step-occurrence-uuid"
+        let turns = (0..<2).map { _ in Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil) }
+        let malformed = Fixture.message(12, Array(stepUUID.utf8)) + [0x0A, 0x80]
+        let valid = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        try fixture.database(blobs: turns, stepBlobs: [malformed, valid])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -660,6 +660,25 @@ struct AntigravityLocalReaderTests {
     }
 
     @Test
+    func `recovered rows retain generation order beside embedded rows`() throws {
+        let fixture = try Fixture()
+        let recovered = Fixture.blobWithRootEnvelope(stepUUID: "recovered-step", seconds: nil)
+        let embedded = Fixture.blobWithRootEnvelope(
+            stepUUID: "embedded-step",
+            input: 200,
+            seconds: 1_787_875_260)
+        let step = Fixture.stepMetadataBlob(stepUUID: "recovered-step", seconds: 1_787_875_140, nanos: 0)
+        let url = try fixture.database(blobs: [recovered, embedded], stepBlobs: [step])
+        let budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {})
+
+        let source = try AntigravityLocalReader.readDatabases([url], budget: budget)
+
+        #expect(source.isComplete)
+        #expect(source.events.map(\.row) == [0, 1])
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_000, 1_787_875_260_250])
+    }
+
+    @Test
     func `unparseable generation occurrence cannot shift a later reused step timestamp`() throws {
         let fixture = try Fixture()
         let stepUUID = "unparseable-generation-step-uuid"

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -453,4 +453,67 @@ struct AntigravityLocalReaderTests {
         #expect(!snapshot.historyCoverageIsEstablished)
         #expect(snapshot.last30DaysTokens == nil)
     }
+
+    @Test
+    func `field 2 root envelope with step table timestamps aggregates complete coverage`() async throws {
+        let fixture = try Fixture()
+        let stepUUID = "step-abc-123"
+        let genBlob = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, model: "gemini-3.7-flash", seconds: nil)
+        let stepBlob = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_832_000, nanos: 250_000_000)
+        try fixture.database(blobs: [genBlob], stepBlobs: [stepBlob])
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.date == "2026-08-27")
+        #expect(report.report.data.first?.inputTokens == 111)
+        #expect(report.report.data.first?.outputTokens == 30)
+        #expect(report.report.data.first?.reasoningTokens == 7)
+        #expect(report.report.data.first?.modelBreakdowns?.first?.modelName == "gemini-3.7-flash")
+        #expect(try await fixture.snapshot().last30DaysTokens == 198)
+    }
+
+    @Test
+    func `field 2 root envelope with reused step UUID consumes step timestamps in order`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "reused-step-uuid"
+        let first = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let second = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let beforeMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
+        let afterMidnight = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        try fixture.database(blobs: [first, second], stepBlobs: [beforeMidnight, afterMidnight])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27", "2026-08-28"])
+        #expect(report.report.data.map(\.requestCount) == [1, 1])
+    }
+
+    @Test
+    func `field 2 root envelope with embedded timestamp in field 9 aggregates complete coverage`() async throws {
+        let fixture = try Fixture()
+        let genBlob = Fixture.blobWithRootEnvelope(
+            stepUUID: "step-embedded",
+            model: "claude-opus-4-6-thinking",
+            seconds: 1_787_832_000)
+        try fixture.database(blobs: [genBlob])
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.date == "2026-08-27")
+        #expect(report.report.data.first?.modelBreakdowns?.first?.modelName == "claude-opus-4-6-thinking")
+        #expect(try await fixture.snapshot().last30DaysTokens == 198)
+    }
+
+    @Test
+    func `field 2 root envelope without timestamp in either gen_metadata or steps fails closed with partial coverage`()
+        async throws
+    {
+        let fixture = try Fixture()
+        let genBlob = Fixture.blobWithRootEnvelope(stepUUID: "missing-step-uuid", seconds: nil)
+        try fixture.database(blobs: [genBlob])
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        let snapshot = try await fixture.snapshot()
+        #expect(!snapshot.historyCoverageIsEstablished)
+        #expect(snapshot.last30DaysTokens == nil)
+    }
 }

--- a/Tests/CodexBarTests/AntigravityLocalScanTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalScanTests.swift
@@ -168,6 +168,29 @@ struct AntigravityLocalScanTests {
     }
 
     @Test
+    func `optional steps scan charges its rows and bytes against the shared job budget`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "budgeted-step-uuid"
+        let genBlob = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let stepBlob = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_832_000)
+        try fixture.database(blobs: [genBlob], stepBlobs: [stepBlob])
+
+        #expect(try fixture.report().coverage == .complete)
+
+        var limits = AntigravityLocalReader.Limits()
+        limits.rows = 1
+        let rowBound = try fixture.report(limits: limits)
+        #expect(rowBound.coverage == .partial)
+        #expect(rowBound.statistics.rows == 2)
+
+        limits = AntigravityLocalReader.Limits()
+        limits.bytes = genBlob.count
+        let byteBound = try fixture.report(limits: limits)
+        #expect(byteBound.coverage == .partial)
+        #expect(byteBound.statistics.attemptedBytes == genBlob.count + stepBlob.count)
+    }
+
+    @Test
     func `recursive aggregate view is rejected without executing its payload query`() throws {
         let fixture = try Fixture()
         let url = try fixture.database()

--- a/Tests/CodexBarTests/AntigravityLocalScanTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalScanTests.swift
@@ -191,6 +191,23 @@ struct AntigravityLocalScanTests {
     }
 
     @Test
+    func `sparse steps table with unrelated leading steps resolves complete coverage`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "sparse-step-uuid"
+        let genBlob = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        var stepBlobs = (0..<300).map { _ in
+            Fixture.stepMetadataBlob(stepUUID: "unrelated-\(UUID().uuidString)", seconds: 1_787_832_000)
+        }
+        stepBlobs.append(Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_832_000))
+        try fixture.database(blobs: [genBlob], stepBlobs: stepBlobs)
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.date == "2026-08-27")
+    }
+
+    @Test
     func `recursive aggregate view is rejected without executing its payload query`() throws {
         let fixture = try Fixture()
         let url = try fixture.database()

--- a/Tests/CodexBarTests/AntigravityLocalScanTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalScanTests.swift
@@ -188,23 +188,65 @@ struct AntigravityLocalScanTests {
         let byteBound = try fixture.report(limits: limits)
         #expect(byteBound.coverage == .partial)
         #expect(byteBound.statistics.attemptedBytes == genBlob.count + stepBlob.count)
+
+        limits = AntigravityLocalReader.Limits()
+        limits.databaseBytes = genBlob.count + stepBlob.count - 1
+        let databaseByteBound = try fixture.report(limits: limits)
+        #expect(databaseByteBound.coverage == .partial)
+        #expect(databaseByteBound.statistics.attemptedBytes == genBlob.count + stepBlob.count)
     }
 
     @Test
-    func `sparse steps table with unrelated leading steps resolves complete coverage`() throws {
+    func `step scan truncation cannot publish already recovered timestamps as complete`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "bounded-step-uuid"
+        let genBlob = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let matchingStep = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_832_000)
+        let trailingStep = Fixture.stepMetadataBlob(stepUUID: "unrelated-step", seconds: 1_787_832_000)
+        try fixture.database(blobs: [genBlob], stepBlobs: [matchingStep, trailingStep])
+        var limits = AntigravityLocalReader.Limits()
+        limits.databaseBytes = genBlob.count + matchingStep.count
+
+        let report = try fixture.report(limits: limits)
+
+        #expect(report.coverage == .partial)
+        #expect(report.statistics.rows == 3)
+        #expect(report.statistics.attemptedBytes == genBlob.count + matchingStep.count + trailingStep.count)
+    }
+
+    @Test
+    func `step lookup reaches beyond the primary row cap within the shared budget`() throws {
         let fixture = try Fixture()
         let stepUUID = "sparse-step-uuid"
         let genBlob = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
-        var stepBlobs = (0..<300).map { _ in
-            Fixture.stepMetadataBlob(stepUUID: "unrelated-\(UUID().uuidString)", seconds: 1_787_832_000)
+        let url = try fixture.database(blobs: [genBlob], stepBlobs: [])
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        let unrelatedCount = 10001
+        let unrelated = Fixture.stepMetadataBlob(stepUUID: "unrelated-step", seconds: 1_787_832_000)
+        try Fixture.execute(database, "BEGIN")
+        do {
+            for index in 0..<unrelatedCount {
+                try Fixture.insertStep(database, row: Int64(index), blob: unrelated)
+            }
+            try Fixture.insertStep(
+                database,
+                row: Int64(unrelatedCount),
+                blob: Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_832_000))
+            try Fixture.insertStep(database, row: Int64(unrelatedCount + 1), blob: unrelated)
+            try Fixture.execute(database, "COMMIT")
+        } catch {
+            try? Fixture.execute(database, "ROLLBACK")
+            throw error
         }
-        stepBlobs.append(Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_832_000))
-        try fixture.database(blobs: [genBlob], stepBlobs: stepBlobs)
+        var limits = AntigravityLocalReader.Limits()
+        limits.duration = 30
 
-        let report = try fixture.report()
+        let report = try fixture.report(limits: limits)
 
         #expect(report.coverage == .complete)
         #expect(report.report.data.first?.date == "2026-08-27")
+        #expect(report.statistics.rows == unrelatedCount + 3)
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityLocalScanTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalScanTests.swift
@@ -150,6 +150,24 @@ struct AntigravityLocalScanTests {
     }
 
     @Test
+    func `optional steps scan does not exhaust embedded timestamp usage rows`() throws {
+        let fixture = try Fixture()
+        let blob = Fixture.blobWithRootEnvelope(seconds: 1_787_832_000)
+        let url = try fixture.database(blobs: [blob], stepBlobs: [])
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "INSERT INTO steps VALUES (0, zeroblob(40)), (1, zeroblob(40))")
+        var limits = AntigravityLocalReader.Limits()
+        limits.rowsPerDatabase = 1
+
+        let report = try fixture.report(limits: limits)
+
+        #expect(report.coverage == .complete)
+        #expect(report.statistics.rows == 1)
+        #expect(report.statistics.attemptedBytes == blob.count)
+    }
+
+    @Test
     func `recursive aggregate view is rejected without executing its payload query`() throws {
         let fixture = try Fixture()
         let url = try fixture.database()

--- a/Tests/CodexBarTests/AntigravityLocalWALTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalWALTests.swift
@@ -117,6 +117,52 @@ struct AntigravityLocalWALTests {
     }
 
     @Test
+    func `steps fallback remains on the generation snapshot after a writer update`() throws {
+        let fixture = try Fixture()
+        defer { withExtendedLifetime(fixture) {} }
+        let stepUUID = "snapshot-step-uuid"
+        let initialSeconds: UInt64 = 1_787_875_140
+        let laterSeconds: UInt64 = 1_787_875_260
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let initialStep = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: initialSeconds, nanos: 0)
+        let laterStep = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: laterSeconds, nanos: 0)
+        let url = try fixture.database()
+        let writer = try Fixture.open(url)
+        defer { sqlite3_close(writer) }
+        try Fixture.execute(writer, "PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0")
+        try Fixture.insert(writer, row: 0, blob: turn)
+        try Fixture.execute(writer, "CREATE TABLE steps (idx INTEGER PRIMARY KEY, metadata BLOB)")
+        try Fixture.insertStep(writer, row: 0, blob: initialStep)
+        var updated = false
+        var budget: AntigravityLocalReader.Budget?
+        defer { budget = nil }
+        budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {
+            // The schema read has established the explicit transaction snapshot before either
+            // payload pass. A later writer commit must remain invisible to both table reads.
+            guard !updated, budget?.statistics.schemaColumns == 2 else { return }
+            updated = true
+            try Fixture.execute(writer, "BEGIN IMMEDIATE")
+            do {
+                try Fixture.execute(writer, "DELETE FROM steps")
+                try Fixture.insertStep(writer, row: 0, blob: laterStep)
+                try Fixture.execute(writer, "COMMIT")
+            } catch {
+                try? Fixture.execute(writer, "ROLLBACK")
+                throw error
+            }
+        })
+
+        let source = try AntigravityLocalReader.readDatabases([url], budget: #require(budget))
+
+        #expect(updated)
+        #expect(source.isComplete)
+        #expect(source.events.count == 1)
+        #expect(source.events.first?.turn.timestampMs == Int64(initialSeconds) * 1000)
+        #expect(try fixture.report().report.data.map(\.date) == ["2026-08-28"])
+        #expect(try Self.checkpoint(writer) == 0)
+    }
+
+    @Test
     func `initially absent WAL sidecars and failed opens leave no reader handles`() throws {
         let fixture = try Fixture()
         defer { withExtendedLifetime(fixture) {} }


### PR DESCRIPTION
## Summary

Recover Antigravity token-history timestamps from the `steps` table when newer `gen_metadata` envelopes omit their embedded timestamp. The primary pass still parses usage/model data from `gen_metadata`; only timestamp-less turns with a step UUID trigger the optional secondary lookup.

The repaired fallback is deliberately bounded and fail-closed:

- step rows share the job-wide 50,000-row, byte, per-database byte, duration, and cancellation budgets
- optional schema discovery runs only when an undated turn actually needs it
- the lookup can reach valid matches beyond 10,000 unrelated rows
- generation and step occurrences align by validated stored indices, including mixed embedded/fallback turns
- recovered and embedded events rejoin in original generation-index order before first-wins deduplication
- duplicate indices, invalid or missing timestamps, ambiguous reused-step counts, malformed matching rows, truncated scans, and SQLite errors keep coverage partial instead of inventing dates
- `NULL`, non-blob, and UUID-less step rows still count as ambiguous occurrences, so one later valid timestamp cannot be stretched across multiple turns
- one timestamp may be shared across multiple turns only when it is the sole valid matching step occurrence

This PR remains scoped to the proven parser/CLI recovery. Two later contributor commits adding an immutable-WAL retry plus menu/widget presentation were removed from this branch and preserved separately for follow-up: immutable reads need a stable private snapshot or equivalent race protection, and the UI work still needs configured-window correctness, cache invalidation, and sanitized before/after proof.

The repaired implementation retains @chid's original parser discovery, contributor commits, and live-session validation; the additional maintainer commits tighten its snapshot, budget, ordering, and ambiguity boundaries.

No changelog entry is included; release notes are generated at release time.

## Verification

- Contributor live proof on 37 sanitized local Antigravity session databases established 30-day history with `steps` present and correctly withheld it from same-data copies with `steps` removed.
- `AntigravityLocal*`: 80 tests across eight suites passed.
- Full isolated local suite on current main ancestry: 997 selections across 84 groups, all first-pass green with retries disabled, zero failed groups, and zero timeouts.
- `make check` passed; SwiftFormat clean and SwiftLint reported zero violations.
- Final complete-candidate review found no actionable P0-P2 defects.

Maintainer verification used synthetic fixtures and repository isolation flags; no real local account data, credentials, browser imports, or installed-app launches were accessed.
