### PR TITLE
Add Warp as a default terminal option

### DIFF
--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -664,7 +664,23 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             return
         }
 
-        if Self.executeAppleScript(terminal.appleScript(command: command)) {
+        // Provider-specific by design: this is Warp terminal routing, not Warp usage-provider policy.
+        if terminal == .warp {
+            Task { @MainActor in
+                do {
+                    try await TerminalApp.launchWarp(command: command)
+                } catch {
+                    CodexBarLog.logger(LogCategories.terminal).warning(
+                        "Warp launch failed, falling back to Terminal.app",
+                        metadata: ["error": error.localizedDescription])
+                    Self.openTerminalInDefaultTerminal(command: command)
+                }
+            }
+            return
+        }
+
+        guard let script = terminal.appleScript(command: command) else { return }
+        if Self.executeAppleScript(script) {
             return
         }
         guard terminal != .terminal else { return }
@@ -676,7 +692,8 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     private static func openTerminalInDefaultTerminal(command: String) {
-        self.executeAppleScript(TerminalApp.terminal.appleScript(command: command))
+        guard let script = TerminalApp.terminal.appleScript(command: command) else { return }
+        self.executeAppleScript(script)
     }
 
     /// Executes an AppleScript and returns `true` on success, `false` on failure.

--- a/Sources/CodexBar/TerminalApp.swift
+++ b/Sources/CodexBar/TerminalApp.swift
@@ -6,6 +6,8 @@ enum TerminalApp: String, CaseIterable, Identifiable {
     case terminal
     case iTerm
     case ghostty
+    /// Provider-specific by design: "warp" is a terminal app here, not the Warp usage provider.
+    case warp
 
     var id: String {
         self.rawValue
@@ -16,6 +18,7 @@ enum TerminalApp: String, CaseIterable, Identifiable {
         case .terminal: "Terminal"
         case .iTerm: "iTerm"
         case .ghostty: "Ghostty"
+        case .warp: "Warp"
         }
     }
 
@@ -24,6 +27,7 @@ enum TerminalApp: String, CaseIterable, Identifiable {
         case .terminal: "com.apple.Terminal"
         case .iTerm: "com.googlecode.iterm2"
         case .ghostty: "com.mitchellh.ghostty"
+        case .warp: "dev.warp.Warp-Stable"
         }
     }
 
@@ -95,7 +99,7 @@ enum TerminalApp: String, CaseIterable, Identifiable {
         self.allCases.filter { $0 == selected || $0.isInstalled(applicationURL: applicationURL) }
     }
 
-    func appleScript(command: String) -> String {
+    func appleScript(command: String) -> String? {
         let escaped = Self.escapeForAppleScript(command)
         return switch self {
         case .terminal:
@@ -125,6 +129,9 @@ enum TerminalApp: String, CaseIterable, Identifiable {
                 new window with configuration {initial input:"\(escaped)" & linefeed}
             end tell
             """
+        // Provider-specific by design: Warp's terminal app has no AppleScript launcher.
+        case .warp:
+            nil
         }
     }
 
@@ -132,5 +139,102 @@ enum TerminalApp: String, CaseIterable, Identifiable {
         command
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    static func warpTabConfig(name: String, command: String, directory: String) -> String {
+        """
+        name = "\(name)"
+
+        [[panes]]
+        id = "main"
+        type = "terminal"
+        directory = "\(self.escapeForTOML(directory))"
+        commands = ["\(self.escapeForTOML(command))"]
+        """
+    }
+
+    @MainActor
+    static func launchWarp(command: String) async throws {
+        let workspace = NSWorkspace.shared
+        guard let schemeURL = URL(string: "warp://"),
+              let applicationURL = workspace.urlForApplication(toOpen: schemeURL)
+        else {
+            throw NSError(
+                domain: "TerminalApp",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Warp is not installed"])
+        }
+
+        let resolvedApplicationURL = applicationURL.resolvingSymlinksInPath().standardizedFileURL
+        let isRunning = workspace.runningApplications.contains {
+            $0.bundleURL?.resolvingSymlinksInPath().standardizedFileURL == resolvedApplicationURL
+        }
+        try await self.launchWarp(
+            command: command,
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser,
+            applicationURL: applicationURL,
+            isRunning: isRunning,
+            launchApplication: {
+                let configuration = NSWorkspace.OpenConfiguration()
+                configuration.activates = true
+                _ = try await workspace.openApplication(at: $0, configuration: configuration)
+            },
+            openURL: { workspace.open($0) },
+            sleep: { try await Task.sleep(for: $0) })
+    }
+
+    @MainActor
+    // swiftlint:disable:next function_parameter_count
+    static func launchWarp(
+        command: String,
+        homeDirectory: URL,
+        applicationURL: URL,
+        isRunning: Bool,
+        launchApplication: (URL) async throws -> Void,
+        openURL: (URL) -> Bool,
+        sleep: (Duration) async throws -> Void) async throws
+    {
+        let name = "codexbar-\(UUID().uuidString.lowercased())"
+        guard let deepLink = URL(string: "warp://tab_config/\(name)") else {
+            throw NSError(domain: "TerminalApp", code: 2)
+        }
+        let configFile = homeDirectory
+            .appendingPathComponent(".warp/tab_configs")
+            .appendingPathComponent("\(name).toml")
+        try FileManager.default.createDirectory(
+            at: configFile.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+
+        do {
+            try self.warpTabConfig(name: name, command: command, directory: homeDirectory.path)
+                .write(to: configFile, atomically: true, encoding: .utf8)
+            if !isRunning {
+                try await launchApplication(applicationURL)
+                try await sleep(.seconds(3))
+            }
+            guard openURL(deepLink) else {
+                throw NSError(
+                    domain: "TerminalApp",
+                    code: 3,
+                    userInfo: [NSLocalizedDescriptionKey: "Warp refused the tab config URL"])
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: configFile)
+            throw error
+        }
+
+        Task.detached {
+            try? await Task.sleep(for: .seconds(30))
+            try? FileManager.default.removeItem(at: configFile)
+        }
+    }
+
+    private static func escapeForTOML(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
     }
 }

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2478,7 +2478,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 707,
+            line: 724,
             anchor: "return .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/TerminalAppTests.swift
+++ b/Tests/CodexBarTests/TerminalAppTests.swift
@@ -50,11 +50,6 @@ struct TerminalAppTests {
     }
 
     @Test
-    func `only three cases exist`() {
-        #expect(TerminalApp.allCases.count == 3)
-    }
-
-    @Test
     func `installed terminals always include Terminal and detected alternatives`() {
         let iTermURL = URL(fileURLWithPath: "/Applications/iTerm.app")
         let installed = TerminalApp.installed { bundleIdentifier in
@@ -70,6 +65,16 @@ struct TerminalAppTests {
         }
 
         #expect(withGhostty == [.terminal, .ghostty])
+    }
+
+    @Test
+    func `installed Warp uses its native launcher`() throws {
+        let warp = try #require(TerminalApp(rawValue: "warp"))
+        let warpURL = URL(fileURLWithPath: "/Applications/Warp.app")
+
+        #expect(warp.bundleIdentifier == "dev.warp.Warp-Stable")
+        #expect(TerminalApp.installed { $0 == warp.bundleIdentifier ? warpURL : nil } == [.terminal, warp])
+        #expect(warp.appleScript(command: "claude") == nil)
     }
 
     @Test
@@ -125,11 +130,84 @@ struct TerminalAppTests {
     }
 
     @Test
-    func `builds terminal-specific launch scripts`() {
+    func `builds escaped Warp tab config`() {
+        let config = TerminalApp.warpTabConfig(
+            name: "codexbar-test",
+            command: "echo \"hi\" && printf 'a\\b\nc\td\r'",
+            directory: #"/tmp/dir "quote"\slash"#)
+
+        #expect(config == #"""
+        name = "codexbar-test"
+
+        [[panes]]
+        id = "main"
+        type = "terminal"
+        directory = "/tmp/dir \"quote\"\\slash"
+        commands = ["echo \"hi\" && printf 'a\\b\nc\td\r'"]
+        """#)
+    }
+
+    @Test
+    @MainActor
+    func `running Warp receives a native tab config`() async throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalAppTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let appURL = URL(fileURLWithPath: "/Applications/Warp.app")
+        var launched = false
+        var openedURL: URL?
+
+        try await TerminalApp.launchWarp(
+            command: "claude",
+            homeDirectory: home,
+            applicationURL: appURL,
+            isRunning: true,
+            launchApplication: { _ in launched = true },
+            openURL: {
+                openedURL = $0
+                return true
+            },
+            sleep: { _ in })
+
+        #expect(launched == false)
+        #expect(openedURL?.absoluteString.hasPrefix("warp://tab_config/codexbar-") == true)
+        let files = try FileManager.default.contentsOfDirectory(
+            at: home.appendingPathComponent(".warp/tab_configs"),
+            includingPropertiesForKeys: nil)
+        let content = try String(contentsOf: #require(files.first), encoding: .utf8)
+        #expect(content.contains(#"commands = ["claude"]"#))
+    }
+
+    @Test
+    @MainActor
+    func `cold Warp launches before routing the tab config`() async throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalAppTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let appURL = URL(fileURLWithPath: "/Applications/Warp.app")
+        var events: [String] = []
+
+        try await TerminalApp.launchWarp(
+            command: "claude",
+            homeDirectory: home,
+            applicationURL: appURL,
+            isRunning: false,
+            launchApplication: { _ in events.append("launch") },
+            openURL: { _ in
+                events.append("open")
+                return true
+            },
+            sleep: { _ in events.append("sleep") })
+
+        #expect(events == ["launch", "sleep", "open"])
+    }
+
+    @Test
+    func `builds terminal-specific launch scripts`() throws {
         let command = #"echo "hello""#
-        let terminalScript = TerminalApp.terminal.appleScript(command: command)
-        let iTermScript = TerminalApp.iTerm.appleScript(command: command)
-        let ghosttyScript = TerminalApp.ghostty.appleScript(command: command)
+        let terminalScript = try #require(TerminalApp.terminal.appleScript(command: command))
+        let iTermScript = try #require(TerminalApp.iTerm.appleScript(command: command))
+        let ghosttyScript = try #require(TerminalApp.ghostty.appleScript(command: command))
 
         #expect(terminalScript.contains(#"tell application "Terminal""#))
         #expect(terminalScript.contains(#"do script "echo \"hello\"""#))


### PR DESCRIPTION
## Summary

- add installed Warp to General > Default Terminal while keeping Terminal.app as the fresh-install default and fallback
- launch Open Terminal commands through Warp's native tab-config URI, including cold starts and temporary-config cleanup
- cover Warp detection, TOML escaping, hot/cold launch ordering, and the provider-name architecture gate

## Testing

- `swift test --filter 'TerminalAppTests|ProviderArchitectureGatekeeperTests|PreferencesPaneSmokeTests'` (81 tests passed)
- `.build/lint-tools/bin/swiftformat Sources Tests --lint`
- `.build/lint-tools/bin/swiftlint --strict --no-cache` (2,055 files, 0 violations)
- `./Scripts/lint.sh lint-macos`
- portable repository checks after the test-sharding gate

`make check` cannot pass its Swift test-sharding self-test on this host because Python's `waitid` lacks `WNOWAIT`; the direct suites and remaining checks above pass.

## Screenshots

Not included: the existing picker UI is unchanged and automatically renders installed terminal app labels and icons.
