### PR TITLE
fix: normalize singular reset labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Usage & Spend: keep stalled or failed Codex catch-up paused until explicit Refresh, preventing background synchronization from restarting CPU-heavy scans (partial fix for #3316). Thanks @heyajulia!
 - Xiaomi MiMo: prevent overlapping local usage tracker updates from colliding on a shared temporary cache file, preserving atomic publication (#3321). Thanks @Lucenx9!
+- Claude: avoid duplicated “Resets Reset” labels when CLI usage supplies a singular reset description (#3317). Thanks @Aternus!
 
 ## 0.56.2 — 2026-08-31
 

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -165,11 +165,12 @@ public enum UsageFormatter {
         if let desc = window.resetDescription {
             let trimmed = desc.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return nil }
-            if trimmed.lowercased().hasPrefix("resets in ") {
-                return self.localized("Resets in %@", String(trimmed.dropFirst("Resets in ".count)))
+            let lowercased = trimmed.lowercased()
+            for prefix in ["resets in ", "reset in "] where lowercased.hasPrefix(prefix) {
+                return self.localized("Resets in %@", String(trimmed.dropFirst(prefix.count)))
             }
-            if trimmed.lowercased().hasPrefix("resets ") {
-                return self.localized("Resets %@", String(trimmed.dropFirst("Resets ".count)))
+            for prefix in ["resets ", "reset "] where lowercased.hasPrefix(prefix) {
+                return self.localized("Resets %@", String(trimmed.dropFirst(prefix.count)))
             }
             return self.localized("Resets %@", trimmed)
         }

--- a/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
+++ b/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
@@ -856,6 +856,80 @@ final class MenuLayoutScreenshotRenderTests: XCTestCase {
 }
 
 extension MenuLayoutScreenshotRenderTests {
+    func test_renderSingularResetLabelProof() throws {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_RESET_LABEL_SCREENSHOT_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_RESET_LABEL_SCREENSHOT_DIR to render the reset label proof.")
+        }
+        UsageFormatter.setLocalizationProvider { $0 }
+        defer { UsageFormatter.clearLocalizationProvider() }
+        let expected = ProcessInfo.processInfo.environment["CODEXBAR_RESET_LABEL_EXPECTED"]
+            ?? "Resets Jul 10 at 2:59am (Europe/Prague)"
+        let metadata = try XCTUnwrap(ProviderDefaults.metadata[.claude])
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: [NamedRateWindow(
+                id: "claude-weekly-scoped-example",
+                title: "Example Model only",
+                window: RateWindow(
+                    usedPercent: 68,
+                    windowMinutes: 10080,
+                    resetsAt: nil,
+                    resetDescription: "Reset Jul 10 at 2:59am (Europe/Prague)"))],
+            updatedAt: Self.now)
+        let directory = URL(fileURLWithPath: dir, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        for style in [ResetTimeDisplayStyle.countdown, .absolute] {
+            let model = UsageMenuCardView.Model.make(.init(
+                provider: .claude,
+                metadata: metadata,
+                snapshot: snapshot,
+                credits: nil,
+                creditsError: nil,
+                dashboard: nil,
+                dashboardError: nil,
+                tokenSnapshot: nil,
+                tokenError: nil,
+                account: AccountInfo(email: nil, plan: nil),
+                isRefreshing: false,
+                lastError: nil,
+                usageBarsShowUsed: true,
+                resetTimeDisplayStyle: style,
+                tokenCostUsageEnabled: false,
+                showOptionalCreditsAndExtraUsage: false,
+                hidePersonalInfo: true,
+                paceVisible: false,
+                usesLiveSubtitle: false,
+                now: Self.now))
+            XCTAssertEqual(model.metrics.count, 1)
+            XCTAssertEqual(model.metrics.first?.resetText, expected)
+            for dark in [false, true] {
+                let view = AnyView(UsageMenuCardUsageSectionView(
+                    model: model,
+                    layoutModel: model,
+                    showBottomDivider: false,
+                    bottomPadding: 12,
+                    width: Self.width)
+                    .environment(\.locale, Locale(identifier: "en_US_POSIX"))
+                    .environment(\.colorScheme, dark ? .dark : .light)
+                    .environment(\.accessibilityEnabled, true)
+                    .background(Color(nsColor: .windowBackgroundColor)))
+                let hosting = NSHostingView(rootView: view)
+                hosting.appearance = NSAppearance(named: dark ? .darkAqua : .aqua)
+                let stem = "reset-label-\(style.rawValue)-\(dark ? "dark" : "light")"
+                let png = try XCTUnwrap(Self.pngData(hosting: hosting))
+                try png.write(to: directory.appendingPathComponent("\(stem).png"))
+                let accessibility = Self.accessibilityText(hosting)
+                XCTAssertTrue(accessibility.contains(expected), accessibility)
+                try accessibility.write(
+                    to: directory.appendingPathComponent("\(stem)-accessibility.txt"),
+                    atomically: true,
+                    encoding: .utf8)
+            }
+        }
+    }
+
     fileprivate static func pngDataWithWindow(hosting: NSHostingView<AnyView>) -> Data? {
         // Native List rows need a window to materialize, but it never needs to be ordered onscreen.
         let size = hosting.fittingSize

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -293,6 +293,71 @@ struct UsageFormatterTests {
         #expect(absolute == "Resets at 23:30 (UTC)")
     }
 
+    @Test(arguments: [
+        ("Reset Jul 10 at 2:59am (Europe/Prague)", "Resets Jul 10 at 2:59am (Europe/Prague)"),
+        ("Resets Jul 10 at 2:59am (Europe/Prague)", "Resets Jul 10 at 2:59am (Europe/Prague)"),
+        ("Reset in 11m", "Resets in 11m"),
+        ("Resets in 11m", "Resets in 11m"),
+        (" \nReSeT at 23:30 (UTC)\t", "Resets at 23:30 (UTC)"),
+        ("  rEsEt In 2h 5m \n", "Resets in 2h 5m"),
+        ("Reset demain à 23:30", "Resets demain à 23:30"),
+        ("at 23:30 (UTC)", "Resets at 23:30 (UTC)"),
+        ("Resetting soon", "Resets Resetting soon"),
+    ])
+    func `reset description normalizes singular and plural labels`(_ description: String, expected: String) {
+        UsageFormatter.clearLocalizationProvider()
+        UsageFormatter.clearLocaleProvider()
+        let window = RateWindow(
+            usedPercent: 68,
+            windowMinutes: 10080,
+            resetsAt: nil,
+            resetDescription: description)
+        for style in [ResetTimeDisplayStyle.countdown, .absolute] {
+            #expect(UsageFormatter.resetLine(for: window, style: style) == expected)
+        }
+    }
+
+    @Test
+    func `normalized reset descriptions retain localization keys`() {
+        UsageFormatter.setLocalizationProvider { key in
+            switch key {
+            case "Resets %@": "Date: %@"
+            case "Resets in %@": "Countdown: %@"
+            default: key
+            }
+        }
+        defer { UsageFormatter.clearLocalizationProvider() }
+
+        for prefix in ["Reset", "Resets"] {
+            for (suffix, expected) in [("in 11m", "Countdown: 11m"), ("at 23:30", "Date: at 23:30")] {
+                let window = RateWindow(
+                    usedPercent: 68,
+                    windowMinutes: nil,
+                    resetsAt: nil,
+                    resetDescription: "\(prefix) \(suffix)")
+                for style in [ResetTimeDisplayStyle.countdown, .absolute] {
+                    #expect(UsageFormatter.resetLine(for: window, style: style) == expected)
+                }
+            }
+        }
+    }
+
+    @Test
+    func `parsed reset date takes precedence over singular description`() {
+        UsageFormatter.clearLocalizationProvider()
+        UsageFormatter.clearLocaleProvider()
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let reset = now.addingTimeInterval(601)
+        let window = RateWindow(
+            usedPercent: 68,
+            windowMinutes: nil,
+            resetsAt: reset,
+            resetDescription: "Reset in 99h")
+        #expect(UsageFormatter.resetLine(for: window, style: .countdown, now: now) == "Resets in 11m")
+        #expect(UsageFormatter.resetLine(for: window, style: .absolute, now: now)
+            == "Resets \(UsageFormatter.resetDescription(from: reset, now: now))")
+    }
+
     @Test
     func `model display name strips trailing dates`() {
         #expect(UsageFormatter.modelDisplayName("claude-opus-4-5-20251101") == "claude-opus-4-5")

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -215,6 +215,7 @@ Model-scoped weekly-window proof (synthetic data, no real accounts or credential
 - Parsing (`ClaudeStatusProbe`):
   - Strips ANSI, locates "Current session" + "Current week" headers.
   - Extracts percent left/used and reset text near those headers.
+  - When a reset date cannot be parsed, the menu preserves its description and normalizes leading `Reset` or `Resets` labels once, including scoped weekly limits.
   - Parses `Account:` and `Org:` lines when present.
   - Surfaces CLI errors (e.g. token expired) directly.
   - Some Education and organization-managed subscriptions return only a subscription notice, with no numeric


### PR DESCRIPTION
## Summary

Fix duplicated `Resets Reset …` labels when a provider supplies a singular reset description and no parsed reset date. The shared formatter now strips either singular or plural English prefixes before applying the existing localized label, preserving the original date/time suffix. Parsed dates retain precedence; the Claude parser, usage accounting, and provider boundaries are unchanged.

Fixes #3317. Thanks @Aternus for the report.

## Verification

- New regressions failed against the old formatter with 14 assertions, covering singular descriptions and localization in countdown and absolute display styles.
- `swift test --no-parallel --filter 'UsageFormatterTests|ClaudeCLIScopedWeeklyUsageTests|ProviderArchitectureGatekeeperTests'`: 101 tests across three suites passed after the fix. Coverage includes plural inputs, mixed case, surrounding whitespace, Unicode suffixes, unchanged non-prefix words, localized formatting keys, and parsed-date precedence.
- A signed, isolated XCTest host rendered the real `UsageMenuCardView.Model.make` → scoped metric → formatter → production usage section using the same synthetic snapshot before and after. Both display styles and light/dark appearances passed exact model and accessibility-text assertions. No real usage store, provider request, account information, or saved credentials were used.
- The snapshot explicitly has no parsed date, so the fallback regression is independent of the current date.
- Changelog and Claude CLI documentation updated.

Final `make check` passed with zero lint violations in 2,076 files. Independent Codex review found no accepted/actionable findings at the configured blocking threshold. Full `make test` passed all 82 groups on the first attempt, with zero failures, retries, or timeouts (1,596.2 seconds including discovery), on unchanged head `bf33ac2776b`. [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33428015049) passed all eight jobs, including both macOS shards, all three Linux builds, lint, and the aggregate gate. GitGuardian also passed.

## Before / after

The images below are synthetic production-component renders, not screenshots of a real account or a full menu interaction.

| Before | After |
| --- | --- |
| ![Before: duplicated reset label](https://github.com/user-attachments/assets/a5821a96-0af2-4bb7-88f0-bbd6f6fc9802) | ![After: normalized reset label](https://github.com/user-attachments/assets/ff166274-b07c-48ad-a646-2972fb8665f1) |
