### PR TITLE
docs: clarify z.ai quotas and widget provider selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.1 — Unreleased
 
 ### Fixed
+- Docs: document existing z.ai credit quotas and explain how to configure independent provider widgets.
 - Antigravity: expose the existing local token-history reader through CLI cost, serve, and dashboard selection, preserving unknown dollar costs and distinguishing unavailable from empty history in text output (investigated alongside #3266). Thanks @chid!
 - Docs: clarify the Codex cost-history refresh floor and explain that Manual stops recurring refreshes, not startup or pending catch-up scans.
 - Codex: preserve calendar spacing in inline cost charts, keep unscanned and unpriced days unknown, honor the selected bucket time zone, and fit year-long histories within the menu (#3232). Thanks @findwangdi!

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -39,6 +39,8 @@ read_when:
 - **CodexBar Burn Down** (`CodexBarBurnDownWidget`): configurable session or weekly burn-down chart, medium only.
 - **CodexBar Burn Down (Combined)** (`CodexBarCombinedBurnDownWidget`): session and weekly burn-down charts, medium only.
 
+Switcher widgets share one remembered provider selection, so switching one updates all Switcher widgets. To keep Claude and Codex visible side by side, add two **CodexBar Usage** widgets and configure each widget's **Provider** separately. Usage widgets read their own configured provider instead of the shared Switcher selection.
+
 ## Provider picker support
 The configurable provider widgets currently expose:
 Codex, Claude, Cursor, Gemini, Alibaba, Antigravity, z.ai, Copilot, MiniMax, Kilo, OpenCode, and OpenCode Go.

--- a/docs/zai.md
+++ b/docs/zai.md
@@ -137,9 +137,11 @@ Copy each value once, on one line. Multi-line or duplicated IDs can make the API
   - `data.limits[]` → each limit entry.
   - `data.planName` (or `plan`, `plan_type`, `packageName`, `level`) → plan label.
 - Limit types:
-  - Shortest `TOKENS_LIMIT` (normally 5 hours) → primary Coding Plan window.
-  - Longer `TOKENS_LIMIT` (normally weekly) → secondary window.
-  - `TIME_LIMIT` → a separate MCP lane, never a fabricated monthly Coding Plan window.
+  - Both `TOKENS_LIMIT` and `CREDIT_LIMIT` supply Coding Plan windows.
+  - A single Coding Plan limit becomes primary. With multiple limits, the first becomes primary and the last becomes secondary after sorting by duration; unknown durations sort last.
+  - `TIME_LIMIT` → a separate MCP lane when a Coding Plan window is available, otherwise the primary MCP window; never a fabricated monthly Coding Plan window.
+- Usage percentage:
+  - An integer `percentage` is required. When a positive `usage` limit and a `currentValue` or `remaining` count are present, the counts determine the used percentage. The result is clamped to 0–100%.
 - Window duration:
   - Unit + number → minutes/hours/days.
 - Reset:
@@ -148,6 +150,8 @@ Copy each value once, on one line. Multi-line or duplicated IDs can make the API
   - `usageDetails[]` per model (MCP usage list).
 
 ## Key files
-- `Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift`
+- `Sources/CodexBarCore/Resources/Plugins/zai.js` (quota parsing and window mapping)
+- `Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift`
 - `Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift`
 - `Sources/CodexBar/ZaiTokenStore.swift` (legacy migration helper)
+- `Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift` (quota fixtures, including credit limits)


### PR DESCRIPTION
## Summary

Document behavior already present in the code:

- z.ai Coding Plan windows accept both token and credit limits; explain duration ordering, count-derived percentages, and MCP placement, and replace the removed Swift parser reference with the current plugin and fixture paths.
- Explain the shared provider selection of Switcher widgets and how to configure two Usage widgets with independent providers.
- Record these documentation corrections in the changelog.

Related: #2522 and #3256. Neither issue is closed by this documentation change: it does not prove every z.ai V3 payload works or change the Switcher's shared-selection behavior. No source code, persistence, provider authentication, or widget rendering changes.

## Verification

- Cross-checked the text against `zai.js`, `CodexBarWidgetBundle.swift`, `CodexBarWidgetProvider.swift`, and `WidgetSelectionStore`.
- `node Scripts/check-documentation-links.mjs` — 187 local links passed.
- `node Scripts/generate-llms.mjs --check` — passed.
- `git diff --check` — passed.
- Isolated Codex review through P2 — no actionable findings.
- The unchanged source/test code passed the full [CI matrix for #3267](https://github.com/steipete/CodexBar/actions/runs/33257952155). This docs-only head still needs its own required CI checks before merge.

No live account or UI proof is claimed; these are source-verified documentation clarifications.
