### PR TITLE
test: preseed Claude identity fixture configuration

### DIFF
--- a/Tests/CodexBarTests/ClaudeActiveAccountIdentityInvalidationTests.swift
+++ b/Tests/CodexBarTests/ClaudeActiveAccountIdentityInvalidationTests.swift
@@ -678,17 +678,25 @@ struct ClaudeActiveAccountIdentityInvalidationTests {
         outcome: ProviderFetchOutcome,
         environment: [String: String] = [:]) throws -> ClaudeIdentityFixture
     {
-        let settings = testSettingsStore(suiteName: "ClaudeActiveAccountIdentityInvalidationTests")
+        var config = testConfigWithAllProvidersDisabled()
+        let claudeIndex = try #require(config.providers.firstIndex { $0.id == UsageProvider.claude.instanceID })
+        config.providers[claudeIndex].enabled = true
+        let settings = testSettingsStore(
+            suiteName: "ClaudeActiveAccountIdentityInvalidationTests",
+            config: config,
+            prepareDefaults: { defaults in
+                // An existing config otherwise opts this fresh fixture into OpenAI web access.
+                defaults.set(false, forKey: "openAIWebAccessEnabled")
+            })
         settings.refreshFrequency = .manual
         settings.statusChecksEnabled = false
         settings.claudeUsageDataSource = source
-        let metadata = ProviderRegistry.shared.metadata
-        for provider in UsageProvider.allCases {
-            try settings.setProviderEnabled(
-                provider: provider,
-                metadata: #require(metadata[provider]),
-                enabled: provider == .claude)
-        }
+        #expect(settings.enabledProvidersOrdered(metadataByProvider: ProviderRegistry.shared.metadata)
+            == [UsageProvider.claude.instanceID])
+        #expect(settings.claudeUsageDataSource == source)
+        #expect(settings.refreshFrequency == .manual)
+        #expect(settings.statusChecksEnabled == false)
+        #expect(settings.openAIWebAccessEnabled == false)
 
         let store = UsageStore(
             fetcher: UsageFetcher(environment: environment),

--- a/Tests/CodexBarTests/PiSessionCostScannerTests.swift
+++ b/Tests/CodexBarTests/PiSessionCostScannerTests.swift
@@ -491,7 +491,9 @@ struct PiSessionCostScannerTests {
         let url = try env.writePiSessionFile(
             relativePath: "2026-04-06T10-00-00-000Z_test.jsonl",
             contents: firstContents)
-        let originalModifiedAt = try #require(
+        let stableModifiedAt = Date(timeIntervalSince1970: floor(day.timeIntervalSince1970))
+        try FileManager.default.setAttributes([.modificationDate: stableModifiedAt], ofItemAtPath: url.path)
+        let cachedModifiedAt = try #require(
             FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date)
 
         let cachedOptions = PiSessionCostScanner.Options(
@@ -507,7 +509,11 @@ struct PiSessionCostScannerTests {
         #expect(firstReport.data.first?.totalTokens == 15)
 
         try secondContents.write(to: url, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.modificationDate: originalModifiedAt], ofItemAtPath: url.path)
+        try FileManager.default.setAttributes([.modificationDate: stableModifiedAt], ofItemAtPath: url.path)
+        let replacedModifiedAt = try #require(
+            FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date)
+        #expect(Int64(cachedModifiedAt.timeIntervalSince1970 * 1000) ==
+            Int64(replacedModifiedAt.timeIntervalSince1970 * 1000))
 
         let staleReport = PiSessionCostScanner.loadDailyReport(
             provider: .codex,


### PR DESCRIPTION
## Summary

Prepare the Claude active-account identity test fixture's provider configuration in memory and persist it once, instead of calling the runtime provider toggle for every registered provider. The repeated setup loop performed synchronous whole-config atomic writes even though each fixture constructs `UsageStore` only after setup, so none of the intermediate notifications or revision increments are observable behavior.

Reuse the existing isolated config/settings helpers, enable only Claude, and explicitly preserve the fixture's intended manual refresh, disabled status checks, Claude data source, and disabled OpenAI web access. The test now asserts that complete initial state on every fixture construction.

Only the test fixture changes. UUID-isolated defaults/config files, test credential stores, missing-credentials scopes, fetch stubs, and seeded account snapshots remain unchanged. There is no production, authentication, persistence-policy, UI, dependency, or user-facing behavior change, so no changelog entry is needed.

## Verification

- 42 focused tests across the Claude identity-invalidation, process-safety, settings-preference, and app-group suites passed.
- `make check` passed with zero format or lint violations.
- Full isolated local suite on the final rebased head: 994 selections across 83 groups, all 83 first-pass green, retries disabled, zero failed groups, and zero timeouts.
- Final independent branch review found no actionable P0-P2 defects.
- The first hosted run exposed an unrelated Pi scanner test fixture that restored a fractional filesystem timestamp after an atomic replacement without proving its millisecond cache key stayed equal. The runner legitimately rescanned when that key shifted. The fixture now pins a whole-second timestamp before both scans and asserts exact key equality; the formerly failing case passed six consecutive focused runs, `make check`, and a clean scoped review.
- Fresh hosted CI is running on exact head `90168b8d48fd62673667b96846e39497fc60b944`.

Tests used the repository's Keychain and credential-file isolation flags with synthetic fixtures. No real provider probes, browser imports, or installed-app launches were used.
