### PR TITLE
fix: preserve weekly reset evidence during credit refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.2 — Unreleased
 
 ### Fixed
+- Codex: preserve pending weekly-reset evidence through credits-only refreshes so eligible low-usage confirmations survive relaunch (partial fix for #3248). Thanks @kcharlan!
 - Agent sessions: stop Codex metadata enrichment and Pi/OMP path resolution when the scan budget expires, and honor the same deadline during Claude Desktop root discovery.
 - Codex: recover cost-history catch-up when removed fork files leave abandoned parent discovery in an existing cache, preserving stored totals and unresolved-fork accounting (partial fix for #2815). Thanks @xiehaibin18!
 - OpenCode Go: omit misleading pace and run-out advice for locally estimated quotas while preserving percentages, resets, and cost history (partial fix for #3286). Thanks @Akagilnc!

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
@@ -323,7 +323,8 @@ extension UsageStore {
             snapshot: row.snapshot,
             error: row.error,
             sourceLabel: row.sourceLabel,
-            credits: self.credits)
+            credits: self.credits,
+            weeklyResetCandidate: row.weeklyResetCandidate)
         self.codexAccountUsageSnapshotStore?.store(self.codexAccountSnapshots)
     }
 

--- a/Tests/CodexBarTests/CodexMonthlyCreditPreservationTests.swift
+++ b/Tests/CodexBarTests/CodexMonthlyCreditPreservationTests.swift
@@ -349,6 +349,7 @@ extension CodexAccountScopedRefreshTests {
             canReauthenticate: false,
             canRemove: false)
         let usage = self.codexSnapshot(email: "biz@example.com", usedPercent: 12)
+        let candidate = CodexWeeklyResetPublicationCandidate(firstObservedAt: usage.updatedAt, snapshot: usage)
         store._setSnapshotForTesting(usage, provider: .codex)
         store.codexAccountSnapshots = [
             CodexAccountUsageSnapshot(
@@ -356,7 +357,8 @@ extension CodexAccountScopedRefreshTests {
                 snapshot: usage,
                 error: nil,
                 sourceLabel: "api",
-                credits: nil),
+                credits: nil,
+                weeklyResetCandidate: candidate),
         ]
         let published = CreditsSnapshot(
             remaining: 0,
@@ -374,12 +376,14 @@ extension CodexAccountScopedRefreshTests {
         await store.refreshCreditsIfNeeded()
         #expect(store.credits?.codexCreditLimit?.limit == 1000)
         #expect(store.codexAccountSnapshots.first?.credits?.codexCreditLimit?.used == 27)
+        #expect(store.codexAccountSnapshots.first?.weeklyResetCandidate?.createdAt == candidate.createdAt)
 
         store.credits = nil
         store.lastCreditsSnapshot = nil
         store.lastCreditsSource = .none
         store.persistPublishedCodexCreditsIntoAccountSnapshotsIfNeeded()
         #expect(store.codexAccountSnapshots.first?.credits == nil)
+        #expect(store.codexAccountSnapshots.first?.weeklyResetCandidate?.createdAt == candidate.createdAt)
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexWeeklyResetPublicationTests.swift
+++ b/Tests/CodexBarTests/CodexWeeklyResetPublicationTests.swift
@@ -77,19 +77,47 @@ extension CodexAccountScopedRefreshTests {
             settings: settings,
             suite: suite,
             snapshotStore: snapshotStore)
+        let refreshedCredits = CreditsSnapshot(remaining: 17, events: [], updatedAt: now)
+        var creditsLoadCount = 0
+        firstLowStore._test_codexCreditsLoaderOverride = {
+            creditsLoadCount += 1
+            return refreshedCredits
+        }
+        defer {
+            firstLowStore._test_codexCreditsLoaderOverride = nil
+            firstLowStore.cancelCodexPlanHistoryBackfill()
+        }
         self.installContextualCodexProvider(on: firstLowStore, sourceLabel: "oauth", kind: .oauth) { _ in
             try await firstLowLoader.load()
         }
+        var candidateAfterUsage: CodexWeeklyResetPublicationCandidate?
+        var candidateAfterCredits: CodexWeeklyResetPublicationCandidate?
         await CodexWeeklyResetConfirmation.$observationDateOverride.withValue(initialLow.updatedAt) {
-            await firstLowStore.refreshProvider(.codex, allowDisabled: true)
+            await firstLowStore.refreshCodexAccountScopedState(allowDisabled: true) { phase in
+                switch phase {
+                case .usage:
+                    candidateAfterUsage = firstLowStore.codexAccountSnapshots.first?.weeklyResetCandidate
+                case .credits:
+                    candidateAfterCredits = firstLowStore.codexAccountSnapshots.first?.weeklyResetCandidate
+                default:
+                    break
+                }
+            }
         }
 
+        #expect(creditsLoadCount == 1)
+        let admittedCandidate = try #require(candidateAfterUsage)
         #expect(firstLowStore.snapshots[.codex]?.updatedAt == prior.updatedAt)
         let persistedCandidate = try #require(snapshotStore.load(
             for: settings.codexVisibleAccountProjection.visibleAccounts).first)
         #expect(persistedCandidate.snapshot?.updatedAt == prior.updatedAt)
+        #expect(persistedCandidate.credits?.remaining == refreshedCredits.remaining)
         #expect(persistedCandidate.weeklyResetCandidate?.snapshot.updatedAt == confirmedLow.updatedAt)
         #expect(persistedCandidate.weeklyResetCandidate?.createdAt == initialLow.updatedAt)
+        let retainedCandidate = try #require(candidateAfterCredits)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        #expect(try encoder.encode(retainedCandidate) == encoder.encode(admittedCandidate))
 
         let laterLoader = SequencedCodexSnapshotLoader(steps: [.success(laterLow)])
         let relaunchedStore = self.makeCodexWeeklyPublicationStore(

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -42,6 +42,9 @@ Usage source picker:
 - Suspicious weekly resets keep the last trusted usage while confirmation is pending. A successful refresh for the
   same account and workspace clears stale connectivity errors even when the reading is withheld; failed, cancelled,
   or superseded refreshes do not clear them. Cached usage, credits, and other accounts remain unchanged.
+- Credits-only updates preserve pending weekly-reset evidence in memory and account-snapshot storage, including
+  when published credits are cleared. Candidate admission, expiry, boundary tolerances, and account guards remain
+  unchanged; preserving evidence does not make an otherwise incompatible reset eligible for publication.
 - Debug logs in `codex-weekly-reset-publication` include fixed reason codes for delayed-candidate
   creation, pruning, revalidation, and account-scoped storage requests. They distinguish source/confidence,
   timing, boundary, identity/plan compatibility, and credit-inventory failures without logging account or credit


### PR DESCRIPTION
## Summary

Preserve the existing weekly-reset publication candidate when the credits-only refresh writer rebuilds an account row. Previously, that writer omitted the defaulted field, replacing admitted evidence with nil in both memory and the account-snapshot file. A later refresh or relaunch could therefore lose the evidence needed for delayed confirmation.

The production change only carries `row.weeklyResetCandidate` into the replacement row. Existing account/workspace matching, credit replacement and clearing, admission, expiry, reset thresholds, boundary tolerances, and the persisted format are unchanged. Neighboring writers were checked: they already preserve the field or deliberately retire it when fresh quota is admitted.

This is a **partial fix for #3248**, following the reporter's [credits-writer evidence](https://github.com/steipete/CodexBar/issues/3248#issuecomment-5471070114). Keep the issue open: the separately reported five-minute rolling reset boundary can still be rejected by the existing 120-second compatibility check. This patch does not relax that policy or claim that the reporter's complete live symptom is resolved. Thanks @kcharlan for the detailed lifecycle capture.

## Verification

- Regression first: two tests failed on the unfixed main behavior with five expected candidate-loss assertions. Candidate admission and the synthetic credits load succeeded; the credits phase then erased the candidate in memory and on disk.
- The file-backed regression now drives the real account-scoped usage→credits sequence, checks that the credits loader ran, compares admitted and retained evidence, reloads the persisted account, and verifies that a later eligible confirmation publishes and retires the candidate normally.
- The standalone credits regression covers both replacing a monthly-credit cap and clearing credits without discarding the existing candidate.
- All provider responses, account identities, credentials, clocks, and persistence files are synthetic or isolated. No live provider, browser import, or real account Keychain probe is involved.
- Isolated Codex review passed with no accepted/actionable findings at the workflow's default P0 scope.
- `make check` passed with zero violations across 2,063 Swift files, including the repository's script and packaging checks.
- Broader focused verification passed 215 tests in five suites (350.827 seconds): account-scoped refresh, weekly-reset confirmation, weekly-reset diagnostics, monthly-credit preservation, and architecture checks.
- Full local `CODEXBAR_TEST_SUITE_TIMEOUT=600 make test` passed: 974 selections across 82 groups, 81 first-pass successes, one recovered full-group retry, zero timeouts or isolated retries; 2,926.0 seconds total. The unchanged login-runner fixture initially missed its output marker and passed on the built-in retry; the timeout outcome and elapsed-time bound passed on both attempts. This is not a first-pass-clean claim.
- The 600-second limit changes only the test-process envelope, retaining every assertion, benchmark threshold, and normal grouping/retry policy. The unchanged native-menu suite previously took 273.791 seconds during the diagnostic recorded in #3299; it passed in this run.
- [Exact-head CI run 33343857786](https://github.com/steipete/CodexBar/actions/runs/33343857786) passed all nine checks on `79c04982535c9ad97bde1d084727cb6c84f84e8e`: both macOS shards, all three Linux builds, lint, changes, the aggregate gate, and GitGuardian.

The changelog and Codex provider documentation describe the preservation boundary and the remaining policy limitation. No new feature or release is included.
