### PR TITLE
fix: honor agent metadata scan deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.2 — Unreleased
 
 ### Fixed
+- Agent sessions: stop Codex metadata enrichment and Pi/OMP path resolution when the scan budget expires, and honor the same deadline during Claude Desktop root discovery.
 - Codex: recover cost-history catch-up when removed fork files leave abandoned parent discovery in an existing cache, preserving stored totals and unresolved-fork accounting (partial fix for #2815). Thanks @xiehaibin18!
 - OpenCode Go: omit misleading pace and run-out advice for locally estimated quotas while preserving percentages, resets, and cost history (partial fix for #3286). Thanks @Akagilnc!
 - OpenRouter: open Activity from Usage Dashboard instead of credit settings (#3290). Thanks @akshayprabhu200!

--- a/Sources/CodexBarCore/AgentSession.swift
+++ b/Sources/CodexBarCore/AgentSession.swift
@@ -149,6 +149,22 @@ struct DirectoryMetadataScanBudget {
         clock() < self.deadline
     }
 
+    func compactMapWhileTimeRemains<Result>(
+        _ urls: [URL],
+        clock: () -> Date = Date.init,
+        transform: (URL) -> Result?) -> [Result]
+    {
+        var results: [Result] = []
+        for url in urls {
+            // Enumeration already charged the entry count; enrichment shares its deadline.
+            guard self.hasTimeRemaining(clock: clock) else { break }
+            if let result = transform(url) {
+                results.append(result)
+            }
+        }
+        return results
+    }
+
     private mutating func entries(
         in directory: URL,
         fileManager: FileManager,
@@ -168,6 +184,7 @@ struct DirectoryMetadataScanBudget {
             guard let url = enumerator.nextObject() as? URL else { break }
             self.remainingEntryCount -= 1
             self.didVisitEntry?()
+            guard self.hasTimeRemaining(clock: clock) else { break }
             let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
             entries.append((url, isDirectory))
         }

--- a/Sources/CodexBarCore/LocalAgentSessionScanner.swift
+++ b/Sources/CodexBarCore/LocalAgentSessionScanner.swift
@@ -428,7 +428,8 @@ public struct LocalAgentSessionScanner: Sendable {
 
         let candidates = days.flatMap { day -> [(url: URL, modifiedAt: Date)] in
             let directory = root.appendingPathComponent(formatter.string(from: day), isDirectory: true)
-            return directoryBudget.files(in: directory, fileManager: fileManager).compactMap { file in
+            let files = directoryBudget.files(in: directory, fileManager: fileManager)
+            return directoryBudget.compactMapWhileTimeRemains(files) { file in
                 guard file.lastPathComponent.hasPrefix("rollout-"), file.pathExtension == "jsonl",
                       let modifiedAt = try? file.resourceValues(
                           forKeys: [.contentModificationDateKey]).contentModificationDate

--- a/Sources/CodexBarCore/PiFamilySessionScanner.swift
+++ b/Sources/CodexBarCore/PiFamilySessionScanner.swift
@@ -822,28 +822,29 @@ struct PiFamilySessionScanner: Sendable {
         let canonicalRoot = Self.canonicalURL(root)
 
         guard directoryBudget.hasTimeRemaining() else { return [] }
-        let projectDirectories: [URL] = switch layout {
+        let projectDirectories: [URL]
+        switch layout {
         case .direct:
-            [canonicalRoot]
+            projectDirectories = [canonicalRoot]
         case .projectDirectories:
-            directoryBudget
-                .childDirectories(in: canonicalRoot, fileManager: fileManager)
-                .map(Self.canonicalURL)
-                .filter { OMPSessionRootResolver.isWithin(root: canonicalRoot, candidate: $0) }
-                .sorted { $0.path < $1.path }
+            let directories = directoryBudget.childDirectories(in: canonicalRoot, fileManager: fileManager)
+            projectDirectories = directoryBudget.compactMapWhileTimeRemains(directories) { directory in
+                let canonical = Self.canonicalURL(directory)
+                return OMPSessionRootResolver.isWithin(root: canonicalRoot, candidate: canonical) ? canonical : nil
+            }.sorted { $0.path < $1.path }
         }
 
         for projectDirectory in projectDirectories {
             guard directoryBudget.hasTimeRemaining() else { break }
-            let files = directoryBudget
-                .files(in: projectDirectory, fileManager: fileManager)
-                .filter { $0.pathExtension == "jsonl" }
-                .map(Self.canonicalURL)
-                .filter { file in
-                    OMPSessionRootResolver.isWithin(root: canonicalRoot, candidate: file) &&
-                        Self.isDirectFile(in: file, projectDirectory: projectDirectory)
-                }
-                .sorted { $0.path < $1.path }
+            let entries = directoryBudget.files(in: projectDirectory, fileManager: fileManager)
+            let files = directoryBudget.compactMapWhileTimeRemains(entries) { entry -> URL? in
+                guard entry.pathExtension == "jsonl" else { return nil }
+                let file = Self.canonicalURL(entry)
+                guard OMPSessionRootResolver.isWithin(root: canonicalRoot, candidate: file),
+                      Self.isDirectFile(in: file, projectDirectory: projectDirectory)
+                else { return nil }
+                return file
+            }.sorted { $0.path < $1.path }
 
             for file in files {
                 guard directoryBudget.hasTimeRemaining() else { break }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeDesktopProjectsLocator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeDesktopProjectsLocator.swift
@@ -72,7 +72,7 @@ public enum ClaudeDesktopProjectsLocator {
         var queue = sessionRoots.map { (url: $0, depth: 0) }
         var visited = Set(sessionRoots.map(\.standardizedFileURL.path))
         var nextIndex = 0
-        while nextIndex < queue.count {
+        while nextIndex < queue.count, budget.hasTimeRemaining() {
             let current = queue[nextIndex]
             nextIndex += 1
             if let projects = self.projectsRoot(under: current.url, fileManager: fileManager) {

--- a/Tests/CodexBarTests/DirectoryMetadataScanBudgetTests.swift
+++ b/Tests/CodexBarTests/DirectoryMetadataScanBudgetTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct DirectoryMetadataScanBudgetTests {
+    private let urls = ["first.jsonl", "skip.txt", "last.jsonl"].map {
+        URL(fileURLWithPath: "/synthetic-sessions/\($0)")
+    }
+
+    @Test
+    func `expired enumeration budget does not start file enrichment`() {
+        let budget = DirectoryMetadataScanBudget(
+            maxEntryCount: 512,
+            maxDepth: 1,
+            timeLimit: 1,
+            startedAt: .distantPast)
+        var enriched: [URL] = []
+        let results = budget.compactMapWhileTimeRemains(self.urls) { url in
+            enriched.append(url)
+            return url
+        }
+
+        #expect(enriched.isEmpty)
+        #expect(results.isEmpty)
+    }
+
+    @Test
+    func `enrichment stops between files when the shared deadline expires`() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 100)
+        let budget = DirectoryMetadataScanBudget(
+            maxEntryCount: 512,
+            maxDepth: 1,
+            timeLimit: 1,
+            startedAt: startedAt)
+        var now = startedAt
+        var enriched: [URL] = []
+        let results = budget.compactMapWhileTimeRemains(self.urls, clock: { now }, transform: { url in
+            enriched.append(url)
+            now = startedAt.addingTimeInterval(2)
+            return url
+        })
+
+        #expect(enriched == [self.urls[0]])
+        #expect(results == [self.urls[0]])
+    }
+
+    @Test
+    func `live budget preserves enrichment filtering and input order`() {
+        let budget = DirectoryMetadataScanBudget(
+            maxEntryCount: 512,
+            maxDepth: 1,
+            timeLimit: 1,
+            startedAt: .distantFuture)
+        let results = budget.compactMapWhileTimeRemains(self.urls) { url in
+            url.pathExtension == "jsonl" ? url.lastPathComponent : nil
+        }
+
+        #expect(results == ["first.jsonl", "last.jsonl"])
+    }
+
+    @Test
+    func `entry fetched after the deadline is not retained`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DirectoryMetadataScanBudgetTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("fixture".utf8).write(to: root.appendingPathComponent("entry.jsonl"))
+        let startedAt = Date(timeIntervalSinceReferenceDate: 100)
+        var budget = DirectoryMetadataScanBudget(
+            maxEntryCount: 1,
+            maxDepth: 1,
+            timeLimit: 1,
+            startedAt: startedAt)
+        var clockReads = 0
+
+        let files = budget.files(in: root, clock: {
+            clockReads += 1
+            return startedAt.addingTimeInterval(clockReads < 3 ? 0 : 2)
+        })
+
+        #expect(clockReads == 3)
+        #expect(files.isEmpty)
+    }
+
+    @Test(arguments: [false, true])
+    func `desktop root discovery honors the shared deadline`(expired: Bool) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DesktopRootScanBudgetTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let projects = root.appendingPathComponent(
+            "Library/Application Support/Claude/claude-code-sessions/.claude/projects", isDirectory: true)
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+        var budget = DirectoryMetadataScanBudget(
+            maxEntryCount: 512,
+            maxDepth: 1,
+            timeLimit: 1,
+            startedAt: expired ? .distantPast : .distantFuture)
+
+        let roots = ClaudeDesktopProjectsLocator.roots(
+            homeDirectory: root,
+            fileManager: .default,
+            budget: &budget)
+
+        #expect(roots == (expired ? [] : [projects]))
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1541,19 +1541,19 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This logged-out-page classifier matches OpenAI's public landing-page brand token."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/AgentSession.swift",
-            line: 412,
+            line: 429,
             anchor: ".appendingPathComponent(\".claude\", isDirectory: true)",
             expectedProviderIDs: ["claude"],
             reason: "The Claude transcript locator follows Claude Code's fixed default projects directory."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/AgentSession.swift",
-            line: 486,
+            line: 503,
             anchor: ".appendingPathComponent(\".claude\", isDirectory: true)",
             expectedProviderIDs: ["claude"],
             reason: "The budgeted Claude transcript locator follows Claude Code's fixed default projects directory."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/AgentSession.swift",
-            line: 593,
+            line: 610,
             anchor: "if value.contains(\"ide\") || value.contains(\"vscode\") || value.contains(\"cursor\") || value.contains(\"zed\") {",
             expectedProviderIDs: ["cursor", "zed"],
             reason: "This session-source classifier recognizes editor-origin strings emitted by upstream clients."),
@@ -3453,7 +3453,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact CLI construct preserves the provider-specific command and output contract."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/AgentSession.swift",
-            line: 198,
+            line: 215,
             anchor: "return AgentSession.Provider.claude.rawValue",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3461,7 +3461,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact host integration normalizes the Claude Desktop wrapper to its agent provider name."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/AgentSession.swift",
-            line: 231,
+            line: 248,
             anchor: "if basename == AgentSession.Provider.codex.rawValue {",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 5,
@@ -3469,7 +3469,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact host integration maps a provider-owned process, path, or window contract."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/AgentSession.swift",
-            line: 287,
+            line: 304,
             anchor: "guard self.provider(for: record) == .claude else { return .cli }",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 2,
@@ -3477,7 +3477,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact host integration maps a provider-owned process, path, or window contract."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/AgentSession.swift",
-            line: 311,
+            line: 328,
             anchor: "guard record.executableBasename.lowercased() == AgentSession.Provider.codex.rawValue,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3485,7 +3485,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact host integration recognizes only the Codex app-server bundled in ChatGPT.app."),
         AllowedProviderConstruct(
             path: "Sources/CodexBarCore/AgentSession.swift",
-            line: 328,
+            line: 345,
             anchor: "URL(fileURLWithPath: $0).lastPathComponent == AgentSession.Provider.claude.rawValue",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,

--- a/docs/agent-sessions-design.md
+++ b/docs/agent-sessions-design.md
@@ -23,6 +23,8 @@ Pi-family processes are handed to one `PiFamilySessionScanner`:
 
 The Pi-family scan receives its own directory entry/time budget, preserving the independent Codex rollout and Claude transcript budgets. Header reads are bounded, pi name lookup uses bounded head/tail windows, future modification dates are clamped to scan time, and displayed titles are stripped of control characters and limited to 64 Unicode scalars.
 
+The same deadline also gates work after enumeration: file-type inspection, Codex modification-time reads, Pi-family path canonicalization, and queued Claude Desktop root probes stop starting work once their budget expires. An in-flight filesystem call can still finish after the deadline; this is a best-effort work budget, not an interruptible wall-clock timeout. Entry counts, depth limits, root selection, and PID-only fallback behavior are unchanged.
+
 ## Presentation and focus
 
 The menu uses `⌘` for Codex, `✦` for Claude Code, and `π` for the Pi family. Pi rows show their dialect tag (`pi` or `omp`) rather than a second provider name. The CLI table includes a `DIALECT` column. Project labels remain the default because descriptive titles can contain sensitive text.


### PR DESCRIPTION
## Summary

Honor the existing local agent-session scan deadline after directory enumeration. Codex previously collected modification times for every returned entry even after enumeration exhausted the time budget; Pi/OMP similarly resolved paths before its next deadline check. Claude Desktop's queued root lookup also started probes after expiry.

The existing directory-budget owner now bounds per-entry enrichment, rechecks the clock after an enumerator returns, and gates queued Claude Desktop root probes. Codex timestamp collection and Pi-family canonicalization use the same deadline-aware helper. Filename filtering, containment checks, ordering, entry/depth limits, process-backed fallbacks, consent, and independent Pi-family budgets are preserved. No auth, provider request, storage, or remote-host behavior changes.

This remains a best-effort work budget: a filesystem operation already in flight cannot be interrupted. No benchmark threshold is increased, and there is no claim of a hard wall-clock guarantee.

## Verification

- The extracted old unbounded enrichment behavior failed both new deterministic expiry tests (four assertions), while the live-budget filtering/order control passed.
- Added controlled-clock coverage for expiration between entries and immediately after enumeration, plus real temporary-directory coverage for expired/live Claude Desktop root discovery. No sleeps or live accounts are needed.
- Initial focused verification passed 25 tests across five suites: deterministic budget cases, the unchanged 250 ms adaptive scanner benchmark, process parsing, Claude mapping, and Pi-family fixtures. Expired/live Desktop roots and the post-enumerator deadline are included in the budget suite.
- Final `make check` passed with zero violations across 2,063 Swift files. The first run found one new test-call formatting violation; only its closure-call syntax was corrected, with behavior unchanged.
- Codex rollout and menu/fallback suites passed. The broader run exposed eight stale architecture-test line anchors after the helper insertion; each was verified against identical main/candidate source text and updated by 17 lines, with reasons, fingerprints, and allowlists unchanged. The final budget/architecture run passed 44 tests in two suites.
- Isolated Codex review passed with no accepted/actionable findings at the workflow's default P0 scope. The subsequent closure-call formatting correction does not change the reviewed behavior.
- The eight-line anchor correction also passed its own isolated P0 review; the unchanged runtime scope was not re-reviewed.
- Exact-head [CI run 33340969532](https://github.com/steipete/CodexBar/actions/runs/33340969532) passed all nine checks, including macOS shards (25m35s and 30m45s), Linux x64/ARM64/musl, lint, and security.
- The full local `make test` attempt did **not** pass: 70 groups passed on the first attempt, group 71 recovered through 12 individual retries, and group 72 plus its isolated `StatusMenuTests` retry hit the 180-second process deadline while later tests were still advancing. No assertion failure was reported. The run selected 974 selections in 82 groups and stopped after 2,727.6 seconds; it made 16 isolated retries in total. Exact-head hosted CI is the passing full-suite evidence, not this local attempt.
- The diagnostic isolated `swift test --skip-build --no-parallel --filter '^CodexBarTests.StatusMenuTests/'` run passed all 176 tests in 273.791 seconds, without the grouped runner's 180-second process deadline. Its assertions and sources are unchanged. This explains why that suite cannot complete within the local runner deadline under the observed conditions; it does not turn the earlier attempt into a full pass.

Discovered while investigating the pre-existing local performance failure recorded in #3293. Changelog and agent-session design documentation are updated. No new feature or release is included.
