### PR TITLE
test: stabilize local database and menu refresh fixtures

### DIFF
--- a/Tests/CodexBarTests/AntigravityLocalScanTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalScanTests.swift
@@ -13,14 +13,21 @@ struct AntigravityLocalScanTests {
     @Test(arguments: [499, 500, 501])
     func `database cap distinguishes below exactly and above limit`(count: Int) throws {
         let fixture = try Fixture()
-        for index in 0..<count {
-            try fixture.database("session-\(index)")
+        let seed = try fixture.database("session-0")
+        // The cap counts distinct files; copy the closed empty database instead of committing 500 schemas.
+        for index in 1..<count {
+            try FileManager.default.copyItem(
+                at: seed,
+                to: seed.deletingLastPathComponent().appendingPathComponent("session-\(index).db"))
         }
         var limits = AntigravityLocalReader.Limits()
         limits.duration = 60
         let report = try fixture.report(limits: limits)
         #expect(report.coverage == (count <= 500 ? .complete : .partial))
         #expect(report.statistics.files == min(count, 500))
+        #expect(report.statistics.rows == 0)
+        #expect(report.statistics.sqliteHandlesOpened == min(count, 500))
+        #expect(report.statistics.sqliteHandlesClosed == report.statistics.sqliteHandlesOpened)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuScopedCodexRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuScopedCodexRefreshTests.swift
@@ -94,6 +94,8 @@ struct StatusMenuScopedCodexRefreshTests {
 
             store._test_providerRefreshOverride = { provider in
                 #expect(provider == .codex)
+                // A settings reload can invalidate the revision-bound fallback account cache.
+                store.accountInfoCache[.codex] = nil
                 store.snapshots[.codex] = Self.snapshot(
                     usedPercent: 37,
                     updatedAt: initialUpdatedAt.addingTimeInterval(60))
@@ -139,11 +141,13 @@ struct StatusMenuScopedCodexRefreshTests {
             let enrichmentDidStart = await creditsStarted.waitUntilSignaled()
             #expect(enrichmentDidStart)
             guard enrichmentDidStart else {
+                releaseCredits.resume()
                 await refreshTask.value
                 return
             }
 
             let expectedCore = try #require(coreModel)
+            #expect(frozen.hasCompatibleTrackedLayout(with: expectedCore))
             let visibleWhileBlocked = monitor.model(for: .codex, fallback: frozen)
             #expect(!monitor.isManualRefreshInFlight(for: .codex))
             #expect(visibleWhileBlocked.metrics.map(\.percent) == expectedCore.metrics.map(\.percent))
@@ -268,7 +272,12 @@ struct StatusMenuScopedCodexRefreshTests {
                     resetsAt: updatedAt.addingTimeInterval(7200),
                     resetDescription: nil)
             },
-            updatedAt: updatedAt)
+            updatedAt: updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "fixture@example.com",
+                accountOrganization: nil,
+                loginMethod: "pro"))
     }
 
     private func emitProbe(_ line: String) {


### PR DESCRIPTION
## Summary

Two test-only repairs found while validating #3267:

- Build each Antigravity database-cap fixture from one committed, closed empty SQLite database and copy it to distinct files. Keep the 499/500/501 cases, default 500-file cap, and 60-second reader budget. Also assert empty rows and balanced read handles. This removes 1,497 redundant schema creations without bypassing discovery or SQLite reads.
- Give both Codex menu-refresh snapshots explicit fixture identity, so invalidating the fallback account cache cannot accidentally turn the test into an incompatible-account scenario. Deliberately clear that cache during refresh and assert layout compatibility while preserving all blocked-enrichment and changed-quota assertions. Release the credits gate before awaiting the refresh task on the timeout path, preventing a late loader from deadlocking cleanup.

No production code, timeout budgets, compatibility rules, credentials, or user-visible behavior changes. No changelog entry is needed for this test-only change. This does not claim to fix every local-host timing stall seen in the broader run.

## Verification

- Before fixing the snapshot identity, the strengthened menu test failed with four issues: incompatible tracked layout, refresh still active, and the old quota remaining frozen. The unrelated reconciliation test passed.
- `swift test --jobs 4 --filter 'StatusMenuScopedCodexRefreshTests|AntigravityLocalScanTests'` passed all 15 tests in 2 suites in 41.095 seconds, with Keychain access suppressed and Codex file isolation enabled. The cap cases still open and close 499/500/500 actual SQLite handles respectively.
- Isolated Codex review through P2 found no actionable defects.
- `make check`, the broader local suite, and exact-head CI are being verified before landing.

All data is synthetic. No live provider, browser-cookie, Keychain, or application UI probe was performed.
