### PR TITLE
fix(antigravity): preserve warm CLI identity and auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.1 — Unreleased
 
 ### Fixed
+- Antigravity: reuse a running `agy` by its verified executable path even when its command line uses a bare name, and preserve CLI sign-in guidance when an IDE fallback has no CSRF token (follow-up to #3146). Thanks @haixing23!
 - Codex: add redacted weekly-reset diagnostic reasons for candidate admission, expiry, and account-scoped storage requests without changing reset publication rules (investigated alongside #3248). Thanks @kcharlan!
 - Docs: distinguish OpenCode-backed Codex OAuth quota from unsupported OpenCode session cost imports, preserving existing provider and account boundaries (investigated alongside #3273). Thanks @pedrommone!
 - Privacy: honor “Hide personal information” for project/source names and paths in cost history and project names in Usage & Spend, preserving costs, tokens, and stored data (#3262). Thanks @vinschger!

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -224,7 +224,8 @@ public enum AntigravityProviderDescriptor {
 
     static func resolveFallbackError(_ previous: Error?, _ current: Error) -> Error {
         if (previous as? AntigravityStatusProbeError) == .authenticationRequired,
-           (current as? AntigravityStatusProbeError) == .notRunning
+           let currentProbeError = current as? AntigravityStatusProbeError,
+           currentProbeError == .notRunning || currentProbeError == .missingCSRFToken
         {
             return previous ?? current
         }
@@ -414,7 +415,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
 
         for info in cliProcesses {
             if let expectedBinaryPath {
-                guard Self.commandLine(info.commandLine, matchesBinaryPath: expectedBinaryPath)
+                guard Self.process(info, matchesBinaryPath: expectedBinaryPath)
                 else {
                     continue
                 }
@@ -469,13 +470,21 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         return remaining > 0 ? remaining : nil
     }
 
-    private static func commandLine(_ commandLine: String, matchesBinaryPath binaryPath: String) -> Bool {
+    private static func process(
+        _ info: AntigravityStatusProbe.ProcessInfoResult,
+        matchesBinaryPath binaryPath: String) -> Bool
+    {
         let candidates = [
             URL(fileURLWithPath: binaryPath).standardizedFileURL.path,
             URL(fileURLWithPath: binaryPath).resolvingSymlinksInPath().standardizedFileURL.path,
         ]
+        if let executablePath = info.executablePath {
+            // argv[0] may be just "agy" or misleading; a known kernel path owns executable identity.
+            guard executablePath.hasPrefix("/") else { return false }
+            return candidates.contains(URL(fileURLWithPath: executablePath).standardizedFileURL.path)
+        }
         return candidates.contains { candidate in
-            commandLine == candidate || commandLine.hasPrefix("\(candidate) ")
+            info.commandLine == candidate || info.commandLine.hasPrefix("\(candidate) ")
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -1052,12 +1052,19 @@ public struct AntigravityStatusProbe: Sendable {
 
     // MARK: - Port detection
 
+    struct ProcessEntry {
+        let pid: Int
+        let command: String
+        var executablePath: String?
+    }
+
     struct ProcessInfoResult {
         let pid: Int
         let extensionPort: Int?
         let extensionServerCSRFToken: String?
         let csrfToken: String
         let commandLine: String
+        var executablePath: String?
     }
 
     struct AntigravityConnectionEndpoint: Equatable {
@@ -1104,12 +1111,12 @@ public struct AntigravityStatusProbe: Sendable {
         scope: ProcessScope = .ideAndCLI) async throws -> [ProcessInfoResult]
     {
         #if canImport(Darwin)
-        let entries = DarwinProcessEnumerator.allPIDs().compactMap { pid -> (pid: Int, command: String)? in
+        let entries = DarwinProcessEnumerator.allPIDs().compactMap { pid -> ProcessEntry? in
             guard let executablePath = DarwinProcessEnumerator.executablePath(pid: pid),
                   DarwinProcessEnumerator.isAntigravityCandidatePath(executablePath)
             else { return nil }
             let command = DarwinProcessEnumerator.commandLine(pid: pid) ?? executablePath
-            return (Int(pid), command)
+            return ProcessEntry(pid: Int(pid), command: command, executablePath: executablePath)
         }
         return try self.processInfos(fromEntries: entries, scope: scope)
         #else
@@ -1140,15 +1147,15 @@ public struct AntigravityStatusProbe: Sendable {
         fromProcessListOutput output: String,
         scope: ProcessScope = .ideAndCLI) throws -> [ProcessInfoResult]
     {
-        let entries = output.split(separator: "\n").compactMap { line -> (pid: Int, command: String)? in
+        let entries = output.split(separator: "\n").compactMap { line -> ProcessEntry? in
             guard let match = Self.matchProcessLine(String(line)) else { return nil }
-            return (match.pid, match.command)
+            return ProcessEntry(pid: match.pid, command: match.command)
         }
         return try self.processInfos(fromEntries: entries, scope: scope)
     }
 
     static func processInfos(
-        fromEntries entries: [(pid: Int, command: String)],
+        fromEntries entries: [ProcessEntry],
         scope: ProcessScope = .ideAndCLI) throws -> [ProcessInfoResult]
     {
         var sawTokenlessIDE = false
@@ -1172,7 +1179,8 @@ public struct AntigravityStatusProbe: Sendable {
                 extensionPort: port,
                 extensionServerCSRFToken: extensionServerCSRFToken,
                 csrfToken: token,
-                commandLine: entry.command))
+                commandLine: entry.command,
+                executablePath: entry.executablePath))
         }
 
         if !results.isEmpty {

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -985,8 +985,10 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
 }
 
 extension AntigravityCLIHTTPSFetchStrategyTests {
-    @Test
-    func `missing IDE cannot replace actionable signed out CLI error`() async {
+    @Test(arguments: [AntigravityStatusProbeError.notRunning, .missingCSRFToken])
+    func `unavailable IDE cannot replace actionable signed out CLI error`(
+        ideError: AntigravityStatusProbeError) async
+    {
         let pipeline = ProviderFetchPipeline(
             resolveStrategies: { _ in
                 [
@@ -995,7 +997,7 @@ extension AntigravityCLIHTTPSFetchStrategyTests {
                         error: .authenticationRequired),
                     AntigravityFallbackFixtureStrategy(
                         id: "antigravity.ide-local",
-                        error: .notRunning),
+                        error: ideError),
                 ]
             },
             resolveFallbackError: AntigravityProviderDescriptor.resolveFallbackError)

--- a/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
+++ b/Tests/CodexBarTests/AntigravityWarmAgyReuseTests.swift
@@ -230,6 +230,79 @@ struct AntigravityWarmAgyReuseTests {
     }
 
     @Test
+    func `warm reuse matches verified executable identity rather than argv spelling`() async throws {
+        let cases: [(command: String, executable: String?, reuses: Bool)] = [
+            ("agy", "/selected/agy", true),
+            ("agy --debug", "/selected/agy", true),
+            ("/selected/agy", "/other/agy", false),
+            ("agy", nil, false),
+            ("/selected/agy", nil, true),
+            ("/selected/agy-helper", nil, false),
+            ("/selected/agy", "agy", false),
+        ]
+        for fixture in cases {
+            let listeningPIDs = AntigravityWarmLockedValues<Int>()
+            let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+                timeout: 2,
+                expectedBinaryPath: "/selected/agy",
+                dependencies: .init(
+                    processInfos: { _ in
+                        try AntigravityStatusProbe.processInfos(fromEntries: [.init(
+                            pid: 6150, command: fixture.command, executablePath: fixture.executable)])
+                    },
+                    listeningPorts: { pid, _ in
+                        listeningPIDs.append(pid)
+                        return [56789]
+                    },
+                    fetchSnapshot: { _, _ in Self.usableSnapshot(email: "selected@example.com") }))
+
+            #expect((result != nil) == fixture.reuses)
+            #expect(listeningPIDs.value == (fixture.reuses ? [6150] : []))
+        }
+    }
+
+    @Test
+    func `process scan keeps kernel identity separate from argv and preserves csrf checks`() throws {
+        let entries: [AntigravityStatusProbe.ProcessEntry] = [
+            .init(pid: 200, command: "agy --debug", executablePath: "/selected/agy"),
+            .init(
+                pid: 201,
+                command: "/Applications/Antigravity.app/language_server --app_data_dir antigravity",
+                executablePath: "/Applications/Antigravity.app/language_server"),
+        ]
+        let results = try AntigravityStatusProbe.processInfos(fromEntries: entries)
+
+        #expect(results.count == 1)
+        #expect(results.first?.commandLine == "agy --debug")
+        #expect(results.first?.executablePath == "/selected/agy")
+        #expect(throws: AntigravityStatusProbeError.missingCSRFToken) {
+            try AntigravityStatusProbe.processInfos(fromEntries: entries, scope: .appOnly)
+        }
+    }
+
+    @Test
+    func `warm reuse matches a selected symlink to the kernel executable path`() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("agy-identity-\(UUID())")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let executable = root.appendingPathComponent("actual agy")
+        let selected = root.appendingPathComponent("agy")
+        try Data("synthetic executable identity".utf8).write(to: executable)
+        try FileManager.default.createSymbolicLink(at: selected, withDestinationURL: executable)
+        let processes = try AntigravityStatusProbe.processInfos(fromEntries: [.init(
+            pid: 6150, command: "agy", executablePath: executable.resolvingSymlinksInPath().path)])
+        let result = try await AntigravityCLIHTTPSFetchStrategy.tryWarmAgyFetch(
+            timeout: 2,
+            expectedBinaryPath: selected.path,
+            dependencies: .init(
+                processInfos: { _ in processes },
+                listeningPorts: { _, _ in [56789] },
+                fetchSnapshot: { _, _ in Self.usableSnapshot(email: "selected@example.com") }))
+
+        #expect(result?.accountEmail == "selected@example.com")
+    }
+
+    @Test
     func `warm probe deadline is shared across discovery and candidates`() async throws {
         let clock = AntigravityWarmTestClock(date: Date(timeIntervalSince1970: 100))
         let listeningPortsCallCount = AntigravityWarmLockedCounter()

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -165,6 +165,11 @@ Differences from the desktop local probe:
   returns parseable usage for the selected account. CodexBar-owned pids are excluded from external reuse so managed
   probe/idle lifecycle accounting stays balanced; if no eligible external server answers, CodexBar uses its managed
   session as before.
+- On macOS, external reuse matches the selected binary against the kernel executable path, not the spelling of
+  `argv[0]`; a bare `agy` command can match, but a conflicting executable cannot. Platforms without that identity
+  retain the absolute command-path check. User/account and managed-process exclusions are unchanged.
+- If `agy` is signed out, an unavailable or tokenless IDE fallback keeps the actionable Terminal sign-in guidance.
+  A successful fallback still supplies usage, and more specific later errors retain their normal precedence.
 - Readiness is endpoint-based: CodexBar retries until one of the quota endpoints parses, because fresh `agy`
   processes can bind a port before the quota service is initialized.
 - App runtime uses a bounded warm session: `agy` is kept alive briefly after a refresh, then stopped on idle. CLI runtime


### PR DESCRIPTION
## Summary

Repair two remaining Antigravity CLI quota-refresh cases from the guarded warm-session work in #3161, investigated alongside #3146 and #2471. This does not change Google OAuth account storage or implement Add Account without the desktop app; those issues remain open.

macOS process discovery already obtains the kernel executable path, but discarded it before warm-session matching. Matching only the command-line prefix rejects a legitimate selected `agy` whose argv starts with a bare name. Carry that existing identity through process discovery and prefer it for exact selected-path matching. A known conflicting kernel path cannot fall back to an absolute-looking argv. Platforms without kernel identity retain the existing absolute command-path check; symlinked selected executables still match their resolved path.

The provider fallback resolver now also preserves actionable CLI sign-in guidance when a later IDE probe has no CSRF token. A usable fallback still supplies usage, and specific later errors retain their normal precedence. Same-user, selected-account, managed-PID exclusions, CSRF requirements for desktop servers, cancellation, deadlines, and process lifecycle remain unchanged. No additional process enumeration, credential access, or diagnostic fields are introduced.

## Verification

- Red-before-green: the new identity matrix and tokenless-IDE sequence failed on the old decision logic (nine assertion issues across the two new cases).
- Focused Antigravity warm-reuse, CLI pipeline, status-probe, and Darwin process suites: 132 tests in four suites passed.
- Coverage includes bare argv, conflicting kernel identity, absent/invalid identity, absolute-path fallback, symlinked paths with spaces, parser-to-warm wiring, desktop CSRF requirements, and existing user/account/process/deadline/cancellation exclusions.
- `make check`: passed, zero violations across 2,050 Swift files.
- Independent Codex review: no actionable blocking findings. Subsequent changes only corrected test placement/negative-case wiring and removed unrelated whitespace changes.
- Full `make test`: passed, 963 selections across 81 groups (1,736.9 seconds). Eighty groups passed first try; unchanged cost-history group 32 timed out at 180 seconds, then all 12 isolated selections passed. No assertion failures; the timeout is not claimed fixed by this PR.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33285510911): all checks passed on `4750101c443bb1854f6cafe75c9f90b3566278bf`, including both macOS shards, Linux arm64/x64/musl, lint, and the aggregate gate. GitGuardian also passed.

All tests use a clean environment with Keychain access suppressed, Codex-file isolation enabled, and live Gemini fetching disabled. These are deterministic process-metadata and pipeline tests, not a claim to have reproduced the reporter's signed-in backend session or desktop-free OAuth flow. Documentation and changelog updated; no release.
