### PR TITLE
Speed up PTY fast-exit stress test

### DIFF
--- a/Tests/CodexBarTests/TTYCommandRunnerTests.swift
+++ b/Tests/CodexBarTests/TTYCommandRunnerTests.swift
@@ -6,13 +6,9 @@ import Testing
 struct TTYCommandRunnerEnvTests {
     private static let harnessPTYTimeout: TimeInterval = 10
 
-    private struct FastExitIterationError: Error, CustomStringConvertible {
+    private struct FastExitIterationOutcome: Sendable {
         let iteration: Int
-        let details: String
-
-        var description: String {
-            "PTY fast-exit iteration \(self.iteration) failed: \(self.details)"
-        }
+        let failureDetails: String?
     }
 
     private final class CallbackCounter: @unchecked Sendable {
@@ -259,19 +255,54 @@ struct TTYCommandRunnerEnvTests {
     }
 
     @Test
-    func `fast process exit drains buffered PTY output`() async throws {
+    func `fast process exit drains buffered PTY output`() async {
         let iterationCount = 50
         let concurrencyLimit = 4
 
-        let completedIterations = try await withThrowingTaskGroup(of: Int.self, returning: [Int].self) { group in
+        let outcomes = await Self.runFastExitIterations(
+            iterationCount: iterationCount,
+            concurrencyLimit: concurrencyLimit)
+        { iteration in
+            Self.runFastExitIteration(iteration)
+        }
+
+        #expect(outcomes.map(\.iteration).sorted() == Array(0..<iterationCount))
+        #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+        for outcome in outcomes.sorted(by: { $0.iteration < $1.iteration }) {
+            #expect(
+                outcome.failureDetails == nil,
+                "PTY fast-exit iteration \(outcome.iteration) failed: \(outcome.failureDetails ?? "unknown failure")")
+        }
+    }
+
+    @Test
+    func `fast exit scheduler drains all iterations after a failure`() async {
+        let iterationCount = 50
+        let outcomes = await Self.runFastExitIterations(iterationCount: iterationCount, concurrencyLimit: 4) {
+            iteration in
+            FastExitIterationOutcome(
+                iteration: iteration,
+                failureDetails: iteration == 7 ? "injected missing output" : nil)
+        }
+
+        #expect(outcomes.map(\.iteration).sorted() == Array(0..<iterationCount))
+        #expect(outcomes.compactMap { $0.failureDetails == nil ? nil : $0.iteration } == [7])
+    }
+
+    private static func runFastExitIterations(
+        iterationCount: Int,
+        concurrencyLimit: Int,
+        operation: @escaping @Sendable (Int) -> FastExitIterationOutcome) async -> [FastExitIterationOutcome]
+    {
+        await withTaskGroup(of: FastExitIterationOutcome.self, returning: [FastExitIterationOutcome].self) { group in
             var nextIteration = 0
-            var completed: [Int] = []
+            var completed: [FastExitIterationOutcome] = []
 
             func addNextIteration() {
                 let iteration = nextIteration
                 nextIteration += 1
                 group.addTask {
-                    try Self.runFastExitIteration(iteration)
+                    operation(iteration)
                 }
             }
 
@@ -279,8 +310,8 @@ struct TTYCommandRunnerEnvTests {
                 addNextIteration()
             }
 
-            while let iteration = try await group.next() {
-                completed.append(iteration)
+            while let outcome = await group.next() {
+                completed.append(outcome)
                 if nextIteration < iterationCount {
                     addNextIteration()
                 }
@@ -288,12 +319,9 @@ struct TTYCommandRunnerEnvTests {
 
             return completed
         }
-
-        #expect(completedIterations.sorted() == Array(0..<iterationCount))
-        #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
     }
 
-    private static func runFastExitIteration(_ iteration: Int) throws -> Int {
+    private static func runFastExitIteration(_ iteration: Int) -> FastExitIterationOutcome {
         let expected = "pty-drain-race"
         let runner = TTYCommandRunner()
 
@@ -309,16 +337,13 @@ struct TTYCommandRunnerEnvTests {
                     settleAfterStop: 0,
                     returnOnEmptyProcessExit: true))
             let clean = result.text.replacingOccurrences(of: "\r", with: "")
-            guard clean.contains(expected) else {
-                throw FastExitIterationError(
-                    iteration: iteration,
-                    details: "PTY output was missing; completion: \(result.completion)")
-            }
-            return iteration
-        } catch let error as FastExitIterationError {
-            throw error
+            return FastExitIterationOutcome(
+                iteration: iteration,
+                failureDetails: clean.contains(expected)
+                    ? nil
+                    : "PTY output was missing; completion: \(result.completion)")
         } catch {
-            throw FastExitIterationError(iteration: iteration, details: String(describing: error))
+            return FastExitIterationOutcome(iteration: iteration, failureDetails: String(describing: error))
         }
     }
 

--- a/Tests/CodexBarTests/TTYCommandRunnerTests.swift
+++ b/Tests/CodexBarTests/TTYCommandRunnerTests.swift
@@ -6,6 +6,15 @@ import Testing
 struct TTYCommandRunnerEnvTests {
     private static let harnessPTYTimeout: TimeInterval = 10
 
+    private struct FastExitIterationError: Error, CustomStringConvertible {
+        let iteration: Int
+        let details: String
+
+        var description: String {
+            "PTY fast-exit iteration \(self.iteration) failed: \(self.details)"
+        }
+    }
+
     private final class CallbackCounter: @unchecked Sendable {
         private let lock = NSLock()
         private var count = 0
@@ -250,11 +259,45 @@ struct TTYCommandRunnerEnvTests {
     }
 
     @Test
-    func `fast process exit drains buffered PTY output`() throws {
+    func `fast process exit drains buffered PTY output`() async throws {
+        let iterationCount = 50
+        let concurrencyLimit = 4
+
+        let completedIterations = try await withThrowingTaskGroup(of: Int.self, returning: [Int].self) { group in
+            var nextIteration = 0
+            var completed: [Int] = []
+
+            func addNextIteration() {
+                let iteration = nextIteration
+                nextIteration += 1
+                group.addTask {
+                    try Self.runFastExitIteration(iteration)
+                }
+            }
+
+            for _ in 0..<min(iterationCount, concurrencyLimit) {
+                addNextIteration()
+            }
+
+            while let iteration = try await group.next() {
+                completed.append(iteration)
+                if nextIteration < iterationCount {
+                    addNextIteration()
+                }
+            }
+
+            return completed
+        }
+
+        #expect(completedIterations.sorted() == Array(0..<iterationCount))
+        #expect(TTYCommandRunner._test_trackedProcessCount() == 0)
+    }
+
+    private static func runFastExitIteration(_ iteration: Int) throws -> Int {
         let expected = "pty-drain-race"
         let runner = TTYCommandRunner()
 
-        for iteration in 0..<50 {
+        do {
             let result = try runner.run(
                 binary: "/bin/echo",
                 send: "",
@@ -266,9 +309,16 @@ struct TTYCommandRunnerEnvTests {
                     settleAfterStop: 0,
                     returnOnEmptyProcessExit: true))
             let clean = result.text.replacingOccurrences(of: "\r", with: "")
-            #expect(
-                clean.contains(expected),
-                "PTY output was missing on iteration \(iteration); completion: \(result.completion)")
+            guard clean.contains(expected) else {
+                throw FastExitIterationError(
+                    iteration: iteration,
+                    details: "PTY output was missing; completion: \(result.completion)")
+            }
+            return iteration
+        } catch let error as FastExitIterationError {
+            throw error
+        } catch {
+            throw FastExitIterationError(iteration: iteration, details: String(describing: error))
         }
     }
 

--- a/Tests/CodexBarTests/TTYCommandRunnerTests.swift
+++ b/Tests/CodexBarTests/TTYCommandRunnerTests.swift
@@ -278,12 +278,14 @@ struct TTYCommandRunnerEnvTests {
     @Test
     func `fast exit scheduler drains all iterations after a failure`() async {
         let iterationCount = 50
-        let outcomes = await Self.runFastExitIterations(iterationCount: iterationCount, concurrencyLimit: 4) {
-            iteration in
-            FastExitIterationOutcome(
-                iteration: iteration,
-                failureDetails: iteration == 7 ? "injected missing output" : nil)
-        }
+        let outcomes = await Self.runFastExitIterations(
+            iterationCount: iterationCount,
+            concurrencyLimit: 4,
+            operation: { iteration in
+                FastExitIterationOutcome(
+                    iteration: iteration,
+                    failureDetails: iteration == 7 ? "injected missing output" : nil)
+            })
 
         #expect(outcomes.map(\.iteration).sorted() == Array(0..<iterationCount))
         #expect(outcomes.compactMap { $0.failureDetails == nil ? nil : $0.iteration } == [7])
@@ -298,7 +300,7 @@ struct TTYCommandRunnerEnvTests {
             var nextIteration = 0
             var completed: [FastExitIterationOutcome] = []
 
-            func addNextIteration() {
+            for _ in 0..<min(iterationCount, concurrencyLimit) {
                 let iteration = nextIteration
                 nextIteration += 1
                 group.addTask {
@@ -306,14 +308,14 @@ struct TTYCommandRunnerEnvTests {
                 }
             }
 
-            for _ in 0..<min(iterationCount, concurrencyLimit) {
-                addNextIteration()
-            }
-
             while let outcome = await group.next() {
                 completed.append(outcome)
                 if nextIteration < iterationCount {
-                    addNextIteration()
+                    let iteration = nextIteration
+                    nextIteration += 1
+                    group.addTask {
+                        operation(iteration)
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

- keep all 50 real `/bin/echo` PTY launches in the fast-exit drain regression
- schedule at most four launches at once with a structured task group
- use one `TTYCommandRunner` per iteration
- convert missing output and runner errors into iteration-specific outcomes so one reproduced failure cannot cancel the remaining stress launches
- verify every iteration completes exactly once and the active-process registry is empty before reporting failures nonfatally
- add a synthetic failure regression proving iteration 7 can fail without truncating the 50-iteration schedule
- leave production code and suite-wide parallelism unchanged

Fixes #3332.

## Performance

The contributor's paired benchmark measured the exact fast-exit test at a 45.758s baseline median and 12.050s candidate median (3.80x faster), and the complete `TTYCommandRunnerEnvTests` suite at 57.251s baseline versus a 23.007s candidate median (2.49x faster).

After maintainer repair and rebase, the exact real 50-launch stress test passed five times, with observed runs in the same roughly 12-14 second range. The complete 30-test TTY suite passed three times. No `pty-drain-race` or test-runner descendants remained.

## Verification

- exact real PTY stress test: 5/5 final-repair runs passed; 50 iteration IDs accounted for on every run
- injected missing-output scheduler regression: all 50 iteration IDs returned and the single failure stayed nonfatal
- `TTYCommandRunnerEnvTests`: 3/3 runs passed (30 tests each)
- `make check`
- final Codex autoreview: no actionable P0-P2 findings
- `make test` with isolated file, session, defaults, and Keychain settings and non-timeout retries disabled: 994 selections, 83/83 groups passed on the first attempt, 0 retries, 0 timeouts
- hosted CI: https://github.com/steipete/CodexBar/actions/runs/33622753276

Receipts:

- base: `4cc3373f3804f19615677cddc1c4eca67b26ee97`
- final candidate: `4db2422a9a224f4d0178ca39d92550d5a1021b8f`
- final tree: `aa68fa0104f5d3595a9af295eae3aca1e9688cb3`
