### PR TITLE
fix: preserve merged cost report details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Local costs: reduce background CPU spent parsing native session timestamps and validating appended Codex history, preserving timestamp precision, daily totals, and fork accounting.
 
 ### Fixed
+- Local costs: preserve token breakdowns, reasoning, request counts, and pricing coverage when combining reports or reopening cached history. Thanks @Pjhhhhh!
 - Codex: preserve pending weekly-reset evidence through credits-only refreshes so eligible low-usage confirmations survive relaunch (partial fix for #3248). Thanks @kcharlan!
 - Agent sessions: stop Codex metadata enrichment and Pi/OMP path resolution when the scan budget expires, and honor the same deadline during Claude Desktop root discovery.
 - Codex: recover cost-history catch-up when removed fork files leave abandoned parent discovery in an existing cache, preserving stored totals and unresolved-fork accounting (partial fix for #2815). Thanks @xiehaibin18!

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -174,7 +174,11 @@ struct SpendDashboardModel: Equatable, Sendable {
         let chartDomain: ClosedRange<Date>
         let modelHistoryCompleteness: ModelHistoryCompleteness
         let tokenMix: CostUsageTokenMix
-        let coverage: CostUsageCoverageCounts
+        let coverageAccumulator: CostUsageCoverageAccumulator
+        var coverage: CostUsageCoverageCounts {
+            self.coverageAccumulator.counts
+        }
+
         let provenance: CostProvenance
         let meteredCost: Double?
         let sessions: [SessionRow]
@@ -202,7 +206,7 @@ struct SpendDashboardModel: Equatable, Sendable {
             chartDomain: ClosedRange<Date>,
             modelHistoryCompleteness: ModelHistoryCompleteness,
             tokenMix: CostUsageTokenMix = CostUsageTokenMix(),
-            coverage: CostUsageCoverageCounts = CostUsageCoverageCounts(),
+            coverageAccumulator: CostUsageCoverageAccumulator = CostUsageCoverageAccumulator(),
             provenance: CostProvenance = .unknown,
             meteredCost: Double? = nil,
             sessions: [SessionRow] = [],
@@ -222,7 +226,7 @@ struct SpendDashboardModel: Equatable, Sendable {
             self.chartDomain = chartDomain
             self.modelHistoryCompleteness = modelHistoryCompleteness
             self.tokenMix = tokenMix
-            self.coverage = coverage
+            self.coverageAccumulator = coverageAccumulator
             self.provenance = provenance
             self.meteredCost = meteredCost
             self.sessions = sessions
@@ -467,7 +471,7 @@ struct SpendDashboardModel: Equatable, Sendable {
             : ModelHistoryCompleteness.incomplete
         let dailyPoints = Self.dailyPoints(summaries: summaries)
         var tokenMix = CostUsageTokenMix()
-        var coverage = CostUsageCoverageCounts()
+        var coverage = CostUsageCoverageAccumulator()
         var metered: Double?
         var hasMeteredCostAmount = false
         var sawVendorMeteredProvenance = false
@@ -475,7 +479,7 @@ struct SpendDashboardModel: Equatable, Sendable {
         for summary in scopedSummaries {
             for windowEntry in summary.entries {
                 tokenMix.merge(.from(entry: windowEntry.entry))
-                coverage.merge(windowEntry.entry.coverageCounts)
+                coverage.add(windowEntry.entry)
             }
             if selectedDay == nil,
                let meteredCost = summary.input.snapshot.meteredCostUSD,
@@ -524,7 +528,7 @@ struct SpendDashboardModel: Equatable, Sendable {
             chartDomain: Self.chartDomain(bounds: bounds, calendar: calendar),
             modelHistoryCompleteness: modelHistoryCompleteness,
             tokenMix: tokenMix,
-            coverage: coverage,
+            coverageAccumulator: coverage,
             provenance: provenance,
             meteredCost: hasMeteredCostAmount ? metered : nil,
             sessions: Self.sessionRows(summaries: summaries, bounds: bounds, calendar: calendar),

--- a/Sources/CodexBar/StatusItemController+OverviewSpend.swift
+++ b/Sources/CodexBar/StatusItemController+OverviewSpend.swift
@@ -63,10 +63,10 @@ struct OverviewSpendSummary: Equatable {
             covered: coveredDays,
             requested: model.requestedDays)
 
-        let coverage = model.groups.reduce(into: CostUsageCoverageCounts()) { result, group in
-            result.merge(group.coverage)
+        let coverage = model.groups.reduce(into: CostUsageCoverageAccumulator()) { result, group in
+            result.merge(group.coverageAccumulator)
         }
-        self.pricingCoverageText = spendDashboardCoverageChipText(coverage)
+        self.pricingCoverageText = spendDashboardCoverageChipText(coverage.counts)
         self.provenanceText = model.groups
             .map(\.provenance)
             .reduce(into: [CostProvenance]()) { values, provenance in

--- a/Sources/CodexBarCore/CostProvenance.swift
+++ b/Sources/CodexBarCore/CostProvenance.swift
@@ -83,6 +83,70 @@ public struct CostUsageCoverageCounts: Sendable, Equatable, Codable {
     }
 }
 
+package enum CostUsageCoverageDetail {
+    case exact
+    case requests
+    case rows
+}
+
+/// Transient aggregation: retain exact coverage, then existing request/row inference if counts cannot fit.
+package struct CostUsageCoverageAccumulator: Sendable, Equatable {
+    package private(set) var exact: CostUsageCoverageCounts? = .init()
+    private var inferred: CostUsageCoverageCounts? = .init()
+    private var rows = CostUsageCoverageCounts()
+
+    package init() {}
+
+    package var counts: CostUsageCoverageCounts {
+        self.exact ?? self.inferred ?? self.rows
+    }
+
+    package mutating func add(_ entry: CostUsageDailyReport.Entry) {
+        // Each materialized input row contributes at most one row, even when request totals overflow.
+        self.rows.merge(entry.coverageCounts(detail: .rows))
+        self.inferred = Self.adding(self.inferred, entry.coverageCounts(detail: .requests))
+        guard self.exact != nil else { return }
+        let explicit = CostUsageCoverageCounts(
+            priced: entry.pricedRequestCount ?? 0,
+            unpriced: entry.unpricedRequestCount ?? 0,
+            unmetered: entry.unmeteredRequestCount ?? 0,
+            estimated: entry.estimatedRequestCount ?? 0)
+        // Validate raw categories before coverageCounts performs inference arithmetic.
+        guard Self.adding(.init(), explicit) != nil else {
+            self.exact = nil
+            return
+        }
+        self.exact = Self.adding(self.exact, entry.coverageCounts)
+    }
+
+    package mutating func merge(_ other: Self) {
+        self.exact = Self.adding(self.exact, other.exact)
+        self.inferred = Self.adding(self.inferred, other.inferred)
+        self.rows.merge(other.rows)
+    }
+
+    private static func adding(
+        _ lhs: CostUsageCoverageCounts?,
+        _ rhs: CostUsageCoverageCounts?) -> CostUsageCoverageCounts?
+    {
+        guard let lhs, let rhs else { return nil }
+        let priced = lhs.priced.addingReportingOverflow(rhs.priced)
+        let unpriced = lhs.unpriced.addingReportingOverflow(rhs.unpriced)
+        let unmetered = lhs.unmetered.addingReportingOverflow(rhs.unmetered)
+        let estimated = lhs.estimated.addingReportingOverflow(rhs.estimated)
+        guard !priced.overflow, !unpriced.overflow, !unmetered.overflow, !estimated.overflow else { return nil }
+        let first = priced.partialValue.addingReportingOverflow(unpriced.partialValue)
+        let second = first.partialValue.addingReportingOverflow(unmetered.partialValue)
+        let total = second.partialValue.addingReportingOverflow(estimated.partialValue)
+        guard !first.overflow, !second.overflow, !total.overflow else { return nil }
+        return CostUsageCoverageCounts(
+            priced: priced.partialValue,
+            unpriced: unpriced.partialValue,
+            unmetered: unmetered.partialValue,
+            estimated: estimated.partialValue)
+    }
+}
+
 /// Token-class mix. `nil` means the source did not establish that class — never treat as zero.
 public struct CostUsageTokenMix: Sendable, Equatable, Codable {
     public var inputTokens: Int?

--- a/Sources/CodexBarCore/CostUsageModels.swift
+++ b/Sources/CodexBarCore/CostUsageModels.swift
@@ -726,6 +726,45 @@ extension CostUsageDailyReport {
         }
     }
 
+    private struct CoverageAccumulator {
+        private(set) var value: CostUsageCoverageCounts? = .init()
+
+        mutating func add(_ entry: Entry) {
+            guard let value = self.value else { return }
+            let explicit = CostUsageCoverageCounts(
+                priced: entry.pricedRequestCount ?? 0,
+                unpriced: entry.unpricedRequestCount ?? 0,
+                unmetered: entry.unmeteredRequestCount ?? 0,
+                estimated: entry.estimatedRequestCount ?? 0)
+            // Validate raw categories before coverageCounts performs inference arithmetic.
+            guard Self.adding(.init(), explicit) != nil else {
+                self.value = nil
+                return
+            }
+            self.value = Self.adding(value, entry.coverageCounts)
+        }
+
+        private static func adding(
+            _ lhs: CostUsageCoverageCounts,
+            _ rhs: CostUsageCoverageCounts) -> CostUsageCoverageCounts?
+        {
+            let priced = lhs.priced.addingReportingOverflow(rhs.priced)
+            let unpriced = lhs.unpriced.addingReportingOverflow(rhs.unpriced)
+            let unmetered = lhs.unmetered.addingReportingOverflow(rhs.unmetered)
+            let estimated = lhs.estimated.addingReportingOverflow(rhs.estimated)
+            guard !priced.overflow, !unpriced.overflow, !unmetered.overflow, !estimated.overflow else { return nil }
+            let first = priced.partialValue.addingReportingOverflow(unpriced.partialValue)
+            let second = first.partialValue.addingReportingOverflow(unmetered.partialValue)
+            let total = second.partialValue.addingReportingOverflow(estimated.partialValue)
+            guard !first.overflow, !second.overflow, !total.overflow else { return nil }
+            return CostUsageCoverageCounts(
+                priced: priced.partialValue,
+                unpriced: unpriced.partialValue,
+                unmetered: unmetered.partialValue,
+                estimated: estimated.partialValue)
+        }
+    }
+
     private struct BreakdownAccumulator {
         var tokenMix = CostUsageTokenMix()
         var requestCount = OptionalCountAccumulator()
@@ -797,7 +836,7 @@ extension CostUsageDailyReport {
     private struct EntryAccumulator {
         var reasoningTokens = OptionalCountAccumulator()
         var requestCount = OptionalCountAccumulator()
-        var coverage = CostUsageCoverageCounts()
+        var coverage = CoverageAccumulator()
         var entryCount = 0
         var hasExplicitCoverage = false
         var inputTokens: Int = 0
@@ -820,7 +859,7 @@ extension CostUsageDailyReport {
             self.reasoningTokens.add(entry.reasoningTokens)
             self.requestCount.add(entry.requestCount)
             // Classify each source before combining costs: a priced source cannot price another source's missing rows.
-            self.coverage.merge(entry.coverageCounts)
+            self.coverage.add(entry)
             self.entryCount += 1
             self.hasExplicitCoverage = self.hasExplicitCoverage
                 || entry.pricedRequestCount != nil || entry.unpricedRequestCount != nil
@@ -902,10 +941,10 @@ extension CostUsageDailyReport {
                 costUSD: self.sawCost ? self.costUSD : nil,
                 modelsUsed: modelsUsed,
                 modelBreakdowns: modelBreakdowns,
-                unpricedRequestCount: includeCoverage ? self.coverage.unpriced : nil,
-                unmeteredRequestCount: includeCoverage ? self.coverage.unmetered : nil,
-                estimatedRequestCount: includeCoverage ? self.coverage.estimated : nil,
-                pricedRequestCount: includeCoverage ? self.coverage.priced : nil)
+                unpricedRequestCount: includeCoverage ? self.coverage.value?.unpriced : nil,
+                unmeteredRequestCount: includeCoverage ? self.coverage.value?.unmetered : nil,
+                estimatedRequestCount: includeCoverage ? self.coverage.value?.estimated : nil,
+                pricedRequestCount: includeCoverage ? self.coverage.value?.priced : nil)
         }
     }
 

--- a/Sources/CodexBarCore/CostUsageModels.swift
+++ b/Sources/CodexBarCore/CostUsageModels.swift
@@ -192,10 +192,10 @@ public struct CostUsageTokenSnapshot: Sendable, Equatable {
         let tokens = entries.compactMap(\.totalTokens)
         let requests = entries.compactMap(\.requestCount)
         var mix = CostUsageTokenMix()
-        var coverage = CostUsageCoverageCounts()
+        var coverage = CostUsageCoverageAccumulator()
         for entry in entries {
             mix.merge(.from(entry: entry))
-            coverage.merge(entry.coverageCounts)
+            coverage.add(entry)
         }
         let coversFullHistory = days >= self.historyDays
         let windowMetered = coversFullHistory ? self.meteredCostUSD : nil
@@ -226,7 +226,7 @@ public struct CostUsageTokenSnapshot: Sendable, Equatable {
             totalRequests: totalRequests,
             entryCount: entries.count,
             tokenMix: mix,
-            coverage: coverage,
+            coverage: coverage.counts,
             provenance: CostProvenance.forWindow(
                 snapshot: self.costProvenance,
                 hasWindowCosts: !costs.isEmpty,
@@ -466,17 +466,21 @@ public struct CostUsageDailyReport: Sendable, Decodable {
         public let estimatedRequestCount: Int?
 
         public var coverageCounts: CostUsageCoverageCounts {
-            let unpriced = max(0, self.unpricedRequestCount ?? 0)
-            let unmetered = max(0, self.unmeteredRequestCount ?? 0)
-            let estimated = max(0, self.estimatedRequestCount ?? 0)
-            if let priced = self.pricedRequestCount {
+            self.coverageCounts(detail: .exact)
+        }
+
+        package func coverageCounts(detail: CostUsageCoverageDetail) -> CostUsageCoverageCounts {
+            let unpriced = detail == .exact ? max(0, self.unpricedRequestCount ?? 0) : 0
+            let unmetered = detail == .exact ? max(0, self.unmeteredRequestCount ?? 0) : 0
+            let estimated = detail == .exact ? max(0, self.estimatedRequestCount ?? 0) : 0
+            if detail == .exact, let priced = self.pricedRequestCount {
                 return CostUsageCoverageCounts(
                     priced: max(0, priced),
                     unpriced: unpriced,
                     unmetered: unmetered,
                     estimated: estimated)
             }
-            if let requests = self.requestCount, requests > 0 {
+            if detail != .rows, let requests = self.requestCount, requests > 0 {
                 let priced = if self.costUSD != nil {
                     max(0, requests - unpriced - unmetered - estimated)
                 } else {
@@ -726,45 +730,6 @@ extension CostUsageDailyReport {
         }
     }
 
-    private struct CoverageAccumulator {
-        private(set) var value: CostUsageCoverageCounts? = .init()
-
-        mutating func add(_ entry: Entry) {
-            guard let value = self.value else { return }
-            let explicit = CostUsageCoverageCounts(
-                priced: entry.pricedRequestCount ?? 0,
-                unpriced: entry.unpricedRequestCount ?? 0,
-                unmetered: entry.unmeteredRequestCount ?? 0,
-                estimated: entry.estimatedRequestCount ?? 0)
-            // Validate raw categories before coverageCounts performs inference arithmetic.
-            guard Self.adding(.init(), explicit) != nil else {
-                self.value = nil
-                return
-            }
-            self.value = Self.adding(value, entry.coverageCounts)
-        }
-
-        private static func adding(
-            _ lhs: CostUsageCoverageCounts,
-            _ rhs: CostUsageCoverageCounts) -> CostUsageCoverageCounts?
-        {
-            let priced = lhs.priced.addingReportingOverflow(rhs.priced)
-            let unpriced = lhs.unpriced.addingReportingOverflow(rhs.unpriced)
-            let unmetered = lhs.unmetered.addingReportingOverflow(rhs.unmetered)
-            let estimated = lhs.estimated.addingReportingOverflow(rhs.estimated)
-            guard !priced.overflow, !unpriced.overflow, !unmetered.overflow, !estimated.overflow else { return nil }
-            let first = priced.partialValue.addingReportingOverflow(unpriced.partialValue)
-            let second = first.partialValue.addingReportingOverflow(unmetered.partialValue)
-            let total = second.partialValue.addingReportingOverflow(estimated.partialValue)
-            guard !first.overflow, !second.overflow, !total.overflow else { return nil }
-            return CostUsageCoverageCounts(
-                priced: priced.partialValue,
-                unpriced: unpriced.partialValue,
-                unmetered: unmetered.partialValue,
-                estimated: estimated.partialValue)
-        }
-    }
-
     private struct BreakdownAccumulator {
         var tokenMix = CostUsageTokenMix()
         var requestCount = OptionalCountAccumulator()
@@ -836,7 +801,7 @@ extension CostUsageDailyReport {
     private struct EntryAccumulator {
         var reasoningTokens = OptionalCountAccumulator()
         var requestCount = OptionalCountAccumulator()
-        var coverage = CoverageAccumulator()
+        var coverage = CostUsageCoverageAccumulator()
         var entryCount = 0
         var hasExplicitCoverage = false
         var inputTokens: Int = 0
@@ -941,10 +906,10 @@ extension CostUsageDailyReport {
                 costUSD: self.sawCost ? self.costUSD : nil,
                 modelsUsed: modelsUsed,
                 modelBreakdowns: modelBreakdowns,
-                unpricedRequestCount: includeCoverage ? self.coverage.value?.unpriced : nil,
-                unmeteredRequestCount: includeCoverage ? self.coverage.value?.unmetered : nil,
-                estimatedRequestCount: includeCoverage ? self.coverage.value?.estimated : nil,
-                pricedRequestCount: includeCoverage ? self.coverage.value?.priced : nil)
+                unpricedRequestCount: includeCoverage ? self.coverage.exact?.unpriced : nil,
+                unmeteredRequestCount: includeCoverage ? self.coverage.exact?.unmetered : nil,
+                estimatedRequestCount: includeCoverage ? self.coverage.exact?.estimated : nil,
+                pricedRequestCount: includeCoverage ? self.coverage.exact?.priced : nil)
         }
     }
 

--- a/Sources/CodexBarCore/CostUsageModels.swift
+++ b/Sources/CodexBarCore/CostUsageModels.swift
@@ -714,7 +714,21 @@ public struct CostUsageDailyReport: Sendable, Decodable {
 }
 
 extension CostUsageDailyReport {
+    private struct OptionalCountAccumulator {
+        private(set) var value: Int?
+        private var overflowed = false
+
+        mutating func add(_ incoming: Int?) {
+            guard let incoming, incoming >= 0, !self.overflowed else { return }
+            let (sum, overflow) = (self.value ?? 0).addingReportingOverflow(incoming)
+            self.value = overflow ? nil : sum
+            self.overflowed = overflow
+        }
+    }
+
     private struct BreakdownAccumulator {
+        var tokenMix = CostUsageTokenMix()
+        var requestCount = OptionalCountAccumulator()
         var totalTokens: Int = 0
         var sawTotalTokens = false
         var costUSD: Double = 0
@@ -729,6 +743,13 @@ extension CostUsageDailyReport {
         var sawPriorityTokens = false
 
         mutating func add(_ breakdown: ModelBreakdown) {
+            self.tokenMix.merge(CostUsageTokenMix(
+                inputTokens: breakdown.inputTokens,
+                outputTokens: breakdown.outputTokens,
+                cacheReadTokens: breakdown.cacheReadTokens,
+                cacheCreationTokens: breakdown.cacheCreationTokens,
+                reasoningTokens: breakdown.reasoningTokens))
+            self.requestCount.add(breakdown.requestCount)
             if let totalTokens = breakdown.totalTokens {
                 self.totalTokens += totalTokens
                 self.sawTotalTokens = true
@@ -760,6 +781,12 @@ extension CostUsageDailyReport {
                 modelName: modelName,
                 costUSD: self.sawCost ? self.costUSD : nil,
                 totalTokens: self.sawTotalTokens ? self.totalTokens : nil,
+                requestCount: self.requestCount.value,
+                inputTokens: self.tokenMix.inputTokens,
+                outputTokens: self.tokenMix.outputTokens,
+                cacheReadTokens: self.tokenMix.cacheReadTokens,
+                cacheCreationTokens: self.tokenMix.cacheCreationTokens,
+                reasoningTokens: self.tokenMix.reasoningTokens,
                 standardCostUSD: self.sawStandardCost ? self.standardCostUSD : nil,
                 priorityCostUSD: self.sawPriorityCost ? self.priorityCostUSD : nil,
                 standardTokens: self.sawStandardTokens ? self.standardTokens : nil,
@@ -768,6 +795,11 @@ extension CostUsageDailyReport {
     }
 
     private struct EntryAccumulator {
+        var reasoningTokens = OptionalCountAccumulator()
+        var requestCount = OptionalCountAccumulator()
+        var coverage = CostUsageCoverageCounts()
+        var entryCount = 0
+        var hasExplicitCoverage = false
         var inputTokens: Int = 0
         var sawInputTokens = false
         var cacheReadTokens: Int = 0
@@ -785,6 +817,14 @@ extension CostUsageDailyReport {
         var breakdowns: [String: BreakdownAccumulator] = [:]
 
         mutating func add(_ entry: Entry) {
+            self.reasoningTokens.add(entry.reasoningTokens)
+            self.requestCount.add(entry.requestCount)
+            // Classify each source before combining costs: a priced source cannot price another source's missing rows.
+            self.coverage.merge(entry.coverageCounts)
+            self.entryCount += 1
+            self.hasExplicitCoverage = self.hasExplicitCoverage
+                || entry.pricedRequestCount != nil || entry.unpricedRequestCount != nil
+                || entry.unmeteredRequestCount != nil || entry.estimatedRequestCount != nil
             let entryDerivedTotalTokens = (entry.inputTokens ?? 0)
                 + (entry.cacheReadTokens ?? 0)
                 + (entry.cacheCreationTokens ?? 0)
@@ -849,16 +889,23 @@ extension CostUsageDailyReport {
                         })
             }()
             let modelsUsed = self.modelsUsed.isEmpty ? nil : self.modelsUsed.sorted()
+            let includeCoverage = self.entryCount > 1 || self.hasExplicitCoverage
             return Entry(
                 date: date,
                 inputTokens: self.sawInputTokens ? self.inputTokens : nil,
                 outputTokens: self.sawOutputTokens ? self.outputTokens : nil,
                 cacheReadTokens: self.sawCacheReadTokens ? self.cacheReadTokens : nil,
                 cacheCreationTokens: self.sawCacheCreationTokens ? self.cacheCreationTokens : nil,
+                reasoningTokens: self.reasoningTokens.value,
                 totalTokens: totalTokens,
+                requestCount: self.requestCount.value,
                 costUSD: self.sawCost ? self.costUSD : nil,
                 modelsUsed: modelsUsed,
-                modelBreakdowns: modelBreakdowns)
+                modelBreakdowns: modelBreakdowns,
+                unpricedRequestCount: includeCoverage ? self.coverage.unpriced : nil,
+                unmeteredRequestCount: includeCoverage ? self.coverage.unmetered : nil,
+                estimatedRequestCount: includeCoverage ? self.coverage.estimated : nil,
+                pricedRequestCount: includeCoverage ? self.coverage.priced : nil)
         }
     }
 
@@ -891,6 +938,7 @@ extension CostUsageDailyReport {
     }
 
     private static func mergedSummary(from entries: [Entry]) -> Summary {
+        var reasoningTokens = OptionalCountAccumulator()
         var totalInputTokens = 0
         var sawTotalInputTokens = false
         var totalOutputTokens = 0
@@ -905,6 +953,7 @@ extension CostUsageDailyReport {
         var sawTotalCostUSD = false
 
         for entry in entries {
+            reasoningTokens.add(entry.reasoningTokens)
             if let inputTokens = entry.inputTokens {
                 totalInputTokens += inputTokens
                 sawTotalInputTokens = true
@@ -936,6 +985,7 @@ extension CostUsageDailyReport {
             totalOutputTokens: sawTotalOutputTokens ? totalOutputTokens : nil,
             cacheReadTokens: sawTotalCacheReadTokens ? totalCacheReadTokens : nil,
             cacheCreationTokens: sawTotalCacheCreationTokens ? totalCacheCreationTokens : nil,
+            reasoningTokens: reasoningTokens.value,
             totalTokens: sawTotalTokens ? totalTokens : nil,
             totalCostUSD: sawTotalCostUSD ? totalCostUSD : nil)
     }

--- a/Tests/CodexBarTests/CostUsageCachedTokenDetailTests.swift
+++ b/Tests/CodexBarTests/CostUsageCachedTokenDetailTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct CostUsageCachedTokenDetailTests {
+    @Test(arguments: [false, true], ["UTC", "Asia/Bangkok"])
+    func `cached resumed rollouts preserve daily token details across local midnight`(
+        forceRefresh: Bool,
+        timeZone: String) async throws
+    {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: timeZone))
+        let timestampA = timeZone == "UTC" ? "2026-08-29T12:00:00Z" : "2026-08-29T16:59:00Z"
+        let timestampB = timeZone == "UTC" ? "2026-08-30T12:00:00Z" : "2026-08-29T17:01:00Z"
+        let dateA = try #require(ISO8601DateFormatter().date(from: timestampA))
+        let dateB = try #require(ISO8601DateFormatter().date(from: timestampB))
+        let nowA = dateA.addingTimeInterval(10)
+        let nowB = dateB.addingTimeInterval(10)
+        let dayA = "2026-08-29"
+        let dayB = "2026-08-30"
+        let directory = env.codexSessionsRoot.appendingPathComponent("2026/08/29", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("synthetic-cross-day.jsonl")
+        let initialLines: [[String: Any]] = [
+            [
+                "type": "session_meta",
+                "timestamp": timestampA,
+                "payload": ["id": "synthetic-cross-day", "cwd": env.root.path],
+            ],
+            Self.turn(timestamp: timestampA, id: "day-a"),
+            Self.event(timestamp: timestampA, total: [100, 20, 10, 4], last: [100, 20, 10, 4]),
+        ]
+        try env.jsonl(initialLines).write(to: file, atomically: false, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: nowA], ofItemAtPath: file.path)
+        let firstMetadata = CostUsageScanner.codexFileMetadata(fileURL: file)
+        let options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            cacheRoot: env.cacheRoot,
+            codexTraceDatabaseURL: env.root.appendingPathComponent("missing-traces.sqlite"),
+            calendar: calendar)
+        #expect(options.forceRescan == false)
+        #expect(options.refreshMinIntervalSeconds == 60)
+
+        let first = try await Self.fetch(now: nowA, forceRefresh: forceRefresh, options: options)
+        #expect(first.sessionTokens == 110)
+        #expect(first.daily.map(\.date) == [dayA])
+        let firstStore = await CostUsageStore(cacheRoot: env.cacheRoot).readSnapshot()
+        let firstFile = try #require(firstStore.files.first)
+        #expect(firstStore.files.count == 1)
+        #expect(firstFile.parsedBytes == firstMetadata.size)
+        #expect(firstFile.scanState.isComplete)
+        #expect(firstFile.coverageSinceDay == dayA)
+        #expect(firstFile.coverageUntilDay == dayA)
+
+        let handle = try FileHandle(forWritingTo: file)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(env.jsonl([
+            Self.turn(timestamp: timestampB, id: "day-b"),
+            Self.event(timestamp: timestampB, total: [160, 40, 16, 7], last: [60, 20, 6, 3]),
+        ]).utf8))
+        try handle.close()
+        try FileManager.default.setAttributes([.modificationDate: nowB], ofItemAtPath: file.path)
+        let appendedMetadata = CostUsageScanner.codexFileMetadata(fileURL: file)
+        #expect(appendedMetadata.fileId == firstMetadata.fileId)
+        #expect(appendedMetadata.size > firstMetadata.size)
+        let second = try await Self.fetch(now: nowB, forceRefresh: forceRefresh, options: options)
+        #expect(second.daily.map(\.date) == [dayA, dayB])
+        #expect(second.daily.first == first.daily.first)
+        #expect(second.sessionTokens == 66)
+        #expect(try #require(second.sessionCostUSD) > 0)
+
+        let reopened = await CostUsageStore(cacheRoot: env.cacheRoot).readSnapshot()
+        let resumedFile = try #require(reopened.files.first)
+        #expect(reopened.files.count == 1)
+        #expect(resumedFile.path == firstFile.path)
+        #expect(resumedFile.inode == firstFile.inode)
+        #expect(resumedFile.parsedBytes == appendedMetadata.size)
+        #expect(resumedFile.scanState.isComplete)
+        #expect(resumedFile.scanState.tokenTimestampsMonotonic == true)
+        #expect(resumedFile.coverageSinceDay == dayA)
+        #expect(resumedFile.coverageUntilDay == dayB)
+        let rows = try reopened.usageRows.map {
+            try JSONDecoder().decode(CostUsageScanner.CodexUsageRow.self, from: $0.payload)
+        }
+        #expect(rows.map(\.day) == [dayA, dayB])
+        let rowB = try #require(rows.first { $0.day == dayB })
+        #expect(rowB.input == 60)
+        #expect(rowB.cached == 20)
+        #expect(rowB.output == 6)
+        #expect(rowB.reasoning == 3)
+        #expect(reopened.dayAggregates.first { $0.day == dayA } == firstStore.dayAggregates.first)
+        #expect(reopened.fileDayAggregates.map(\.aggregate.day) == [dayA, dayB])
+        #expect(reopened.dayAggregates.map(\.day) == [dayA, dayB])
+        for aggregates in [reopened.dayAggregates, reopened.fileDayAggregates.map(\.aggregate)] {
+            let aggregateB = try #require(aggregates.first { $0.day == dayB })
+            #expect(aggregateB.inputTokens == 60)
+            #expect(aggregateB.cachedTokens == 20)
+            #expect(aggregateB.outputTokens == 6)
+            #expect(aggregateB.reasoningTokens == 3)
+        }
+
+        let cached = await CostUsageFetcher.loadCachedCodexTokenSnapshot(
+            now: nowB,
+            historyDays: 30,
+            includePiSessions: false,
+            scannerOptions: options)
+        #expect(cached?.sessionTokens == 66)
+        #expect(cached?.sessionCostUSD == second.sessionCostUSD)
+        let cachedSnapshot = try #require(cached)
+        #expect(cachedSnapshot.daily.count == second.daily.count)
+        for (actual, expected) in zip(cachedSnapshot.daily, second.daily) {
+            #expect(actual.date == expected.date)
+            #expect(actual.totalTokens == expected.totalTokens)
+            #expect(actual.costUSD == expected.costUSD)
+            #expect(CostUsageTokenMix.from(entry: actual) == CostUsageTokenMix.from(entry: expected))
+            #expect(actual.modelBreakdowns == expected.modelBreakdowns)
+            #expect(actual.requestCount == expected.requestCount)
+            #expect(actual.coverageCounts == expected.coverageCounts)
+        }
+        let dashboard = SpendDashboardModel.build(
+            inputs: [.init(provider: .codex, displayName: "Codex", snapshot: cachedSnapshot)],
+            requestedDays: 30,
+            now: nowB,
+            calendar: calendar)
+        let group = try #require(dashboard.groups.first)
+        let expectedMix = CostUsageTokenMix(
+            inputTokens: 160, outputTokens: 16, cacheReadTokens: 40, reasoningTokens: 7)
+        #expect(group.tokenMix == expectedMix)
+        #expect(group.displayedModels.first?.tokenMix == expectedMix)
+
+        let stable = try await Self.fetch(
+            now: nowB.addingTimeInterval(120), forceRefresh: forceRefresh, options: options)
+        #expect(stable.daily == second.daily)
+        #expect(stable.sessionTokens == 66)
+        let stableStore = await CostUsageStore(cacheRoot: env.cacheRoot).readSnapshot()
+        #expect(stableStore.usageRows == reopened.usageRows)
+        #expect(stableStore.dayAggregates == reopened.dayAggregates)
+        #expect(stableStore.fileDayAggregates == reopened.fileDayAggregates)
+    }
+
+    private static func fetch(
+        now: Date,
+        forceRefresh: Bool,
+        options: CostUsageScanner.Options) async throws -> CostUsageTokenSnapshot
+    {
+        try await CostUsageFetcher.loadTokenSnapshot(
+            provider: .codex,
+            environment: [:],
+            now: now,
+            forceRefresh: forceRefresh,
+            historyDays: 30,
+            allowPricingRefresh: false,
+            includePiSessions: false,
+            scannerOptions: options)
+    }
+
+    private static func turn(timestamp: String, id: String) -> [String: Any] {
+        [
+            "type": "turn_context",
+            "timestamp": timestamp,
+            "payload": ["model": "openai/gpt-5.4", "turn_id": id],
+        ]
+    }
+
+    private static func event(timestamp: String, total: [Int], last: [Int]) -> [String: Any] {
+        [
+            "type": "event_msg",
+            "timestamp": timestamp,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "total_token_usage": self.tokens(total),
+                    "last_token_usage": self.tokens(last),
+                ],
+            ],
+        ]
+    }
+
+    private static func tokens(_ values: [Int]) -> [String: Int] {
+        [
+            "input_tokens": values[0],
+            "cached_input_tokens": values[1],
+            "output_tokens": values[2],
+            "reasoning_output_tokens": values[3],
+        ]
+    }
+}

--- a/Tests/CodexBarTests/CostUsageCoverageAggregationTests.swift
+++ b/Tests/CodexBarTests/CostUsageCoverageAggregationTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct CostUsageCoverageAggregationTests {
+    enum OverflowKind: CaseIterable {
+        case sameCategory
+        case combinedCategories
+        case inferredRequests
+    }
+
+    @Test(arguments: [false, true], OverflowKind.allCases)
+    func `separate day coverage overflow keeps snapshot and dashboard usable`(
+        dashboard: Bool,
+        kind: OverflowKind) throws
+    {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(ISO8601DateFormatter().date(from: "2026-08-30T12:00:00Z"))
+        let entries = [Int.max, 1, 1].enumerated().map { index, count in
+            CostUsageDailyReport.Entry(
+                date: "2026-08-\(28 + index)",
+                inputTokens: 8,
+                outputTokens: 2,
+                totalTokens: 10,
+                requestCount: kind == .inferredRequests ? count : nil,
+                costUSD: 1,
+                modelsUsed: nil,
+                modelBreakdowns: nil,
+                unmeteredRequestCount: kind == .combinedCategories && index == 1 ? 1 : nil,
+                pricedRequestCount: kind == .inferredRequests ? nil :
+                    (kind == .combinedCategories && index == 1 ? 0 : count))
+        }
+        let merged = CostUsageDailyReport.merged([.init(data: entries, summary: nil)])
+        let snapshot = CostUsageTokenSnapshot(
+            sessionTokens: 10,
+            sessionCostUSD: 1,
+            last30DaysTokens: 30,
+            last30DaysCostUSD: 3,
+            daily: merged.data,
+            updatedAt: now)
+        let coverage: CostUsageCoverageCounts
+        if dashboard {
+            let model = SpendDashboardModel.build(
+                inputs: [.init(provider: .codex, displayName: "Codex", snapshot: snapshot)],
+                requestedDays: 30,
+                now: now,
+                calendar: calendar)
+            let group = try #require(model.groups.first)
+            #expect(group.totalCost == 3)
+            #expect(group.totalTokens == 30)
+            coverage = group.coverage
+        } else {
+            let summary = snapshot.summary(forLastDays: 30, calendar: calendar)
+            #expect(summary.totalCostUSD == 3)
+            #expect(summary.totalTokens == 30)
+            #expect(summary.totalRequests == nil)
+            coverage = summary.coverage
+        }
+        #expect(coverage == CostUsageCoverageCounts(priced: 3))
+        #expect(coverage.total == 3)
+        #expect(coverage.coverageRatio == 1)
+    }
+
+    @Test(arguments: [false, true])
+    func `account and currency grouping retain coverage fallbacks for overview`(_ separateCurrencies: Bool) throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(ISO8601DateFormatter().date(from: "2026-08-30T12:00:00Z"))
+        let inputs = [Int.max, 1, 1].enumerated().map { index, count in
+            SpendDashboardModel.ProviderInput(
+                id: "synthetic-source-\(index)",
+                provider: .codex,
+                displayName: "Synthetic source \(index)",
+                snapshot: CostUsageTokenSnapshot(
+                    sessionTokens: 10,
+                    sessionCostUSD: 1,
+                    last30DaysTokens: 10,
+                    last30DaysCostUSD: 1,
+                    currencyCode: separateCurrencies && index > 0 ? "EUR" : "USD",
+                    daily: [.init(
+                        date: "2026-08-30",
+                        inputTokens: 8,
+                        outputTokens: 2,
+                        totalTokens: 10,
+                        requestCount: count,
+                        costUSD: 1,
+                        modelsUsed: nil,
+                        modelBreakdowns: nil,
+                        pricedRequestCount: count)],
+                    updatedAt: now))
+        }
+        let model = SpendDashboardModel.build(inputs: inputs, requestedDays: 30, now: now, calendar: calendar)
+        #expect(model.groups.count == (separateCurrencies ? 2 : 1))
+        #expect(model.groups.flatMap(\.providers).count == 3)
+        #expect(model.groups.compactMap(\.totalTokens).reduce(0, +) == 30)
+        if separateCurrencies {
+            #expect(model.groups.first { $0.currencyCode == "USD" }?.totalCost == 1)
+            #expect(model.groups.first { $0.currencyCode == "EUR" }?.totalCost == 2)
+        } else {
+            #expect(model.groups.first?.totalCost == 3)
+        }
+        let overview = OverviewSpendSummary(model: model, providerCount: 3)
+        #expect(overview.pricingCoverageText == spendDashboardCoverageChipText(.init(priced: 3)))
+    }
+
+    @Test
+    func `invalid categories retain valid request inference in direct window consumers`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(ISO8601DateFormatter().date(from: "2026-08-30T12:00:00Z"))
+        let snapshot = CostUsageTokenSnapshot(
+            sessionTokens: 10,
+            sessionCostUSD: 1,
+            last30DaysTokens: 10,
+            last30DaysCostUSD: 1,
+            daily: [.init(
+                date: "2026-08-30",
+                inputTokens: 8,
+                outputTokens: 2,
+                totalTokens: 10,
+                requestCount: 7,
+                costUSD: 1,
+                modelsUsed: nil,
+                modelBreakdowns: nil,
+                unpricedRequestCount: Int.max,
+                unmeteredRequestCount: 1)],
+            updatedAt: now)
+        let summary = snapshot.summary(forLastDays: 30, calendar: calendar)
+        #expect(summary.coverage == CostUsageCoverageCounts(priced: 7))
+        #expect(summary.totalRequests == 7)
+        #expect(summary.totalCostUSD == 1)
+        let model = SpendDashboardModel.build(
+            inputs: [.init(provider: .codex, displayName: "Codex", snapshot: snapshot)],
+            requestedDays: 30,
+            now: now,
+            calendar: calendar)
+        let group = try #require(model.groups.first)
+        #expect(group.coverage == summary.coverage)
+        #expect(group.totalCost == 1)
+    }
+
+    @Test
+    func `representable boundary retains original coverage classifications`() {
+        var accumulator = CostUsageCoverageAccumulator()
+        for counts in [
+            CostUsageCoverageCounts(priced: Int.max - 3),
+            CostUsageCoverageCounts(unpriced: 1, unmetered: 1, estimated: 1),
+        ] {
+            accumulator.add(.init(
+                date: "2026-08-30",
+                inputTokens: nil,
+                outputTokens: nil,
+                totalTokens: nil,
+                costUSD: 1,
+                modelsUsed: nil,
+                modelBreakdowns: nil,
+                unpricedRequestCount: counts.unpriced,
+                unmeteredRequestCount: counts.unmetered,
+                estimatedRequestCount: counts.estimated,
+                pricedRequestCount: counts.priced))
+        }
+        #expect(accumulator.counts == CostUsageCoverageCounts(
+            priced: Int.max - 3, unpriced: 1, unmetered: 1, estimated: 1))
+        #expect(accumulator.counts.total == Int.max)
+        #expect(accumulator.counts.coverageRatio != nil)
+    }
+}

--- a/Tests/CodexBarTests/CostUsageDailyReportMergeTests.swift
+++ b/Tests/CodexBarTests/CostUsageDailyReportMergeTests.swift
@@ -3,6 +3,204 @@ import Testing
 @testable import CodexBarCore
 
 struct CostUsageDailyReportMergeTests {
+    @Test(arguments: [nil, 0, 7] as [Int?])
+    func `single report merge preserves known zero and missing token classes`(_ value: Int?) throws {
+        let mix = CostUsageTokenMix(
+            inputTokens: value,
+            outputTokens: value,
+            cacheReadTokens: value,
+            cacheCreationTokens: value,
+            reasoningTokens: value)
+        let original = Self.tokenDetailReport(mix: mix, totalTokens: 50)
+        let merged = CostUsageDailyReport.merged([original])
+        let entry = try #require(merged.data.first)
+        #expect(entry == original.data.first)
+        #expect(CostUsageTokenMix.from(entry: entry) == mix)
+        #expect(try Self.mix(#require(entry.modelBreakdowns?.first)) == mix)
+        #expect(entry.coverageCounts == original.data.first?.coverageCounts)
+        #expect(merged.summary?.reasoningTokens == value)
+        #expect(merged.summary?.totalTokens == 50)
+    }
+
+    @Test
+    func `merged token details sum without adding reasoning to total tokens`() throws {
+        let first = Self.tokenDetailReport(
+            mix: .init(inputTokens: 100, outputTokens: 20, cacheReadTokens: 10, reasoningTokens: 8),
+            totalTokens: 120)
+        let second = Self.tokenDetailReport(
+            mix: .init(
+                inputTokens: 50,
+                outputTokens: 10,
+                cacheReadTokens: 5,
+                cacheCreationTokens: 0,
+                reasoningTokens: 2),
+            totalTokens: 60)
+        let merged = CostUsageDailyReport.merged([first, second])
+        let expectedMix = CostUsageTokenMix(
+            inputTokens: 150, outputTokens: 30, cacheReadTokens: 15, cacheCreationTokens: 0, reasoningTokens: 10)
+        let entry = try #require(merged.data.first)
+        #expect(CostUsageTokenMix.from(entry: entry) == expectedMix)
+        let breakdown = try #require(entry.modelBreakdowns?.first)
+        #expect(Self.mix(breakdown) == expectedMix)
+        #expect(entry.totalTokens == 180)
+        #expect(breakdown.totalTokens == 180)
+        #expect(merged.summary?.totalTokens == 180)
+        #expect(merged.summary?.reasoningTokens == 10)
+    }
+
+    @Test(arguments: [false, true])
+    func `merged token detail overflow remains unknown after later contributions`(_ separateDays: Bool) throws {
+        let values = [Int.max, 1, 5]
+        let reports = values.enumerated().map { index, value in
+            CostUsageDailyReport(
+                data: [.init(
+                    date: separateDays ? "2026-08-\(10 + index)" : "2026-08-10",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    reasoningTokens: value,
+                    totalTokens: 0,
+                    costUSD: nil,
+                    modelsUsed: ["gpt-5.4"],
+                    modelBreakdowns: [.init(
+                        modelName: "gpt-5.4",
+                        costUSD: nil,
+                        totalTokens: 0,
+                        inputTokens: value,
+                        outputTokens: value,
+                        cacheReadTokens: value,
+                        cacheCreationTokens: value,
+                        reasoningTokens: value)])],
+                summary: nil)
+        }
+        let merged = CostUsageDailyReport.merged(reports)
+        #expect(merged.summary?.reasoningTokens == nil)
+        #expect(merged.summary?.totalTokens == 0)
+        if !separateDays {
+            let entry = try #require(merged.data.first)
+            #expect(entry.reasoningTokens == nil)
+            #expect(try Self.mix(#require(entry.modelBreakdowns?.first)) == CostUsageTokenMix())
+        }
+    }
+
+    private static func tokenDetailReport(mix: CostUsageTokenMix, totalTokens: Int) -> CostUsageDailyReport {
+        CostUsageDailyReport(
+            data: [.init(
+                date: "2026-08-30",
+                inputTokens: mix.inputTokens,
+                outputTokens: mix.outputTokens,
+                cacheReadTokens: mix.cacheReadTokens,
+                cacheCreationTokens: mix.cacheCreationTokens,
+                reasoningTokens: mix.reasoningTokens,
+                totalTokens: totalTokens,
+                costUSD: 1,
+                modelsUsed: ["gpt-5.4"],
+                modelBreakdowns: [.init(
+                    modelName: "gpt-5.4",
+                    costUSD: 1,
+                    totalTokens: totalTokens,
+                    inputTokens: mix.inputTokens,
+                    outputTokens: mix.outputTokens,
+                    cacheReadTokens: mix.cacheReadTokens,
+                    cacheCreationTokens: mix.cacheCreationTokens,
+                    reasoningTokens: mix.reasoningTokens)])],
+            summary: nil)
+    }
+
+    private static func mix(_ breakdown: CostUsageDailyReport.ModelBreakdown) -> CostUsageTokenMix {
+        .init(
+            inputTokens: breakdown.inputTokens,
+            outputTokens: breakdown.outputTokens,
+            cacheReadTokens: breakdown.cacheReadTokens,
+            cacheCreationTokens: breakdown.cacheCreationTokens,
+            reasoningTokens: breakdown.reasoningTokens)
+    }
+
+    @Test
+    func `merge preserves input coverage before combining costs and requests`() throws {
+        let inferred = Self.coverageEntry(cost: 1, requests: 3, unpriced: 1)
+        let unmetered = Self.coverageEntry(cost: nil, requests: nil, unmetered: 2)
+        let explicit = Self.coverageEntry(cost: 1, requests: 4, unpriced: 1, estimated: 3, priced: 0)
+        let merged = CostUsageDailyReport.merged([
+            .init(data: [inferred], summary: nil),
+            .init(data: [unmetered], summary: nil),
+            .init(data: [explicit], summary: nil),
+        ])
+        let entry = try #require(merged.data.first)
+        #expect(entry.coverageCounts == CostUsageCoverageCounts(priced: 2, unpriced: 2, unmetered: 2, estimated: 3))
+        #expect(entry.requestCount == 7)
+        #expect(entry.costUSD == 2)
+
+        let explicitOnly = CostUsageDailyReport.merged([.init(data: [explicit], summary: nil)])
+        #expect(explicitOnly.data.first?.pricedRequestCount == 0)
+        #expect(explicitOnly.data.first?.coverageCounts == explicit.coverageCounts)
+        let unmeteredOnly = CostUsageDailyReport.merged([.init(data: [unmetered], summary: nil)])
+        #expect(unmeteredOnly.data.first?.coverageCounts == unmetered.coverageCounts)
+        #expect(unmeteredOnly.data.first?.requestCount == nil)
+    }
+
+    @Test(arguments: [nil, 0, 3] as [Int?])
+    func `merge retains known request counts without inventing unknown requests`(_ count: Int?) throws {
+        let entry = CostUsageDailyReport.Entry(
+            date: "2026-08-30",
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: 0,
+            requestCount: count,
+            costUSD: nil,
+            modelsUsed: ["gpt-5.4"],
+            modelBreakdowns: [.init(modelName: "gpt-5.4", costUSD: nil, totalTokens: 0, requestCount: count)])
+        let report = CostUsageDailyReport(data: [entry], summary: nil)
+        let merged = CostUsageDailyReport.merged([report, report])
+        let result = try #require(merged.data.first)
+        #expect(result.requestCount == count.map { $0 * 2 })
+        #expect(result.modelBreakdowns?.first?.requestCount == count.map { $0 * 2 })
+    }
+
+    @Test
+    func `overflowed request counts stay unknown after a later known count`() {
+        let reports = [Int.max, 1, 3].map { count in
+            CostUsageDailyReport(
+                data: [.init(
+                    date: "2026-08-30",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 0,
+                    requestCount: count,
+                    costUSD: nil,
+                    modelsUsed: ["gpt-5.4"],
+                    modelBreakdowns: [.init(
+                        modelName: "gpt-5.4", costUSD: nil, totalTokens: 0, requestCount: count)],
+                    pricedRequestCount: 0)],
+                summary: nil)
+        }
+        let merged = CostUsageDailyReport.merged(reports)
+        #expect(merged.data.first?.requestCount == nil)
+        #expect(merged.data.first?.modelBreakdowns?.first?.requestCount == nil)
+    }
+
+    private static func coverageEntry(
+        cost: Double?,
+        requests: Int?,
+        unpriced: Int? = nil,
+        unmetered: Int? = nil,
+        estimated: Int? = nil,
+        priced: Int? = nil) -> CostUsageDailyReport.Entry
+    {
+        .init(
+            date: "2026-08-30",
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: nil,
+            requestCount: requests,
+            costUSD: cost,
+            modelsUsed: nil,
+            modelBreakdowns: nil,
+            unpricedRequestCount: unpriced,
+            unmeteredRequestCount: unmetered,
+            estimatedRequestCount: estimated,
+            pricedRequestCount: priced)
+    }
+
     @Test
     func `merged report sums overlapping day totals and model breakdowns`() {
         let native = CostUsageDailyReport(

--- a/Tests/CodexBarTests/CostUsageDailyReportMergeTests.swift
+++ b/Tests/CodexBarTests/CostUsageDailyReportMergeTests.swift
@@ -201,6 +201,48 @@ struct CostUsageDailyReportMergeTests {
             pricedRequestCount: priced)
     }
 
+    @Test(arguments: [false, true])
+    func `unrepresentable merged coverage retains row fallback without trapping`(_ acrossCategories: Bool) throws {
+        let first = Self.coverageEntry(cost: 1, requests: nil, priced: Int.max)
+        let second = Self.coverageEntry(
+            cost: 1,
+            requests: nil,
+            unmetered: acrossCategories ? 1 : nil,
+            priced: acrossCategories ? 0 : 1)
+        let later = Self.coverageEntry(cost: 1, requests: nil, priced: 1)
+        let merged = CostUsageDailyReport.merged([
+            .init(data: [first], summary: nil),
+            .init(data: [second], summary: nil),
+            .init(data: [later], summary: nil),
+        ])
+        let entry = try #require(merged.data.first)
+        #expect(entry.pricedRequestCount == nil)
+        #expect(entry.unpricedRequestCount == nil)
+        #expect(entry.unmeteredRequestCount == nil)
+        #expect(entry.estimatedRequestCount == nil)
+        #expect(entry.requestCount == nil)
+        #expect(entry.costUSD == 3)
+        #expect(entry.coverageCounts == CostUsageCoverageCounts(priced: 1))
+        #expect(entry.coverageCounts.total == 1)
+        #expect(entry.coverageCounts.coverageRatio == 1)
+    }
+
+    @Test(arguments: [nil, 7] as [Int?])
+    func `unrepresentable source coverage retains inferred fallback without trapping`(_ requests: Int?) throws {
+        let source = Self.coverageEntry(cost: 1, requests: requests, unpriced: Int.max, unmetered: 1)
+        let merged = CostUsageDailyReport.merged([.init(data: [source], summary: nil)])
+        let entry = try #require(merged.data.first)
+        #expect(entry.pricedRequestCount == nil)
+        #expect(entry.unpricedRequestCount == nil)
+        #expect(entry.unmeteredRequestCount == nil)
+        #expect(entry.estimatedRequestCount == nil)
+        #expect(entry.requestCount == requests)
+        #expect(entry.costUSD == 1)
+        #expect(entry.coverageCounts == CostUsageCoverageCounts(priced: requests ?? 1))
+        #expect(entry.coverageCounts.total == requests ?? 1)
+        #expect(entry.coverageCounts.coverageRatio == 1)
+    }
+
     @Test
     func `merged report sums overlapping day totals and model breakdowns`() {
         let native = CostUsageDailyReport(

--- a/Tests/CodexBarTests/CostUsageStoreReadViewTests.swift
+++ b/Tests/CodexBarTests/CostUsageStoreReadViewTests.swift
@@ -219,7 +219,7 @@ extension CostUsageStoreReadWorkTests {
     }
 
     @Test
-    func `missing parent forks retain unmetered coverage in project and session reports`() throws {
+    func `missing parent forks retain unmetered coverage in project and session reports`() async throws {
         let fixture = try ReadWorkFixture(fileCount: 2, rowsPerFile: 4, incomplete: true)
         defer { fixture.remove() }
         var cache = fixture.canonical
@@ -238,6 +238,9 @@ extension CostUsageStoreReadWorkTests {
         try fixture.expectProjectionParity(baseline)
         let report = fixture.fullReport(baseline)
         #expect(report.data.first?.unmeteredRequestCount == 1)
+        let cached = try #require(await fixture.cachedSnapshot(details: true))
+        #expect(cached.snapshot.daily.first?.coverageCounts == report.data.first?.coverageCounts)
+        #expect(cached.snapshot.summary(forLastDays: 1, calendar: fixture.calendar).coverage.unmetered == 1)
         #expect(report.summary?.totalTokens == 52)
         let view = fixture.store.syncLoadCodexReadView(calendar: fixture.calendar, purpose: .report)
         let sessions = view.sessions(

--- a/Tests/CodexBarTests/OverviewSpendSummaryTests.swift
+++ b/Tests/CodexBarTests/OverviewSpendSummaryTests.swift
@@ -165,7 +165,21 @@ struct OverviewSpendSummaryTests {
         coverage: CostUsageCoverageCounts? = nil,
         provenance: CostProvenance = .listPriceEstimate) -> SpendDashboardModel.CurrencyGroup
     {
-        SpendDashboardModel.CurrencyGroup(
+        let counts = coverage ?? CostUsageCoverageCounts(priced: providers.count)
+        var accumulator = CostUsageCoverageAccumulator()
+        accumulator.add(.init(
+            date: "2026-08-30",
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: totalTokens,
+            costUSD: totalCost,
+            modelsUsed: nil,
+            modelBreakdowns: nil,
+            unpricedRequestCount: counts.unpriced,
+            unmeteredRequestCount: counts.unmetered,
+            estimatedRequestCount: counts.estimated,
+            pricedRequestCount: counts.priced))
+        return SpendDashboardModel.CurrencyGroup(
             currencyCode: currencyCode,
             providers: providers,
             models: [],
@@ -176,7 +190,7 @@ struct OverviewSpendSummaryTests {
             coveredDayCount: coveredDayCount,
             chartDomain: Date(timeIntervalSince1970: 0)...Date(timeIntervalSince1970: 86400),
             modelHistoryCompleteness: totalCost == nil ? .incomplete : .complete,
-            coverage: coverage ?? CostUsageCoverageCounts(priced: providers.count),
+            coverageAccumulator: accumulator,
             provenance: provenance)
     }
 }

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2414,7 +2414,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SpendDashboardModel.swift",
-            line: 1089,
+            line: 1093,
             anchor: "guard provider == .mistral || provider == .openrouter || provider == .xai else { return displayCalendar }",
             expectedProviderIDs: ["mistral", "openrouter", "xai"],
             expectedReferenceCount: 3,

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -41,6 +41,7 @@ sessions, Codex projects, and a 365-day token heatmap. A heatmap day with no cov
 and is not clickable. Custom list-price overlays are documented in `docs/model-pricing.md`.
 Cached and combined reports retain token-class details and known request counts. Coverage is combined from each
 source's existing classification, so a priced source cannot hide another source's unpriced or unmetered rows.
+If coverage totals cannot fit, aggregation falls back to existing request or daily-row inference without changing costs or stored data.
 
 OpenCodex `~/.opencodex/usage.jsonl` is an opt-in, read-only spend source (off by default). It is not a quota
 Provider. When both OpenCodex logs and native Codex sessions are present they stay on separate rows; merging would

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -39,6 +39,8 @@ adds or ranks amounts across currencies.
 The page also shows token mix (input / output / cache / reasoning), priced/unpriced/unmetered/estimated coverage,
 sessions, Codex projects, and a 365-day token heatmap. A heatmap day with no coverage is a gap, not zero activity,
 and is not clickable. Custom list-price overlays are documented in `docs/model-pricing.md`.
+Cached and combined reports retain token-class details and known request counts. Coverage is combined from each
+source's existing classification, so a priced source cannot hide another source's unpriced or unmetered rows.
 
 OpenCodex `~/.opencodex/usage.jsonl` is an opt-in, read-only spend source (off by default). It is not a quota
 Provider. When both OpenCodex logs and native Codex sessions are present they stay on separate rows; merging would


### PR DESCRIPTION
## Summary

Fix information loss in the shared cost-report merger. Cached Codex hydration runs through this merger even with one input, so established reasoning and per-model token details could disappear after reopening history. Combining native and supplemental reports also discarded known request counts and unpriced/unmetered/estimated coverage.

Preserve the five per-model token classes, daily/summary reasoning, and known daily/model request counts. Reuse the existing token-mix semantics and preserve missing versus explicit zero; overflowing optional counts remain unknown. Resolve coverage using each input's existing classification before combining costs, so a priced source cannot relabel another source's unmetered rows. Ordinary single-source inferred coverage stays implicit.

Coverage aggregation checks each category and the combined total before inference or publication. If those counts cannot fit, their optional metadata stays absent and the existing inferred-coverage fallback remains available; valid costs, token details, and independently known request counts are retained. Later contributions cannot revive an overflowed aggregate.

The same transient accumulator now covers daily reports, snapshot windows, dashboard currency groups, and Overview across currencies. Exact and inferred-request totals are checked independently; if neither fits, existing daily-row inference is bounded by the actual input rows. Currency groups carry those fallback details through the final Overview aggregation; no fallback state is stored or serialized.

This leaves storage, scanner accounting, pricing, explicit/derived total-token arithmetic, source/account boundaries, and UI layout unchanged. Reasoning is not added again to total tokens. Documentation and the Unreleased changelog are updated.

Found while investigating #3303, but **this does not fix or close that report**. The synthetic same-file day-A → day-B append already produced the correct persisted day-B row before this repair; it exposed this separate cached-detail omission. Thanks @Pjhhhhh for the report that led to it.

## Verification

- Regression-first: the isolated report/cache/dashboard tests failed before the production repair (10 tests across two suites; 42 failed assertions in the expanded red run). Missing token classes, request counts, coverage, and dashboard token mix were reproduced without credentials.
- First focused pass: 62 tests across four suites passed, including four ordinary/forced-refresh × UTC/local-midnight scan → SQLite reopen → cached snapshot → dashboard-model cases.
- Broader focused run passed: 103 tests across seven suites in 7.541 seconds. It includes the actual cached unresolved-fork coverage path, store read-view tests, fetcher tests, OpenCodex fan-out, and dashboard-model assertions.
- Review follow-ups: regressions reproduced signal-5 crashes for same-day coverage addition and for subsequent multi-day window aggregation. The intermediate focused pass was 105 tests across seven suites; the final expanded pass is 130 tests across ten suites in 4.748 seconds, including snapshot/dashboard/Overview paths, separate days/accounts/currencies, request fallback, and the representable integer boundary.
- Final `make check` passed: 2,068 Swift files, zero lint violations, repository/script checks passed; the parser hash remains current and unchanged.
- The subsequent full run caught a stale architecture-guard line anchor after the dashboard field moved. Updating only the expected line from 1089 to 1093 preserved the anchor, allowed providers, and reference fingerprint. All 39 architecture-guard tests then passed in 29.319 seconds; `make check` was rerun and passed.
- Scoped Codex autoreview found no accepted/actionable P0 findings in the original patch and each separately reviewed follow-up.
- Final `CODEXBAR_TEST_SUITE_TIMEOUT=600 make test` passed all 978 selections across 82 groups in 1,892.4 seconds: 81 groups passed first attempt and one PTY lifecycle group recovered on its configured retry. The individual PTY test hit its unchanged 10-second deadline initially, then passed in 2.511 seconds. No group timeout or isolated-selection retry occurred.
- All nine checks passed on final candidate `ce5d10611ad418c50cae230d5efa3b53be1332f4`, including both macOS shards and all three Linux builds: [CI run 33358778133](https://github.com/steipete/CodexBar/actions/runs/33358778133).
- Two earlier full runs were deliberately stopped for the overflow findings. A third failed at the stale architecture anchor, including its configured retry; none is counted as a pass. The final passing run above supersedes them.

The new scan/cache fixtures use temporary session/cache roots, disabled pricing refresh, explicit missing trace-database paths, and the repository's Keychain/credential-file isolation. No real provider, browser, Keychain, or installed-app state was used. Dashboard behavior is checked through its stable model seam; this is a data-aggregation repair, not a layout change.
