### PR TITLE
fix: keep cached status submenus provider-scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Claude and Vertex AI: reuse model normalization and pricing lookups within each local scan, including unknown models, while preserving per-request dated and context-tier pricing.
 
 ### Fixed
+- Menu bar: keep status components and website links scoped to their provider when switching cached tabs, preventing Claude status from appearing under Grok or Codex (#3320). Thanks @gianpaj!
 - Usage & Spend: keep stalled or failed Codex catch-up paused until explicit Refresh, preventing background synchronization from restarting CPU-heavy scans (partial fix for #3316). Thanks @heyajulia!
 - Xiaomi MiMo: prevent overlapping local usage tracker updates from colliding on a shared temporary cache file, preserving atomic publication (#3321). Thanks @Lucenx9!
 - Claude: avoid duplicated “Resets Reset” labels when CLI usage supplies a singular reset description (#3317). Thanks @Aternus!

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -474,7 +474,8 @@ extension StatusItemController {
                 to: menu,
                 context: menuContext,
                 switcherSelection: contentSelection)
-            self.addActionableSections(context.descriptor.sections, to: menu, width: context.menuWidth)
+            self.addActionableSections(
+                context.descriptor.sections, to: menu, width: context.menuWidth, provider: context.currentProvider)
             self.cacheVisibleMergedSwitcherContent(
                 in: menu,
                 selection: contentSelection,
@@ -837,6 +838,7 @@ extension StatusItemController {
         _ sections: [MenuDescriptor.Section],
         to menu: NSMenu,
         width: CGFloat,
+        provider: UsageProvider?,
         captureMenu: NSMenu? = nil)
     {
         let actionableSections = sections.filter { section in section.entries.contains(where: \ .isActionable) }
@@ -897,7 +899,7 @@ extension StatusItemController {
                     self.attachStatusComponentsSubmenuIfNeeded(
                         to: item,
                         action: action,
-                        menu: captureMenu ?? menu,
+                        provider: provider,
                         width: width)
                     if case let .switchAccount(targetProvider) = action,
                        let subtitle = self.switchAccountSubtitle(for: targetProvider)
@@ -1615,12 +1617,12 @@ extension StatusItemController {
     func attachStatusComponentsSubmenuIfNeeded(
         to item: NSMenuItem,
         action: MenuDescriptor.MenuAction,
-        menu: NSMenu,
+        provider: UsageProvider?,
         width: CGFloat)
     {
         guard action == .statusPage,
-              let statusProvider = self.menuProvider(for: menu) ?? self.lastMenuProvider?.firstPartyProvider,
-              let submenu = self.makeStatusComponentsSubmenu(provider: statusProvider, width: width)
+              let provider,
+              let submenu = self.makeStatusComponentsSubmenu(provider: provider, width: width)
         else { return }
         item.action = nil
         item.submenu = submenu

--- a/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSmartUpdate.swift
@@ -140,6 +140,7 @@ extension StatusItemController {
             context.descriptor.sections,
             to: target,
             width: context.menuWidth,
+            provider: context.currentProvider,
             captureMenu: captureMenu)
     }
 }

--- a/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
@@ -9,25 +9,30 @@ extension StatusItemController {
         selectedProvider: UsageProvider?,
         descriptor: MenuDescriptor) -> CGFloat
     {
-        let sectionSets: [[MenuDescriptor.Section]] = if self.shouldMergeIcons, providers.count > 1 {
+        let sectionSets: [(provider: UsageProvider?, sections: [MenuDescriptor.Section])] = if self.shouldMergeIcons,
+                                                                                               providers.count > 1
+        {
             providers.map { provider in
                 if provider == selectedProvider {
-                    return descriptor.sections
+                    return (provider, descriptor.sections)
                 }
-                return self.makeMenuDescriptor(
+                return (provider, self.makeMenuDescriptor(
                     provider: provider,
-                    includeContextualActions: true).sections
+                    includeContextualActions: true).sections)
             }
         } else {
-            [descriptor.sections]
+            [(selectedProvider, descriptor.sections)]
         }
         return self.measuredMenuCardWidth(for: sectionSets)
     }
 
-    func measuredMenuCardWidth(for sectionSets: [[MenuDescriptor.Section]]) -> CGFloat {
+    func measuredMenuCardWidth(
+        for sectionSets: [(provider: UsageProvider?, sections: [MenuDescriptor.Section])]) -> CGFloat
+    {
         let baselineWidth = Self.menuCardBaseWidth
-        return sectionSets.reduce(baselineWidth) { width, sections in
-            max(width, self.measuredStandardMenuWidth(for: sections, baseWidth: baselineWidth))
+        return sectionSets.reduce(baselineWidth) { width, entry in
+            max(width, self.measuredStandardMenuWidth(
+                for: entry.sections, baseWidth: baselineWidth, provider: entry.provider))
         }
     }
 
@@ -52,15 +57,20 @@ extension StatusItemController {
             remoteAgentHosts: self.agentSessions.remoteHosts)
     }
 
-    func measuredStandardMenuWidth(for sections: [MenuDescriptor.Section], baseWidth: CGFloat) -> CGFloat {
-        let cacheKey = self.measuredStandardMenuWidthCacheKey(for: sections, baseWidth: baseWidth)
+    func measuredStandardMenuWidth(
+        for sections: [MenuDescriptor.Section],
+        baseWidth: CGFloat,
+        provider: UsageProvider? = nil) -> CGFloat
+    {
+        let cacheKey = self.measuredStandardMenuWidthCacheKey(
+            for: sections, baseWidth: baseWidth, provider: provider)
         if let cached = self.measuredStandardMenuWidthCache[cacheKey] {
             return cached
         }
 
         let measuringMenu = NSMenu()
         measuringMenu.autoenablesItems = false
-        self.addActionableSections(sections, to: measuringMenu, width: baseWidth)
+        self.addActionableSections(sections, to: measuringMenu, width: baseWidth, provider: provider)
         let measured = ceil(measuringMenu.size.width)
         if self.measuredStandardMenuWidthCache.count >= Self.measuredStandardMenuWidthCacheLimit {
             self.measuredStandardMenuWidthCache.removeAll(keepingCapacity: true)
@@ -71,10 +81,12 @@ extension StatusItemController {
 
     private func measuredStandardMenuWidthCacheKey(
         for sections: [MenuDescriptor.Section],
-        baseWidth: CGFloat) -> String
+        baseWidth: CGFloat,
+        provider: UsageProvider?) -> String
     {
         var parts = [
             "base=\(Int((baseWidth * 100).rounded()))",
+            "status=\(self.store.statusChecksEnabled):\(provider?.rawValue ?? "none")",
             "font=\(Self.menuCardHeightTextScaleToken())",
             self.menuLocalizationSignature(),
         ]

--- a/Tests/CodexBarTests/CodexWorkspacesNativeProofTests.swift
+++ b/Tests/CodexBarTests/CodexWorkspacesNativeProofTests.swift
@@ -44,7 +44,7 @@ final class CodexWorkspacesNativeProofTests: XCTestCase {
         let gateEnabled = CodexWorkspacesMenuAvailability.isEnabledForCurrentProcess
         let menu = NSMenu()
         let descriptor = controller.makeMenuDescriptor(provider: .codex, includeContextualActions: true)
-        controller.addActionableSections(descriptor.sections, to: menu, width: 320)
+        controller.addActionableSections(descriptor.sections, to: menu, width: 320, provider: .codex)
         let workspacesIndex = menu.items.firstIndex { $0.title == L("Workspaces") }
         XCTAssertEqual(workspacesIndex != nil, gateEnabled)
 

--- a/Tests/CodexBarTests/CodexWorkspacesNavigationTests.swift
+++ b/Tests/CodexBarTests/CodexWorkspacesNavigationTests.swift
@@ -74,7 +74,7 @@ struct CodexWorkspacesNavigationTests {
             includeContextualActions: true,
             codexWorkspacesMenuEnabled: true)
         let menu = NSMenu()
-        controller.addActionableSections(descriptor.sections, to: menu, width: 320)
+        controller.addActionableSections(descriptor.sections, to: menu, width: 320, provider: .codex)
 
         let item = try #require(menu.items.first { $0.title == L("Workspaces") })
         #expect(item.view == nil)
@@ -85,7 +85,7 @@ struct CodexWorkspacesNavigationTests {
         #expect(item.representedObject as? String == CodexWorkspacesWindowIdentity.menuItem)
 
         menu.removeAllItems()
-        controller.addActionableSections(descriptor.sections, to: menu, width: 320)
+        controller.addActionableSections(descriptor.sections, to: menu, width: 320, provider: .codex)
         #expect(menu.items.count(where: { $0.title == L("Workspaces") }) == 1)
     }
 

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -151,12 +151,12 @@ extension StatusMenuTests {
             ]),
         ]
 
-        let narrowWidth = controller.measuredMenuCardWidth(for: [narrow])
-        let stableWidth = controller.measuredMenuCardWidth(for: [narrow, wide])
+        let narrowWidth = controller.measuredMenuCardWidth(for: [(.codex, narrow)])
+        let stableWidth = controller.measuredMenuCardWidth(for: [(.codex, narrow), (.claude, wide)])
 
         #expect(narrowWidth == StatusItemController.menuCardBaseWidth)
         #expect(stableWidth > narrowWidth)
-        #expect(controller.measuredMenuCardWidth(for: [wide, narrow]) == stableWidth)
+        #expect(controller.measuredMenuCardWidth(for: [(.claude, wide), (.codex, narrow)]) == stableWidth)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -994,7 +994,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "The memory-pressure debug fixture installs its synthetic entry in the Codex cache slot."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1100,
+            line: 1102,
             anchor: "controller.refreshOpenMenuIfStillVisible(menu, provider: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -2534,7 +2534,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1133,
+            line: 1135,
             anchor: "return .provider((self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex).instanceID)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2542,7 +2542,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1146,
+            line: 1148,
             anchor: "return self.store.enabledFirstPartyProvidersForDisplay().first ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
@@ -142,7 +142,7 @@ extension StatusMenuTests {
         #expect(controller.measuredStandardMenuWidthCache.count == 1)
 
         let menu = NSMenu()
-        controller.addActionableSections([longSection], to: menu, width: longWidth)
+        controller.addActionableSections([longSection], to: menu, width: longWidth, provider: nil)
         guard menu.items.indices.contains(1),
               case let .action(title, .focusAgentSession) = longSection.entries[1],
               let view = menu.items[1].view

--- a/Tests/CodexBarTests/StatusMenuProviderNativeProofTests.swift
+++ b/Tests/CodexBarTests/StatusMenuProviderNativeProofTests.swift
@@ -1,0 +1,155 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import XCTest
+@testable import CodexBar
+
+/// Opt-in native menu proof with disposable settings and no provider transports.
+@MainActor
+final class StatusMenuProviderNativeProofTests: XCTestCase {
+    func test_warmedStatusProviderMenu() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let directoryPath = environment["CODEXBAR_STATUS_PROVIDER_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_STATUS_PROVIDER_PROOF_DIR for isolated native UI proof.")
+        }
+        guard SettingsStore.isRunningTests,
+              environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment[CodexCredentialFileAccess.isolationEnvironmentKey] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1",
+              environment["CODEXBAR_TEST_CODEX_FILE_FIXTURES"] == nil
+        else {
+            return XCTFail("Native proof requires credential and session isolation.")
+        }
+        let directory = URL(fileURLWithPath: directoryPath, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fixture = try CodexWorkspacesNavigationFixture()
+        defer { fixture.cleanup() }
+        let providers: [UsageProvider] = [.claude, .codex, .grok]
+        for provider in providers {
+            fixture.settings.setProviderEnabled(
+                provider: provider,
+                metadata: ProviderDescriptorRegistry.descriptor(for: provider).metadata,
+                enabled: true)
+            _ = fixture.settings.setMergedOverviewProviderSelection(
+                provider: provider,
+                isSelected: false,
+                activeProviders: providers)
+        }
+        fixture.settings.mergeIcons = true
+        fixture.settings.selectedMenuProvider = .claude
+        fixture.settings.mergedMenuLastSelectedWasOverview = false
+        fixture.settings.statusChecksEnabled = true
+        for provider in providers {
+            fixture.store._setSnapshotForTesting(
+                UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: 25,
+                        windowMinutes: 300,
+                        resetsAt: Date().addingTimeInterval(3600),
+                        resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: Date()),
+                provider: provider)
+        }
+        fixture.store.statusComponents[.claude] = [
+            ProviderStatusComponent(id: "claude", name: "Claude.ai", indicator: .none, status: "operational"),
+        ]
+        fixture.store.statusComponents[.codex] = [
+            ProviderStatusComponent(id: "codex", name: "Codex", indicator: .none, status: "operational"),
+        ]
+
+        let oldRendering = StatusItemController.menuCardRenderingEnabled
+        let oldRefresh = StatusItemController.menuRefreshEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = oldRendering
+            StatusItemController.setMenuRefreshEnabledForTesting(oldRefresh)
+        }
+        let controller = fixture.makeController()
+        defer { controller.releaseStatusItemsForTesting() }
+        let menu = try XCTUnwrap(controller.mergedMenu)
+        let application = NSApplication.shared
+        guard application.delegate == nil, UserDefaults.standard.object(forKey: "NSOpen") == nil else {
+            return XCTFail("Native proof requires a standalone test application.")
+        }
+        let oldPolicy = application.activationPolicy()
+        let previousApplication = NSWorkspace.shared.frontmostApplication
+        let host = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 160),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        host.title = "CodexBar Synthetic Status Proof"
+        host.isReleasedWhenClosed = false
+        host.center()
+        let button = StatusProviderProofButton(frame: NSRect(x: 140, y: 65, width: 200, height: 32))
+        button.title = "Open provider menu"
+        button.proofMenu = menu
+        button.target = button
+        button.action = #selector(StatusProviderProofButton.openMenu)
+        host.contentView?.addSubview(button)
+        defer {
+            menu.cancelTracking()
+            host.close()
+            _ = application.setActivationPolicy(oldPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApplication?.activate()
+            }
+        }
+        XCTAssertTrue(application.setActivationPolicy(.regular))
+        application.finishLaunching()
+        application.activate(ignoringOtherApps: true)
+        host.makeKeyAndOrderFront(nil)
+
+        // Common-mode receipts keep updating while the external driver interacts with NSMenu.
+        let timer = Timer(timeInterval: 0.1, repeats: true) { _ in
+            MainActor.assumeIsolated {
+                guard let menu = button.proofMenu else { return }
+                let statusItem = menu.items.first { $0.title == L("Status Page") }
+                let submenu = statusItem?.submenu
+                let receipt: [String: String] = [
+                    "pid": String(ProcessInfo.processInfo.processIdentifier),
+                    "window": String(host.windowNumber),
+                    "selected": fixture.settings.selectedMenuProvider?.rawValue ?? "none",
+                    "statusProvider": submenu?.items.first?.toolTip
+                        ?? submenu?.items.last?.identifier?.rawValue ?? "website-only",
+                    "cachedSelections": String(controller.mergedSwitcherContentCaches[ObjectIdentifier(menu)]?
+                        .count ?? 0),
+                ]
+                do {
+                    try JSONEncoder().encode(receipt).write(
+                        to: directory.appendingPathComponent("state.json"), options: .atomic)
+                } catch {
+                    XCTFail("Could not write native proof receipt: \(error)")
+                }
+                if FileManager.default.fileExists(atPath: directory.appendingPathComponent("done").path) {
+                    menu.cancelTracking()
+                }
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        defer { timer.invalidate() }
+        let deadline = Date().addingTimeInterval(600)
+        let done = directory.appendingPathComponent("done").path
+        while !FileManager.default.fileExists(atPath: done), Date() < deadline {
+            if let event = application.nextEvent(
+                matching: .any, until: Date().addingTimeInterval(0.02), inMode: .default, dequeue: true)
+            {
+                application.sendEvent(event)
+            }
+            _ = RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: done), "Native proof timed out")
+    }
+}
+
+@MainActor
+private final class StatusProviderProofButton: NSButton {
+    var proofMenu: NSMenu?
+
+    @objc func openMenu() {
+        self.proofMenu?.popUp(positioning: nil, at: NSPoint(x: 0, y: self.bounds.maxY), in: self)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuSwitcherWarmupTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherWarmupTests.swift
@@ -8,23 +8,28 @@ import XCTest
 /// switch attaches cached, pre-laid-out rows (flicker fix follow-up).
 @MainActor
 final class StatusMenuSwitcherWarmupTests: XCTestCase {
-    private func makeController() -> (controller: StatusItemController, menu: NSMenu) {
+    private func makeController(
+        selectedProvider: UsageProvider = .codex,
+        statusChecksEnabled: Bool = false) -> (controller: StatusItemController, menu: NSMenu)
+    {
         StatusItemController.menuCardRenderingEnabled = false
         StatusItemController.setMenuRefreshEnabledForTesting(false)
         let settings = testSettingsStore(
             suiteName: "StatusMenuSwitcherWarmupTests",
             tokenAccountStore: InMemoryTokenAccountStore())
         settings.providerDetectionCompleted = true
-        settings.statusChecksEnabled = false
+        settings.statusChecksEnabled = statusChecksEnabled
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
+        settings.selectedMenuProvider = selectedProvider.instanceID
+        settings.mergedMenuLastSelectedWasOverview = false
         let registry = ProviderRegistry.shared
         for provider in UsageProvider.allCases {
             guard let metadata = registry.metadata[provider] else { continue }
             settings.setProviderEnabled(
                 provider: provider,
                 metadata: metadata,
-                enabled: provider == .claude || provider == .codex)
+                enabled: [.claude, .codex, .grok].contains(provider))
         }
 
         let fetcher = UsageFetcher()
@@ -32,7 +37,7 @@ final class StatusMenuSwitcherWarmupTests: XCTestCase {
         let controller = StatusItemController(
             store: store,
             settings: settings,
-            account: fetcher.loadAccountInfo(),
+            account: AccountInfo(email: nil, plan: nil),
             updater: DisabledUpdaterController(),
             preferencesSelection: PreferencesSelection(),
             statusBar: testStatusBar())
@@ -94,6 +99,71 @@ final class StatusMenuSwitcherWarmupTests: XCTestCase {
         XCTAssertEqual(firstItems?.count, secondItems?.count)
         for (selection, items) in firstItems ?? [:] {
             XCTAssertTrue(secondItems?[selection]?.elementsEqual(items, by: ===) == true)
+        }
+    }
+
+    func test_warmedStatusSubmenusRemainScopedAcrossSwitchesAndReopen() throws {
+        for initialProvider: UsageProvider in [.claude, .codex, .grok] {
+            for provider: UsageProvider in [.grok, .codex, .claude] where provider != initialProvider {
+                let (controller, menu) = self.makeController(
+                    selectedProvider: initialProvider,
+                    statusChecksEnabled: true)
+                defer { controller.releaseStatusItemsForTesting() }
+                controller.warmMergedSwitcherSiblingContent(in: menu)
+                let caches = try XCTUnwrap(controller.mergedSwitcherContentCaches[ObjectIdentifier(menu)])
+                let cached = try XCTUnwrap(caches[.provider(provider.instanceID)])
+                let cachedStatus = try XCTUnwrap(cached.items.first { $0.title == L("Status Page") })
+                try self.assertStatusProvider(provider, item: cachedStatus, controller: controller)
+
+                controller.preservingMergedSwitcherContentCachesDuringInvalidation {
+                    controller.selectedMenuProvider = provider.instanceID
+                }
+                controller.updateMenuContentPreservingSwitcher(
+                    menu,
+                    context: StatusItemController.MenuUpdateContext(
+                        provider: provider,
+                        currentProvider: provider,
+                        switcherSelection: .provider(provider.instanceID),
+                        menuWidth: controller.menuCardWidth(
+                            for: controller.store.enabledFirstPartyProvidersForDisplay(),
+                            selectedProvider: provider,
+                            descriptor: controller.makeMenuDescriptor(
+                                provider: provider, includeContextualActions: true)),
+                        codexAccountDisplay: nil,
+                        tokenAccountDisplay: nil,
+                        openAIContext: controller.openAIWebContext(currentProvider: provider, showAllAccounts: false),
+                        descriptor: controller.makeMenuDescriptor(provider: provider, includeContextualActions: true)))
+                let liveStatus = try XCTUnwrap(menu.items.first { $0.title == L("Status Page") })
+                XCTAssertTrue(liveStatus.submenu === cachedStatus.submenu)
+                try self.assertStatusProvider(provider, item: liveStatus, controller: controller)
+
+                controller.menuDidClose(menu)
+                controller.menuWillOpen(menu)
+                try self.assertStatusProvider(
+                    provider,
+                    item: XCTUnwrap(menu.items.first { $0.title == L("Status Page") }),
+                    controller: controller)
+            }
+        }
+    }
+
+    private func assertStatusProvider(
+        _ provider: UsageProvider,
+        item: NSMenuItem,
+        controller: StatusItemController) throws
+    {
+        if provider == .grok {
+            XCTAssertNil(item.submenu, "Grok has a website link, not another provider's components")
+            XCTAssertEqual(item.action, #selector(StatusItemController.openStatusPage))
+        } else {
+            let submenu = try XCTUnwrap(item.submenu)
+            if submenu.items.first?.identifier == nil {
+                XCTAssertTrue(controller.hydrateHostedSubviewMenuIfNeeded(submenu))
+            }
+            let link = try XCTUnwrap(submenu.items.last)
+            XCTAssertEqual(link.identifier?.rawValue, provider.rawValue)
+            XCTAssertEqual(link.action, #selector(StatusItemController.openStatusPageFromMenuItem(_:)))
+            XCTAssertTrue(link.target === controller)
         }
     }
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -15,6 +15,7 @@ read_when:
 - Toggle: Settings → Advanced → “Check provider status”.
 - `UsageStore` polls status and stores `ProviderStatus` for indicator/description.
 - Menu shows incident summary + freshness; icon overlays indicator.
+- Cached provider tabs retain their own status components and website links, including on the first switch after opening the merged menu; providers without a curated component submenu keep a plain website link.
 
 ## Workspace incidents
 - Feed: `https://www.google.com/appsstatus/dashboard/incidents.json`.


### PR DESCRIPTION
Fixes #3320.

Background menu warmup built each sibling's status submenu from the provider selected in the live capture menu. Opening Claude could therefore cache Claude's component list under Grok or Codex. The provider cards themselves were already built from the correct provider.

Pass the rendered provider explicitly through action-row construction and width measurement. Keep the live menu for interaction ownership only; remove the selected/last-provider fallback from status submenu construction. Preserve existing warmup, cache reuse, curated component feeds, and website-only status actions. Width cache keys now include the rendering provider and status-check setting.

Regression coverage exercises all six directed switches between Claude, Codex, and Grok, verifies the warmed cache payload and submenu reuse, hydrates provider-scoped links, and checks close/reopen behavior. Includes an opt-in signed native proof fixture using disposable settings, synthetic snapshots/components, credential/session isolation, and a provider-transport trap.

### Verification

- Current-main regression reproduced wrong-provider submenus and missing expected submenus before the fix.
- `swift test --no-parallel --filter 'StatusMenuSwitcherWarmupTests|StatusMenuHostedSubmenuRefreshTests|StatusMenuSwitcherRefreshTests|MenuCardViewRecyclingTests|StatusMenuHeightCacheTests|ProviderArchitectureGatekeeperTests'`: 102 tests passed. Three exact architecture-anchor line numbers moved with the source; policy/fingerprints are unchanged.
- `make check`: passed, zero lint violations across 2,077 files.
- Codex autoreview: scoped clean, no accepted/actionable findings at the configured P0 threshold; maintainer source review also completed.
- Matching Developer ID-signed XCTest host, real NSMenu and provider switcher driven with Peekaboo: first Claude → Grok switch keeps a plain website action; Codex shows its own component and `codex` link identity; close/reopen Claude shows Claude.ai and `claude` link identity. Three warmed cache selections observed. No real provider probes, saved-account reads, or installed-app restart.
- Full `make test`: all 82 groups / 982 selections passed on the first attempt, zero failed groups, retries, or timeouts (954.4 seconds).
- Exact-head [CI](https://github.com/steipete/CodexBar/actions/runs/33433789358): all eight required jobs passed, including both macOS shards, all three Linux builds, lint, and the aggregate check; GitGuardian also passed. No CI failure or retry was needed.

The initial native harness setup attempt used a detached menu and hit its provider-refresh trap; no provider transport ran. The corrected proof uses the controller-owned merged menu and fresh synthetic usage snapshots. Public screenshots below contain only the synthetic test host's windows; unrelated desktop captures were excluded.

### Before / after

Before: reporter-provided screenshot from #3320 (Grok incorrectly shows Claude components).

![Reported wrong-provider status submenu](https://github.com/user-attachments/assets/6fea8ebc-57a3-4f45-bf75-a40197e3f99f)

After: synthetic native Grok menu, with its plain status-page action.

![Grok keeps a plain status-page action](https://github.com/user-attachments/assets/80c5309f-cf6f-460f-ad85-990995d74974)

After: the same native menu switched to Codex and its status submenu opened.

![Codex shows its own status component](https://github.com/user-attachments/assets/47ae7ecb-359e-40e8-86b8-41535094259e)

Changelog and status documentation updated. Thanks @gianpaj for the report and follow-up.
