### PR TITLE
fix(opencodego): omit pace advice for local quota estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.56.2 — Unreleased
 
+### Fixed
+- OpenCode Go: omit misleading pace and run-out advice for locally estimated quotas while preserving percentages, resets, and cost history (partial fix for #3286). Thanks @Akagilnc!
+
 ## 0.56.1 — 2026-08-30
 
 ### Performance

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -974,6 +974,7 @@ struct MenuBarLayoutPreview: View {
             self.store.weeklyPace(
                 provider: provider,
                 window: $0,
+                dataConfidence: snapshot.dataConfidence,
                 now: now)
         }
         let runsOut = pace
@@ -1011,13 +1012,22 @@ struct MenuBarLayoutPreview: View {
             automaticText: provider == .mistral && automaticRenderWindow == nil
                 ? StatusItemController.mistralSpendDisplayText(snapshot: snapshot)
                 : nil,
-            sessionPace: self.store.menuBarLayoutPaceText(provider: provider, window: session, now: now),
+            sessionPace: self.store.menuBarLayoutPaceText(
+                provider: provider,
+                window: session,
+                dataConfidence: snapshot.dataConfidence,
+                now: now),
             weeklyPace: self.store.menuBarLayoutPaceText(
                 provider: provider,
                 window: weekly,
+                dataConfidence: snapshot.dataConfidence,
                 now: now,
                 minimumElapsedPercent: 1),
-            automaticPace: self.store.menuBarLayoutPaceText(provider: provider, window: automatic, now: now),
+            automaticPace: self.store.menuBarLayoutPaceText(
+                provider: provider,
+                window: automatic,
+                dataConfidence: snapshot.dataConfidence,
+                now: now),
             runsOut: runsOut,
             balance: MenuBarLayoutBalanceResolver.balance(provider: provider, snapshot: snapshot),
             costToday: costToday.map {
@@ -1030,15 +1040,18 @@ struct MenuBarLayoutPreview: View {
                 sessionPaceDelta: self.store.menuBarLayoutPaceDelta(
                     provider: provider,
                     window: session,
+                    dataConfidence: snapshot.dataConfidence,
                     now: now),
                 weeklyPaceDelta: self.store.menuBarLayoutPaceDelta(
                     provider: provider,
                     window: weekly,
+                    dataConfidence: snapshot.dataConfidence,
                     now: now,
                     minimumElapsedPercent: 1),
                 automaticPaceDelta: self.store.menuBarLayoutPaceDelta(
                     provider: provider,
                     window: automatic,
+                    dataConfidence: snapshot.dataConfidence,
                     now: now),
                 runsOutMinutes: pace?.etaSeconds.map { Int(($0 / 60).rounded()) },
                 balanceRemainingUSD: balanceAmounts.remaining,

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -937,8 +937,10 @@ extension UsageMenuCardView.Model {
             account: input.account,
             override: input.planOverride,
             metadata: input.metadata)
+        let paceVisible = input.paceVisible && ProviderDescriptorRegistry.descriptor(for: input.provider).pace
+            .allowsPace(dataConfidence: input.snapshot?.dataConfidence ?? .unknown)
         let metrics = Self.redactedMetrics(
-            Self.paceGatedMetrics(Self.metrics(input: input), paceVisible: input.paceVisible),
+            Self.paceGatedMetrics(Self.metrics(input: input), paceVisible: paceVisible),
             provider: input.provider,
             hidePersonalInfo: input.hidePersonalInfo)
         let openAIAPIUsage = input.snapshot?.openAIAPIUsage

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -244,6 +244,8 @@ struct MenuDescriptor {
             let resetStyle = settings.resetTimeDisplayStyle
             let labels = Self.rateWindowLabels(provider: provider, metadata: meta, snapshot: snap)
             let presentation = ProviderDescriptorRegistry.descriptor(for: provider).presentation
+            let paceVisible = settings.paceVisible && ProviderDescriptorRegistry.descriptor(for: provider).pace
+                .allowsPace(dataConfidence: snap.dataConfidence)
             if let primary = snap.primary {
                 let primaryDetail = primary.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
                 let primaryDescriptionIsDetail = presentation.menu.usesPrimaryDescriptionAsDetail(snapshot: snap)
@@ -277,14 +279,14 @@ struct MenuDescriptor {
                 {
                     entries.append(.text(primaryDetail, .secondary))
                 }
-                if settings.paceVisible,
+                if paceVisible,
                    presentation.menu.showsPrimaryWeeklyPace,
-                   let pace = store.weeklyPace(provider: provider, window: primary)
+                   let pace = store.weeklyPace(provider: provider, window: primary, dataConfidence: snap.dataConfidence)
                 {
                     let paceSummary = UsagePaceText.weeklySummary(provider: provider, pace: pace)
                     entries.append(.text(paceSummary, .secondary))
                 }
-                if settings.paceVisible,
+                if paceVisible,
                    let paceSummary = UsagePaceText.sessionSummary(provider: provider, window: primary)
                 {
                     entries.append(.text(paceSummary, .secondary))
@@ -317,8 +319,8 @@ struct MenuDescriptor {
                 {
                     entries.append(.text(detail, .secondary))
                 }
-                if settings.paceVisible,
-                   let pace = store.weeklyPace(provider: provider, window: weekly)
+                if paceVisible,
+                   let pace = store.weeklyPace(provider: provider, window: weekly, dataConfidence: snap.dataConfidence)
                 {
                     let paceSummary = UsagePaceText.weeklySummary(provider: provider, pace: pace)
                     entries.append(.text(paceSummary, .secondary))

--- a/Sources/CodexBar/PredictivePaceWarnings.swift
+++ b/Sources/CodexBar/PredictivePaceWarnings.swift
@@ -166,7 +166,11 @@ extension UsageStore {
         }
 
         if let weeklyWindow = self.predictivePaceWarningWeeklyWindow(provider: provider, snapshot: snapshot),
-           let weeklyPace = self.weeklyPace(provider: provider, window: weeklyWindow, now: now)
+           let weeklyPace = self.weeklyPace(
+               provider: provider,
+               window: weeklyWindow,
+               dataConfidence: snapshot.dataConfidence,
+               now: now)
         {
             candidates.append((window: .weekly, rateWindow: weeklyWindow, pace: weeklyPace))
         }

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -566,10 +566,18 @@ struct ProvidersPane: View {
         let weeklyPace = if let codexProjection,
                             let weekly = codexProjection.rateWindow(for: .weekly)
         {
-            self.store.weeklyPace(provider: provider, window: weekly, now: now)
+            self.store.weeklyPace(
+                provider: provider,
+                window: weekly,
+                dataConfidence: snapshot?.dataConfidence ?? .unknown,
+                now: now)
         } else {
             paceWindow.flatMap { window in
-                self.store.weeklyPace(provider: provider, window: window, now: now)
+                self.store.weeklyPace(
+                    provider: provider,
+                    window: window,
+                    dataConfidence: snapshot?.dataConfidence ?? .unknown,
+                    now: now)
             }
         }
         let input = UsageMenuCardView.Model.Input(

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -960,7 +960,11 @@ extension StatusItemController {
                 combinedLanes: combinedLanes,
                 percentWindow: percentWindow)
             pace = paceWindow.flatMap { window in
-                self.store.weeklyPace(provider: provider, window: window, now: now)
+                self.store.weeklyPace(
+                    provider: provider,
+                    window: window,
+                    dataConfidence: snapshot?.dataConfidence ?? .unknown,
+                    now: now)
             }
         case .resetTime:
             return MenuBarDisplayText.displayText(

--- a/Sources/CodexBar/StatusItemController+IconObservation.swift
+++ b/Sources/CodexBar/StatusItemController+IconObservation.swift
@@ -169,9 +169,15 @@ extension StatusItemController {
                 guard case let .pace(window) = token else { return nil }
                 return window
             })
-        if metrics.contains(.sessionPace) { paceWindows.insert(.session) }
-        if metrics.contains(.weeklyPace) { paceWindows.insert(.weekly) }
-        if metrics.contains(.automaticPace) { paceWindows.insert(.automatic) }
+        if metrics.contains(.sessionPace) {
+            paceWindows.insert(.session)
+        }
+        if metrics.contains(.weeklyPace) {
+            paceWindows.insert(.weekly)
+        }
+        if metrics.contains(.automaticPace) {
+            paceWindows.insert(.automatic)
+        }
         let needsRunsOut = metrics.contains(.runsOutIn)
         guard !paceWindows.isEmpty || needsRunsOut else { return nil }
 
@@ -189,13 +195,18 @@ extension StatusItemController {
                 let pace = self.store.menuBarLayoutPaceText(
                     provider: provider,
                     window: window,
+                    dataConfidence: snapshot?.dataConfidence ?? .unknown,
                     now: now,
                     minimumElapsedPercent: percentWindow == .weekly ? 1 : nil)
                 return "\(percentWindow.rawValue)=\(pace ?? "nil")"
             }
         if needsRunsOut {
             let runsOutMinutes = (windows.weekly ?? windows.automatic)
-                .flatMap { self.store.weeklyPace(provider: provider, window: $0, now: now) }
+                .flatMap { self.store.weeklyPace(
+                    provider: provider,
+                    window: $0,
+                    dataConfidence: snapshot?.dataConfidence ?? .unknown,
+                    now: now) }
                 .flatMap(\.etaSeconds)
                 .map { Int(($0 / 60).rounded()) }
             components.append("runsOut=\(runsOutMinutes.map { String($0) } ?? "nil")")

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -90,6 +90,7 @@ extension StatusItemController {
             self.store.weeklyPace(
                 provider: provider,
                 window: $0,
+                dataConfidence: snapshot?.dataConfidence ?? .unknown,
                 now: now)
         }
         let runsOut = pace
@@ -123,15 +124,18 @@ extension StatusItemController {
             sessionPace: self.store.menuBarLayoutPaceText(
                 provider: provider,
                 window: windows.session,
+                dataConfidence: snapshot?.dataConfidence ?? .unknown,
                 now: now),
             weeklyPace: self.store.menuBarLayoutPaceText(
                 provider: provider,
                 window: windows.weekly,
+                dataConfidence: snapshot?.dataConfidence ?? .unknown,
                 now: now,
                 minimumElapsedPercent: 1),
             automaticPace: self.store.menuBarLayoutPaceText(
                 provider: provider,
                 window: windows.automatic,
+                dataConfidence: snapshot?.dataConfidence ?? .unknown,
                 now: now),
             runsOut: runsOut,
             balance: MenuBarLayoutBalanceResolver.balance(provider: provider, snapshot: snapshot),
@@ -141,15 +145,18 @@ extension StatusItemController {
                 sessionPaceDelta: self.store.menuBarLayoutPaceDelta(
                     provider: provider,
                     window: windows.session,
+                    dataConfidence: snapshot?.dataConfidence ?? .unknown,
                     now: now),
                 weeklyPaceDelta: self.store.menuBarLayoutPaceDelta(
                     provider: provider,
                     window: windows.weekly,
+                    dataConfidence: snapshot?.dataConfidence ?? .unknown,
                     now: now,
                     minimumElapsedPercent: 1),
                 automaticPaceDelta: self.store.menuBarLayoutPaceDelta(
                     provider: provider,
                     window: windows.automatic,
+                    dataConfidence: snapshot?.dataConfidence ?? .unknown,
                     now: now),
                 runsOutMinutes: pace?.etaSeconds.map { Int(($0 / 60).rounded()) },
                 balanceRemainingUSD: balanceAmounts.remaining,

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -223,10 +223,18 @@ extension StatusItemController {
         let weeklyPace = if let codexProjection,
                             let weekly = codexProjection.rateWindow(for: .weekly)
         {
-            self.store.weeklyPace(provider: target, window: weekly, now: now)
+            self.store.weeklyPace(
+                provider: target,
+                window: weekly,
+                dataConfidence: snapshot?.dataConfidence ?? .unknown,
+                now: now)
         } else {
             paceWindow.flatMap { window in
-                self.store.weeklyPace(provider: target, window: window, now: now)
+                self.store.weeklyPace(
+                    provider: target,
+                    window: window,
+                    dataConfidence: snapshot?.dataConfidence ?? .unknown,
+                    now: now)
             }
         }
         let forecast: SessionEquivalentForecast? = if let codexProjection,

--- a/Sources/CodexBar/UsageStore+HistoricalPace.swift
+++ b/Sources/CodexBar/UsageStore+HistoricalPace.swift
@@ -8,11 +8,13 @@ extension UsageStore {
     func weeklyPace(
         provider: UsageProvider,
         window: RateWindow,
+        dataConfidence: UsageDataConfidence,
         now: Date = .init(),
         minimumExpectedPercent: Double = 3,
         minimumElapsedPercent: Double? = nil) -> UsagePace?
     {
-        guard window.remainingPercent > 0 else { return nil }
+        guard ProviderDescriptorRegistry.descriptor(for: provider).pace.allowsPace(dataConfidence: dataConfidence),
+              window.remainingPercent > 0 else { return nil }
         let resolved: UsagePace?
         let elapsedWindow: RateWindow
         let workDays = self.settings.weeklyProgressWorkDays
@@ -67,6 +69,7 @@ extension UsageStore {
     func menuBarLayoutPaceText(
         provider: UsageProvider,
         window: RateWindow?,
+        dataConfidence: UsageDataConfidence,
         now: Date = .init(),
         minimumExpectedPercent: Double = 3,
         minimumElapsedPercent: Double? = nil)
@@ -77,6 +80,7 @@ extension UsageStore {
                 self.weeklyPace(
                     provider: provider,
                     window: $0,
+                    dataConfidence: dataConfidence,
                     now: now,
                     minimumExpectedPercent: minimumExpectedPercent,
                     minimumElapsedPercent: minimumElapsedPercent)
@@ -89,6 +93,7 @@ extension UsageStore {
     func menuBarLayoutPaceDelta(
         provider: UsageProvider,
         window: RateWindow?,
+        dataConfidence: UsageDataConfidence,
         now: Date = .init(),
         minimumExpectedPercent: Double = 3,
         minimumElapsedPercent: Double? = nil)
@@ -99,6 +104,7 @@ extension UsageStore {
                 self.weeklyPace(
                     provider: provider,
                     window: $0,
+                    dataConfidence: dataConfidence,
                     now: now,
                     minimumExpectedPercent: minimumExpectedPercent,
                     minimumElapsedPercent: minimumElapsedPercent)

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -552,6 +552,8 @@ enum CLIRenderer {
         weeklyWorkDays: Int? = nil,
         now: Date = Date()) -> ProviderPacePayload?
     {
+        guard ProviderDescriptorRegistry.descriptor(for: provider).pace
+            .allowsPace(dataConfidence: snapshot.dataConfidence) else { return nil }
         let primary = snapshot.primary.flatMap {
             self.pacePayload(
                 provider: provider,
@@ -605,6 +607,7 @@ enum CLIRenderer {
                 title: labels.primary,
                 window: primary,
                 paceSlot: .primary,
+                dataConfidence: snapshot.dataConfidence,
                 context: context,
                 now: now,
                 lines: &lines)
@@ -634,6 +637,7 @@ enum CLIRenderer {
             title: labels.secondary,
             window: weekly,
             paceSlot: .secondary,
+            dataConfidence: snapshot.dataConfidence,
             context: context,
             now: now,
             lines: &lines)
@@ -688,13 +692,15 @@ enum CLIRenderer {
     {
         guard labels.showsTertiary, let tertiary = snapshot.tertiary else { return }
         lines.append(self.rateLine(title: labels.tertiary, window: tertiary, useColor: context.useColor))
-        if let pace = self.paceLine(
-            provider: provider,
-            window: tertiary,
-            slot: .tertiary,
-            weeklyWorkDays: context.weeklyWorkDays,
-            useColor: context.useColor,
-            now: now)
+        if ProviderDescriptorRegistry.descriptor(for: provider).pace
+            .allowsPace(dataConfidence: snapshot.dataConfidence),
+            let pace = self.paceLine(
+                provider: provider,
+                window: tertiary,
+                slot: .tertiary,
+                weeklyWorkDays: context.weeklyWorkDays,
+                useColor: context.useColor,
+                now: now)
         {
             lines.append(pace)
         }
@@ -805,18 +811,20 @@ enum CLIRenderer {
         title: String,
         window: RateWindow,
         paceSlot: ProviderPaceSlot,
+        dataConfidence: UsageDataConfidence,
         context: RenderContext,
         now: Date,
         lines: inout [String])
     {
         lines.append(self.rateLine(title: title, window: window, useColor: context.useColor))
-        if let pace = self.paceLine(
-            provider: provider,
-            window: window,
-            slot: paceSlot,
-            weeklyWorkDays: context.weeklyWorkDays,
-            useColor: context.useColor,
-            now: now)
+        if ProviderDescriptorRegistry.descriptor(for: provider).pace.allowsPace(dataConfidence: dataConfidence),
+           let pace = self.paceLine(
+               provider: provider,
+               window: window,
+               slot: paceSlot,
+               weeklyWorkDays: context.weeklyWorkDays,
+               useColor: context.useColor,
+               now: now)
         {
             lines.append(pace)
         }

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoProviderDescriptor.swift
@@ -80,7 +80,9 @@ public enum OpenCodeGoProviderDescriptor {
                 resetWindowPace: .windowDuration(minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
                 inferredMonthlyDuration: .windowDuration(minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
                 primary: .session(maximumMinutes: 300),
-                secondary: .weekly),
+                secondary: .weekly,
+                // Device-local costs cannot establish the account's quota usage or billing-cycle boundaries.
+                allowsEstimatedUsage: false),
             history: .alwaysTracked,
             presentation: ProviderUsagePresentation(
                 costPresenter: { snapshot in
@@ -404,8 +406,12 @@ struct OpenCodeGoAPIUsageFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
         guard context.sourceMode == .auto else { return false }
-        if error is CancellationError { return false }
-        if let urlError = error as? URLError, urlError.code == .cancelled { return false }
+        if error is CancellationError {
+            return false
+        }
+        if let urlError = error as? URLError, urlError.code == .cancelled {
+            return false
+        }
         return true
     }
 }

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -231,6 +231,7 @@ public struct ProviderPaceCapability: Sendable {
     public let tertiary: ProviderStandardPaceLane?
     public let showsHeadroomHint: Bool
     public let sessionPaceWindowRule: ProviderPaceWindowRule
+    public let allowsEstimatedUsage: Bool
 
     public init(
         resetWindowPace: ProviderPaceWindowRule = .unsupported,
@@ -239,7 +240,8 @@ public struct ProviderPaceCapability: Sendable {
         secondary: ProviderStandardPaceLane? = nil,
         tertiary: ProviderStandardPaceLane? = nil,
         showsHeadroomHint: Bool = false,
-        sessionPaceWindowRule: ProviderPaceWindowRule = .unsupported)
+        sessionPaceWindowRule: ProviderPaceWindowRule = .unsupported,
+        allowsEstimatedUsage: Bool = true)
     {
         self.resetWindowPace = resetWindowPace
         self.inferredMonthlyDuration = inferredMonthlyDuration
@@ -248,6 +250,11 @@ public struct ProviderPaceCapability: Sendable {
         self.tertiary = tertiary
         self.showsHeadroomHint = showsHeadroomHint
         self.sessionPaceWindowRule = sessionPaceWindowRule
+        self.allowsEstimatedUsage = allowsEstimatedUsage
+    }
+
+    public func allowsPace(dataConfidence: UsageDataConfidence) -> Bool {
+        self.allowsEstimatedUsage || dataConfidence != .estimated
     }
 
     public func supportsResetWindowPace(window: RateWindow, now: Date) -> Bool {

--- a/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
@@ -339,7 +339,7 @@ extension HistoricalUsagePaceTests {
         ])
         store._setCodexHistoricalDatasetForTesting(twoWeeksDataset)
 
-        let computed = store.weeklyPace(provider: .codex, window: window, now: now)
+        let computed = store.weeklyPace(provider: .codex, window: window, dataConfidence: .unknown, now: now)
         let linear = UsagePace.weekly(
             window: window,
             now: now,
@@ -381,7 +381,11 @@ extension HistoricalUsagePaceTests {
             dataset,
             accountKey: store.codexOwnershipContext().canonicalKey)
 
-        let computed = try #require(store.weeklyPace(provider: .codex, window: window, now: now))
+        let computed = try #require(store.weeklyPace(
+            provider: .codex,
+            window: window,
+            dataConfidence: .unknown,
+            now: now))
 
         #expect(abs(expected.expectedUsedPercent - linear.expectedUsedPercent) > 0.001)
         #expect(expected.runOutProbability != nil)
@@ -441,7 +445,11 @@ extension HistoricalUsagePaceTests {
             dataset,
             accountKey: store.codexOwnershipContext().canonicalKey)
 
-        let computed = try #require(store.weeklyPace(provider: .codex, window: window, now: now))
+        let computed = try #require(store.weeklyPace(
+            provider: .codex,
+            window: window,
+            dataConfidence: .unknown,
+            now: now))
 
         #expect(historical.runOutProbability != nil)
         #expect(abs(computed.expectedUsedPercent - scheduled.expectedUsedPercent) < 0.001)
@@ -467,7 +475,7 @@ extension HistoricalUsagePaceTests {
             resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60),
             resetDescription: nil)
 
-        let pace = store.weeklyPace(provider: .zai, window: window, now: now)
+        let pace = store.weeklyPace(provider: .zai, window: window, dataConfidence: .unknown, now: now)
 
         #expect(pace != nil)
         #expect(abs((pace?.deltaPercent ?? 0) - (40 - (3.0 / 7.0 * 100.0))) < 0.001)
@@ -500,10 +508,13 @@ extension HistoricalUsagePaceTests {
             resetsAt: now.addingTimeInterval(7 * 24 * 60 * 60 - 60 * 60),
             resetDescription: nil)
 
-        #expect(store.menuBarLayoutPaceText(provider: .zai, window: deficit, now: now) == "+17%")
-        #expect(store.menuBarLayoutPaceText(provider: .zai, window: reserve, now: now) == "-13%")
-        #expect(store.menuBarLayoutPaceText(provider: .zai, window: tooEarly, now: now) == nil)
-        #expect(store.menuBarLayoutPaceText(provider: .zai, window: nil, now: now) == nil)
+        #expect(store
+            .menuBarLayoutPaceText(provider: .zai, window: deficit, dataConfidence: .unknown, now: now) == "+17%")
+        #expect(store
+            .menuBarLayoutPaceText(provider: .zai, window: reserve, dataConfidence: .unknown, now: now) == "-13%")
+        #expect(store
+            .menuBarLayoutPaceText(provider: .zai, window: tooEarly, dataConfidence: .unknown, now: now) == nil)
+        #expect(store.menuBarLayoutPaceText(provider: .zai, window: nil, dataConfidence: .unknown, now: now) == nil)
     }
 
     @MainActor
@@ -523,12 +534,17 @@ extension HistoricalUsagePaceTests {
             resetsAt: now.addingTimeInterval(7 * 24 * 60 * 60 - 4 * 60 * 60),
             resetDescription: nil)
 
-        #expect(store.menuBarLayoutPaceText(provider: .zai, window: barelyIntoWindow, now: now) == nil)
-        #expect(store.weeklyPace(provider: .zai, window: barelyIntoWindow, now: now) == nil)
+        #expect(store.menuBarLayoutPaceText(
+            provider: .zai,
+            window: barelyIntoWindow,
+            dataConfidence: .unknown,
+            now: now) == nil)
+        #expect(store.weeklyPace(provider: .zai, window: barelyIntoWindow, dataConfidence: .unknown, now: now) == nil)
         #expect(
             store.menuBarLayoutPaceText(
                 provider: .zai,
                 window: barelyIntoWindow,
+                dataConfidence: .unknown,
                 now: now,
                 minimumElapsedPercent: 1)
                 == "+3%")
@@ -536,6 +552,7 @@ extension HistoricalUsagePaceTests {
             store.weeklyPace(
                 provider: .zai,
                 window: barelyIntoWindow,
+                dataConfidence: .unknown,
                 now: now,
                 minimumElapsedPercent: 1))
         #expect(abs(pace.expectedUsedPercent - (4.0 / 168.0 * 100.0)) < 0.001)
@@ -571,17 +588,19 @@ extension HistoricalUsagePaceTests {
             dataset,
             accountKey: store.codexOwnershipContext().canonicalKey)
 
-        #expect(store.weeklyPace(provider: .codex, window: window, now: now) == nil)
+        #expect(store.weeklyPace(provider: .codex, window: window, dataConfidence: .unknown, now: now) == nil)
         let pace = try #require(
             store.weeklyPace(
                 provider: .codex,
                 window: window,
+                dataConfidence: .unknown,
                 now: now,
                 minimumElapsedPercent: 1))
         #expect(pace.expectedUsedPercent < 1)
         #expect(store.menuBarLayoutPaceText(
             provider: .codex,
             window: window,
+            dataConfidence: .unknown,
             now: now,
             minimumElapsedPercent: 1) != nil)
     }
@@ -617,6 +636,7 @@ extension HistoricalUsagePaceTests {
             store.weeklyPace(
                 provider: .amp,
                 window: window,
+                dataConfidence: .unknown,
                 now: now,
                 minimumElapsedPercent: 1))
         #expect(pace.expectedUsedPercent > 1)
@@ -688,7 +708,7 @@ extension HistoricalUsagePaceTests {
             resetsAt: resetsAt,
             resetDescription: nil)
 
-        let pace = try #require(store.weeklyPace(provider: .zai, window: window, now: now))
+        let pace = try #require(store.weeklyPace(provider: .zai, window: window, dataConfidence: .unknown, now: now))
 
         #expect(abs(pace.expectedUsedPercent - 60) < 0.001)
         #expect(abs(pace.deltaPercent) < 0.001)
@@ -709,7 +729,7 @@ extension HistoricalUsagePaceTests {
             resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60),
             resetDescription: nil)
 
-        let pace = store.weeklyPace(provider: .factory, window: window, now: now)
+        let pace = store.weeklyPace(provider: .factory, window: window, dataConfidence: .unknown, now: now)
 
         #expect(pace == nil)
     }

--- a/Tests/CodexBarTests/OpenCodeGoEstimatedPaceTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoEstimatedPaceTests.swift
@@ -1,0 +1,212 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCLI
+
+@MainActor
+struct OpenCodeGoEstimatedPaceTests {
+    @Test(arguments: [UsageDataConfidence.estimated, .unknown, .exact])
+    func `CLI quota and disclosure survive while only authoritative windows get pace`(
+        confidence: UsageDataConfidence)
+    {
+        let snapshot = OpenCodeGoPaceTestSupport.snapshot(confidence: confidence)
+        let expectedPace = confidence != .estimated
+        let context = RenderContext(
+            header: "OpenCode Go",
+            status: nil,
+            useColor: false,
+            resetStyle: .countdown,
+            notes: CodexBarCLI.usageTextNotes(
+                provider: .opencodego,
+                sourceMode: .auto,
+                resolvedSourceLabel: expectedPace ? "local+api" : "local",
+                dataConfidence: confidence))
+        let text = CLIRenderer.renderText(
+            provider: .opencodego,
+            snapshot: snapshot,
+            credits: nil,
+            context: context,
+            now: OpenCodeGoPaceTestSupport.now)
+        let pace = CLIRenderer.providerPacePayload(
+            provider: .opencodego, snapshot: snapshot, now: OpenCodeGoPaceTestSupport.now)
+
+        #expect(text.contains("Monthly: 95% left"))
+        #expect(text.contains("Weekly: 96% left"))
+        #expect(text.contains("Resets in"))
+        #expect(text.contains("Quota estimated from local usage history") == !expectedPace)
+        #expect(text.contains("Pace:") == expectedPace)
+        #expect(text.contains("Lasts until reset") == expectedPace)
+        #expect((pace != nil) == expectedPace)
+        if expectedPace {
+            #expect(pace?.primary != nil)
+            #expect(pace?.secondary != nil)
+            #expect(pace?.tertiary != nil)
+        }
+    }
+
+    @Test
+    func `encoded local usage omits pace but keeps confidence and reset windows`() throws {
+        let snapshot = OpenCodeGoPaceTestSupport.snapshot(confidence: .estimated, now: Date())
+        let payload = ProviderPayload(
+            provider: .opencodego,
+            account: nil,
+            version: nil,
+            source: "local",
+            status: nil,
+            usage: snapshot,
+            credits: nil,
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: nil,
+            pace: CLIRenderer.providerPacePayload(provider: .opencodego, snapshot: snapshot))
+        let data = try JSONEncoder().encode(payload)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let usage = try #require(json["usage"] as? [String: Any])
+
+        #expect(json["pace"] == nil)
+        #expect(usage["dataConfidence"] as? String == "estimated")
+        #expect((usage["tertiary"] as? [String: Any])?["usedPercent"] as? Double == 5)
+        #expect((usage["tertiary"] as? [String: Any])?["resetsAt"] != nil)
+    }
+
+    @Test(arguments: [UsageDataConfidence.estimated, .unknown, .exact])
+    func `menu card preserves quotas but does not forecast from local estimates`(
+        confidence: UsageDataConfidence) throws
+    {
+        let model = UsageMenuCardView.Model.make(OpenCodeGoPaceTestSupport.input(confidence: confidence))
+        let monthly = try #require(model.metrics.first { $0.id == "tertiary" })
+        let expectedPace = confidence != .estimated
+
+        #expect(model.metrics.map(\.title) == ["5-hour", "Weekly", "Monthly"])
+        #expect(monthly.percentLabel == "95% left")
+        #expect(monthly.resetText != nil)
+        #expect(model.usageNotes == (expectedPace ? [] : [L("Quota estimated from local usage history")]))
+        #expect((monthly.detailRightText != nil) == expectedPace)
+        #expect((monthly.pacePercent != nil) == expectedPace)
+        if !expectedPace {
+            #expect(model.metrics.allSatisfy { $0.pacePercent == nil })
+            #expect(model.metrics.allSatisfy { $0.detailLeftText == nil && $0.detailRightText == nil })
+        }
+    }
+
+    @Test(arguments: [UsageDataConfidence.estimated, .unknown, .exact])
+    func `menu bar pace uses the displayed snapshot confidence instead of the selected account`(
+        confidence: UsageDataConfidence) throws
+    {
+        let settings = testSettingsStore(
+            suiteName: "OpenCodeGoEstimatedPaceTests-layout-\(confidence)",
+            config: testConfigWithAllProvidersDisabled())
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+        let expectedPace = confidence != .estimated
+        store._setSnapshotForTesting(
+            OpenCodeGoPaceTestSupport.snapshot(confidence: expectedPace ? .estimated : .exact), provider: .opencodego)
+        let window = try #require(OpenCodeGoPaceTestSupport.snapshot(confidence: confidence).secondary)
+        let pace = store.weeklyPace(
+            provider: .opencodego, window: window, dataConfidence: confidence, now: OpenCodeGoPaceTestSupport.now)
+        let text = store.menuBarLayoutPaceText(
+            provider: .opencodego, window: window, dataConfidence: confidence, now: OpenCodeGoPaceTestSupport.now)
+        let delta = store.menuBarLayoutPaceDelta(
+            provider: .opencodego, window: window, dataConfidence: confidence, now: OpenCodeGoPaceTestSupport.now)
+
+        #expect((pace != nil) == expectedPace)
+        #expect((text != nil) == expectedPace)
+        #expect((delta != nil) == expectedPace)
+        if !expectedPace {
+            for mode in [MenuBarDisplayMode.pace, .both] {
+                #expect(MenuBarDisplayText.displayText(
+                    mode: mode, percentWindow: window, pace: pace, showUsed: false) == "96%")
+            }
+        }
+        #expect(store.weeklyPace(
+            provider: .zai, window: window, dataConfidence: .estimated, now: OpenCodeGoPaceTestSupport.now) != nil)
+    }
+
+    @Test
+    func `only OpenCode Go opts out of estimated pace`() {
+        for provider in UsageProvider.allCases {
+            let capability = ProviderDescriptorRegistry.descriptor(for: provider).pace
+            #expect(capability.allowsPace(dataConfidence: .estimated) == (provider != .opencodego))
+            #expect(capability.allowsPace(dataConfidence: .unknown))
+            #expect(capability.allowsPace(dataConfidence: .exact))
+        }
+    }
+
+    @Test(arguments: [UsageDataConfidence.estimated, .unknown, .exact])
+    func `legacy menu omits estimate forecasts without hiding quota rows`(confidence: UsageDataConfidence) {
+        let settings = testSettingsStore(
+            suiteName: "OpenCodeGoEstimatedPaceTests-legacy-\(confidence)",
+            config: testConfigWithAllProvidersDisabled())
+        settings.paceVisible = true
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+        store._setSnapshotForTesting(
+            OpenCodeGoPaceTestSupport.snapshot(confidence: confidence, now: Date()), provider: .opencodego)
+        let menu = MenuDescriptor.build(
+            provider: .opencodego,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updateReady: false)
+        let texts = menu.sections.flatMap(\.entries).compactMap { entry -> String? in
+            guard case let .text(text, _) = entry else { return nil }
+            return text
+        }
+
+        #expect(texts.contains { $0.contains("Monthly") })
+        #expect(texts.contains { $0.contains("Pace:") } == (confidence != .estimated))
+    }
+}
+
+enum OpenCodeGoPaceTestSupport {
+    static let now = Date(timeIntervalSince1970: 10_368_000)
+
+    static func snapshot(confidence: UsageDataConfidence, now: Date = Self.now) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 0, windowMinutes: 300, resetsAt: now.addingTimeInterval(3 * 3600), resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 4,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(8 * 3600),
+                resetDescription: nil),
+            tertiary: RateWindow(
+                usedPercent: 5,
+                windowMinutes: 43200,
+                resetsAt: now.addingTimeInterval(6 * 86400),
+                resetDescription: nil),
+            updatedAt: now,
+            dataConfidence: confidence)
+    }
+
+    static func input(confidence: UsageDataConfidence) -> UsageMenuCardView.Model.Input {
+        .init(
+            provider: .opencodego,
+            metadata: ProviderDefaults.metadata[.opencodego]!,
+            snapshot: self.snapshot(confidence: confidence),
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: true,
+            now: self.now)
+    }
+}

--- a/Tests/CodexBarTests/PaceVisibilityScreenshotRenderTests.swift
+++ b/Tests/CodexBarTests/PaceVisibilityScreenshotRenderTests.swift
@@ -34,6 +34,26 @@ final class PaceVisibilityScreenshotRenderTests: XCTestCase {
         }
     }
 
+    func test_renderOpenCodeGoEstimateScreenshots() throws {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_OPENCODEGO_PACE_SCREENSHOT_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_OPENCODEGO_PACE_SCREENSHOT_DIR to render local quota estimate screenshots.")
+        }
+        let directory = URL(fileURLWithPath: NSString(string: dir).expandingTildeInPath, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        for (name, appearance, scheme) in [
+            ("light", NSAppearance.Name.aqua, ColorScheme.light),
+            ("dark", NSAppearance.Name.darkAqua, ColorScheme.dark),
+        ] {
+            let model = UsageMenuCardView.Model.make(OpenCodeGoPaceTestSupport.input(confidence: .estimated))
+            let view = AnyView(UsageMenuCardView(model: model, width: Self.width)
+                .padding(12)
+                .background(Color(nsColor: .windowBackgroundColor))
+                .environment(\.colorScheme, scheme))
+            let data = try XCTUnwrap(Self.pngData(for: view, appearance: appearance))
+            try data.write(to: directory.appendingPathComponent("opencodego-estimated-\(name).png"), options: .atomic)
+        }
+    }
+
     /// A Claude account running ahead of the sustainable rate, so the stripe and
     /// the forecast text both have something to render.
     private static func input(paceVisible: Bool) -> UsageMenuCardView.Model.Input {
@@ -76,9 +96,9 @@ final class PaceVisibilityScreenshotRenderTests: XCTestCase {
             now: Self.now)
     }
 
-    private static func pngData(for view: AnyView) -> Data? {
+    private static func pngData(for view: AnyView, appearance: NSAppearance.Name = .darkAqua) -> Data? {
         let hosting = NSHostingView(rootView: view)
-        hosting.appearance = NSAppearance(named: .darkAqua)
+        hosting.appearance = NSAppearance(named: appearance)
         let size = hosting.fittingSize
         guard size.width > 0, size.height > 0 else { return nil }
         hosting.frame = CGRect(origin: .zero, size: size)

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -856,7 +856,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This provider-owned adapter passes its fixed identity to shared logging or cache infrastructure."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/PredictivePaceWarnings.swift",
-            line: 206,
+            line: 210,
             anchor: "preferredEmail: snapshot.accountEmail(for: .codex),",
             expectedProviderIDs: ["codex"],
             reason: "This exact provider-owned construct passes a fixed identity to shared infrastructure."),
@@ -1066,13 +1066,13 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This named provider resolver supplies its fixed provider identity to the shared presentation helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+HistoricalPace.swift",
-            line: 154,
+            line: 160,
             anchor: "let ownership = self.codexOwnershipContext(preferredEmail: snapshot.accountEmail(for: .codex))",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+HistoricalPace.swift",
-            line: 213,
+            line: 219,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -1970,7 +1970,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1051,
+            line: 1053,
             anchor: "if input.provider == .sub2api {",
             expectedProviderIDs: ["sub2api"],
             expectedReferenceCount: 1,
@@ -1978,7 +1978,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "The sub2api menu card localizes and groups provider-owned usage detail rows for display."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1123,
+            line: 1125,
             anchor: "if provider == .kiro,",
             expectedProviderIDs: ["kilo", "kiro"],
             expectedReferenceCount: 2,
@@ -1986,7 +1986,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1146,
+            line: 1148,
             anchor: "if provider == .minimax {",
             expectedProviderIDs: ["codex", "minimax"],
             expectedReferenceCount: 2,
@@ -1994,7 +1994,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1181,
+            line: 1183,
             anchor: "guard let loginMethod = snapshot?.loginMethod(for: .kilo) else {",
             expectedProviderIDs: ["kilo"],
             expectedReferenceCount: 1,
@@ -2002,7 +2002,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1260,
+            line: 1262,
             anchor: "if input.provider == .antigravity {",
             expectedProviderIDs: ["antigravity", "mistral"],
             expectedReferenceCount: 2,
@@ -2010,7 +2010,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1280,
+            line: 1282,
             anchor: "if input.provider == .codex, let codexProjection = input.codexProjection {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2018,7 +2018,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1296,
+            line: 1298,
             anchor: "if input.provider != .codex, let weekly = snapshot.secondary {",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "codex", "perplexity", "sub2api"],
             expectedReferenceCount: 5,
@@ -2032,7 +2032,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1336,
+            line: 1338,
             anchor: "if input.provider == .kilo || input.provider == .kimi,",
             expectedProviderIDs: ["kilo", "kimi"],
             expectedReferenceCount: 2,
@@ -2040,7 +2040,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1393,
+            line: 1395,
             anchor: "if input.provider == .zai, let resetText = Self.localizedZaiPeriodicResetText(primary) {",
             expectedProviderIDs: ["zai"],
             expectedReferenceCount: 1,
@@ -2048,7 +2048,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1437,
+            line: 1439,
             anchor: "var paceDetail = if input.provider == .kimi {",
             expectedProviderIDs: ["kimi"],
             expectedReferenceCount: 1,
@@ -2056,7 +2056,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1453,
+            line: 1455,
             anchor: "if input.provider == .warp,",
             expectedProviderIDs: ["chutes", "kilo", "kiro", "litellm", "sub2api", "warp"],
             expectedReferenceCount: 6,
@@ -2064,7 +2064,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1486,
+            line: 1488,
             anchor: "if input.provider == .alibaba || input.provider == .alibabatokenplan,",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "copilot", "crof", "manus", "perplexity", "zenmux"],
             expectedReferenceCount: 8,
@@ -2081,7 +2081,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1527,
+            line: 1529,
             anchor: "if input.provider == .synthetic,",
             expectedProviderIDs: ["synthetic"],
             expectedReferenceCount: 1,
@@ -2097,7 +2097,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 455,
+            line: 457,
             anchor: "if provider == .kiro {",
             expectedProviderIDs: ["kiro"],
             expectedReferenceCount: 1,
@@ -2105,7 +2105,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 469,
+            line: 471,
             anchor: "} else if provider == .kilo {",
             expectedProviderIDs: ["kilo", "mimo", "openrouter", "poe"],
             expectedReferenceCount: 4,
@@ -2113,7 +2113,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 664,
+            line: 666,
             anchor: "let target = provider ?? store.enabledFirstPartyProviders().first ?? .codex",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 4,
@@ -2121,7 +2121,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 692,
+            line: 694,
             anchor: "if provider == .factory, snapshot.tertiary != nil {",
             expectedProviderIDs: ["alibabatokenplan", "amp", "codex", "crof", "doubao", "factory", "grok", "sub2api"],
             expectedReferenceCount: 11,
@@ -2141,7 +2141,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 767,
+            line: 769,
             anchor: "let cleaned = if provider == .codex {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2165,7 +2165,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/PredictivePaceWarnings.swift",
-            line: 178,
+            line: 182,
             anchor: "if provider == .codex {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 2,
@@ -2173,7 +2173,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/PredictivePaceWarnings.swift",
-            line: 204,
+            line: 208,
             anchor: "if provider == .codex {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2550,7 +2550,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+MenuBarLayout.swift",
-            line: 209,
+            line: 216,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2670,7 +2670,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+HistoricalPace.swift",
-            line: 207,
+            line: 213,
             anchor: "let codexSnapshot = self.snapshots[.codex]",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/QoderProviderBehaviorTests.swift
+++ b/Tests/CodexBarTests/QoderProviderBehaviorTests.swift
@@ -1013,7 +1013,8 @@ extension QoderProviderBehaviorTests {
 
         #expect(depletedSnapshot.primary?.windowMinutes == nil)
         #expect(restoredPrimary.windowMinutes == nil)
-        #expect(store.weeklyPace(provider: .qoder, window: restoredPrimary, now: Date()) == nil)
+        #expect(store
+            .weeklyPace(provider: .qoder, window: restoredPrimary, dataConfidence: .unknown, now: Date()) == nil)
 
         for snapshot in [depletedSnapshot, restoredSnapshot] {
             store.handleSessionQuotaTransition(provider: .qoder, snapshot: snapshot)

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -58,6 +58,8 @@ usage is a separate [OpenAI provider](openai.md), not Codex subscription quota.
   key is configured, a cached or manual session cookie can still overlay the legacy web values (plus Zen balance).
   Both paths keep local daily cost history and never trigger a fresh browser import. When no authoritative overlay is
   available, the menu and text CLI label the quota as estimated, and JSON includes `dataConfidence: "estimated"`.
+  Estimated quota keeps its percentages and reset dates but does not show pace, reserve, or run-out advice in the
+  menu, menu-bar layouts, or CLI; device-local costs cannot establish account-wide consumption or the billing cycle.
 - OpenCode Go cost history chart: `opencode.ai` has no daily-granularity endpoint, so per-day cost/request buckets
   come from local `opencode-go` assistant costs in `opencode.db`, keyed by device-local calendar day. Successful web
   usage remains workspace-scoped and is never blended with device-wide local costs, so it does not show cost history.


### PR DESCRIPTION
## Summary

Addresses the misleading-forecast part of #3286. Device-local OpenCode Go costs cannot establish account-wide quota consumption or the real billing cycle, so an estimated snapshot must not say “Lasts until reset.”

The provider descriptor now opts estimated OpenCode Go data out of pace advice. The menu card, legacy menu, CLI text/JSON, custom menu-bar fields, and layout previews use that policy. Shared pace helpers require the confidence of the displayed snapshot rather than consulting the globally selected account.

Quota percentages, reset dates, the estimate disclosure, local cost history, credentials, and stored data are unchanged. Authoritative API/web overlays (including the existing `unknown` confidence value) retain pace. Other providers keep their existing behavior. This does not import keys from OpenCode's `auth.json`, so #3286 should remain open for that separate auth-source decision.

Compatibility review: `ProviderPayload.pace` is already optional, and the base renderer already omits it when no lane can produce pace. Estimated OpenCode Go snapshots now use that existing unavailable-pace representation. The encoded-payload regression explicitly checks omission while preserving confidence and quota/reset fields; no replacement field or compatibility shim is introduced.

## Verification

- Before the fix, the new regression produced eight expected assertion failures across CLI and menu presentation.
- Focused regression run: 47 tests across four suites passed, covering estimated/unknown/exact confidence, JSON omission, legacy/card presentation, menu-bar percentage fallback, opposite selected-account/preview confidence, and other-provider controls.
- Rebuilt and exercised the actual CLI against a synthetic two-row OpenCode SQLite history with networking denied, browser cookies off, and Keychain/session isolation. Before: `source: local`, `dataConfidence: estimated`, 0%/4%/5% used, plus reserve and “Lasts until reset” advice. After: the same source/confidence/percentages and reset fields, with no pace object or text advice.
- Native SwiftUI card renders below use the same synthetic snapshot and production view/model before and after, in both appearances. No real account data, credentials, desktop capture, or live provider probes were used. This is offscreen card-render proof, not a claim of interactive menu-bar testing.
- The initial full run stopped at group 61 because existing architecture exceptions still referenced their old source line numbers. The follow-up changes only 25 line-number anchors; exception text, provider fingerprints, and rationales are unchanged. The architecture gate plus OpenCode Go regression then passed (45 tests/two suites).
- Final `make test` passes: 970 selections across 81 groups, all first-pass, zero failures/retries/timeouts (1,234 seconds). `make check` passes with zero violations across 2,058 Swift files, and independent Codex review found no actionable P0 findings. [Final-head CI](https://github.com/steipete/CodexBar/actions/runs/33325809129) is green: all nine checks, including both macOS shards, all Linux builds/tests, lint, security, and the aggregate gate.

Focused command (run with credential/session test isolation enabled):

```sh
swift test --filter 'OpenCodeGoEstimatedPaceTests|PaceVisibilityScreenshotRenderTests.test_renderOpenCodeGoEstimateScreenshots|HistoricalUsagePaceBackfillAuthorityTests|QoderProviderBehaviorTests'
```

Set `CODEXBAR_OPENCODEGO_PACE_SCREENSHOT_DIR` to a temporary output directory to render the synthetic card.

## Before / after

| Appearance | Before | After |
| --- | --- | --- |
| Light | ![Before: estimated quota with a reserve forecast](https://github.com/user-attachments/assets/ad8f7896-a623-440e-90c0-11ce5987c513) | ![After: estimated quota without a forecast](https://github.com/user-attachments/assets/e31faa0a-c2b6-436c-8e6b-50e1374720aa) |
| Dark | ![Before: estimated quota with a reserve forecast](https://github.com/user-attachments/assets/948e6954-47a5-45b9-8d24-1a762b816684) | ![After: estimated quota without a forecast](https://github.com/user-attachments/assets/c9e5f8ef-52ee-422d-b7d6-755be4d4a766) |

Thanks @Akagilnc for the detailed report.
