### PR TITLE
perf(test): prefilter provider architecture scan

### DIFF
--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -302,6 +302,29 @@ struct ProviderArchitectureGatekeeperTests {
     }
 
     @Test
+    func `provider candidate prefilter preserves recognized lexical shapes`() {
+        let providerIDs: Set = ["claude", "codex", "cursor", "gemini"]
+        let fixtures: [(source: String, expected: Set<String>)] = [
+            ("makeRow(provider: .claude)", ["claude"]),
+            ("let provider = UsageProvider.codex", ["codex"]),
+            (#"let provider = "cursor""#, ["cursor"]),
+            (#"let provider = ".gemini.""#, ["gemini"]),
+            (#"let provider = "\(choose(.claude))""#, ["claude"]),
+            (#"let url = "https://example.com/codex""#, []),
+            ("let value = object.cursorBudget", []),
+            ("let value = unrelated", []),
+        ]
+
+        for fixture in fixtures {
+            let literals = Self.quotedStringLiterals(in: fixture.source)
+            #expect(Self.providerIDCandidates(
+                in: fixture.source,
+                quotedLiterals: literals,
+                providerIDs: providerIDs) == fixture.expected)
+        }
+    }
+
+    @Test
     func `provider reference scanner sees through inline block comments`() {
         let assignment = "let provider: UsageProvider = /* fallback */ .claude"
         let labeled = "choose(provider: /* fallback */ .claude)"
@@ -4080,12 +4103,16 @@ struct ProviderArchitectureGatekeeperTests {
             let code = self.codeBeforeLineComment(line)
             guard !code.trimmingCharacters(in: .whitespaces).isEmpty else { return [] }
             let quotedLiterals = self.quotedStringLiterals(in: code)
+            let providerIDCandidates = self.providerIDCandidates(
+                in: code,
+                quotedLiterals: quotedLiterals,
+                providerIDs: providerIDs)
             let plainStringRanges = quotedLiterals.compactMap { literal -> Range<String.Index>? in
                 code[literal.range].contains("\\(") ? nil : literal.range
             }
             var matches: [String] = []
             var newlyRecognizedMatches: [String] = []
-            for providerID in providerIDs {
+            for providerID in providerIDs where providerIDCandidates.contains(providerID) {
                 for strength in self.dottedProviderReferenceStrengths(
                     providerID,
                     in: code,
@@ -4099,15 +4126,17 @@ struct ProviderArchitectureGatekeeperTests {
                 }
             }
             for literal in quotedLiterals {
-                for providerID in providerIDs where self.isProviderIDLiteral(
-                    providerID,
-                    literal: literal.value,
-                    range: literal.range,
-                    line: code,
-                    statement: statementContexts[index])
-                {
-                    matches.append(providerID)
-                }
+                let normalizedLiteral = literal.value.lowercased()
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+                guard providerIDCandidates.contains(normalizedLiteral),
+                      self.isProviderIDLiteral(
+                          normalizedLiteral,
+                          literal: literal.value,
+                          range: literal.range,
+                          line: code,
+                          statement: statementContexts[index])
+                else { continue }
+                matches.append(normalizedLiteral)
             }
             guard !matches.isEmpty else { return [] }
             return [ProviderReference(
@@ -4115,6 +4144,38 @@ struct ProviderArchitectureGatekeeperTests {
                 providerOccurrences: matches,
                 newlyRecognizedProviderOccurrences: newlyRecognizedMatches)]
         }
+    }
+
+    private static func providerIDCandidates(
+        in line: String,
+        quotedLiterals: [QuotedStringLiteral],
+        providerIDs: Set<String>) -> Set<String>
+    {
+        var candidates: Set<String> = []
+        var searchStart = line.startIndex
+        while let dot = line[searchStart...].firstIndex(of: ".") {
+            let identifierStart = line.index(after: dot)
+            var identifierEnd = identifierStart
+            while identifierEnd < line.endIndex, self.isIdentifierCharacter(line[identifierEnd]) {
+                identifierEnd = line.index(after: identifierEnd)
+            }
+            if identifierStart < identifierEnd {
+                let identifier = String(line[identifierStart..<identifierEnd])
+                if providerIDs.contains(identifier) {
+                    candidates.insert(identifier)
+                }
+            }
+            searchStart = identifierEnd
+        }
+
+        for literal in quotedLiterals {
+            let normalizedLiteral = literal.value.lowercased()
+                .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            if providerIDs.contains(normalizedLiteral) {
+                candidates.insert(normalizedLiteral)
+            }
+        }
+        return candidates
     }
 
     private enum ProviderReferenceStrength: Equatable {

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -303,7 +303,8 @@ struct ProviderArchitectureGatekeeperTests {
 
     @Test
     func `provider candidate prefilter preserves recognized lexical shapes`() {
-        let providerIDs: Set = ["claude", "codex", "cursor", "gemini"]
+        let providerIDs: Set = ["claude", "codex", "cursor", "gemini", "foo-bar", "foo.bar", "🦞"]
+        let exactDottedCandidates = Self.exactDottedProviderIDCandidates(providerIDs)
         let fixtures: [(source: String, expected: Set<String>)] = [
             ("makeRow(provider: .claude)", ["claude"]),
             ("let provider = UsageProvider.codex", ["codex"]),
@@ -312,6 +313,9 @@ struct ProviderArchitectureGatekeeperTests {
             (#"let provider = "\(choose(.claude))""#, ["claude"]),
             (#"let url = "https://example.com/codex""#, []),
             ("let value = object.cursorBudget", []),
+            ("return .foo-bar", ["foo-bar"]),
+            ("return .foo.bar", ["foo.bar"]),
+            ("return .🦞", ["🦞"]),
             ("let value = unrelated", []),
         ]
 
@@ -320,8 +324,30 @@ struct ProviderArchitectureGatekeeperTests {
             #expect(Self.providerIDCandidates(
                 in: fixture.source,
                 quotedLiterals: literals,
-                providerIDs: providerIDs) == fixture.expected)
+                providerIDs: providerIDs,
+                exactDottedCandidates: exactDottedCandidates) == fixture.expected)
         }
+    }
+
+    @Test
+    func `provider reference scanner preserves symbolic provider IDs`() {
+        for providerID in ["foo-bar", "foo.bar", "🦞"] {
+            let dotted = Self.providerReferences(in: "return .\(providerID)", providerIDs: [providerID])
+            let literal = Self.providerReferences(in: "return \"\(providerID)\"", providerIDs: [providerID])
+            let suffixed = Self.providerReferences(in: "return .\(providerID)Suffix", providerIDs: [providerID])
+            let quoted = Self.providerReferences(
+                in: "let value = \"prefix .\(providerID) suffix\"",
+                providerIDs: [providerID])
+
+            #expect(dotted.first?.providerIDs == [providerID])
+            #expect(literal.first?.providerIDs == [providerID])
+            #expect(suffixed.isEmpty)
+            #expect(quoted.isEmpty)
+        }
+
+        #expect(Self.providerReferences(in: "return .", providerIDs: [""]).first?.providerIDs == [""])
+        #expect(Self.providerReferences(in: "return .member", providerIDs: [""]).isEmpty)
+        #expect(Self.providerReferences(in: "return \"\"", providerIDs: [""]).isEmpty)
     }
 
     @Test
@@ -4099,6 +4125,7 @@ struct ProviderArchitectureGatekeeperTests {
     private static func providerReferences(in source: String, providerIDs: Set<String>) -> [ProviderReference] {
         let lines = source.components(separatedBy: .newlines)
         let statementContexts = self.statementContexts(for: lines)
+        let exactDottedCandidates = self.exactDottedProviderIDCandidates(providerIDs)
         return lines.enumerated().flatMap { index, line -> [ProviderReference] in
             let code = self.codeBeforeLineComment(line)
             guard !code.trimmingCharacters(in: .whitespaces).isEmpty else { return [] }
@@ -4106,7 +4133,8 @@ struct ProviderArchitectureGatekeeperTests {
             let providerIDCandidates = self.providerIDCandidates(
                 in: code,
                 quotedLiterals: quotedLiterals,
-                providerIDs: providerIDs)
+                providerIDs: providerIDs,
+                exactDottedCandidates: exactDottedCandidates)
             let plainStringRanges = quotedLiterals.compactMap { literal -> Range<String.Index>? in
                 code[literal.range].contains("\\(") ? nil : literal.range
             }
@@ -4146,10 +4174,22 @@ struct ProviderArchitectureGatekeeperTests {
         }
     }
 
+    private static func exactDottedProviderIDCandidates(
+        _ providerIDs: Set<String>) -> [(providerID: String, needle: String)]
+    {
+        providerIDs.compactMap { providerID in
+            guard providerID.isEmpty || providerID.contains(where: { !self.isIdentifierCharacter($0) }) else {
+                return nil
+            }
+            return (providerID, ".\(providerID)")
+        }
+    }
+
     private static func providerIDCandidates(
         in line: String,
         quotedLiterals: [QuotedStringLiteral],
-        providerIDs: Set<String>) -> Set<String>
+        providerIDs: Set<String>,
+        exactDottedCandidates: [(providerID: String, needle: String)]) -> Set<String>
     {
         var candidates: Set<String> = []
         var searchStart = line.startIndex
@@ -4166,6 +4206,12 @@ struct ProviderArchitectureGatekeeperTests {
                 }
             }
             searchStart = identifierEnd
+        }
+
+        // This is only candidate admission. The unchanged dotted scanner below rechecks plain-string ranges,
+        // identifier boundaries, and policy positions before producing a reference.
+        for candidate in exactDottedCandidates where line.contains(candidate.needle) {
+            candidates.insert(candidate.providerID)
         }
 
         for literal in quotedLiterals {


### PR DESCRIPTION
Closes #3327

## Summary

- derive the small set of provider IDs that can occur on each source line before running the expensive dotted-reference classifier
- normalize quoted provider literals once instead of testing every provider ID
- preserve the legacy scanner for symbolic Swift identifiers such as emoji or punctuation-bearing IDs through a precomputed exact-match fallback; all 69 current provider IDs stay on the fast path
- cover dotted cases, qualified cases, raw literals, interpolations, URLs, identifier suffixes, quoted text, empty IDs, and unrelated lines

This changes only the architecture gatekeeper test scanner. Production code, test-runner behavior, sharding, retries, and time allowances are unchanged.

## Equivalence proof

I temporarily kept the pre-change scanner beside the candidate and compared their exact `[ProviderReference]` output for every shipped Swift source, using all 69 current provider IDs and the existing provider-owned-folder exclusion. I repeated the comparison after maintainer hardening with a symbolic-ID corpus covering emoji, punctuation, empty IDs, suffix boundaries, log literals, and URLs. Both comparisons produced no differences in matched file/line positions, occurrence multiplicity and order, provider IDs, or newly-recognized occurrence tracking.

The temporary legacy scanner was then removed. Permanent regressions retain the relevant lexical, symbolic-ID, and false-positive boundaries without carrying the old lines × providers implementation.

## Performance

The contributor's paired baseline measured the gatekeeper suite at a 26.605s median and the candidate at 4.379s. After rebasing and hardening, three local no-build runs measured the final suite at 4.566s, 4.244s, and 4.366s (4.366s median); warm command wall times were 5.27s and 5.36s. The symbolic fallback is empty for today's provider set, so it does not change the fast path.

## Verification

- focused `ProviderArchitectureGatekeeperTests`: 41/41 passed
- temporary legacy-vs-candidate shipped-source and symbolic-corpus differential: exact match
- `make check`
- final Codex autoreview: no actionable P0-P2 findings
- `make test` under isolated file, session, defaults, and Keychain settings with non-timeout retries disabled: 994 selections, 83/83 groups passed on the first attempt, 0 retries, 0 timeouts
- hosted CI: https://github.com/steipete/CodexBar/actions/runs/33611499077

Receipts:

- base: `98b86f39db63d230e2a7f78cdb013a845af33213`
- rebased contributor commit: `0cce565d290854f8d4c754a8495282acb989f0a0`
- final candidate: `fee5d0d58ced8ef87d930672a6e1d9c5bffefdde`
- final tree: `8c8e03eb24db76640db368d8d0a831c66f776adc`
