### PR TITLE
test(cost): seed fresh migration corpora exclusively

### DIFF
--- a/Tests/CodexBarTests/CostUsageCacheWideMigrationTests.swift
+++ b/Tests/CodexBarTests/CostUsageCacheWideMigrationTests.swift
@@ -289,7 +289,7 @@ struct CostUsageCacheWideMigrationTests {
                     + #"{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":10},"#
                     + #""model":"openai/gpt-5.2-codex"}}}"#,
             ]
-            return try env.writeCodexSessionFile(
+            return try env.seedCodexSessionFile(
                 day: day,
                 filename: String(format: "migration-%04d.jsonl", index),
                 contents: lines.joined(separator: "\n") + "\n")


### PR DESCRIPTION
## Summary

Use the existing exclusive-create fixture helper for the initial migration-test corpus. The eight executed migration cases create 4,713 fresh files in UUID-isolated environments and only start scanner reads after setup returns. Atomic replacement is unnecessary at this boundary.

This is one test-only call-site change. Corpus bytes, names, counts, modification-time ordering, scan budgets, migration assertions, and the shared atomic replacement writer remain unchanged. Existing fixture-helper tests cover byte/path/count parity, existing-file/directory/symlink rejection, day-directory errors, and atomic replacement semantics.

## Verification

- `swift test --jobs 4 --filter 'CostUsageCacheWideMigrationTests|CostUsageFixtureSeedTests'`: seven tests across two suites passed, including eight migration cases and all fixture-helper cases.
- `make check`: passed with zero violations across 2,050 Swift files.
- Independent Codex review: no actionable blocking findings.
- Full `make test`: passed, all 963 selections across 81 groups on the first attempt; zero failed groups, timeouts, or retries (2,086.4 seconds total).
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33287199767): all required checks passed, including both macOS shards, Linux arm64/x64, lint, and the aggregate gate. GitGuardian passed; musl was correctly skipped by the test-only path gate.

Tests use a clean environment with Keychain access suppressed, Codex-file isolation enabled, and live Gemini fetching disabled. No app launch or live provider/account access is needed for this test-only change.

This removes redundant fixture publication work; it does not claim to fix the intermittent cost-history group timeout or demonstrate a quantified speedup. No timeout or sharding changes. No user-visible behavior change, changelog entry, or release.
