### PR TITLE
fix(codex): explain delayed reset admission decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.1 — Unreleased
 
 ### Fixed
+- Codex: add redacted weekly-reset diagnostic reasons for candidate admission, expiry, and account-scoped storage requests without changing reset publication rules (investigated alongside #3248). Thanks @kcharlan!
 - Docs: distinguish OpenCode-backed Codex OAuth quota from unsupported OpenCode session cost imports, preserving existing provider and account boundaries (investigated alongside #3273). Thanks @pedrommone!
 - Privacy: honor “Hide personal information” for project/source names and paths in cost history and project names in Usage & Spend, preserving costs, tokens, and stored data (#3262). Thanks @vinschger!
 - Docs: document existing z.ai credit quotas and explain how to configure independent provider widgets.

--- a/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexWeeklyResetConfirmation.swift
@@ -233,127 +233,164 @@ struct CodexWeeklyResetConfirmation: Sendable {
         return .publishConfirmation
     }
 
-    static func makeDelayedCandidate(
+    static func evaluateDelayedCandidateCreation(
         previous: UsageSnapshot?,
         initial: UsageSnapshot,
         confirmation: UsageSnapshot,
         sourceEvidence: SourceEvidence,
-        observedAt: Date? = nil) -> CodexWeeklyResetPublicationCandidate?
+        observedAt: Date? = nil) -> CandidateCreation
     {
         let observedAt = observedAt ?? self.observationDate
         guard sourceEvidence.previousIsExactOAuth,
               sourceEvidence.initialIsExactOAuth,
-              sourceEvidence.confirmationIsExactOAuth,
-              let previous,
-              previous.dataConfidence == .exact,
+              sourceEvidence.confirmationIsExactOAuth
+        else { return .rejected(.sourceNotExactOAuth) }
+        guard let previous else { return .rejected(.missingPreviousSnapshot) }
+        guard previous.dataConfidence == .exact,
               initial.dataConfidence == .exact,
-              confirmation.dataConfidence == .exact,
-              isFinite(previous.updatedAt),
-              isFinite(initial.updatedAt),
-              isFinite(confirmation.updatedAt),
-              isFinite(observedAt),
-              initial.updatedAt > previous.updatedAt,
-              confirmation.updatedAt > initial.updatedAt,
-              let previousWeekly = CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: previous),
+              confirmation.dataConfidence == .exact
+        else { return .rejected(.confidenceNotExact) }
+        guard self.isFinite(previous.updatedAt),
+              self.isFinite(initial.updatedAt),
+              self.isFinite(confirmation.updatedAt),
+              self.isFinite(observedAt)
+        else { return .rejected(.invalidObservationTime) }
+        guard initial.updatedAt > previous.updatedAt,
+              confirmation.updatedAt > initial.updatedAt
+        else { return .rejected(.nonMonotonicObservationTime) }
+        guard let previousWeekly = CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: previous),
               let initialWeekly = CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: initial),
-              let confirmationWeekly = CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: confirmation),
-              previousWeekly.usedPercent.isFinite,
-              previousWeekly.usedPercent > Self.resetThreshold,
-              initialWeekly.usedPercent.isFinite,
-              initialWeekly.usedPercent <= Self.resetThreshold,
-              confirmationWeekly.usedPercent.isFinite,
-              confirmationWeekly.usedPercent <= Self.resetThreshold,
-              let previousBoundary = validResetBoundary(previousWeekly, capturedAt: previous.updatedAt),
+              let confirmationWeekly = CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: confirmation)
+        else { return .rejected(.missingWeeklyWindow) }
+        guard previousWeekly.usedPercent.isFinite else { return .rejected(.invalidWeeklyUsage) }
+        guard previousWeekly.usedPercent > Self.resetThreshold else { return .rejected(.resetThresholdMismatch) }
+        guard initialWeekly.usedPercent.isFinite else { return .rejected(.invalidWeeklyUsage) }
+        guard initialWeekly.usedPercent <= Self.resetThreshold else { return .rejected(.resetThresholdMismatch) }
+        guard confirmationWeekly.usedPercent.isFinite else { return .rejected(.invalidWeeklyUsage) }
+        guard confirmationWeekly.usedPercent <= Self.resetThreshold else { return .rejected(.resetThresholdMismatch) }
+        guard let previousBoundary = validResetBoundary(previousWeekly, capturedAt: previous.updatedAt),
               let initialBoundary = validResetBoundary(initialWeekly, capturedAt: initial.updatedAt),
               let confirmationBoundary = validResetBoundary(
                   confirmationWeekly,
-                  capturedAt: confirmation.updatedAt),
-              abs(initialBoundary.timeIntervalSince(confirmationBoundary))
-              < resetEquivalenceToleranceSeconds,
-              isSupportedDelayedBoundary(previous: previousBoundary, current: initialBoundary),
-              isSupportedDelayedBoundary(previous: previousBoundary, current: confirmationBoundary),
-              haveCompatibleAccountIdentities(previous, initial, confirmation),
-              haveCompatiblePlans(previous, initial, confirmation),
-              haveStablePositiveCreditInventory(previous, initial, confirmation)
+                  capturedAt: confirmation.updatedAt)
+        else { return .rejected(.invalidResetBoundary) }
+        guard abs(initialBoundary.timeIntervalSince(confirmationBoundary)) < self.resetEquivalenceToleranceSeconds
         else {
-            return nil
+            return .rejected(.inconsistentResetBoundary)
         }
-        return CodexWeeklyResetPublicationCandidate(
+        guard self.isSupportedDelayedBoundary(previous: previousBoundary, current: initialBoundary),
+              self.isSupportedDelayedBoundary(previous: previousBoundary, current: confirmationBoundary)
+        else { return .rejected(.unsupportedResetBoundary) }
+        guard self.haveCompatibleAccountIdentities(previous, initial, confirmation) else {
+            return .rejected(.accountMismatch)
+        }
+        guard self.haveCompatiblePlans(previous, initial, confirmation) else { return .rejected(.planMismatch) }
+        if let reason = positiveCreditInventoryRejection(previous, initial, confirmation) {
+            return .rejected(reason)
+        }
+        return .created(CodexWeeklyResetPublicationCandidate(
             firstObservedAt: initial.updatedAt,
             createdAt: observedAt,
-            snapshot: confirmation)
+            snapshot: confirmation))
     }
 
-    static func delayedCandidateDecision(
+    static func evaluateDelayedCandidate(
         previous: UsageSnapshot?,
         candidate: CodexWeeklyResetPublicationCandidate,
         current: UsageSnapshot,
         currentIsExactOAuth: Bool,
-        observedAt: Date? = nil) -> DelayedCandidateDecision
+        observedAt: Date? = nil) -> DelayedEvaluation
     {
         let observedAt = observedAt ?? self.observationDate
+        if let reason = self.delayedCandidateRejection(
+            candidate, observedAt: observedAt, currentUpdatedAt: current.updatedAt)
+        {
+            return DelayedEvaluation(decision: .discardCandidate, reason: reason)
+        }
+        let age = observedAt.timeIntervalSince(candidate.createdAt)
+        guard currentIsExactOAuth else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .sourceNotExactOAuth)
+        }
+        guard let previous else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .missingPreviousSnapshot)
+        }
+        guard previous.dataConfidence == .exact,
+              candidate.snapshot.dataConfidence == .exact,
+              current.dataConfidence == .exact
+        else { return DelayedEvaluation(decision: .discardCandidate, reason: .confidenceNotExact) }
+        guard let previousWeekly = CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: previous),
+              let candidateWeekly = CodexConsumerProjection.sourceRateWindow(
+                  for: .weekly,
+                  snapshot: candidate.snapshot),
+              let currentWeekly = CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: current)
+        else { return DelayedEvaluation(decision: .discardCandidate, reason: .missingWeeklyWindow) }
+        guard previousWeekly.usedPercent.isFinite else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .invalidWeeklyUsage)
+        }
+        guard previousWeekly.usedPercent > Self.resetThreshold else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .resetThresholdMismatch)
+        }
+        guard candidateWeekly.usedPercent.isFinite else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .invalidWeeklyUsage)
+        }
+        guard candidateWeekly.usedPercent <= Self.resetThreshold else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .resetThresholdMismatch)
+        }
+        guard currentWeekly.usedPercent.isFinite else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .invalidWeeklyUsage)
+        }
+        guard currentWeekly.usedPercent <= Self.resetThreshold else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .resetThresholdMismatch)
+        }
+        guard let previousBoundary = Self.validResetBoundary(previousWeekly, capturedAt: previous.updatedAt),
+              let candidateBoundary = Self.validResetBoundary(
+                  candidateWeekly,
+                  capturedAt: candidate.snapshot.updatedAt),
+              let currentBoundary = Self.validResetBoundary(currentWeekly, capturedAt: current.updatedAt)
+        else { return DelayedEvaluation(decision: .discardCandidate, reason: .invalidResetBoundary) }
+        guard abs(candidateBoundary.timeIntervalSince(currentBoundary)) < Self.resetEquivalenceToleranceSeconds else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .inconsistentResetBoundary)
+        }
+        guard Self.isSupportedDelayedBoundary(previous: previousBoundary, current: candidateBoundary),
+              Self.isSupportedDelayedBoundary(previous: previousBoundary, current: currentBoundary)
+        else { return DelayedEvaluation(decision: .discardCandidate, reason: .unsupportedResetBoundary) }
+        guard Self.haveCompatibleAccountIdentities(previous, candidate.snapshot, current) else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .accountMismatch)
+        }
+        guard Self.haveCompatiblePlans(previous, candidate.snapshot, current) else {
+            return DelayedEvaluation(decision: .discardCandidate, reason: .planMismatch)
+        }
+        if let reason = Self.positiveCreditInventoryRejection(previous, candidate.snapshot, current) {
+            return DelayedEvaluation(decision: .discardCandidate, reason: reason)
+        }
+        guard current.updatedAt > candidate.snapshot.updatedAt else {
+            return DelayedEvaluation(decision: .retainCandidate, reason: .staleObservation)
+        }
+        return age >= Self.delayedCandidateMinimumAge
+            ? DelayedEvaluation(decision: .publishCurrent, reason: .confirmedObservation)
+            : DelayedEvaluation(decision: .retainCandidate, reason: .minimumDelay)
+    }
+
+    static func delayedCandidateRejection(
+        _ candidate: CodexWeeklyResetPublicationCandidate,
+        observedAt: Date,
+        currentUpdatedAt: Date? = nil) -> Reason?
+    {
         guard candidate.evidenceVersion == CodexWeeklyResetPublicationCandidate.currentEvidenceVersion else {
-            return .discardCandidate
+            return .evidenceVersionMismatch
         }
         guard self.isFinite(candidate.firstObservedAt),
               self.isFinite(candidate.createdAt),
               self.isFinite(candidate.snapshot.updatedAt),
-              self.isFinite(current.updatedAt),
+              currentUpdatedAt.map(self.isFinite) ?? true,
               self.isFinite(observedAt)
         else {
-            return .discardCandidate
+            return .invalidObservationTime
         }
         let age = observedAt.timeIntervalSince(candidate.createdAt)
-        guard age >= 0, age <= Self.delayedCandidateMaximumAge else { return .discardCandidate }
-        guard currentIsExactOAuth,
-              let previous,
-              previous.dataConfidence == .exact,
-              candidate.snapshot.dataConfidence == .exact,
-              current.dataConfidence == .exact,
-              let previousWeekly = CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: previous),
-              let candidateWeekly = CodexConsumerProjection.sourceRateWindow(
-                  for: .weekly,
-                  snapshot: candidate.snapshot),
-              let currentWeekly = CodexConsumerProjection.sourceRateWindow(for: .weekly, snapshot: current),
-              previousWeekly.usedPercent.isFinite,
-              previousWeekly.usedPercent > Self.resetThreshold,
-              candidateWeekly.usedPercent.isFinite,
-              candidateWeekly.usedPercent <= Self.resetThreshold,
-              currentWeekly.usedPercent.isFinite,
-              currentWeekly.usedPercent <= Self.resetThreshold,
-              let previousBoundary = Self.validResetBoundary(previousWeekly, capturedAt: previous.updatedAt),
-              let candidateBoundary = Self.validResetBoundary(
-                  candidateWeekly,
-                  capturedAt: candidate.snapshot.updatedAt),
-              let currentBoundary = Self.validResetBoundary(currentWeekly, capturedAt: current.updatedAt),
-              abs(candidateBoundary.timeIntervalSince(currentBoundary))
-              < Self.resetEquivalenceToleranceSeconds,
-              Self.isSupportedDelayedBoundary(previous: previousBoundary, current: candidateBoundary),
-              Self.isSupportedDelayedBoundary(previous: previousBoundary, current: currentBoundary),
-              Self.haveCompatibleAccountIdentities(previous, candidate.snapshot, current),
-              Self.haveCompatiblePlans(previous, candidate.snapshot, current),
-              Self.haveStablePositiveCreditInventory(previous, candidate.snapshot, current)
-        else {
-            return .discardCandidate
-        }
-        guard current.updatedAt > candidate.snapshot.updatedAt else { return .retainCandidate }
-        return age >= Self.delayedCandidateMinimumAge ? .publishCurrent : .retainCandidate
-    }
-
-    static func shouldRetainDelayedCandidate(
-        _ candidate: CodexWeeklyResetPublicationCandidate,
-        observedAt: Date) -> Bool
-    {
-        guard candidate.evidenceVersion == CodexWeeklyResetPublicationCandidate.currentEvidenceVersion,
-              self.isFinite(candidate.firstObservedAt),
-              self.isFinite(candidate.createdAt),
-              self.isFinite(candidate.snapshot.updatedAt),
-              self.isFinite(observedAt)
-        else {
-            return false
-        }
-        let age = observedAt.timeIntervalSince(candidate.createdAt)
-        return age >= 0 && age <= self.delayedCandidateMaximumAge
+        guard age >= 0 else { return .futureCandidate }
+        guard age <= self.delayedCandidateMaximumAge else { return .expiredCandidate }
+        return nil
     }
 
     private static func haveCompatibleAccountIdentities(_ snapshots: UsageSnapshot...) -> Bool {
@@ -373,15 +410,14 @@ struct CodexWeeklyResetConfirmation: Sendable {
         return plans.allSatisfy { $0 == first }
     }
 
-    private static func haveStablePositiveCreditInventory(_ snapshots: UsageSnapshot...) -> Bool {
+    private static func positiveCreditInventoryRejection(_ snapshots: UsageSnapshot...) -> Reason? {
         let creditSnapshots = snapshots.compactMap(\.codexResetCredits)
-        guard creditSnapshots.count == snapshots.count,
-              creditSnapshots.allSatisfy({ Self.isFinite($0.updatedAt) }),
-              zip(creditSnapshots, creditSnapshots.dropFirst()).allSatisfy({ pair in
-                  pair.1.updatedAt >= pair.0.updatedAt
-              })
-        else {
-            return false
+        guard creditSnapshots.count == snapshots.count else { return .missingCreditInventory }
+        guard creditSnapshots.allSatisfy({ Self.isFinite($0.updatedAt) }) else { return .invalidCreditObservationTime }
+        guard zip(creditSnapshots, creditSnapshots.dropFirst()).allSatisfy({ pair in
+            pair.1.updatedAt >= pair.0.updatedAt
+        }) else {
+            return .nonMonotonicCreditObservationTime
         }
         let inventories = creditSnapshots.map { credits -> [AvailableCreditIdentity]? in
             let available = credits.availableCredits(at: credits.updatedAt)
@@ -405,12 +441,12 @@ struct CodexWeeklyResetConfirmation: Sendable {
                 return (lhs.expiresAt ?? .distantPast) < (rhs.expiresAt ?? .distantPast)
             }
         }
-        guard let firstInventory = inventories.first,
-              let first = firstInventory
+        guard let firstInventory = inventories.first, let first = firstInventory,
+              inventories.allSatisfy({ $0 != nil })
         else {
-            return false
+            return .inconsistentAvailableCreditCount
         }
-        return inventories.allSatisfy { $0 == first }
+        return inventories.allSatisfy { $0 == first } ? nil : .changedCreditInventory
     }
 
     private static func isSupportedDelayedBoundary(previous: Date, current: Date) -> Bool {

--- a/Sources/CodexBar/Providers/Codex/CodexWeeklyResetDiagnostics.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexWeeklyResetDiagnostics.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+extension CodexWeeklyResetConfirmation {
+    /// Fixed codes only: never include account identities, credit IDs, or provider payloads.
+    enum Reason: String, Sendable {
+        case candidateCreated
+        case sourceNotExactOAuth
+        case missingPreviousSnapshot
+        case confidenceNotExact
+        case invalidObservationTime
+        case nonMonotonicObservationTime
+        case missingWeeklyWindow
+        case invalidWeeklyUsage
+        case resetThresholdMismatch
+        case invalidResetBoundary
+        case inconsistentResetBoundary
+        case unsupportedResetBoundary
+        case accountMismatch
+        case planMismatch
+        case missingCreditInventory
+        case invalidCreditObservationTime
+        case nonMonotonicCreditObservationTime
+        case inconsistentAvailableCreditCount
+        case changedCreditInventory
+        case evidenceVersionMismatch
+        case futureCandidate
+        case expiredCandidate
+        case staleObservation
+        case minimumDelay
+        case confirmedObservation
+    }
+
+    enum CandidateCreation: Sendable {
+        case created(CodexWeeklyResetPublicationCandidate)
+        case rejected(Reason)
+
+        var candidate: CodexWeeklyResetPublicationCandidate? {
+            guard case let .created(candidate) = self else { return nil }
+            return candidate
+        }
+
+        var reason: Reason {
+            switch self {
+            case .created: .candidateCreated
+            case let .rejected(reason): reason
+            }
+        }
+    }
+
+    struct DelayedEvaluation: Equatable, Sendable {
+        let decision: DelayedCandidateDecision
+        let reason: Reason
+    }
+}
+
+extension UsageStore {
+    enum CodexWeeklyResetPersistenceDecision: String, Sendable {
+        case missingExpectedGuard
+        case accountChanged
+        case ambiguousActiveAccount
+        case existingAccountChanged
+        case noCandidateChange
+        case missingCandidateOrBaseline
+        case storeUnavailable
+        case storeRequested
+
+        var diagnosticMetadata: [String: String] {
+            ["stage": "candidatePersistence", "decision": self.rawValue]
+        }
+    }
+}

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexWeeklyResetCandidatePersistence.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexWeeklyResetCandidatePersistence.swift
@@ -2,21 +2,28 @@ import CodexBarCore
 import Foundation
 
 extension UsageStore {
+    @discardableResult
     func persistCodexWeeklyResetPublicationCandidate(
         _ candidate: CodexWeeklyResetPublicationCandidate?,
         expectedGuard: CodexAccountScopedRefreshGuard?,
-        previousSnapshot: UsageSnapshot?)
+        previousSnapshot: UsageSnapshot?) -> CodexWeeklyResetPersistenceDecision
     {
-        guard let expectedGuard else { return }
+        guard let expectedGuard else {
+            return Self.recordCodexWeeklyResetPersistenceDecision(.missingExpectedGuard)
+        }
         let currentGuard = self.freshCodexAccountScopedRefreshGuard()
-        guard Self.codexScopedRefreshGuardsMatchAccount(expectedGuard, currentGuard) else { return }
+        guard Self.codexScopedRefreshGuardsMatchAccount(expectedGuard, currentGuard) else {
+            return Self.recordCodexWeeklyResetPersistenceDecision(.accountChanged)
+        }
 
         let visibleAccounts = self.freshCodexVisibleAccountsForSnapshotHydration()
         let activeMatches = visibleAccounts.filter {
             $0.isActive && Self.codexScopedRefreshGuardsMatchAccount(
                 currentGuard, Self.codexScopedRefreshGuard(for: $0))
         }
-        guard activeMatches.count == 1, let account = activeMatches.first else { return }
+        guard activeMatches.count == 1, let account = activeMatches.first else {
+            return Self.recordCodexWeeklyResetPersistenceDecision(.ambiguousActiveAccount)
+        }
 
         // Single-account refresh clears memory before admission; keep the persisted rows and their credits intact.
         var records = self.codexAccountSnapshots
@@ -25,8 +32,13 @@ extension UsageStore {
         if let index = records.firstIndex(where: { $0.id == account.id }) {
             let existing = records[index]
             guard Self.codexScopedRefreshGuardsMatchAccount(
-                currentGuard, Self.codexScopedRefreshGuard(for: existing.account)) else { return }
-            guard existing.weeklyResetCandidate != nil || candidate != nil else { return }
+                currentGuard, Self.codexScopedRefreshGuard(for: existing.account))
+            else {
+                return Self.recordCodexWeeklyResetPersistenceDecision(.existingAccountChanged)
+            }
+            guard existing.weeklyResetCandidate != nil || candidate != nil else {
+                return Self.recordCodexWeeklyResetPersistenceDecision(.noCandidateChange)
+            }
             records[index] = CodexAccountUsageSnapshot(
                 account: existing.account,
                 snapshot: existing.snapshot,
@@ -35,7 +47,9 @@ extension UsageStore {
                 credits: existing.credits,
                 weeklyResetCandidate: candidate)
         } else {
-            guard let candidate, let previousSnapshot else { return }
+            guard let candidate, let previousSnapshot else {
+                return Self.recordCodexWeeklyResetPersistenceDecision(.missingCandidateOrBaseline)
+            }
             let identity = previousSnapshot.identity(for: .codex)
             let relabeled = previousSnapshot.withIdentity(ProviderIdentitySnapshot(
                 providerID: .codex,
@@ -52,5 +66,16 @@ extension UsageStore {
         }
         self.codexAccountSnapshots = records
         self.codexAccountUsageSnapshotStore?.store(records)
+        // The store has a Void contract and handles disk errors internally; this is not a write-success claim.
+        return Self.recordCodexWeeklyResetPersistenceDecision(
+            self.codexAccountUsageSnapshotStore == nil ? .storeUnavailable : .storeRequested)
+    }
+
+    private static func recordCodexWeeklyResetPersistenceDecision(
+        _ decision: CodexWeeklyResetPersistenceDecision) -> CodexWeeklyResetPersistenceDecision
+    {
+        CodexBarLog.logger(LogCategories.provider(.codex, scope: "weekly-reset-publication")).debug(
+            "Codex weekly reset candidate persistence decision", metadata: decision.diagnosticMetadata)
+        return decision
     }
 }

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexWeeklyResetConfirmation.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexWeeklyResetConfirmation.swift
@@ -11,7 +11,7 @@ extension UsageStore {
         var withheldSuccess: ProviderFetchResult?
     }
 
-    private struct CodexWeeklyResetPublicationTrace {
+    struct CodexWeeklyResetPublicationTrace {
         let previousSnapshot: UsageSnapshot?
         let missingWindowBackfillSnapshot: UsageSnapshot?
         let publicationBaseline: UsageSnapshot?
@@ -37,8 +37,13 @@ extension UsageStore {
         observedAt: Date = CodexWeeklyResetConfirmation.observationDate,
         fetchConfirmation: @escaping CodexWeeklyConfirmationFetch) async -> CodexWeeklyResetPublicationAdmission
     {
-        var candidateForRetry = pendingCandidate.flatMap {
-            CodexWeeklyResetConfirmation.shouldRetainDelayedCandidate($0, observedAt: observedAt) ? $0 : nil
+        var candidateForRetry: CodexWeeklyResetPublicationCandidate? = pendingCandidate.flatMap {
+            if let reason = CodexWeeklyResetConfirmation.delayedCandidateRejection($0, observedAt: observedAt) {
+                Self.logCodexWeeklyResetCandidateDecision(
+                    stage: "candidateRetention", decision: "discardCandidate", reason: reason)
+                return nil
+            }
+            return $0
         }
         guard case let .success(rawInitialResult) = initialOutcome.result else {
             return CodexWeeklyResetPublicationAdmission(outcome: initialOutcome, pendingCandidate: candidateForRetry)
@@ -94,7 +99,7 @@ extension UsageStore {
         }
 
         if let pendingCandidate = candidateForRetry {
-            let delayedDecision = CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            let evaluation = CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
                 previous: previousSnapshot,
                 candidate: pendingCandidate,
                 current: rawInitialSnapshot,
@@ -102,14 +107,15 @@ extension UsageStore {
                 observedAt: observedAt)
             Self.logCodexWeeklyResetPublicationDecision(
                 stage: "delayedConfirmation",
-                decision: String(describing: delayedDecision),
+                decision: String(describing: evaluation.decision),
+                reason: evaluation.reason,
                 trace: CodexWeeklyResetPublicationTrace(
                     previousSnapshot: previousSnapshot,
                     missingWindowBackfillSnapshot: missingWindowBackfillSnapshot,
                     publicationBaseline: publicationBaseline,
                     initialSnapshot: rawInitialSnapshot,
                     confirmationSnapshot: pendingCandidate.snapshot))
-            switch delayedDecision {
+            switch evaluation.decision {
             case .publishCurrent:
                 return CodexWeeklyResetPublicationAdmission(
                     outcome: publicationInitialOutcome,
@@ -173,22 +179,43 @@ extension UsageStore {
                 outcome: confirmationOutcome,
                 pendingCandidate: nil)
         case .preservePrevious:
-            let candidate = CodexWeeklyResetConfirmation.makeDelayedCandidate(
-                previous: previousSnapshot,
-                initial: rawInitialSnapshot,
-                confirmation: confirmationSnapshot,
-                sourceEvidence: .init(
-                    previousIsExactOAuth: previousSourceLabel?
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                        .lowercased() == "oauth",
-                    initialIsExactOAuth: Self.isExactCodexOAuthResult(rawInitialResult),
-                    confirmationIsExactOAuth: Self.isExactCodexOAuthResult(confirmationResult)),
+            let candidate = Self.makeCodexDelayedCandidate(
+                previousSourceLabel: previousSourceLabel,
+                initialResult: rawInitialResult,
+                confirmationResult: confirmationResult,
+                trace: confirmationTrace,
                 observedAt: observedAt)
             return CodexWeeklyResetPublicationAdmission(
                 outcome: nil,
                 pendingCandidate: candidate,
                 withheldSuccess: confirmationResult)
         }
+    }
+
+    private nonisolated static func makeCodexDelayedCandidate(
+        previousSourceLabel: String?,
+        initialResult: ProviderFetchResult,
+        confirmationResult: ProviderFetchResult,
+        trace: CodexWeeklyResetPublicationTrace,
+        observedAt: Date) -> CodexWeeklyResetPublicationCandidate?
+    {
+        let evaluation = CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
+            previous: trace.previousSnapshot,
+            initial: trace.initialSnapshot,
+            confirmation: confirmationResult.usage.scoped(to: .codex),
+            sourceEvidence: .init(
+                previousIsExactOAuth: previousSourceLabel?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased() == "oauth",
+                initialIsExactOAuth: Self.isExactCodexOAuthResult(initialResult),
+                confirmationIsExactOAuth: Self.isExactCodexOAuthResult(confirmationResult)),
+            observedAt: observedAt)
+        Self.logCodexWeeklyResetPublicationDecision(
+            stage: "candidateCreation",
+            decision: evaluation.candidate == nil ? "rejected" : "created",
+            reason: evaluation.reason,
+            trace: trace)
+        return evaluation.candidate
     }
 
     private nonisolated static func codexMissingWeeklyAdmission(
@@ -241,13 +268,17 @@ extension UsageStore {
         observedAt: Date) -> CodexWeeklyResetPublicationCandidate?
     {
         guard let candidate else { return nil }
-        let decision = CodexWeeklyResetConfirmation.delayedCandidateDecision(
+        let evaluation = CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
             previous: previousSnapshot,
             candidate: candidate,
             current: initialSnapshot,
             currentIsExactOAuth: Self.isExactCodexOAuthResult(initialResult),
             observedAt: observedAt)
-        return decision == .discardCandidate ? nil : candidate
+        Self.logCodexWeeklyResetCandidateDecision(
+            stage: "preservedInitialCandidate",
+            decision: String(describing: evaluation.decision),
+            reason: evaluation.reason)
+        return evaluation.decision == .discardCandidate ? nil : candidate
     }
 
     private nonisolated static func logCodexWeeklyResetInitialDecision(
@@ -278,12 +309,38 @@ extension UsageStore {
     private nonisolated static func logCodexWeeklyResetPublicationDecision(
         stage: String,
         decision: String,
+        reason: CodexWeeklyResetConfirmation.Reason? = nil,
         trace: CodexWeeklyResetPublicationTrace)
+    {
+        CodexBarLog.logger(LogCategories.provider(.codex, scope: "weekly-reset-publication")).debug(
+            "Codex weekly reset publication decision",
+            metadata: self.codexWeeklyResetPublicationMetadata(
+                stage: stage, decision: decision, reason: reason, trace: trace))
+    }
+
+    private nonisolated static func logCodexWeeklyResetCandidateDecision(
+        stage: String,
+        decision: String,
+        reason: CodexWeeklyResetConfirmation.Reason)
+    {
+        CodexBarLog.logger(LogCategories.provider(.codex, scope: "weekly-reset-publication")).debug(
+            "Codex weekly reset candidate decision",
+            metadata: ["stage": stage, "decision": decision, "reason": reason.rawValue])
+    }
+
+    nonisolated static func codexWeeklyResetPublicationMetadata(
+        stage: String,
+        decision: String,
+        reason: CodexWeeklyResetConfirmation.Reason? = nil,
+        trace: CodexWeeklyResetPublicationTrace) -> [String: String]
     {
         var metadata: [String: String] = [
             "stage": stage,
             "decision": decision,
         ]
+        if let reason {
+            metadata["reason"] = reason.rawValue
+        }
         Self.appendCodexWeeklyResetTrace(
             snapshot: trace.previousSnapshot,
             prefix: "previousSnapshot",
@@ -317,9 +374,7 @@ extension UsageStore {
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                     .lowercased()
             })
-        CodexBarLog.logger(LogCategories.provider(.codex, scope: "weekly-reset-publication")).debug(
-            "Codex weekly reset publication decision",
-            metadata: metadata)
+        return metadata
     }
 
     private nonisolated static func codexWeeklyResetCompatibility(

--- a/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetConfirmationTests.swift
@@ -664,12 +664,12 @@ extension CodexWeeklyResetConfirmationTests {
                 status: .available,
                 capturedAt: self.capturedAt.addingTimeInterval(2),
                 expiresAt: expiry))
-        let candidate = try #require(CodexWeeklyResetConfirmation.makeDelayedCandidate(
+        let candidate = try #require(CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
             previous: previous,
             initial: initial,
             confirmation: confirmation,
             sourceEvidence: .allExactOAuth,
-            observedAt: initial.updatedAt))
+            observedAt: initial.updatedAt).candidate)
         #expect(candidate.firstObservedAt == initial.updatedAt)
         #expect(candidate.createdAt == initial.updatedAt)
 
@@ -699,26 +699,26 @@ extension CodexWeeklyResetConfirmationTests {
                 expiresAt: expiry))
 
         #expect(
-            CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
                 previous: previous,
                 candidate: candidate,
                 current: tooSoon,
                 currentIsExactOAuth: true,
-                observedAt: tooSoon.updatedAt) == .retainCandidate)
+                observedAt: tooSoon.updatedAt).decision == .retainCandidate)
         #expect(
-            CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
                 previous: previous,
                 candidate: candidate,
                 current: laterRefresh,
                 currentIsExactOAuth: true,
-                observedAt: laterRefresh.updatedAt) == .publishCurrent)
+                observedAt: laterRefresh.updatedAt).decision == .publishCurrent)
         #expect(
-            CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
                 previous: previous,
                 candidate: candidate,
                 current: expiredRefresh,
                 currentIsExactOAuth: true,
-                observedAt: expiredRefresh.updatedAt) == .discardCandidate)
+                observedAt: expiredRefresh.updatedAt).decision == .discardCandidate)
     }
 
     @Test
@@ -746,50 +746,50 @@ extension CodexWeeklyResetConfirmationTests {
                 status: .available,
                 capturedAt: self.capturedAt.addingTimeInterval(2),
                 expiresAt: expiry))
-        let candidate = try #require(CodexWeeklyResetConfirmation.makeDelayedCandidate(
+        let candidate = try #require(CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
             previous: previous,
             initial: initial,
             confirmation: confirmation,
             sourceEvidence: .allExactOAuth,
-            observedAt: self.capturedAt))
+            observedAt: self.capturedAt).candidate)
         let validUntil = self.capturedAt.addingTimeInterval(30 * 60)
         let expiredAt = validUntil.addingTimeInterval(1)
 
-        #expect(CodexWeeklyResetConfirmation.shouldRetainDelayedCandidate(candidate, observedAt: validUntil))
-        #expect(!CodexWeeklyResetConfirmation.shouldRetainDelayedCandidate(candidate, observedAt: expiredAt))
-        #expect(!CodexWeeklyResetConfirmation.shouldRetainDelayedCandidate(
+        #expect(CodexWeeklyResetConfirmation.delayedCandidateRejection(candidate, observedAt: validUntil) == nil)
+        #expect(!(CodexWeeklyResetConfirmation.delayedCandidateRejection(candidate, observedAt: expiredAt) == nil))
+        #expect(!(CodexWeeklyResetConfirmation.delayedCandidateRejection(
             candidate,
-            observedAt: self.capturedAt.addingTimeInterval(-1)))
-        #expect(CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            observedAt: self.capturedAt.addingTimeInterval(-1)) == nil))
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
             previous: previous,
             candidate: candidate,
             current: confirmation,
             currentIsExactOAuth: true,
-            observedAt: self.capturedAt.addingTimeInterval(60)) == .retainCandidate)
-        #expect(CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            observedAt: self.capturedAt.addingTimeInterval(60)).decision == .retainCandidate)
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
             previous: previous,
             candidate: candidate,
             current: confirmation,
             currentIsExactOAuth: true,
-            observedAt: expiredAt) == .discardCandidate)
-        #expect(CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            observedAt: expiredAt).decision == .discardCandidate)
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
             previous: previous,
             candidate: candidate,
             current: initial,
             currentIsExactOAuth: true,
-            observedAt: expiredAt) == .discardCandidate)
-        #expect(CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            observedAt: expiredAt).decision == .discardCandidate)
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
             previous: previous,
             candidate: candidate,
             current: confirmation,
             currentIsExactOAuth: false,
-            observedAt: self.capturedAt.addingTimeInterval(30)) == .discardCandidate)
-        #expect(CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            observedAt: self.capturedAt.addingTimeInterval(30)).decision == .discardCandidate)
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
             previous: previous,
             candidate: candidate,
             current: self.identified(confirmation, email: "other@example.com", plan: "pro"),
             currentIsExactOAuth: true,
-            observedAt: self.capturedAt.addingTimeInterval(30)) == .discardCandidate)
+            observedAt: self.capturedAt.addingTimeInterval(30)).decision == .discardCandidate)
     }
 
     @Test
@@ -817,12 +817,12 @@ extension CodexWeeklyResetConfirmationTests {
                 status: .available,
                 capturedAt: self.capturedAt.addingTimeInterval(2),
                 expiresAt: expiry))
-        let candidate = try #require(CodexWeeklyResetConfirmation.makeDelayedCandidate(
+        let candidate = try #require(CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
             previous: previous,
             initial: initial,
             confirmation: confirmation,
             sourceEvidence: .allExactOAuth,
-            observedAt: self.capturedAt))
+            observedAt: self.capturedAt).candidate)
         let futureProviderObservation = self.exactIdentifiedSnapshot(
             offset: 120,
             weeklyUsed: 0.5,
@@ -832,29 +832,29 @@ extension CodexWeeklyResetConfirmationTests {
                 capturedAt: self.capturedAt.addingTimeInterval(120),
                 expiresAt: expiry))
 
-        #expect(CodexWeeklyResetConfirmation.delayedCandidateDecision(
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
             previous: previous,
             candidate: candidate,
             current: futureProviderObservation,
             currentIsExactOAuth: true,
-            observedAt: self.capturedAt.addingTimeInterval(59)) == .retainCandidate)
-        #expect(CodexWeeklyResetConfirmation.delayedCandidateDecision(
+            observedAt: self.capturedAt.addingTimeInterval(59)).decision == .retainCandidate)
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
             previous: previous,
             candidate: candidate,
             current: futureProviderObservation,
             currentIsExactOAuth: true,
-            observedAt: self.capturedAt.addingTimeInterval(60)) == .publishCurrent)
+            observedAt: self.capturedAt.addingTimeInterval(60)).decision == .publishCurrent)
 
         let futureCandidate = CodexWeeklyResetPublicationCandidate(
             firstObservedAt: initial.updatedAt,
             createdAt: self.capturedAt.addingTimeInterval(1),
             snapshot: confirmation)
-        #expect(CodexWeeklyResetConfirmation.delayedCandidateDecision(
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
             previous: previous,
             candidate: futureCandidate,
             current: futureProviderObservation,
             currentIsExactOAuth: true,
-            observedAt: self.capturedAt) == .discardCandidate)
+            observedAt: self.capturedAt).decision == .discardCandidate)
     }
 
     @Test
@@ -904,11 +904,11 @@ extension CodexWeeklyResetConfirmationTests {
                 capturedAt: self.capturedAt.addingTimeInterval(2),
                 expiresAt: expiry))
 
-        #expect(CodexWeeklyResetConfirmation.makeDelayedCandidate(
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
             previous: previous,
             initial: initial,
             confirmation: confirmation,
-            sourceEvidence: .allExactOAuth) != nil)
+            sourceEvidence: .allExactOAuth).candidate != nil)
     }
 
     @Test
@@ -943,11 +943,11 @@ extension CodexWeeklyResetConfirmationTests {
                 capturedAt: self.capturedAt.addingTimeInterval(2),
                 expiresAt: expiry))
 
-        #expect(CodexWeeklyResetConfirmation.makeDelayedCandidate(
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
             previous: previous,
             initial: initial,
             confirmation: confirmation,
-            sourceEvidence: .allExactOAuth) == nil)
+            sourceEvidence: .allExactOAuth).candidate == nil)
     }
 
     @Test
@@ -976,7 +976,7 @@ extension CodexWeeklyResetConfirmationTests {
                 capturedAt: self.capturedAt.addingTimeInterval(2),
                 expiresAt: expiry))
 
-        #expect(CodexWeeklyResetConfirmation.makeDelayedCandidate(
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
             previous: previous,
             initial: initial,
             confirmation: self.exactIdentifiedSnapshot(
@@ -987,15 +987,15 @@ extension CodexWeeklyResetConfirmationTests {
                     status: .available,
                     capturedAt: self.capturedAt.addingTimeInterval(2),
                     expiresAt: expiry)),
-            sourceEvidence: .allExactOAuth) == nil)
-        #expect(CodexWeeklyResetConfirmation.makeDelayedCandidate(
+            sourceEvidence: .allExactOAuth).candidate == nil)
+        #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
             previous: previous.withCodexResetCredits(self.resetCredits(
                 status: .available,
                 capturedAt: self.capturedAt,
                 expiresAt: expiry)),
             initial: initial,
             confirmation: confirmation,
-            sourceEvidence: .allExactOAuth) == nil)
+            sourceEvidence: .allExactOAuth).candidate == nil)
     }
 }
 

--- a/Tests/CodexBarTests/CodexWeeklyResetDiagnosticsTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetDiagnosticsTests.swift
@@ -1,0 +1,277 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CodexWeeklyResetDiagnosticsTests {
+    private typealias Reason = CodexWeeklyResetConfirmation.Reason
+    private static let epoch = Date(timeIntervalSince1970: 1_800_000_000)
+    private static let oldBoundary = epoch.addingTimeInterval(500_000)
+    private static let newBoundary = oldBoundary.addingTimeInterval(7 * 24 * 60 * 60)
+    private static let expiry = newBoundary.addingTimeInterval(24 * 60 * 60)
+
+    @Test
+    func `candidate rejection reasons preserve the existing fail closed outcomes`() {
+        let cases: [(Reason, (inout Fixture) -> Void)] = [
+            (.sourceNotExactOAuth, { $0.source = .init(
+                previousIsExactOAuth: false, initialIsExactOAuth: true, confirmationIsExactOAuth: true) }),
+            (.missingPreviousSnapshot, { $0.hasPrevious = false }),
+            (.confidenceNotExact, { $0.confirmation.confidence = .estimated }),
+            (.invalidObservationTime, { $0.observedAt = Date(timeIntervalSince1970: .nan) }),
+            (.nonMonotonicObservationTime, { $0.confirmation.updatedAt = $0.initial.updatedAt }),
+            (.missingWeeklyWindow, { $0.initial.usedPercent = nil }),
+            (.invalidWeeklyUsage, { $0.confirmation.usedPercent = .nan }),
+            (.resetThresholdMismatch, { $0.previous.usedPercent = 1 }),
+            (.resetThresholdMismatch, { $0.initial.usedPercent = 2 }),
+            (.resetThresholdMismatch, { $0.confirmation.usedPercent = 2 }),
+            (.invalidResetBoundary, { $0.confirmation.boundary = $0.confirmation.updatedAt }),
+            (.inconsistentResetBoundary, { $0.confirmation.boundary = Self.newBoundary.addingTimeInterval(120) }),
+            (.unsupportedResetBoundary, {
+                $0.initial.boundary = Self.oldBoundary.addingTimeInterval(1)
+                $0.confirmation.boundary = $0.initial.boundary
+            }),
+            (.accountMismatch, { $0.confirmation.email = "other@example.com" }),
+            (.planMismatch, { $0.confirmation.plan = "other-plan" }),
+            (.missingCreditInventory, { $0.initial.hasCredits = false }),
+            (.invalidCreditObservationTime, { $0.initial.creditTime = Date(timeIntervalSince1970: .nan) }),
+            (.nonMonotonicCreditObservationTime, { $0.initial.creditTime = Self.epoch.addingTimeInterval(-1) }),
+            (.inconsistentAvailableCreditCount, { $0.confirmation.availableCount = 0 }),
+            (.inconsistentAvailableCreditCount, { $0.confirmation.availableCount = 2 }),
+            (.changedCreditInventory, { $0.confirmation.creditID = "different-credit" }),
+            (.changedCreditInventory, { $0.confirmation.creditExpiry = Self.expiry.addingTimeInterval(0.059) }),
+        ]
+        for (reason, mutate) in cases {
+            var fixture = Fixture()
+            mutate(&fixture)
+            let evaluation = fixture.creation()
+            #expect(evaluation.candidate == nil, "Unexpected candidate for \(reason.rawValue)")
+            #expect(evaluation.reason == reason)
+        }
+    }
+
+    @Test
+    func `candidate diagnostics report the first failed prerequisite`() {
+        var fixture = Fixture()
+        fixture.hasPrevious = false
+        fixture.source = .init(
+            previousIsExactOAuth: true, initialIsExactOAuth: false, confirmationIsExactOAuth: true)
+        #expect(fixture.creation().reason == .sourceNotExactOAuth)
+        fixture.source = .allExactOAuth
+        #expect(fixture.creation().reason == .missingPreviousSnapshot)
+        fixture.hasPrevious = true
+        fixture.confirmation.email = "other@example.com"
+        fixture.confirmation.plan = "other-plan"
+        fixture.confirmation.hasCredits = false
+        #expect(fixture.creation().reason == .accountMismatch)
+        fixture.confirmation.email = fixture.previous.email
+        #expect(fixture.creation().reason == .planMismatch)
+        fixture.confirmation.plan = fixture.previous.plan
+        #expect(fixture.creation().reason == .missingCreditInventory)
+    }
+
+    @Test
+    func `boundary diagnostic cutoffs keep the existing equivalence rules`() {
+        for advance in [0.0, 0.999, 1.0, 119.999, 120.0] {
+            var fixture = Fixture()
+            fixture.initial.boundary = Self.oldBoundary.addingTimeInterval(advance)
+            fixture.confirmation.boundary = fixture.initial.boundary
+            let accepted = advance < 1 || advance >= 120
+            #expect((fixture.creation().candidate != nil) == accepted)
+            #expect(fixture.creation().reason == (accepted ? .candidateCreated : .unsupportedResetBoundary))
+        }
+        for difference in [119.999, 120.0] {
+            var fixture = Fixture()
+            fixture.confirmation.boundary = Self.newBoundary.addingTimeInterval(difference)
+            #expect(fixture.creation().reason == (difference < 120 ? .candidateCreated : .inconsistentResetBoundary))
+        }
+    }
+
+    @Test
+    func `delayed evaluation explains retention and expiration without changing timing`() throws {
+        let fixture = Fixture()
+        let creation = fixture.creation()
+        let candidate = try #require(creation.candidate)
+        #expect(creation.reason == .candidateCreated)
+        #expect(candidate.firstObservedAt == fixture.initial.updatedAt)
+        #expect(candidate.createdAt == fixture.observedAt)
+        let current = Sample(offset: 61, usedPercent: 0.5, boundary: Self.newBoundary)
+        let cases: [(TimeInterval, CodexWeeklyResetConfirmation.DelayedCandidateDecision, Reason)] = [
+            (-1, .discardCandidate, .futureCandidate),
+            (59, .retainCandidate, .minimumDelay),
+            (60, .publishCurrent, .confirmedObservation),
+            (1800, .publishCurrent, .confirmedObservation),
+            (1801, .discardCandidate, .expiredCandidate),
+        ]
+        for (age, decision, reason) in cases {
+            let observedAt = candidate.createdAt.addingTimeInterval(age)
+            let evaluation = CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
+                previous: fixture.previous.snapshot,
+                candidate: candidate,
+                current: current.snapshot,
+                currentIsExactOAuth: true,
+                observedAt: observedAt)
+            #expect(evaluation.decision == decision)
+            #expect(evaluation.reason == reason)
+            let retentionReason = CodexWeeklyResetConfirmation.delayedCandidateRejection(
+                candidate, observedAt: observedAt)
+            #expect(retentionReason == (decision == .discardCandidate ? reason : nil))
+        }
+        let stale = CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
+            previous: fixture.previous.snapshot,
+            candidate: candidate,
+            current: candidate.snapshot,
+            currentIsExactOAuth: true,
+            observedAt: candidate.createdAt.addingTimeInterval(60))
+        #expect(stale == .init(decision: .retainCandidate, reason: .staleObservation))
+    }
+
+    @Test
+    func `delayed evaluation diagnoses incompatible current evidence`() throws {
+        let fixture = Fixture()
+        let candidate = try #require(fixture.creation().candidate)
+        let cases: [(Reason, (inout Sample) -> Void)] = [
+            (.confidenceNotExact, { $0.confidence = .unknown }),
+            (.invalidObservationTime, { $0.updatedAt = Date(timeIntervalSince1970: .infinity) }),
+            (.missingWeeklyWindow, { $0.usedPercent = nil }),
+            (.invalidWeeklyUsage, { $0.usedPercent = .nan }),
+            (.resetThresholdMismatch, { $0.usedPercent = 2 }),
+            (.invalidResetBoundary, { $0.boundary = nil }),
+            (.inconsistentResetBoundary, { $0.boundary = Self.newBoundary.addingTimeInterval(120) }),
+            (.accountMismatch, { $0.email = "other@example.com" }),
+            (.planMismatch, { $0.plan = nil }),
+            (.missingCreditInventory, { $0.hasCredits = false }),
+            (.changedCreditInventory, { $0.creditID = "different-credit" }),
+        ]
+        for (reason, mutate) in cases {
+            var current = Sample(offset: 61, usedPercent: 0.5, boundary: Self.newBoundary)
+            mutate(&current)
+            let evaluation = CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
+                previous: fixture.previous.snapshot,
+                candidate: candidate,
+                current: current.snapshot,
+                currentIsExactOAuth: true,
+                observedAt: candidate.createdAt.addingTimeInterval(60))
+            #expect(evaluation == .init(decision: .discardCandidate, reason: reason))
+        }
+    }
+
+    @Test
+    func `candidate version and date validation is shared by pruning and revalidation`() throws {
+        let fixture = Fixture()
+        let candidate = try #require(fixture.creation().candidate)
+        var payload = try #require(JSONSerialization
+            .jsonObject(with: JSONEncoder().encode(candidate)) as? [String: Any])
+        payload["evidenceVersion"] = CodexWeeklyResetPublicationCandidate.currentEvidenceVersion + 1
+        let unsupported = try JSONDecoder().decode(
+            CodexWeeklyResetPublicationCandidate.self, from: JSONSerialization.data(withJSONObject: payload))
+        let invalidTime = CodexWeeklyResetPublicationCandidate(
+            firstObservedAt: Date(timeIntervalSince1970: .nan),
+            createdAt: fixture.observedAt,
+            snapshot: fixture.confirmation.snapshot)
+        for (invalid, reason) in [
+            (unsupported, Reason.evidenceVersionMismatch),
+            (invalidTime, .invalidObservationTime),
+        ] {
+            #expect(CodexWeeklyResetConfirmation.delayedCandidateRejection(
+                invalid, observedAt: fixture.observedAt) == reason)
+            #expect(CodexWeeklyResetConfirmation.evaluateDelayedCandidate(
+                previous: fixture.previous.snapshot,
+                candidate: invalid,
+                current: fixture.confirmation.snapshot,
+                currentIsExactOAuth: true,
+                observedAt: fixture.observedAt)
+                == .init(decision: .discardCandidate, reason: reason))
+        }
+    }
+
+    @Test
+    func `publication diagnostic metadata adds only the fixed reason code`() {
+        let fixture = Fixture()
+        let trace = UsageStore.CodexWeeklyResetPublicationTrace(
+            previousSnapshot: fixture.previous.snapshot,
+            missingWindowBackfillSnapshot: nil,
+            publicationBaseline: fixture.previous.snapshot,
+            initialSnapshot: fixture.initial.snapshot,
+            confirmationSnapshot: fixture.confirmation.snapshot)
+        let baseline = UsageStore.codexWeeklyResetPublicationMetadata(
+            stage: "candidateCreation", decision: "rejected", trace: trace)
+        let diagnosed = UsageStore.codexWeeklyResetPublicationMetadata(
+            stage: "candidateCreation", decision: "rejected", reason: .changedCreditInventory, trace: trace)
+        #expect(diagnosed == baseline.merging(
+            ["reason": "changedCreditInventory"],
+            uniquingKeysWith: { _, new in new }))
+        let values = diagnosed.values.joined(separator: " ")
+        for sensitive in ["sentinel@example.com", "sentinel-workspace", "sentinel-plan", "sentinel-credit"] {
+            #expect(!values.contains(sensitive))
+        }
+        #expect(!values.contains(fixture.previous.snapshot.codexResetCredits?.credits.first?.id ?? "missing-credit"))
+    }
+
+    private struct Fixture {
+        var previous = Sample(offset: 0, usedPercent: 80, boundary: oldBoundary)
+        var initial = Sample(offset: 1, usedPercent: 0, boundary: newBoundary)
+        var confirmation = Sample(offset: 2, usedPercent: 0, boundary: newBoundary)
+        var source = CodexWeeklyResetConfirmation.SourceEvidence.allExactOAuth
+        var hasPrevious = true
+        var observedAt = epoch.addingTimeInterval(1)
+
+        func creation() -> CodexWeeklyResetConfirmation.CandidateCreation {
+            CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
+                previous: self.hasPrevious ? self.previous.snapshot : nil,
+                initial: self.initial.snapshot,
+                confirmation: self.confirmation.snapshot,
+                sourceEvidence: self.source,
+                observedAt: self.observedAt)
+        }
+    }
+
+    private struct Sample {
+        var updatedAt: Date
+        var usedPercent: Double?
+        var boundary: Date?
+        var confidence = UsageDataConfidence.exact
+        var email: String? = "sentinel@example.com"
+        var plan: String? = "sentinel-plan"
+        var hasCredits = true
+        var creditTime: Date
+        var availableCount = 1
+        var creditID = "sentinel-credit"
+        var creditExpiry = expiry
+
+        init(offset: TimeInterval, usedPercent: Double, boundary: Date) {
+            self.updatedAt = epoch.addingTimeInterval(offset)
+            self.creditTime = self.updatedAt
+            self.usedPercent = usedPercent
+            self.boundary = boundary
+        }
+
+        var snapshot: UsageSnapshot {
+            let credits = CodexRateLimitResetCreditsSnapshot(
+                credits: [CodexRateLimitResetCredit(
+                    id: self.creditID,
+                    resetType: "codex_rate_limits",
+                    status: .available,
+                    grantedAt: epoch,
+                    expiresAt: self.creditExpiry,
+                    redeemStartedAt: nil,
+                    redeemedAt: nil,
+                    title: nil,
+                    description: nil)],
+                availableCount: self.availableCount,
+                updatedAt: self.creditTime)
+            return UsageSnapshot(
+                primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: oldBoundary, resetDescription: nil),
+                secondary: self.usedPercent.map {
+                    RateWindow(usedPercent: $0, windowMinutes: 10080, resetsAt: self.boundary, resetDescription: nil)
+                },
+                codexResetCredits: self.hasCredits ? credits : nil,
+                updatedAt: self.updatedAt,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: self.email,
+                    accountOrganization: "sentinel-workspace",
+                    loginMethod: self.plan),
+                dataConfidence: self.confidence)
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodexWeeklyResetPersistenceDiagnosticsTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetPersistenceDiagnosticsTests.swift
@@ -1,0 +1,80 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `candidate persistence reasons distinguish guard rejection from storage requests`() throws {
+        let suite = "CodexWeeklyResetPersistenceDiagnosticsTests"
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .off
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "persistence-diagnostic@example.com",
+            identity: .providerAccount(id: "acct-persistence-diagnostic"))
+        defer { settings._test_liveSystemCodexAccount = nil }
+        let now = Date()
+        let previous = self.codexWeeklySnapshot(
+            email: "persistence-diagnostic@example.com",
+            weeklyUsedPercent: 80,
+            weeklyReset: now.addingTimeInterval(500_000),
+            updatedAt: now)
+        let candidate = CodexWeeklyResetPublicationCandidate(firstObservedAt: now, snapshot: previous)
+        let recordingStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = self.makeCodexWeeklyPublicationStore(
+            settings: settings, suite: suite, snapshotStore: recordingStore)
+        let expected = store.freshCodexAccountScopedRefreshGuard()
+        let wrongAccount = CodexAccountScopedRefreshGuard(
+            source: expected.source,
+            identity: .providerAccount(id: "different-account"),
+            accountKey: expected.accountKey,
+            authFingerprint: expected.authFingerprint)
+
+        #expect(store.persistCodexWeeklyResetPublicationCandidate(
+            candidate, expectedGuard: nil, previousSnapshot: previous) == .missingExpectedGuard)
+        #expect(store.persistCodexWeeklyResetPublicationCandidate(
+            candidate, expectedGuard: wrongAccount, previousSnapshot: previous) == .accountChanged)
+        #expect(store.persistCodexWeeklyResetPublicationCandidate(
+            nil, expectedGuard: expected, previousSnapshot: previous) == .missingCandidateOrBaseline)
+        #expect(store.codexAccountSnapshots.isEmpty)
+        #expect(recordingStore.storedSnapshots.isEmpty)
+
+        #expect(store.persistCodexWeeklyResetPublicationCandidate(
+            candidate, expectedGuard: expected, previousSnapshot: previous) == .storeRequested)
+        #expect(recordingStore.storedSnapshots.first?.weeklyResetCandidate?.createdAt == candidate.createdAt)
+        #expect(store.persistCodexWeeklyResetPublicationCandidate(
+            nil, expectedGuard: expected, previousSnapshot: previous) == .storeRequested)
+        #expect(recordingStore.storedSnapshots.first?.weeklyResetCandidate == nil)
+        #expect(store.persistCodexWeeklyResetPublicationCandidate(
+            nil, expectedGuard: expected, previousSnapshot: previous) == .noCandidateChange)
+
+        let memoryOnly = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite + "-memory")
+        #expect(memoryOnly.codexAccountUsageSnapshotStore == nil)
+        #expect(memoryOnly.persistCodexWeeklyResetPublicationCandidate(
+            candidate, expectedGuard: expected, previousSnapshot: previous) == .storeUnavailable)
+        #expect(memoryOnly.codexAccountSnapshots.first?.weeklyResetCandidate?.createdAt == candidate.createdAt)
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-reset-diagnostic-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let blockingFile = root.appendingPathComponent("not-a-directory")
+        let sentinel = Data("synthetic storage blocker".utf8)
+        try sentinel.write(to: blockingFile)
+        let snapshotURL = blockingFile.appendingPathComponent("snapshots.json")
+        let diskFailure = self.makeCodexWeeklyPublicationStore(
+            settings: settings,
+            suite: suite + "-disk-failure",
+            snapshotStore: FileCodexAccountUsageSnapshotStore(fileURL: snapshotURL))
+        #expect(diskFailure.persistCodexWeeklyResetPublicationCandidate(
+            candidate, expectedGuard: expected, previousSnapshot: previous) == .storeRequested)
+        #expect(!FileManager.default.fileExists(atPath: snapshotURL.path))
+        #expect(try Data(contentsOf: blockingFile) == sentinel)
+        #expect(diskFailure.codexAccountSnapshots.first?.weeklyResetCandidate?.createdAt == candidate.createdAt)
+        #expect(UsageStore.CodexWeeklyResetPersistenceDecision.storeRequested.diagnosticMetadata == [
+            "stage": "candidatePersistence", "decision": "storeRequested",
+        ])
+    }
+}

--- a/Tests/CodexBarTests/CodexWeeklyResetPublicationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetPublicationTests.swift
@@ -184,10 +184,11 @@ extension CodexAccountScopedRefreshTests {
                     attempts: [])
             })
         #expect(admission.outcome == nil)
-        store.persistCodexWeeklyResetPublicationCandidate(
+        let persistenceDecision = store.persistCodexWeeklyResetPublicationCandidate(
             admission.pendingCandidate,
             expectedGuard: store.freshCodexAccountScopedRefreshGuard(),
             previousSnapshot: previous)
+        #expect(persistenceDecision == .storeRequested)
 
         #expect(store.codexAccountSnapshots.count == 1)
         #expect(store.codexAccountSnapshots.first?.weeklyResetCandidate == nil)
@@ -249,10 +250,14 @@ extension CodexAccountScopedRefreshTests {
             createdAt: now,
             snapshot: ownerSnapshot)
 
-        store.persistCodexWeeklyResetPublicationCandidate(
+        #expect(store.persistCodexWeeklyResetPublicationCandidate(
+            candidate, expectedGuard: nil, previousSnapshot: ownerSnapshot) == .missingExpectedGuard)
+        #expect(store.codexAccountSnapshots.count == 1)
+        let persistenceDecision = store.persistCodexWeeklyResetPublicationCandidate(
             candidate,
             expectedGuard: store.freshCodexAccountScopedRefreshGuard(),
             previousSnapshot: ownerSnapshot)
+        #expect(persistenceDecision == .storeRequested)
 
         #expect(store.codexAccountSnapshots.count == 2)
         #expect(store.codexAccountSnapshots.first { $0.id == sibling.id }?.snapshot?.secondary?.usedPercent == 42)
@@ -826,12 +831,12 @@ extension CodexAccountScopedRefreshTests {
                 capturedAt: now.addingTimeInterval(-1899),
                 expiresAt: expiry),
             dataConfidence: .exact)
-        let candidate = try #require(CodexWeeklyResetConfirmation.makeDelayedCandidate(
+        let candidate = try #require(CodexWeeklyResetConfirmation.evaluateDelayedCandidateCreation(
             previous: previous,
             initial: initial,
             confirmation: confirmation,
             sourceEvidence: .allExactOAuth,
-            observedAt: initial.updatedAt))
+            observedAt: initial.updatedAt).candidate)
         let expiredLow = self.codexWeeklySnapshot(
             email: email,
             weeklyUsedPercent: 0.5,

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -42,6 +42,11 @@ Usage source picker:
 - Suspicious weekly resets keep the last trusted usage while confirmation is pending. A successful refresh for the
   same account and workspace clears stale connectivity errors even when the reading is withheld; failed, cancelled,
   or superseded refreshes do not clear them. Cached usage, credits, and other accounts remain unchanged.
+- Debug logs in `codex-weekly-reset-publication` include fixed reason codes for delayed-candidate
+  creation, pruning, revalidation, and account-scoped storage requests. They distinguish source/confidence,
+  timing, boundary, identity/plan compatibility, and credit-inventory failures without logging account or credit
+  identifiers. Codes describe the first rejected prerequisite; they do not relax confirmation policy or prove the
+  cause of a past stale reading. `storeRequested` means the file-store call was made, not that a disk write succeeded.
 - `additional_rate_limits[]` (model-specific limits such as GPT-5.3-Codex-Spark) map to named
   `UsageSnapshot.extraRateWindows` entries. Spark uses stable `codex-spark` / `codex-spark-weekly` ids and
   `Codex Spark 5-hour` / `Codex Spark Weekly` titles. When the field is absent, the snapshot is unchanged.


### PR DESCRIPTION
## Summary

Make the next reproduction of #3248 diagnosable without changing reset-publication policy. The reported stale reading is real, but the app-side input or rejected guard responsible for it is still unknown. This PR does not claim to fix that incident and does not close the issue.

Candidate creation and delayed evaluation now return typed reason codes from the same guards that make the decision. Candidate pruning and revalidation use shared version/date/age validation. The existing debug-log category also reports account-scoped storage guard outcomes; `storeRequested` means the store was called, not that a disk write succeeded.

All reset thresholds, comparison tolerances, account ownership guards, candidate Codable fields, and storage behavior remain unchanged. New diagnostic values are fixed codes, not account names, workspace names, plan values, credit IDs, expiry values, or raw provider payloads. Existing redacted snapshot fields remain unchanged. Documentation and changelog describe the diagnostic scope.

## Verification

- Focused reset-confirmation, diagnostic, and account-scoped refresh suites: 168 tests passed. This includes existing relaunch, sibling-account, workspace, and withheld-error coverage.
- New rejection matrix and exact timing/boundary tests cover the first rejected prerequisite, 59/60-second confirmation delay, 1800/1801-second expiry, and unchanged 1/120-second boundary rules.
- Metadata tests verify that only the fixed reason field is added and sensitive sentinel identity/credit values remain absent.
- Persistence tests distinguish rejected guards, no-op updates, missing storage, and an actual unwritable file-store destination. A write failure still reports only `storeRequested` and preserves the established best-effort behavior.
- `make check`: passed, zero violations across 2,050 Swift files.
- Independent Codex review: no actionable blocking findings; admission predicates/order/thresholds, ownership checks, schema preservation, and diagnostic redaction inspected.
- Full `make test`: 963 selections across 81 groups passed on the first attempt; zero failed groups, retries, or timeouts (1,241.1 seconds).
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33283444584): passed on `8ab6222703099783c5a0f0d48e62c12baee5235a`, including both macOS test shards, Linux arm64/x64/musl, lint, and the aggregate gate. GitGuardian also passed.

Local tests use an explicit clean environment with Keychain access suppressed and Codex-file isolation enabled. No live provider/account probing, UI changes, release, or claim of a reproduced backend reset.
