### PR TITLE
perf: streamline Claude cost metadata detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Performance
 - Local costs: reduce background CPU spent parsing native session timestamps and validating appended Codex history, preserving timestamp precision, daily totals, and fork accounting.
 - Codex: reuse one decoded SQLite baseline per native cost scan, avoiding repeated unchanged-save decoding while rechecking database changes and filesystem state.
+- Claude and Vertex AI: reduce CPU spent classifying local transcript metadata, preserving provider detection, Unicode handling, and token/cost totals.
 
 ### Fixed
 - Local costs: preserve token breakdowns, reasoning, request counts, and pricing coverage when combining reports or reopening cached history. Thanks @Pjhhhhh!

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
@@ -425,7 +425,7 @@ extension CostUsageScanner {
         }
     }
 
-    private static func isVertexAIUsageEntry(obj: [String: Any]) -> Bool {
+    static func isVertexAIUsageEntry(obj: [String: Any]) -> Bool {
         // Primary detection: Vertex AI message IDs and request IDs have "vrtx" prefix
         // e.g., "msg_vrtx_0154LUXjFVzQGUca3yK2RUeo", "req_vrtx_011CWjK86SWeFuXqZKUtgB1H"
         if let message = obj["message"] as? [String: Any],
@@ -449,30 +449,8 @@ extension CostUsageScanner {
             return true
         }
 
-        // Fallback: check for explicit Vertex AI metadata fields
-        var candidates: [[String: Any]] = [obj]
-        if let metadata = obj["metadata"] as? [String: Any] {
-            candidates.append(metadata)
-        }
-        if let request = obj["request"] as? [String: Any] {
-            candidates.append(request)
-        }
-        if let context = obj["context"] as? [String: Any] {
-            candidates.append(context)
-        }
-        if let client = obj["client"] as? [String: Any] {
-            candidates.append(client)
-        }
-        if let message = obj["message"] as? [String: Any] {
-            if let metadata = message["metadata"] as? [String: Any] {
-                candidates.append(metadata)
-            }
-            if let request = message["request"] as? [String: Any] {
-                candidates.append(request)
-            }
-        }
-
-        return candidates.contains { Self.containsVertexAIMetadata(in: $0) }
+        // The recursive walk already includes root and message metadata, requests, context, and client.
+        return Self.containsVertexAIMetadata(in: obj)
     }
 
     /// Detects Vertex AI model names by format.
@@ -487,13 +465,12 @@ extension CostUsageScanner {
 
     private static func containsVertexAIMetadata(in dict: [String: Any]) -> Bool {
         for (key, value) in dict {
-            let lowerKey = key.lowercased()
-            if lowerKey.contains("vertex") || lowerKey.contains("gcp") {
+            if self.containsClaudeVertexMarker(key, includeGCP: true) {
                 return true
             }
-            if Self.vertexProviderKeys.contains(lowerKey),
+            if self.vertexProviderKeys.contains(key.lowercased()),
                let text = value as? String,
-               Self.stringLooksVertex(text)
+               containsClaudeVertexMarker(text)
             {
                 return true
             }
@@ -523,8 +500,35 @@ extension CostUsageScanner {
         return false
     }
 
-    private static func stringLooksVertex(_ value: String) -> Bool {
-        value.lowercased().contains("vertex")
+    private static func containsClaudeVertexMarker(_ value: String, includeGCP: Bool = false) -> Bool {
+        let asciiMatch = value.utf8.withContiguousStorageIfAvailable { bytes -> Bool? in
+            // Validate the entire decoded string before matching: a later combining scalar can
+            // change Foundation's substring semantics even when the marker itself is ASCII.
+            guard bytes.allSatisfy({ $0 < 0x80 }) else { return nil }
+            for index in bytes.indices {
+                let first = bytes[index] | 0x20
+                if first == 0x76, index + 5 < bytes.count, // vertex
+                   bytes[index + 1] | 0x20 == 0x65,
+                   bytes[index + 2] | 0x20 == 0x72,
+                   bytes[index + 3] | 0x20 == 0x74,
+                   bytes[index + 4] | 0x20 == 0x65,
+                   bytes[index + 5] | 0x20 == 0x78
+                {
+                    return true
+                }
+                if includeGCP, first == 0x67, index + 2 < bytes.count, // gcp
+                   bytes[index + 1] | 0x20 == 0x63,
+                   bytes[index + 2] | 0x20 == 0x70
+                {
+                    return true
+                }
+            }
+            return false
+        }.flatMap(\.self)
+        if let asciiMatch { return asciiMatch }
+
+        let lower = value.lowercased()
+        return lower.contains("vertex") || (includeGCP && lower.contains("gcp"))
     }
 
     private static func claudeRootCandidates(for rootPath: String) -> [String] {

--- a/Tests/CodexBarTests/CostUsageClaudeVertexClassifierTests.swift
+++ b/Tests/CodexBarTests/CostUsageClaudeVertexClassifierTests.swift
@@ -1,0 +1,276 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct CostUsageClaudeVertexClassifierTests {
+    private static func fixtures() throws -> [[String: Any]] {
+        var fixtures: [[String: Any]] = [
+            [:], ["vertex": false], ["GCP": 0], ["vertex_enabled": NSNull()],
+            ["metadata": ["provider": "anthropic"]],
+            ["request": ["API_PROVIDER": "Google-Vertex-AI"]],
+            ["context": ["client": ["backend": "vertex"]]],
+            ["client": ["nested": [["platform": "vertexai"]]]],
+            ["message": ["metadata": ["source": "VERTEX"]]],
+            ["message": ["request": ["vendor": "vertex"]]],
+            ["message": ["content": [["type": "tool_use", "input": ["gcp_project": false]]]]],
+            ["message": ["content": [["type": "text", "text": "vertex"]]]],
+            ["metadata": ["provider": false]], ["metadata": ["provider": 1]],
+            ["metadata": ["provider": NSNull()]], ["metadata": ["provider": ["vertex"]]],
+            ["metadata": ["provider": [["provider": "vertex"]]]],
+            ["metadata": ["provider": [[["provider": "vertex"]]]]],
+            ["metadata": ["provider": "gcp"]], ["not_provider": "vertex"],
+            ["message": ["id": "msg_vrtx_123"]], ["requestId": "req_vrtx_123"],
+            ["message": ["id": "msg_VRTX_123"]], ["requestId": "req_vrtx"],
+            ["message": ["model": "claude-sonnet-4-6@20260217"]],
+            ["message": ["model": "Claude-sonnet-4-6@20260217"]],
+            ["message": ["model": "other@20260217"]],
+        ]
+        let markers = [
+            "", "v", "verte", "vertex", "VERTEX", "VeRtEx", "prevertexpost", "vertices", "ver tex",
+            "gcp", "GCP", "prefixGCPsuffix", "gc", "gc_p", "vertex\0", "\0vertex", "\r\nvertex",
+            "vértex", "ve\u{301}rtex", "verteｘ", "ｖｅｒｔｅｘ", "vertex\u{301}", "gcp\u{301}",
+            "日本vertex", "vertex🦞", "İVERTEX", "VERTEXİ", "ver\u{200D}tex", "\u{FEFF}vertex",
+        ]
+        let providerKeys = [
+            "provider", "platform", "backend", "api_provider", "apiprovider", "api_type", "apitype",
+            "source", "vendor", "client", "PROVIDER", "Api_Provider", "provider_suffix", "proviDERİ",
+        ]
+        for marker in markers {
+            fixtures.append([marker: false])
+            for key in providerKeys {
+                fixtures.append(["metadata": [key: marker]])
+            }
+        }
+        for body in [
+            String(repeating: "synthetic text 123. ", count: 2048),
+            String(repeating: "synthetic café 日本 🦞. ", count: 2048),
+        ] {
+            fixtures.append(["message": ["content": [["type": "text", "text": body + "vertex"]]]])
+            fixtures.append(["metadata": ["provider": body]])
+            fixtures.append(["metadata": ["provider": body + "VERTEX"]])
+            fixtures.append([body + "GCP": 0])
+        }
+        // Decode escaped keys/values first, exactly as the JSONL ingestion path does.
+        for json in [
+            #"{"metadata":{"pro\u0076ider":"\u0076ertex"}}"#,
+            #"{"metadata":{"\u0067cp":false}}"#,
+            #"{"metadata":{"provider":"vertex\u0301"}}"#,
+            #"{"metadata":{"provider":"\u65e5\u672cVERTEX"}}"#,
+        ] {
+            try fixtures.append(#require(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]))
+        }
+        return try fixtures.map {
+            try #require(JSONSerialization.jsonObject(
+                with: JSONSerialization.data(withJSONObject: $0)) as? [String: Any])
+        }
+    }
+
+    @Test
+    func `decoded metadata preserves historical classification`() throws {
+        for (index, fixture) in try Self.fixtures().enumerated() {
+            #expect(
+                CostUsageScanner.isVertexAIUsageEntry(obj: fixture)
+                    == LegacyClaudeVertexClassifier.isVertexAIUsageEntry(obj: fixture),
+                "fixture \(index)")
+        }
+        // Lock down surprising existing rules independently of the differential oracle.
+        #expect(CostUsageScanner.isVertexAIUsageEntry(obj: ["vertex": false]))
+        #expect(CostUsageScanner.isVertexAIUsageEntry(obj: ["GCP": 0]))
+        #expect(!CostUsageScanner.isVertexAIUsageEntry(obj: ["provider": "gcp"]))
+        #expect(!CostUsageScanner.isVertexAIUsageEntry(obj: ["nested": [[["provider": "vertex"]]]]))
+        #expect(!CostUsageScanner.isVertexAIUsageEntry(obj: ["text": "vertex"]))
+    }
+
+    @Test
+    func `Claude and Vertex ingestion preserve historical rows days tokens and costs`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        let timestamps = ["2026-08-29T06:59:59.123Z", "2026-08-29T07:00:00Z", "2026-08-30T07:00:00Z"]
+        let since = Date(timeIntervalSince1970: 1_787_875_200)
+        let until = Date(timeIntervalSince1970: 1_788_130_800)
+        let range = CostUsageScanner.CostUsageDayRange(since: since, until: until, calendar: calendar)
+        let entries = try Self.fixtures().enumerated().map { index, fixture in
+            var entry = fixture
+            entry["type"] = "assistant"
+            entry["timestamp"] = timestamps[index % timestamps.count]
+            entry["requestId"] = entry["requestId"] ?? "request-\(index)"
+            var message = entry["message"] as? [String: Any] ?? [:]
+            message["id"] = message["id"] ?? "message-\(index)"
+            message["model"] = message["model"] ?? "claude-sonnet-4-6"
+            message["usage"] = [
+                "input_tokens": 200 + index, "output_tokens": 80,
+                "cache_creation_input_tokens": 50, "cache_read_input_tokens": 25,
+                "cache_creation": ["ephemeral_1h_input_tokens": 20],
+            ] as [String: Any]
+            entry["message"] = message
+            return entry
+        }
+        let vertex = entries.filter { LegacyClaudeVertexClassifier.isVertexAIUsageEntry(obj: $0) }
+        let claude = entries.filter { !LegacyClaudeVertexClassifier.isVertexAIUsageEntry(obj: $0) }
+        #expect(!vertex.isEmpty && !claude.isEmpty)
+        let malformed = "{invalid json}\n{\"type\":\"assistant\",\"usage\":null}\n"
+        let allFile = try env.writeClaudeProjectFile(
+            relativePath: "all/session.jsonl", contents: env.jsonl(entries) + malformed)
+        for (name, filter, expectedEntries, provider) in [
+            ("claude", CostUsageScanner.ClaudeLogProviderFilter.excludeVertexAI, claude, UsageProvider.claude),
+            ("vertex", .vertexAIOnly, vertex, .vertexai),
+        ] {
+            let expectedFile = try env.writeClaudeProjectFile(
+                relativePath: "\(name)/session.jsonl", contents: env.jsonl(expectedEntries))
+            let expected = CostUsageScanner.parseClaudeFile(
+                fileURL: expectedFile,
+                range: range,
+                providerFilter: .all,
+                modelsDevCatalog: ModelsDevCatalog(providers: [:]),
+                modelsDevCacheRoot: env.cacheRoot)
+            let actual = CostUsageScanner.parseClaudeFile(
+                fileURL: allFile,
+                range: range,
+                providerFilter: filter,
+                modelsDevCatalog: ModelsDevCatalog(providers: [:]),
+                modelsDevCacheRoot: env.cacheRoot)
+            #expect(actual.rows == expected.rows)
+            #expect(actual.rows.count == expectedEntries.count)
+            #expect(actual.days == expected.days)
+            #expect(actual.days.count == 3)
+            #expect(actual.rows.contains { $0.costNanos > 0 })
+            #expect(try actual.parsedBytes == Int64(Data(((env.jsonl(entries)) + malformed).utf8).count))
+
+            var options = CostUsageScanner.Options(
+                claudeProjectsRoots: [allFile.deletingLastPathComponent()],
+                cacheRoot: env.cacheRoot.appendingPathComponent(name),
+                calendar: calendar)
+            options.claudeLogProviderFilter = filter
+            options.refreshMinIntervalSeconds = 0
+            let actualReport = CostUsageScanner.loadDailyReport(
+                provider: provider, since: since, until: until, now: until, options: options)
+            options.claudeProjectsRoots = [expectedFile.deletingLastPathComponent()]
+            options.cacheRoot = env.cacheRoot.appendingPathComponent("expected-\(name)")
+            options.claudeLogProviderFilter = .all
+            let expectedReport = CostUsageScanner.loadDailyReport(
+                provider: .claude, since: since, until: until, now: until, options: options)
+            #expect(actualReport.data == expectedReport.data)
+            #expect(actualReport.summary == expectedReport.summary)
+        }
+    }
+}
+
+/// Frozen pre-optimization predicate: keep traversal and Foundation string semantics independent.
+private enum LegacyClaudeVertexClassifier {
+    private static let vertexProviderKeys: Set<String> = [
+        "provider",
+        "platform",
+        "backend",
+        "api_provider",
+        "apiprovider",
+        "api_type",
+        "apitype",
+        "source",
+        "vendor",
+        "client",
+    ]
+
+    static func isVertexAIUsageEntry(obj: [String: Any]) -> Bool {
+        // Primary detection: Vertex AI message IDs and request IDs have "vrtx" prefix
+        // e.g., "msg_vrtx_0154LUXjFVzQGUca3yK2RUeo", "req_vrtx_011CWjK86SWeFuXqZKUtgB1H"
+        if let message = obj["message"] as? [String: Any],
+           let messageId = message["id"] as? String,
+           messageId.contains("_vrtx_")
+        {
+            return true
+        }
+        if let requestId = obj["requestId"] as? String,
+           requestId.contains("_vrtx_")
+        {
+            return true
+        }
+
+        // Secondary detection: model name with @ version separator (Vertex AI format)
+        // e.g., "claude-opus-4-5@20251101" vs "claude-opus-4-5-20251101"
+        if let message = obj["message"] as? [String: Any],
+           let model = message["model"] as? String,
+           Self.modelNameLooksVertex(model)
+        {
+            return true
+        }
+
+        // Fallback: check for explicit Vertex AI metadata fields
+        var candidates: [[String: Any]] = [obj]
+        if let metadata = obj["metadata"] as? [String: Any] {
+            candidates.append(metadata)
+        }
+        if let request = obj["request"] as? [String: Any] {
+            candidates.append(request)
+        }
+        if let context = obj["context"] as? [String: Any] {
+            candidates.append(context)
+        }
+        if let client = obj["client"] as? [String: Any] {
+            candidates.append(client)
+        }
+        if let message = obj["message"] as? [String: Any] {
+            if let metadata = message["metadata"] as? [String: Any] {
+                candidates.append(metadata)
+            }
+            if let request = message["request"] as? [String: Any] {
+                candidates.append(request)
+            }
+        }
+
+        return candidates.contains { Self.containsVertexAIMetadata(in: $0) }
+    }
+
+    /// Detects Vertex AI model names by format.
+    /// Vertex AI uses @ for version separator: claude-opus-4-5@20251101
+    /// Anthropic API uses -: claude-opus-4-5-20251101
+    private static func modelNameLooksVertex(_ model: String) -> Bool {
+        // Vertex AI model format: claude-{variant}@{version}
+        // Examples: claude-opus-4-5@20251101, claude-sonnet-4-5@20250514
+        guard model.hasPrefix("claude-") else { return false }
+        return model.contains("@")
+    }
+
+    private static func containsVertexAIMetadata(in dict: [String: Any]) -> Bool {
+        for (key, value) in dict {
+            let lowerKey = key.lowercased()
+            if lowerKey.contains("vertex") || lowerKey.contains("gcp") {
+                return true
+            }
+            if Self.vertexProviderKeys.contains(lowerKey),
+               let text = value as? String,
+               Self.stringLooksVertex(text)
+            {
+                return true
+            }
+            if let nested = value as? [String: Any] {
+                if Self.containsVertexAIMetadata(in: nested) {
+                    return true
+                }
+            } else if let array = value as? [Any] {
+                if Self.containsVertexAIMetadata(in: array) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    private static func containsVertexAIMetadata(in array: [Any]) -> Bool {
+        for entry in array {
+            if let dict = entry as? [String: Any] {
+                if self.containsVertexAIMetadata(in: dict) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    private static func stringLooksVertex(_ value: String) -> Bool {
+        value.lowercased().contains("vertex")
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -222,6 +222,23 @@ Initial decoding, semantic equality, filesystem reconciliation, report generatio
 still cost work proportional to retained history. These counters do not measure installed-app idle CPU;
 refresh cadence, scan budgets, timestamp parsing and incremental-order validation are unchanged.
 
+Claude/Vertex metadata classification searches decoded ASCII strings with case-folded bytes, keeping
+the original Foundation lowercase/substring predicate for non-ASCII or noncontiguous strings. Check
+the whole string for ASCII before matching; combining characters after a marker can affect the old
+predicate. The recursive dictionary/array walk still visits the same content, but no longer repeats
+root/message metadata subtrees already visited through the root. `CostUsageClaudeVertexClassifierTests`
+compares with the frozen old predicate and checks complete filtered rows, daily tokens/costs, and reports,
+including decoded JSON escapes, Unicode boundaries, nested arrays, and false/numeric metadata flags.
+Claude-only source files are excluded from the Codex parser hash, so this optimization does not
+invalidate native Codex caches or change predecessor adoption.
+
+A second optimized synthetic check against main `354191af9` used three fresh-cache scans per provider
+with 32–128 KiB text bodies. Median CPU decreased by 3–18% across Claude/Vertex cases (the 3% case is
+small); a separate long-provider-string stress case decreased by 73–75%. The isolated decoded metadata
+predicate used about half the CPU on ordinary nested metadata. Every daily token component and cost
+matched, including the existing unset public request counts. Fixture generation was outside timing;
+wall time was recorded separately under host load. These results do not measure idle-app CPU.
+
 ### Adaptive refresh fixtures
 
 Heuristics and timer tests seed disabled providers through `testSettingsStore(config:)`, which saves the


### PR DESCRIPTION
## Summary

Reduce CPU spent classifying Claude and Vertex AI transcript metadata without changing provider detection, accounting, refresh cadence, or scan budgets. A fresh profile of a correctly signed 0.56.2 build attributed about 36% of sampled CPU during Claude history ingestion to this detector.

The recursive root walk already visits metadata, request, context, client, and nested message dictionaries. Stop revisiting those subtrees, and match decoded ASCII marker strings directly instead of using Foundation substring searches. Non-ASCII and noncontiguous strings retain the original Foundation predicate; checking the whole string before taking the fast path preserves combining-character behavior. Primary message/request IDs, model-name detection, and existing flag/array semantics remain unchanged.

## Evidence

On base `354191af9`, the classifier-only optimized candidate produced exactly the same accounting output as the baseline. An independent signed-CLI benchmark used 100,000 synthetic events, three paired runs, and fresh cache roots:

| Metric | Baseline | Candidate |
| --- | ---: | ---: |
| Median cold-scan CPU | 11.637 s | 9.960 s |
| Tokens | 15,000,000 | 15,000,000 |
| Estimated cost | $105.00 | $105.00 |

That is **14.4% less cold-scan CPU**. Complete cold/warm JSON output matched, excluding the capture timestamp. Isolated classification used about half the CPU in the normal synthetic cases; larger text-heavy ingestion cases improved by 3–18%. These are controlled workload results, not a measured percentage reduction for whole-app idle CPU.

Regression coverage compares against the frozen old predicate and checks complete provider-separated rows, daily totals, costs, JSON escapes, Unicode boundaries, nested dictionaries/arrays, and false/numeric metadata flags. This Claude-only source change does not alter the Codex parser hash or predecessor-cache adoption.

## Validation

- Before base integration: 46 focused tests and all 9,848 full-suite tests passed; all 82 groups succeeded on the first pass without retries or timeouts.
- After rebasing onto merged [PR #3312](https://github.com/steipete/CodexBar/pull/3312): `make check` passed with zero violations, and final independent P0–P2 Codex review found no actionable issues.
- Full combined-base `make test` is running; this PR will not merge until it and exact-head CI are green.

## Scope

This complements the separately owned decoded-baseline work in [PR #3312](https://github.com/steipete/CodexBar/pull/3312). It does not change SQLite reconstruction or priority aggregation. Live CPU remained elevated in cached Codex report decoding, so this PR does not claim to eliminate all background CPU work. No visual behavior changes, release publication, or raw session/trace uploads.
