### PR TITLE
test: isolate Cursor cache mutation callbacks

### DIFF
--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1451,11 +1451,15 @@ extension CursorStatusProbeTests {
         #expect(CursorStatusProbe.commitBrowserLoginSession(staleSession))
         defer { CookieHeaderCache.clear(provider: .cursor) }
 
-        let testSession = CursorStatusProbeTestSession { request in
+        let replacementCommitted = LockIsolated<Bool?>(nil)
+        let handler: @Sendable (URLRequest) throws -> (HTTPURLResponse, Data) = { request in
             let requestURL = try #require(request.url)
             let cookie = request.value(forHTTPHeaderField: "Cookie")
             if cookie == staleSession.cookieHeader {
-                #expect(CursorStatusProbe.commitBrowserLoginSession(replacementSession))
+                // Only the required response is guaranteed to run before fetch and cache teardown finish.
+                if requestURL.path == "/api/usage-summary" {
+                    replacementCommitted.setValue(CursorStatusProbe.commitBrowserLoginSession(replacementSession))
+                }
                 return makeCursorStatusProbeResponse(
                     url: requestURL,
                     body: #"{"error":"unauthorized"}"#,
@@ -1477,6 +1481,7 @@ extension CursorStatusProbeTests {
                 throw URLError(.badURL)
             }
         }
+        let testSession = CursorStatusProbeTestSession(handler: handler)
 
         let baseURL = try #require(URL(string: "https://cursor-web.test"))
         let snapshot = try await CursorStatusProbe(
@@ -1487,8 +1492,10 @@ extension CursorStatusProbeTests {
             appAuthStore: CursorAppAuthSessionProviderStub(session: nil)).fetch()
 
         #expect(snapshot.accountEmail == "replacement@example.com")
+        #expect(replacementCommitted.value == true)
         #expect(CookieHeaderCache.load(provider: .cursor)?.cookieHeader == replacementSession.cookieHeader)
         #expect(CookieHeaderCache.load(provider: .cursor)?.authenticationFailurePolicy == .stopFallback)
+        try self.replayOptionalResponsesAfterCacheCleanup(cookieHeader: staleSession.cookieHeader, handler: handler)
     }
 
     @Test
@@ -1499,14 +1506,17 @@ extension CursorStatusProbeTests {
         #expect(CursorStatusProbe.commitBrowserLoginSession(selectedSession))
         defer { CookieHeaderCache.clear(provider: .cursor) }
 
-        let testSession = CursorStatusProbeTestSession { request in
+        let backgroundReplacementStored = LockIsolated<Bool?>(nil)
+        let handler: @Sendable (URLRequest) throws -> (HTTPURLResponse, Data) = { request in
             let requestURL = try #require(request.url)
             let cookie = request.value(forHTTPHeaderField: "Cookie")
             if cookie == selectedSession.cookieHeader {
-                #expect(!CookieHeaderCache.storeResult(
-                    provider: .cursor,
-                    cookieHeader: "background=replacement",
-                    sourceLabel: "Background refresh"))
+                if requestURL.path == "/api/usage-summary" {
+                    backgroundReplacementStored.setValue(CookieHeaderCache.storeResult(
+                        provider: .cursor,
+                        cookieHeader: "background=replacement",
+                        sourceLabel: "Background refresh"))
+                }
             } else {
                 Issue.record("Rejected selected session unexpectedly switched to \(cookie ?? "<none>")")
             }
@@ -1515,6 +1525,7 @@ extension CursorStatusProbeTests {
                 body: #"{"error":"unauthorized"}"#,
                 statusCode: 401)
         }
+        let testSession = CursorStatusProbeTestSession(handler: handler)
 
         let baseURL = try #require(URL(string: "https://cursor-web.test"))
         let probe = CursorStatusProbe(
@@ -1527,9 +1538,27 @@ extension CursorStatusProbeTests {
         await #expect(throws: CursorStatusProbeError.self) {
             _ = try await probe.fetch()
         }
+        #expect(backgroundReplacementStored.value == false)
         #expect(!testSession.requestCookies.contains("background=replacement"))
         #expect(CookieHeaderCache.load(provider: .cursor)?.cookieHeader == selectedSession.cookieHeader)
         #expect(CookieHeaderCache.load(provider: .cursor)?.authenticationFailurePolicy == .stopFallback)
+        try self.replayOptionalResponsesAfterCacheCleanup(cookieHeader: selectedSession.cookieHeader, handler: handler)
+    }
+
+    private func replayOptionalResponsesAfterCacheCleanup(
+        cookieHeader: String,
+        handler: @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)) throws
+    {
+        CookieHeaderCache.clear(provider: .cursor)
+        // Replay retained callbacks after teardown without depending on URLSession cancellation timing.
+        for path in ["/api/auth/me", "/api/dashboard/get-sand-usage-status"] {
+            let url = try #require(URL(string: "https://cursor-web.test\(path)"))
+            var request = URLRequest(url: url)
+            request.httpMethod = path == "/api/auth/me" ? "GET" : "POST"
+            request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+            _ = try handler(request)
+            #expect(CookieHeaderCache.load(provider: .cursor) == nil)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fix a pre-existing lifetime race in two Cursor test fixtures, discovered while validating #3270. This changes tests only; Cursor authentication, account selection, and production cancellation behavior are unchanged.

The custom URLProtocol can retain a response handler after a cancelled optional request finishes from the caller's perspective. Both fixtures previously mutated the global cookie cache from every request callback, so a late callback could repopulate the cache after cleanup or report an assertion after the test had already passed.

Limit the simulated cache changes to the required usage-summary response, record their results in the existing lock-isolated test helper, and assert them in the test body. Replay the same optional response closures after cleanup to prove they cannot change the cache. This is a deterministic fixture-callback regression check, not a claim of reproducing every URLSession cancellation interleaving.

## Verification

- Red before green: adding post-cleanup callback replay to the old fixtures failed both affected tests, with six reported issues.
- Focused Cursor status and usage-events suites: 72 tests passed.
- Repeated focused run: ten clean runs of 72 tests (720 test executions), using `swift test --skip-build --no-parallel --filter 'CursorStatusProbeTests|CursorUsageEventsFetcherTests'`.
- `make check`: passed, zero violations across 2,047 Swift files.
- Independent Codex review: no actionable blocking findings.
- Full `make test`: passed, 962 selections across 81 groups in 1,614 seconds. Eighty groups passed first try; unchanged cost-history group 32 exceeded its 180-second deadline, then all 12 isolated selection retries passed. No assertion failures. The changed Cursor group passed first try.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33280735644): passed on `095bbd302e173103e7248c0befcad3e362124dce`, including both macOS test shards, Linux x64/arm64 builds, lint, and the aggregate check. Linux musl was intentionally skipped by the path gate for this test-only change.

All local Swift/XCTest runs use an explicit clean environment with Keychain suppression and Codex-file isolation. No live account, provider, or UI probing is needed for this test-only change. No changelog entry or release.
