### PR TITLE
docs: clarify OpenCode quota and cost boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.1 — Unreleased
 
 ### Fixed
+- Docs: distinguish OpenCode-backed Codex OAuth quota from unsupported OpenCode session cost imports, preserving existing provider and account boundaries (investigated alongside #3273). Thanks @pedrommone!
 - Privacy: honor “Hide personal information” for project/source names and paths in cost history and project names in Usage & Spend, preserving costs, tokens, and stored data (#3262). Thanks @vinschger!
 - Docs: document existing z.ai credit quotas and explain how to configure independent provider widgets.
 - Antigravity: expose the existing local token-history reader through CLI cost, serve, and dashboard selection, preserving unknown dollar costs and distinguishing unavailable from empty history in text output (investigated alongside #3266). Thanks @chid!

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -60,6 +60,8 @@ Usage source picker:
   Automatic mode also suppresses unscoped CLI fallback whenever a managed workspace is selected. Explicit
   managed-account workspace selection is stored in CodexBar's private managed-account metadata; it never edits the
   source `auth.json` or publishes an `account_id` change back to another application's credential file.
+- Reusing OpenCode OAuth enables remote account quota, not OpenCode session token/cost ingestion. See
+  [OpenCode with Codex or OpenAI](opencode.md#using-opencode-with-codex-or-openai) for the current history boundary.
 
 ### Advanced profile-home accounts
 - Managed Codex accounts remain the default multi-account path.

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -23,6 +23,22 @@ read_when:
 - Secondary window: optional weekly usage (`weeklyUsage.usagePercent`, `weeklyUsage.resetInSec`).
 - Resets computed as `now + resetInSec`.
 
+## Using OpenCode with Codex or OpenAI
+
+Codex account quota and local token/cost history are separate data sources. The Codex provider reads session and
+weekly quota from the signed-in account's remote usage endpoint; those percentages do not come from local session
+logs.
+
+If OpenCode holds your Codex OAuth session, the explicitly enabled **External Codex OAuth sources** setting can
+reuse its `openai` OAuth entry for remote quota. Native Codex credentials take precedence, and an explicit
+`CODEX_HOME` prevents external fallback. External credentials stay read-only; stale credentials fail closed, and
+API-key entries are ignored. See [Codex external OAuth sources](codex.md#optional-external-oauth-sources-off-by-default).
+
+This does not import OpenCode sessions into Codex token or spend totals. The base OpenCode provider tracks its web
+dashboard, while the local SQLite reader described here selects only `opencode-go` assistant records for OpenCode Go.
+Ordinary OpenCode sessions using OpenAI/Codex are not currently included in local cost history. OpenAI API-platform
+usage is a separate [OpenAI provider](openai.md), not Codex subscription quota.
+
 ## Notes
 - Responses are `text/javascript` with serialized objects; parse via regex.
 - Missing workspace ID or rolling usage fields should raise parse errors; omitted weekly usage stays absent.


### PR DESCRIPTION
## Summary

Clarify the distinction raised in #3273 between remote Codex account quota and local OpenCode session token/cost history. Link the existing opt-in external OAuth flow without implying it imports session history, bypasses native credential precedence, or accepts API keys. Distinguish ordinary OpenCode sessions from the existing OpenCode Go SQLite reader and OpenAI API-platform usage.

This is documentation only. No auth, scanning, attribution, storage, or privacy behavior changes, and #3273 remains open for the requested importer design. Add the corresponding 0.56.1 Unreleased changelog note and credit the reporter.

## Verification

- Documentation links: 190 local links passed.
- Generated llms index: unchanged and valid.
- Focused existing OAuth/SQLite fixture tests: all 54 tests across two suites passed (73.399 seconds), with Keychain access suppressed and Codex file isolation enabled.
- `make check`: passed. Independent Codex review: no actionable findings at the default P0 reporting threshold; the docs were also cross-checked against the credential loader, provider descriptor, and SQLite reader.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33270504078): passed lint, Linux x64, Linux ARM64 and the aggregate gate. macOS tests and Linux musl were intentionally skipped by the existing docs-only path filter; GitGuardian passed.
- Runtime, tests, scripts, package files, and Makefile are byte-identical to the just-verified privacy candidate `f21fa598cdb1cf514aa4509afb65a060f50b0de5`, whose full `make test` passed 960 selections across all 80 groups (one timeout group recovered through 12 standard isolated retries) and whose [CI passed](https://github.com/steipete/CodexBar/actions/runs/33267227641). This docs-only delta does not claim another full-suite run or a live-account probe.

Related: #3273 (not a fix for session ingestion).
