### PR TITLE
fix: enable Antigravity local cost routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.1 — Unreleased
 
 ### Fixed
+- Antigravity: expose the existing local token-history reader through CLI cost, serve, and dashboard selection, preserving unknown dollar costs and unavailable histories (investigated alongside #3266). Thanks @chid!
 - Docs: clarify the Codex cost-history refresh floor and explain that Manual stops recurring refreshes, not startup or pending catch-up scans.
 - Codex: preserve calendar spacing in inline cost charts, keep unscanned and unpriced days unknown, honor the selected bucket time zone, and fit year-long histories within the menu (#3232). Thanks @findwangdi!
 - Claude: price the documented Kimi `k3[1m]` context alias in local usage reports, including freshly downloaded prices, without changing model names or mixing provider catalogs; refresh affected Pi costs while preserving native Codex caches (investigated alongside #2374). Thanks @joeVenner!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.56.1 — Unreleased
 
 ### Fixed
-- Antigravity: expose the existing local token-history reader through CLI cost, serve, and dashboard selection, preserving unknown dollar costs and unavailable histories (investigated alongside #3266). Thanks @chid!
+- Antigravity: expose the existing local token-history reader through CLI cost, serve, and dashboard selection, preserving unknown dollar costs and distinguishing unavailable from empty history in text output (investigated alongside #3266). Thanks @chid!
 - Docs: clarify the Codex cost-history refresh floor and explain that Manual stops recurring refreshes, not startup or pending catch-up scans.
 - Codex: preserve calendar spacing in inline cost charts, keep unscanned and unpriced days unknown, honor the selected bucket time zone, and fit year-long histories within the menu (#3232). Thanks @findwangdi!
 - Claude: price the documented Kimi `k3[1m]` context alias in local usage reports, including freshly downloaded prices, without changing model names or mixing provider catalogs; refresh affected Pi costs while preserving native Codex caches (investigated alongside #2374). Thanks @joeVenner!

--- a/Sources/CodexBarCLI/CLICostCommand.swift
+++ b/Sources/CodexBarCLI/CLICostCommand.swift
@@ -163,6 +163,10 @@ extension CodexBarCLI {
         useColor: Bool) -> String
     {
         let name = ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
+        // Provider-specific by design: Antigravity exposes token history, not priced estimates.
+        if provider == .antigravity {
+            return Self.renderLocalTokenHistoryText(name: name, snapshot: snapshot, useColor: useColor)
+        }
         // Provider-specific by design: Codex cost is explicitly an API-equivalent local-session estimate.
         let title = provider == .codex
             ? "\(name) API-equivalent estimate (not billed)"
@@ -200,6 +204,30 @@ extension CodexBarCLI {
         return [header, todayLine, monthLine, meteredLine, hintLine]
             .compactMap(\.self)
             .joined(separator: "\n")
+    }
+
+    private static func renderLocalTokenHistoryText(
+        name: String,
+        snapshot: CostUsageTokenSnapshot,
+        useColor: Bool) -> String
+    {
+        let header = Self.costHeaderLine("\(name) Token History", useColor: useColor)
+        let hint = "Local token history · dollar costs unavailable"
+        guard snapshot.historyCoverageIsEstablished else {
+            return [header, "Local token history is unavailable or incomplete.", hint].joined(separator: "\n")
+        }
+        let today = snapshot.sessionTokens.map { "\(UsageFormatter.tokenCountString($0)) tokens" } ?? "—"
+        let total = snapshot.last30DaysTokens.map { "\(UsageFormatter.tokenCountString($0)) tokens" } ?? "—"
+        let historyLabel = snapshot.historyLabel
+            ?? (snapshot.historyDays == 1 ? "Today" : "Last \(snapshot.historyDays) days")
+        let lines: [String?] = [
+            header,
+            "Today: \(today)",
+            "\(historyLabel): \(total)",
+            snapshot.daily.isEmpty ? "No token usage found in the selected period." : nil,
+            hint,
+        ]
+        return lines.compactMap(\.self).joined(separator: "\n")
     }
 
     private static func renderProjectCostText(header: String, snapshot: CostUsageTokenSnapshot) -> String {

--- a/Sources/CodexBarCLI/CLICostCommand.swift
+++ b/Sources/CodexBarCLI/CLICostCommand.swift
@@ -223,7 +223,7 @@ extension CodexBarCLI {
         let lines: [String?] = [
             header,
             "Today: \(today)",
-            "\(historyLabel): \(total)",
+            snapshot.historyDays == 1 ? nil : "\(historyLabel): \(total)",
             snapshot.daily.isEmpty ? "No token usage found in the selected period." : nil,
             hint,
         ]

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -123,7 +123,9 @@ extension CodexBarCLI {
 
         Description:
           Print local token cost usage from Claude/Codex native logs plus supported pi and OMP sessions.
-          This does not require web or CLI access and uses cached scan results unless --refresh is provided.
+          Antigravity token history is also read locally, with dollar costs left unknown.
+          Local readers need no web or provider CLI access; Cursor uses its authenticated dashboard API.
+          Use --refresh to bypass cached scan results.
           Experimental: use --provider-native-only to exclude pi and OMP session mirrors.
 
         Examples:
@@ -131,6 +133,7 @@ extension CodexBarCLI {
           codexbar cost --provider codex --group-by project
           codexbar cost --provider codex --group-by session
           codexbar cost --provider claude --format json --pretty
+          codexbar cost --provider antigravity --format json
         """
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -82,7 +82,8 @@ public enum AntigravityProviderDescriptor {
                     resolveFallbackError: self.resolveFallbackError)),
             cli: ProviderCLIConfig(
                 name: "antigravity",
-                versionDetector: nil))
+                versionDetector: nil,
+                supportsCostCommand: true))
     }
 
     private static let quotaSummaryPrefix = "antigravity-quota-summary-"

--- a/Tests/CodexBarTests/AntigravityCLICostTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLICostTests.swift
@@ -12,12 +12,14 @@ struct AntigravityCLICostTests {
         #expect(CodexBarCLI.costSupportedProviderNames().contains("Antigravity"))
     }
 
-    @Test(arguments: ["valid", "absent", "corrupt", "unsupported-time"])
+    @Test(arguments: ["valid", "empty", "absent", "corrupt", "unsupported-time"])
     func `local cost transports preserve tokens unknown dollars and unavailable history`(source: String) async throws {
         let fixture = try AntigravityLocalFixture()
         switch source {
         case "valid":
             try fixture.database(blobs: [AntigravityLocalFixture.blob()])
+        case "empty":
+            try fixture.database()
         case "corrupt":
             let url = try fixture.database()
             try Data("not a database".utf8).write(to: url)
@@ -46,17 +48,25 @@ struct AntigravityCLICostTests {
         #expect(payloads.count == 1)
         #expect(payload.provider == "antigravity")
         #expect(payload.source == "local")
-        #expect(payload.historyCoverageIsEstablished == (source == "valid"))
-        #expect(payload.last30DaysTokens == (source == "valid" ? 198 : nil))
-        #expect(payload.last30DaysCostUSD == nil)
+        let established = source == "valid" || source == "empty"
+        let expectedTokens: Int? = source == "empty" ? 0 : (source == "valid" ? 198 : nil)
+        let expectedCost: Double? = source == "empty" ? 0 : nil
+        #expect(payload.historyCoverageIsEstablished == established)
+        #expect(payload.last30DaysTokens == expectedTokens)
+        #expect(payload.last30DaysCostUSD == expectedCost)
         #expect(payload.provenance == "unknown")
         #expect(payload.error == nil)
 
         let json = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(payload)) as? [String: Any])
-        #expect(json["last30DaysTokens"] as? Int == (source == "valid" ? 198 : nil))
-        #expect(json["last30DaysCostUSD"] == nil)
+        #expect(json["last30DaysTokens"] as? Int == expectedTokens)
+        #expect(json["last30DaysCostUSD"] as? Double == expectedCost)
         let text = CodexBarCLI.renderCostText(provider: .antigravity, snapshot: snapshot, useColor: false)
         #expect(!text.contains("$0"))
+        #expect(text.contains("Antigravity Token History"))
+        #expect(!text.contains("API-rate estimate"))
+        #expect(text.contains("dollar costs unavailable"))
+        #expect(text.contains("Local token history is unavailable or incomplete.") == !established)
+        #expect(text.contains("No token usage found in the selected period.") == (source == "empty"))
         if source == "valid" { #expect(text.contains("198")) }
     }
 }

--- a/Tests/CodexBarTests/AntigravityCLICostTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLICostTests.swift
@@ -1,0 +1,62 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBarCLI
+
+struct AntigravityCLICostTests {
+    @Test
+    func `local Antigravity history participates in explicit and combined cost selections`() {
+        #expect(CodexBarCLI.costProviders(from: .single(.antigravity)) == [.antigravity])
+        #expect(CodexBarCLI.costProviders(from: .custom([.codex, .antigravity])) == [.codex, .antigravity])
+        #expect(CodexBarCLI.costProviders(from: .all).contains(.antigravity))
+        #expect(CodexBarCLI.costSupportedProviderNames().contains("Antigravity"))
+    }
+
+    @Test(arguments: ["valid", "absent", "corrupt", "unsupported-time"])
+    func `local cost transports preserve tokens unknown dollars and unavailable history`(source: String) async throws {
+        let fixture = try AntigravityLocalFixture()
+        switch source {
+        case "valid":
+            try fixture.database(blobs: [AntigravityLocalFixture.blob()])
+        case "corrupt":
+            let url = try fixture.database()
+            try Data("not a database".utf8).write(to: url)
+        case "unsupported-time":
+            try fixture.database(blobs: [AntigravityLocalFixture.blob(seconds: nil)])
+        default: break
+        }
+        let snapshot = try await fixture.snapshot()
+        let providers = CodexBarCLI.costProviders(from: .single(.antigravity))
+        let payloads = await CodexBarCLI.collectConfiguredCostPayloads(
+            providers: providers,
+            config: CodexBarConfig(providers: [ProviderConfig(id: .antigravity, enabled: true)]),
+            context: ServeCostCollectionContext(
+                configFingerprint: "antigravity-local-cost-fixture",
+                providerTimeout: nil,
+                requestDeadline: nil,
+                now: { ContinuousClock().now },
+                providerOperations: CLIServeOperationCoordinator()))
+        { provider, header in
+            #expect(provider == .antigravity)
+            #expect(header == nil)
+            return CodexBarCLI.makeCostPayload(
+                provider: provider, snapshot: snapshot, error: nil, calendar: AntigravityLocalFixture.calendar)
+        }
+        let payload = try #require(payloads.first)
+        #expect(payloads.count == 1)
+        #expect(payload.provider == "antigravity")
+        #expect(payload.source == "local")
+        #expect(payload.historyCoverageIsEstablished == (source == "valid"))
+        #expect(payload.last30DaysTokens == (source == "valid" ? 198 : nil))
+        #expect(payload.last30DaysCostUSD == nil)
+        #expect(payload.provenance == "unknown")
+        #expect(payload.error == nil)
+
+        let json = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(payload)) as? [String: Any])
+        #expect(json["last30DaysTokens"] as? Int == (source == "valid" ? 198 : nil))
+        #expect(json["last30DaysCostUSD"] == nil)
+        let text = CodexBarCLI.renderCostText(provider: .antigravity, snapshot: snapshot, useColor: false)
+        #expect(!text.contains("$0"))
+        if source == "valid" { #expect(text.contains("198")) }
+    }
+}

--- a/Tests/CodexBarTests/AntigravityCLICostTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLICostTests.swift
@@ -4,6 +4,23 @@ import Testing
 @testable import CodexBarCLI
 
 struct AntigravityCLICostTests {
+    @Test(arguments: [1, 30])
+    func `local token history shows each selected window once`(historyDays: Int) {
+        let snapshot = CostUsageTokenSnapshot(
+            sessionTokens: 198,
+            sessionCostUSD: nil,
+            last30DaysTokens: 198,
+            last30DaysCostUSD: nil,
+            historyDays: historyDays,
+            daily: [],
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let text = CodexBarCLI.renderCostText(provider: .antigravity, snapshot: snapshot, useColor: false)
+        let lines = text.split(separator: "\n")
+        #expect(lines.filter { $0.hasPrefix("Today:") } == ["Today: 198 tokens"])
+        #expect(lines.contains("Last 30 days: 198 tokens") == (historyDays == 30))
+        #expect(text.contains("dollar costs unavailable"))
+    }
+
     @Test
     func `local Antigravity history participates in explicit and combined cost selections`() {
         #expect(CodexBarCLI.costProviders(from: .single(.antigravity)) == [.antigravity])

--- a/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
+++ b/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
@@ -132,8 +132,8 @@ struct DashboardSnapshotBuilderTests {
         #expect(object["generatedAt"] as? String == "2027-01-15T08:00:00Z")
     }
 
-    @Test
-    func `producer provider filter collects and returns exactly one row`() async throws {
+    @Test(arguments: [UsageProvider.codex, .antigravity])
+    func `producer provider filter collects and returns exactly one row`(provider: UsageProvider) async throws {
         let recorder = DashboardProviderSelectionRecorder()
         let producer = DashboardSnapshotProducer(
             collectUsage: { providers in
@@ -168,13 +168,13 @@ struct DashboardSnapshotBuilderTests {
             config: config,
             refreshInterval: 60,
             codexBarVersion: nil,
-            providers: [.codex])
+            providers: [provider])
         let object = try self.jsonObject(result.payload)
         let providers = try #require(object["providers"] as? [[String: Any]])
 
-        #expect(providers.compactMap { $0["id"] as? String } == ["codex"])
-        #expect(await recorder.usageProviders() == [.codex])
-        #expect(await recorder.costProviders() == [.codex])
+        #expect(providers.compactMap { $0["id"] as? String } == [provider.rawValue])
+        #expect(await recorder.usageProviders() == [provider])
+        #expect(await recorder.costProviders() == [provider])
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1337,25 +1337,25 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCLI/CLICostCommand.swift",
-            line: 211,
+            line: 239,
             anchor: "lines.append(Self.costEstimateHint(provider: .codex))",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCLI/CLICostCommand.swift",
-            line: 234,
+            line: 262,
             anchor: "lines.append(Self.costEstimateHint(provider: .codex))",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCLI/CLICostCommand.swift",
-            line: 614,
+            line: 642,
             anchor: "let account = try context.resolvedAccounts(for: .cursor).first",
             expectedProviderIDs: ["cursor"],
             reason: "The Cursor-only cookie-settings resolver passes its fixed identity to token-account helpers."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCLI/CLICostCommand.swift",
-            line: 615,
+            line: 643,
             anchor: "return context.settingsSnapshot(for: .cursor, account: account)?.cursor",
             expectedProviderIDs: ["cursor"],
             reason: "The Cursor-only cookie-settings resolver passes its fixed identity to token-account helpers."),
@@ -3427,7 +3427,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact CLI construct preserves the provider-specific command and output contract."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCLI/CLICostCommand.swift",
-            line: 300,
+            line: 328,
             anchor: "provider == .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3435,7 +3435,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact CLI construct preserves the provider-specific command and output contract."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCLI/CLICostCommand.swift",
-            line: 385,
+            line: 413,
             anchor: "let projects = provider == .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3443,7 +3443,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact CLI construct preserves the provider-specific command and output contract."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCLI/CLICostCommand.swift",
-            line: 624,
+            line: 652,
             anchor: "guard provider == .cursor else { return nil }",
             expectedProviderIDs: ["cursor"],
             expectedReferenceCount: 1,
@@ -3451,7 +3451,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact CLI construct preserves the provider-specific command and output contract."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCLI/CLICostCommand.swift",
-            line: 644,
+            line: 672,
             anchor: "guard provider == .cursor, settings?.cookieSource == .manual else { return nil }",
             expectedProviderIDs: ["cursor"],
             expectedReferenceCount: 1,

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -259,6 +259,10 @@ Both overrides and `HOME` come from the same refresh environment. Declared roots
 discovery still visits only the immediate entries of the recognized directories. This is machine-local token history,
 not account attribution or dollar pricing. No language server, provider CLI, browser, credentials, or network is used.
 
+Use `codexbar cost --provider antigravity --format json` to read this same local history from the CLI.
+The cost endpoint and dashboard also include it when Antigravity is selected. Token counts do not imply known dollar
+costs, and these entry points do not expand the supported timestamp layouts described below.
+
 SQLite is authoritative when present. An unreadable root, malformed database, unsupported event layout, or exhausted
 budget never authorizes replacement by a smaller/stale JSONL cache. Complete empty databases and complete histories
 outside the selected window establish empty history; absent sources and partial scans do not. Partial reports remain

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,7 +65,8 @@ See `docs/configuration.md` for the schema.
     `--format text|json`, and treats `toon` like any other unrecognized value.
 - `codexbar cost` prints token cost usage for Claude, Codex, Cursor, and Antigravity.
   - Claude and Codex are scanned from local session logs without web/CLI access.
-  - Antigravity reads supported local token history without web, provider CLI, or credential access. Dollar costs stay unknown; unsupported timestamps and incomplete histories remain unavailable (see `docs/antigravity.md`). The same provider selection applies to `serve /cost` and dashboard cost collection.
+  - Antigravity reads supported local token history without web, provider CLI, or credential access. It does not estimate dollar costs; unsupported timestamps and incomplete histories remain unavailable (see `docs/antigravity.md`). The same provider selection applies to `serve /cost` and dashboard cost collection.
+    Text output labels this as token history and distinguishes unavailable or incomplete history from a complete period with no recorded usage.
   - Cursor is fetched from the cookie-authenticated cursor.com dashboard API (macOS only; see `docs/cursor.md`) and honors the configured cookie source: a non-empty Manual header is required and forwarded, while Off fails explicitly instead of silently omitting Cursor.
   - `--format text|json` (default: text). `--json` includes the same cost concepts as Settings → Usage & Spend (token mix, `provenance`, coverage), but it is not the dashboard Export JSON schema. CLI places mix fields under each provider's `totals` and emits `provenance`/`coverage` on that provider object; Export JSON nests `tokenMix`, `provenance`, and `coverage` under `groups[]`.
   - OpenCodex appears as a separate `opencodex` payload only when **Include OpenCodex usage logs** is on in Settings. That payload does not invent `projects` (OpenCodex logs have no workspace path).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -63,8 +63,9 @@ See `docs/configuration.md` for the schema.
     no denormalization — intended for agents that want a token-cheaper alternative to parsing JSON. `usage --format
     toon` is the only command that supports it; every other command still advertises and accepts only
     `--format text|json`, and treats `toon` like any other unrecognized value.
-- `codexbar cost` prints token cost usage for Claude, Codex, and Cursor.
+- `codexbar cost` prints token cost usage for Claude, Codex, Cursor, and Antigravity.
   - Claude and Codex are scanned from local session logs without web/CLI access.
+  - Antigravity reads supported local token history without web, provider CLI, or credential access. Dollar costs stay unknown; unsupported timestamps and incomplete histories remain unavailable (see `docs/antigravity.md`). The same provider selection applies to `serve /cost` and dashboard cost collection.
   - Cursor is fetched from the cookie-authenticated cursor.com dashboard API (macOS only; see `docs/cursor.md`) and honors the configured cookie source: a non-empty Manual header is required and forwarded, while Off fails explicitly instead of silently omitting Cursor.
   - `--format text|json` (default: text). `--json` includes the same cost concepts as Settings → Usage & Spend (token mix, `provenance`, coverage), but it is not the dashboard Export JSON schema. CLI places mix fields under each provider's `totals` and emits `provenance`/`coverage` on that provider object; Export JSON nests `tokenMix`, `provenance`, and `coverage` under `groups[]`.
   - OpenCodex appears as a separate `opencodex` payload only when **Include OpenCodex usage logs** is on in Settings. That payload does not invent `projects` (OpenCodex logs have no workspace path).


### PR DESCRIPTION
## Summary

Enable Antigravity's already-supported local token-history reader in the shared CLI cost-provider registry. The missing descriptor flag excluded explicit `cost --provider antigravity` requests, `serve /cost`, and dashboard cost collection even though the existing fetcher supports this provider.

The reader, accepted timestamps, recognized filesystem roots, credentials, pricing, and storage behavior are unchanged. Valid local history keeps its token counts and unknown dollar costs; missing, corrupt, and unsupported histories remain unestablished rather than confirmed zero. Help and provider documentation now describe that boundary.

This isolates the independent capability omission identified in #3266, with credit to @chid. It does not include that PR's timestamp-recovery proposal and does not close it. The broader proposal remains open because an execution ID and step creation time do not establish the existing per-invocation timestamp contract.

## Verification

- Before the descriptor fix, the new routing/transport regression selection failed with nine assertions: explicit and combined cost selection dropped Antigravity, serve collection returned no payload, and dashboard cost selection omitted it.
- Added synthetic SQLite-to-fetcher-to-text/JSON/serve coverage for valid, absent, corrupt, and unsupported-time history. Parameterized dashboard provider routing for Codex and Antigravity; quota collection is stubbed, with no live accounts or credentials.
- Focused tests, full sharded suite, lint, and exact-head CI are recorded in the landing proof below once complete.
- Isolated Codex autoreview reported no accepted/actionable findings.

No real provider/account probe, app-bundle launch, or release is included.
