### PR TITLE
fix: decode Cursor ASCII UTF-16LE auth blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.1 — Unreleased
 
 ### Fixed
+- Cursor: correctly decode BOM-less ASCII UTF-16LE app-token database values without changing other decoding or cached-account fallback rules (extracted from #2398). Thanks @markmay!
 - Tests: isolate Cursor, Augment, Factory, and Notion saved sessions from user files, including test child processes, while preserving production storage and owner-only permissions.
 - Codex: publish completed cost catch-up from validated caches without starting another scan, preserve actual scan timestamps, and retain prior totals when native or Pi/OMP history is unavailable (partial follow-up to #3243). Thanks @zhulijin1991!
 - Antigravity: reuse a running `agy` by its verified executable path even when its command line uses a bare name, and preserve CLI sign-in guidance when an IDE fallback has no CSRF token (follow-up to #3146). Thanks @haixing23!

--- a/Sources/CodexBarCore/Providers/Cursor/CursorAppAuth.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorAppAuth.swift
@@ -306,6 +306,17 @@ struct CursorAppAuthStore: CursorAppAuthSessionProviding {
         case SQLITE_BLOB:
             guard let bytes = sqlite3_column_blob(stmt, index) else { return nil }
             let data = Data(bytes: bytes, count: Int(sqlite3_column_bytes(stmt, index)))
+            // ASCII UTF16LE is also valid UTF8 with NULs, so the fallback below cannot recognize it.
+            if data.count.isMultiple(of: 2),
+               stride(from: 0, to: data.count, by: 2).allSatisfy({
+                   (1..<128).contains(data[$0]) && data[$0 + 1] == 0
+               }),
+               let decoded = String(data: data, encoding: .utf16LittleEndian),
+               // Keep invalid-but-present tokens present: a missing session permits cached-account fallback.
+               !decoded.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                return decoded
+            }
             return String(data: data, encoding: .utf8)
                 ?? String(data: data, encoding: .utf16LittleEndian)
         default:

--- a/Tests/CodexBarTests/CursorAppAuthEncodingTests.swift
+++ b/Tests/CodexBarTests/CursorAppAuthEncodingTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import SQLite3
+import Testing
+@testable import CodexBarCore
+
+struct CursorAppAuthEncodingTests {
+    @Test(arguments: [false, true])
+    func `text and UTF8 blobs preserve usable app tokens`(asText: Bool) throws {
+        let token = try makeCursorAppAuthToken()
+        let value: SQLiteValue = asText ? .text(token) : .blob(Data(token.utf8))
+        let session = try #require(try Self.load(value))
+        #expect(session.accessToken == token)
+        #expect(session.isUsable)
+    }
+
+    @Test(arguments: [false, true])
+    func `ASCII UTF16LE blobs decode without normalizing the app token`(padded: Bool) throws {
+        let original = try makeCursorAppAuthToken()
+        let token = padded ? " \t" + original + "\r\n" : original
+        let bytes = Data(token.utf8.flatMap { [$0, 0] })
+        let session = try #require(try Self.load(.blob(bytes)))
+        #expect(session.accessToken == token)
+        #expect(session.isUsable)
+    }
+
+    @Test(arguments: [
+        "ordinary", "\"quoted\"", " padded \n", "Málaga", "mixed\0value",
+    ])
+    func `other UTF8 blobs remain byte exact`(token: String) throws {
+        let session = try #require(try Self.load(.blob(Data(token.utf8))))
+        #expect(Data(session.accessToken.utf8) == Data(token.utf8))
+    }
+
+    @Test(arguments: [false, true])
+    func `UTF8 NULs outside a usable JWT payload are not reinterpreted`(inHeader: Bool) throws {
+        let token = try makeCursorAppAuthToken()
+        let malformed = inHeader ? "\0" + token : token + "\0"
+        #expect(CursorAppAuthSession(accessToken: malformed).isUsable)
+        let session = try #require(try Self.load(.blob(Data(malformed.utf8))))
+        #expect(session.accessToken == malformed)
+        #expect(session.isUsable)
+    }
+
+    private static let compatibilityBytes: [[UInt8]] = [
+        [0x41, 0, 0x42], // Odd length must not drop the last byte.
+        [0x41, 0, 0, 0, 0x42, 0], // An embedded NUL is not ASCII token text.
+        [0, 0x41, 0, 0x42], // Do not add big-endian detection.
+        [0xFF, 0xFE, 0x41, 0, 0x42, 0], // Preserve Foundation's BOM handling.
+        [0xFE, 0xFF, 0, 0x41, 0, 0x42],
+        [0xEF, 0xBB, 0xBF, 0x41], // UTF8 BOM handling also belongs to Foundation.
+        [0xE9, 0, 0x61, 0], // Existing UTF8-failure to UTF16LE fallback.
+        [0, 0xD8], // Unpaired surrogate.
+        [0xFF], // Invalid in both decoders.
+        [0x20, 0, 0x09, 0, 0x0D, 0, 0x0A, 0], // Keep a present invalid session distinct from no session.
+        [0],
+        [],
+    ]
+
+    @Test(arguments: Self.compatibilityBytes)
+    func `other blobs retain the original decoding and missing session semantics`(bytes: [UInt8]) throws {
+        let data = Data(bytes)
+        let decoded = String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .utf16LittleEndian)
+        let expected = decoded.flatMap { token in
+            token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : token
+        }
+        let session = try Self.load(.blob(data))
+        #expect(session?.accessToken == expected)
+    }
+
+    @Test
+    func `SQLite text keeps its existing NUL terminator behavior`() throws {
+        let session = try #require(try Self.load(.text("before\0after")))
+        #expect(session.accessToken == "before")
+    }
+
+    private enum SQLiteValue {
+        case text(String)
+        case blob(Data)
+    }
+
+    private static func load(_ value: SQLiteValue) throws -> CursorAppAuthSession? {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-encoding-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("state.vscdb")
+        var database: OpaquePointer?
+        try #require(sqlite3_open(databaseURL.path, &database) == SQLITE_OK)
+        defer { sqlite3_close(database) }
+        try #require(sqlite3_exec(
+            database, "CREATE TABLE ItemTable(key TEXT PRIMARY KEY, value BLOB);", nil, nil, nil) == SQLITE_OK)
+        var statement: OpaquePointer?
+        try #require(sqlite3_prepare_v2(
+            database, "INSERT INTO ItemTable VALUES('cursorAuth/accessToken', ?);", -1, &statement, nil) == SQLITE_OK)
+        defer { sqlite3_finalize(statement) }
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        let binding: Int32 = switch value {
+        case let .text(token):
+            sqlite3_bind_text(statement, 1, token, Int32(token.utf8.count), transient)
+        case let .blob(data) where data.isEmpty:
+            sqlite3_bind_zeroblob(statement, 1, 0)
+        case let .blob(data):
+            data.withUnsafeBytes { bytes in
+                sqlite3_bind_blob(statement, 1, bytes.baseAddress, Int32(bytes.count), transient)
+            }
+        }
+        try #require(binding == SQLITE_OK)
+        try #require(sqlite3_step(statement) == SQLITE_DONE)
+        let before = try Data(contentsOf: databaseURL)
+        let session = try CursorAppAuthStore(dbPath: databaseURL.path).loadSession()
+        #expect(try Data(contentsOf: databaseURL) == before)
+        return session
+    }
+}

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -15,6 +15,9 @@ Cursor.app session and falls back to cookies when the app token is missing, expi
 
 1) **Cursor.app local auth** (preferred in Automatic mode)
    - Reads Cursor.app's VS Code-style global state DB for `ItemTable` key `cursorAuth/accessToken`.
+   - BLOB decoding recognizes BOM-less ASCII UTF-16LE tokens before UTF-8, which would otherwise keep interleaved
+     NUL bytes. Other encodings retain the existing UTF-8/UTF-16LE fallback; tokens are not normalized, and malformed
+     nonempty values remain distinct from a missing session so they cannot enable stale cached-account fallback.
    - Files consulted by SQLite:
      - macOS main DB: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`
      - Active WAL sidecars when present: `state.vscdb-wal` and `state.vscdb-shm`


### PR DESCRIPTION
## Summary

Fix the existing Cursor.app SQLite BLOB decoder so BOM-less ASCII UTF-16LE access tokens reach the existing app-auth path intact. Those bytes also decode as UTF-8 with interleaved NULs, so the old UTF-8-first expression never reached its UTF-16LE fallback and a usable synthetic token became unusable.

This extracts only the decoding bug fix from #2398, with credit to @markmay. The source picker and App Token-only mode remain in that open feature PR for maintainer review.

## Compatibility boundary

- Recognize only even-length ASCII UTF-16LE pairs with nonzero low bytes and zero high bytes, and return the decoded string without normalization.
- Preserve the original UTF-8/UTF-16LE expression for every other input, including malformed bytes, BOM behavior, embedded NULs, and whitespace-only values. Invalid-but-present sessions must not become missing sessions, because missing sessions can permit persisted-account fallback.
- Leave SQLite TEXT handling, account/source selection, token validation, persistence, active/idle WAL behavior, and Linux support unchanged.
- Update the Cursor documentation and Unreleased changelog.

## Verification

- Red-before-green proof uses temporary SQLite databases and synthetic tokens only. Both padded and unpadded UTF-16LE fixtures failed token equality and usability before the fix; all compatibility cases passed. An initial fixture compile issue and an incorrect UTF-8 BOM expectation were corrected before that clean reproduction.
- Focused `swift test --jobs 4 --no-parallel --filter 'CursorAppAuthEncodingTests|CursorAppAuthRegressionTests|CursorStatusProbeTests|CursorSessionStoreTests|ProviderArchitectureGatekeeperTests'`: 93 tests in five suites passed. A behavior-equivalent empty-BLOB test-helper cleanup afterward is covered by the final focused rerun and full suite below.
- Final `swift test --jobs 4 --no-parallel --filter CursorAppAuthEncodingTests`: six tests covering 24 cases passed.
- `make check`: passed with zero violations across 2,056 Swift files after replacing the test helper's ternary with explicit switch cases.
- Independent Codex autoreview: no actionable blocking findings in the scoped repair.
- Full `make test`: all 968 selections in 81 groups passed on the first attempt, with zero failed/timed-out groups or retries (958.0 seconds total).
- Exact-head [CI](https://github.com/steipete/CodexBar/actions/runs/33301704244): passed on the first workflow attempt, including both macOS shards, Linux x64/arm64/musl, lint, and the aggregate gate. The macOS jobs waited for runners before starting; no workflow rerun or source change was needed.

Local commands use a clean environment with Keychain suppression, Codex-file isolation, session-file isolation, and live provider fetching disabled. No real Cursor database, account, provider request, or UI was used for this proof. The supported encoding contract comes from the existing decoder; this does not claim that a current Cursor installation was observed using this format. No release or feature mode is included.
