### PR TITLE
fix(grok): preserve billing semantics in nonempty requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Codex: avoid repeated full scans after trace-log pruning, while retaining the latest validated cost history through temporary trace-database failures (#3318). Thanks @brzvsk!
 
 ### Fixed
+- Grok: restore the grok.com billing fetch, which grok.com now rejects when it receives an empty request message (`grpc-status 13`); the client sends the weekly usage period explicitly. SuperGrok Heavy weekly-limit responses that declare a per-period limit without a used amount are now treated as a wire-published 0% instead of unknown usage, so the menu usage bar returns instead of an unavailable-usage diagnostic.
 - Menu bar: keep status components and website links scoped to their provider when switching cached tabs, preventing Claude status from appearing under Grok or Codex (#3320). Thanks @gianpaj!
 - Usage & Spend: keep stalled or failed Codex catch-up paused until explicit Refresh, preventing background synchronization from restarting CPU-heavy scans (partial fix for #3316). Thanks @heyajulia!
 - Xiaomi MiMo: prevent overlapping local usage tracker updates from colliding on a shared temporary cache file, preserving atomic publication (#3321). Thanks @Lucenx9!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@
 - Codex: avoid repeated full scans after trace-log pruning, while retaining the latest validated cost history through temporary trace-database failures (#3318). Thanks @brzvsk!
 
 ### Fixed
-- Grok: restore the grok.com billing fetch, which grok.com now rejects when it receives an empty request message (`grpc-status 13`); the client sends the weekly usage period explicitly. SuperGrok Heavy weekly-limit responses that declare a per-period limit without a used amount are now treated as a wire-published 0% instead of unknown usage, so the menu usage bar returns instead of an unavailable-usage diagnostic.
 - Menu bar: keep status components and website links scoped to their provider when switching cached tabs, preventing Claude status from appearing under Grok or Codex (#3320). Thanks @gianpaj!
 - Usage & Spend: keep stalled or failed Codex catch-up paused until explicit Refresh, preventing background synchronization from restarting CPU-heavy scans (partial fix for #3316). Thanks @heyajulia!
 - Xiaomi MiMo: prevent overlapping local usage tracker updates from colliding on a shared temporary cache file, preserving atomic publication (#3321). Thanks @Lucenx9!
 - Claude: avoid duplicated “Resets Reset” labels when CLI usage supplies a singular reset description (#3317). Thanks @Aternus!
+- Grok: send a nonempty billing request while preserving legacy monthly usage and leaving unknown percentages unchanged (#3336). Thanks @CharlieLZ!
 
 ## 0.56.2 — 2026-08-31
 

--- a/Sources/CodexBarCore/Providers/Grok/GrokCreditsProxyFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokCreditsProxyFetcher.swift
@@ -78,22 +78,6 @@ public enum GrokCreditsProxyFetcher {
                 subscriptionTier: subscriptionTier)
         }
 
-        // A unified-billing account with no on-demand credits (cap 0 / used 0) has no credit
-        // usage to report — the grok.com Usage page shows 0% used for the weekly period. The
-        // missing `creditUsagePercent` here is the proto3 zero-omission, not unknown usage, so
-        // this zero is wire-published and can fill the usage bar.
-        if config.isUnifiedBillingUser == true,
-           config.onDemandCap?.val == 0,
-           config.onDemandUsed?.val == 0,
-           resetsAt != nil
-        {
-            return GrokWebBillingSnapshot(
-                usedPercent: 0,
-                resetsAt: resetsAt,
-                subscriptionTier: subscriptionTier,
-                usedPercentIsWirePublished: true)
-        }
-
         if resetsAt != nil {
             return GrokWebBillingSnapshot(
                 usedPercent: nil,
@@ -126,7 +110,6 @@ public enum GrokCreditsProxyFetcher {
         let onDemandCap: CreditsAmount?
         let onDemandUsed: CreditsAmount?
         let subscriptionTier: String?
-        let isUnifiedBillingUser: Bool?
     }
 
     private struct CurrentPeriod: Decodable {

--- a/Sources/CodexBarCore/Providers/Grok/GrokCreditsProxyFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokCreditsProxyFetcher.swift
@@ -78,6 +78,22 @@ public enum GrokCreditsProxyFetcher {
                 subscriptionTier: subscriptionTier)
         }
 
+        // A unified-billing account with no on-demand credits (cap 0 / used 0) has no credit
+        // usage to report — the grok.com Usage page shows 0% used for the weekly period. The
+        // missing `creditUsagePercent` here is the proto3 zero-omission, not unknown usage, so
+        // this zero is wire-published and can fill the usage bar.
+        if config.isUnifiedBillingUser == true,
+           config.onDemandCap?.val == 0,
+           config.onDemandUsed?.val == 0,
+           resetsAt != nil
+        {
+            return GrokWebBillingSnapshot(
+                usedPercent: 0,
+                resetsAt: resetsAt,
+                subscriptionTier: subscriptionTier,
+                usedPercentIsWirePublished: true)
+        }
+
         if resetsAt != nil {
             return GrokWebBillingSnapshot(
                 usedPercent: nil,
@@ -110,6 +126,7 @@ public enum GrokCreditsProxyFetcher {
         let onDemandCap: CreditsAmount?
         let onDemandUsed: CreditsAmount?
         let subscriptionTier: String?
+        let isUnifiedBillingUser: Bool?
     }
 
     private struct CurrentPeriod: Decodable {

--- a/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
@@ -116,6 +116,17 @@ public enum GrokWebBillingFetcher {
         URL(string: "https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig")!
     private static let requestTimeoutSeconds: TimeInterval = 15
 
+    /// `GetGrokCreditsConfigRequest { usage_period_type: WEEKLY }` carried as a
+    /// grpc-web frame (flags byte, big-endian payload length, payload `08 02`).
+    ///
+    /// grok.com's billing API rejects a zero-length request message with
+    /// `grpc-status 13` ("Missing request message."), so the empty frame that
+    /// this client previously sent is refused. The web client serializes the
+    /// active usage period explicitly; proto3 omits zero-valued fields, so
+    /// UNSPECIFIED would serialize to an empty message the API also rejects.
+    /// SuperGrok plans are displayed as weekly limits.
+    private static let weeklyCreditsConfigRequest = Data([0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x02])
+
     public static func fetch(
         credentials: GrokCredentials,
         session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
@@ -207,8 +218,7 @@ public enum GrokWebBillingFetcher {
     {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
-        request.timeoutInterval = Self.requestTimeoutSeconds
-        request.httpBody = Data([0x00, 0x00, 0x00, 0x00, 0x00])
+        request.httpBody = Self.weeklyCreditsConfigRequest
         if let authorizationHeader {
             request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
         }
@@ -305,15 +315,25 @@ public enum GrokWebBillingFetcher {
             field.path.starts(with: [1, 6])
                 || (field.path == [1, 8, 1] && (field.value == 1 || field.value == 2))
         }
+        // A period that declares a per-period bound with an empty used amount is a fully
+        // determined zero-usage response (Weekly SuperGrok Heavy limit frame): the wire
+        // publishes the period limit at [1,4,2]/[1,5,2] and carries no used amount at all.
+        // That zero is real, unlike a period-only frame with no limit, which stays unknown.
+        let hasDefinedPeriodLimit = scan.varintFields.contains { field in
+            (field.path == [1, 4, 2] || field.path == [1, 5, 2])
+                && field.value > 0 && field.value < 1_000_000_000_000
+        }
         let noUsageYet =
             parsedPercent == nil && scan.fixed32Fields.isEmpty && reset != nil && hasUsagePeriod
+        let zeroUsageIsWirePublished =
+            parsedPercent != nil || (noUsageYet && hasDefinedPeriodLimit)
         guard let percent = parsedPercent ?? (noUsageYet ? 0 : nil) else {
             throw GrokWebBillingError.parseFailed
         }
         return GrokWebBillingSnapshot(
             usedPercent: percent,
             resetsAt: reset,
-            usedPercentIsWirePublished: parsedPercent != nil)
+            usedPercentIsWirePublished: zeroUsageIsWirePublished)
     }
 
     static func looksLikeProtobufPayload(_ data: Data) -> Bool {

--- a/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
@@ -116,16 +116,9 @@ public enum GrokWebBillingFetcher {
         URL(string: "https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig")!
     private static let requestTimeoutSeconds: TimeInterval = 15
 
-    /// `GetGrokCreditsConfigRequest { usage_period_type: WEEKLY }` carried as a
-    /// grpc-web frame (flags byte, big-endian payload length, payload `08 02`).
-    ///
-    /// grok.com's billing API rejects a zero-length request message with
-    /// `grpc-status 13` ("Missing request message."), so the empty frame that
-    /// this client previously sent is refused. The web client serializes the
-    /// active usage period explicitly; proto3 omits zero-valued fields, so
-    /// UNSPECIFIED would serialize to an empty message the API also rejects.
-    /// SuperGrok plans are displayed as weekly limits.
-    private static let weeklyCreditsConfigRequest = Data([0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x02])
+    /// Explicit field 1 = false (exclude_legacy_monthly_usage) keeps the request nonempty
+    /// without changing the default billing semantics. This field is not a period selector.
+    private static let creditsConfigRequest = Data([0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x00])
 
     public static func fetch(
         credentials: GrokCredentials,
@@ -218,7 +211,8 @@ public enum GrokWebBillingFetcher {
     {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
-        request.httpBody = Self.weeklyCreditsConfigRequest
+        request.timeoutInterval = Self.requestTimeoutSeconds
+        request.httpBody = Self.creditsConfigRequest
         if let authorizationHeader {
             request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
         }
@@ -315,25 +309,15 @@ public enum GrokWebBillingFetcher {
             field.path.starts(with: [1, 6])
                 || (field.path == [1, 8, 1] && (field.value == 1 || field.value == 2))
         }
-        // A period that declares a per-period bound with an empty used amount is a fully
-        // determined zero-usage response (Weekly SuperGrok Heavy limit frame): the wire
-        // publishes the period limit at [1,4,2]/[1,5,2] and carries no used amount at all.
-        // That zero is real, unlike a period-only frame with no limit, which stays unknown.
-        let hasDefinedPeriodLimit = scan.varintFields.contains { field in
-            (field.path == [1, 4, 2] || field.path == [1, 5, 2])
-                && field.value > 0 && field.value < 1_000_000_000_000
-        }
         let noUsageYet =
             parsedPercent == nil && scan.fixed32Fields.isEmpty && reset != nil && hasUsagePeriod
-        let zeroUsageIsWirePublished =
-            parsedPercent != nil || (noUsageYet && hasDefinedPeriodLimit)
         guard let percent = parsedPercent ?? (noUsageYet ? 0 : nil) else {
             throw GrokWebBillingError.parseFailed
         }
         return GrokWebBillingSnapshot(
             usedPercent: percent,
             resetsAt: reset,
-            usedPercentIsWirePublished: zeroUsageIsWirePublished)
+            usedPercentIsWirePublished: parsedPercent != nil)
     }
 
     static func looksLikeProtobufPayload(_ data: Data) -> Bool {

--- a/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
@@ -75,7 +75,7 @@ struct GrokCreditsProxyFetcherTests {
                 }
                 """.utf8))
 
-        let expectedReset = try Self.date("2026-09-07T12:35:57Z")
+        let expectedReset = try Self.date("2026-09-07T12:35:57.056343+00:00")
         // Zero on-demand spending does not establish the included subscription usage.
         #expect(snapshot.usedPercent == nil)
         #expect(!snapshot.usedPercentIsWirePublished)

--- a/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
@@ -54,6 +54,58 @@ struct GrokCreditsProxyFetcherTests {
     }
 
     @Test
+    func `unified billing zero on demand credits reports wire published zero percent`() throws {
+        let snapshot = try GrokCreditsProxyFetcher.parseSnapshot(
+            Data(
+                """
+                {
+                  "config": {
+                    "isUnifiedBillingUser": true,
+                    "currentPeriod": {
+                      "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                      "start": "2026-08-31T12:35:57.056343+00:00",
+                      "end": "2026-09-07T12:35:57.056343+00:00"
+                    },
+                    "onDemandCap": { "val": 0 },
+                    "onDemandUsed": { "val": 0 },
+                    "prepaidBalance": { "val": 0 },
+                    "topUpMethod": "TOP_UP_METHOD_SAVED_PAYMENT_METHOD",
+                    "billingPeriodEnd": "2026-09-07T12:35:57.056343+00:00"
+                  }
+                }
+                """.utf8))
+
+        let expectedReset = try Self.date("2026-09-07T12:35:57Z")
+        #expect(snapshot.usedPercent == 0)
+        #expect(snapshot.usedPercentIsWirePublished)
+        #expect(snapshot.resetsAt == expectedReset)
+        #expect(snapshot.subscriptionTier == nil)
+    }
+
+    @Test
+    func `period only proxy payload without unified flag stays unknown`() throws {
+        let snapshot = try GrokCreditsProxyFetcher.parseSnapshot(
+            Data(
+                """
+                {
+                  "config": {
+                    "currentPeriod": {
+                      "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                      "start": "2026-08-31T12:35:57.056343+00:00",
+                      "end": "2026-09-07T12:35:57.056343+00:00"
+                    },
+                    "onDemandCap": { "val": 0 },
+                    "onDemandUsed": { "val": 0 },
+                    "billingPeriodEnd": "2026-09-07T12:35:57.056343+00:00"
+                  }
+                }
+                """.utf8))
+
+        #expect(snapshot.usedPercent == nil)
+        #expect(!snapshot.usedPercentIsWirePublished)
+    }
+
+    @Test
     func `derives percent from on demand cap and usage`() throws {
         let snapshot = try GrokCreditsProxyFetcher.parseSnapshot(
             Data(

--- a/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
@@ -54,7 +54,7 @@ struct GrokCreditsProxyFetcherTests {
     }
 
     @Test
-    func `unified billing without a published percent keeps subscription usage unknown`() throws {
+    func `unified billing without a published percent keeps subscription usage unknown`() async throws {
         let snapshot = try GrokCreditsProxyFetcher.parseSnapshot(
             Data(
                 """
@@ -78,9 +78,17 @@ struct GrokCreditsProxyFetcherTests {
         let expectedReset = try Self.date("2026-09-07T12:35:57.056343+00:00")
         // Zero on-demand spending does not establish the included subscription usage.
         #expect(snapshot.usedPercent == nil)
-        #expect(!snapshot.usedPercentIsWirePublished)
         #expect(snapshot.resetsAt == expectedReset)
         #expect(snapshot.subscriptionTier == nil)
+
+        let result = try await GrokOAuthFetchStrategy.resolvingUnknownUsage(
+            snapshot,
+            credentials: Self.credentials,
+            grpcBilling: { _ in GrokWebBillingSnapshot(usedPercent: 35, resetsAt: nil) })
+
+        #expect(result.snapshot.usedPercent == 35)
+        #expect(result.snapshot.resetsAt == expectedReset)
+        #expect(result.sourceLabel == "grok-web")
     }
 
     @Test
@@ -103,7 +111,6 @@ struct GrokCreditsProxyFetcherTests {
                 """.utf8))
 
         #expect(snapshot.usedPercent == nil)
-        #expect(!snapshot.usedPercentIsWirePublished)
     }
 
     @Test

--- a/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokCreditsProxyFetcherTests.swift
@@ -54,7 +54,7 @@ struct GrokCreditsProxyFetcherTests {
     }
 
     @Test
-    func `unified billing zero on demand credits reports wire published zero percent`() throws {
+    func `unified billing without a published percent keeps subscription usage unknown`() throws {
         let snapshot = try GrokCreditsProxyFetcher.parseSnapshot(
             Data(
                 """
@@ -76,8 +76,9 @@ struct GrokCreditsProxyFetcherTests {
                 """.utf8))
 
         let expectedReset = try Self.date("2026-09-07T12:35:57Z")
-        #expect(snapshot.usedPercent == 0)
-        #expect(snapshot.usedPercentIsWirePublished)
+        // Zero on-demand spending does not establish the included subscription usage.
+        #expect(snapshot.usedPercent == nil)
+        #expect(!snapshot.usedPercentIsWirePublished)
         #expect(snapshot.resetsAt == expectedReset)
         #expect(snapshot.subscriptionTier == nil)
     }

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -669,6 +669,35 @@ struct GrokWebBillingFetcherTests {
     }
 
     @Test
+    func `parses live weekly limit billing response as zero percent`() throws {
+        // Capture from grok.com on 2026-09-01: `GetGrokCreditsConfigRequest { usage_period_type:
+        // WEEKLY }` → Weekly SuperGrok Heavy Limit, 0% used, reset Sep 7 2026 12:35:57Z.
+        // The frame declares a per-period limit with no used amount ([1,4,2]/[1,5,2] > 0), so the
+        // zero usage is a wire-published value, unlike a period-only frame with unknown usage.
+        let data = Data([
+            0x00, 0x00, 0x00, 0x00, 0x44, 0x0A, 0x42, 0x12,
+            0x00, 0x1A, 0x00, 0x22, 0x0B, 0x08, 0xAD, 0xEA,
+            0xD5, 0xD4, 0x06, 0x10, 0xD8, 0xF3, 0xEE, 0x1A,
+            0x2A, 0x0B, 0x08, 0xAD, 0xDF, 0xFA, 0xD4, 0x06,
+            0x10, 0xD8, 0xF3, 0xEE, 0x1A, 0x42, 0x1C, 0x08,
+            0x02, 0x12, 0x0B, 0x08, 0xAD, 0xEA, 0xD5, 0xD4,
+            0x06, 0x10, 0xD8, 0xF3, 0xEE, 0x1A, 0x1A, 0x0B,
+            0x08, 0xAD, 0xDF, 0xFA, 0xD4, 0x06, 0x10, 0xD8,
+            0xF3, 0xEE, 0x1A, 0x58, 0x01, 0x62, 0x00, 0x68,
+            0x01, 0x80, 0x00, 0x00, 0x00, 0x0F, 0x67, 0x72,
+            0x70, 0x63, 0x2D, 0x73, 0x74, 0x61, 0x74, 0x75,
+            0x73, 0x3A, 0x30, 0x0D, 0x0A,
+        ])
+
+        let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
+            data,
+            now: Date(timeIntervalSince1970: 1_788_000_000))
+
+        #expect(snapshot.usedPercent == 0)
+        #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_788_784_557))
+        #expect(snapshot.subscriptionTier == nil)
+        #expect(snapshot.usedPercentIsWirePublished)
+    }
     func `parses omitted zero percent with current billing period`() throws {
         let data = Data([
             0x00, 0x00, 0x00, 0x00, 0x2A, 0x0A, 0x28, 0x12,
@@ -770,7 +799,7 @@ struct GrokWebBillingFetcherTests {
             endpoint: endpoint)
 
         #expect(GrokWebBillingStubURLProtocol.requests.count == 1)
-        #expect(GrokWebBillingStubURLProtocol.requestBodies == [Data([0x00, 0x00, 0x00, 0x00, 0x00])])
+        #expect(GrokWebBillingStubURLProtocol.requestBodies == [Data([0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x02])])
         #expect(snapshot.usedPercent == 55.5)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(reset)))
     }

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -667,13 +667,13 @@ struct GrokWebBillingFetcherTests {
         // no-usage-yet reading and must never travel as a published percent.
         #expect(!snapshot.usedPercentIsWirePublished)
     }
+}
 
+extension GrokWebBillingFetcherTests {
     @Test
-    func `parses live weekly limit billing response as zero percent`() throws {
-        // Capture from grok.com on 2026-09-01: `GetGrokCreditsConfigRequest { usage_period_type:
-        // WEEKLY }` → Weekly SuperGrok Heavy Limit, 0% used, reset Sep 7 2026 12:35:57Z.
-        // The frame declares a per-period limit with no used amount ([1,4,2]/[1,5,2] > 0), so the
-        // zero usage is a wire-published value, unlike a period-only frame with unknown usage.
+    func `fractional billing timestamps do not publish a usage percent`() async throws {
+        // Captured frame from #3336. The nonzero [1,4,2]/[1,5,2] varints are timestamp
+        // nanoseconds, not limits or usage; the frame has no credit_usage_percent field.
         let data = Data([
             0x00, 0x00, 0x00, 0x00, 0x44, 0x0A, 0x42, 0x12,
             0x00, 0x1A, 0x00, 0x22, 0x0B, 0x08, 0xAD, 0xEA,
@@ -696,8 +696,49 @@ struct GrokWebBillingFetcherTests {
         #expect(snapshot.usedPercent == 0)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_788_784_557))
         #expect(snapshot.subscriptionTier == nil)
-        #expect(snapshot.usedPercentIsWirePublished)
+        #expect(!snapshot.usedPercentIsWirePublished)
+
+        let proxy = GrokWebBillingSnapshot(
+            usedPercent: nil,
+            resetsAt: Date(timeIntervalSince1970: 1_788_700_000),
+            subscriptionTier: "SuperGrok Heavy")
+        let result = try await GrokOAuthFetchStrategy.resolvingUnknownUsage(
+            proxy,
+            credentials: Self.credentials,
+            grpcBilling: { _ in snapshot })
+
+        #expect(result.snapshot == proxy)
+        #expect(result.sourceLabel == "grok-cli-proxy")
+        let usage = GrokUsageSnapshot(
+            billing: nil,
+            webBilling: result.snapshot,
+            credentials: Self.credentials,
+            localSummary: nil,
+            cliVersion: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_788_000_000)).toUsageSnapshot()
+        #expect(usage.primary == nil)
+        #expect(usage.loginMethod(for: .grok) == "SuperGrok Heavy")
     }
+
+    @Test(arguments: [Float(0), Float(20)])
+    func `parsed wire percentages replace unknown proxy usage`(percent: Float) async throws {
+        let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
+            Self.grpcFrame(Self.protobufPayload(usedPercent: percent, resetEpoch: 1_800_604_803)),
+            now: Date(timeIntervalSince1970: 1_799_000_000))
+        let proxyReset = Date(timeIntervalSince1970: 1_800_000_003)
+        let result = try await GrokOAuthFetchStrategy.resolvingUnknownUsage(
+            GrokWebBillingSnapshot(usedPercent: nil, resetsAt: proxyReset, subscriptionTier: "SuperGrok Heavy"),
+            credentials: Self.credentials,
+            grpcBilling: { _ in snapshot })
+
+        #expect(snapshot.usedPercentIsWirePublished)
+        #expect(result.snapshot.usedPercent == Double(percent))
+        #expect(result.snapshot.resetsAt == proxyReset)
+        #expect(result.snapshot.subscriptionTier == "SuperGrok Heavy")
+        #expect(result.sourceLabel == "grok-web")
+    }
+
+    @Test
     func `parses omitted zero percent with current billing period`() throws {
         let data = Data([
             0x00, 0x00, 0x00, 0x00, 0x2A, 0x0A, 0x28, 0x12,
@@ -799,7 +840,7 @@ struct GrokWebBillingFetcherTests {
             endpoint: endpoint)
 
         #expect(GrokWebBillingStubURLProtocol.requests.count == 1)
-        #expect(GrokWebBillingStubURLProtocol.requestBodies == [Data([0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x02])])
+        #expect(GrokWebBillingStubURLProtocol.requestBodies == [Data([0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x00])])
         #expect(snapshot.usedPercent == 55.5)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(reset)))
     }
@@ -845,6 +886,10 @@ struct GrokWebBillingFetcherTests {
 
         #expect(attempts.current() == 2)
         #expect(GrokWebBillingStubURLProtocol.requests.count == 2)
+        #expect(GrokWebBillingStubURLProtocol.requests.allSatisfy { $0.timeoutInterval == 15 })
+        #expect(GrokWebBillingStubURLProtocol.requestBodies == Array(
+            repeating: Data([0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x00]),
+            count: 2))
         #expect(snapshot.usedPercent == 25)
         #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(reset)))
     }
@@ -949,6 +994,7 @@ extension GrokWebBillingFetcherTests {
             #expect(request.value(forHTTPHeaderField: "Cookie") == "sso=session; sso-rw=session")
             #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
             #expect(request.value(forHTTPHeaderField: "x-user-agent") == "connect-es/2.1.1")
+            #expect(request.timeoutInterval == 15)
             let response = HTTPURLResponse(
                 url: endpoint,
                 statusCode: 200,
@@ -964,6 +1010,7 @@ extension GrokWebBillingFetcherTests {
             endpoint: endpoint)
 
         #expect(snapshot.usedPercent == 9)
+        #expect(GrokWebBillingStubURLProtocol.requestBodies == [Data([0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x00])])
     }
 
     @Test
@@ -984,6 +1031,7 @@ extension GrokWebBillingFetcherTests {
         GrokWebBillingStubURLProtocol.handler = { request in
             #expect(request.value(forHTTPHeaderField: "Cookie") == "sso=session")
             #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer token-123")
+            #expect(request.timeoutInterval == 15)
             let response = HTTPURLResponse(
                 url: endpoint,
                 statusCode: 200,
@@ -999,6 +1047,7 @@ extension GrokWebBillingFetcherTests {
             endpoint: endpoint)
 
         #expect(snapshot.usedPercent == 9)
+        #expect(GrokWebBillingStubURLProtocol.requestBodies == [Data([0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x00])])
     }
 
     @Test

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -84,12 +84,19 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
      that omit `subscription_tier_display` all drop the plan overlay and fall
      back to the OIDC SuperGrok label. There is no process-lifetime tier cache.
 4) **grok.com billing gRPC-web fallback** (best-effort)
-   - POSTs `GetGrokCreditsConfigRequest { usage_period_type: WEEKLY }` (gRPC-web
-     binary frame `00 00 00 00 02 08 02`) to
+   - POSTs `GetGrokCreditsConfigRequest { exclude_legacy_monthly_usage: false }`
+     (gRPC-web binary frame `00 00 00 00 02 08 00`) to
      `https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig`.
-     grok.com now rejects a zero-length request message with `grpc-status 13`
-     ("Missing request message."); proto3 would omit a zero-valued `UNSPECIFIED`
-     enum, so the weekly period is sent explicitly.
+     Explicitly encoding the default boolean supplies a nonempty protobuf message
+     for the reported `grpc-status 13` ("Missing request message.") rejection,
+     without excluding legacy monthly usage or selecting a billing period.
+     The current public web-client descriptor defines field 1 as this boolean,
+     not a weekly/monthly enum, and the web client requests `{}`. False preserves
+     that implicit proto3 default; whether the nonempty encoding restores the
+     affected account's response still requires live confirmation.
+     Protocol references: the public [billing descriptor](https://cdn.grok.com/_next/static/chunks/32g78bk5hhe1q.js),
+     [web billing query](https://cdn.grok.com/_next/static/chunks/062ueaj23tfo3.js)
+     (checked 2026-09-01), and [proto3 field presence](https://protobuf.dev/programming-guides/field_presence/).
    - This endpoint now requires the browser-held Web Key Exchange (WKE) keypair.
      Cookie-only authentication can fail with gRPC status 16 and
      `no-credentials`; signing in through Chrome alone cannot provide that proof
@@ -113,12 +120,10 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
    - Parses the returned protobuf enough to recover used percent and
      reset timestamp, accepting both gRPC-web frames and the raw protobuf form
      returned by some successful requests. A current billing period with an
-     omitted proto3 `credit_usage_percent` is treated as zero usage. When that
-     period also declares a per-period limit (varint fields `[1,4,2]`/`[1,5,2]`
-     with no used amount, the Weekly SuperGrok Heavy limit frame), the zero is
-     wire-published rather than inferred and is eligible for the step-3 adoption
-     rule. This keeps billing visible when `grok agent stdio` returns
-     `Method not found`.
+     omitted proto3 `credit_usage_percent` is treated as zero usage only on this
+     surface; it is not wire-published and cannot replace an unknown proxy percent.
+     Nonzero timestamp nanoseconds at `[1,4,2]`/`[1,5,2]` do not change that rule.
+     This keeps billing visible when `grok agent stdio` returns `Method not found`.
 5) **Local session signals** (informational fallback)
    - Walks `~/.grok/sessions/<encoded-cwd>/<session-id>/signals.json` files (last 30 days).
    - Aggregates `totalTokensBeforeCompaction`, `contextTokensUsed`, `modelsUsed`,

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -84,8 +84,12 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
      that omit `subscription_tier_display` all drop the plan overlay and fall
      back to the OIDC SuperGrok label. There is no process-lifetime tier cache.
 4) **grok.com billing gRPC-web fallback** (best-effort)
-   - POSTs an empty gRPC-web protobuf request to
+   - POSTs `GetGrokCreditsConfigRequest { usage_period_type: WEEKLY }` (gRPC-web
+     binary frame `00 00 00 00 02 08 02`) to
      `https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig`.
+     grok.com now rejects a zero-length request message with `grpc-status 13`
+     ("Missing request message."); proto3 would omit a zero-valued `UNSPECIFIED`
+     enum, so the weekly period is sent explicitly.
    - This endpoint now requires the browser-held Web Key Exchange (WKE) keypair.
      Cookie-only authentication can fail with gRPC status 16 and
      `no-credentials`; signing in through Chrome alone cannot provide that proof
@@ -109,8 +113,12 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
    - Parses the returned protobuf enough to recover used percent and
      reset timestamp, accepting both gRPC-web frames and the raw protobuf form
      returned by some successful requests. A current billing period with an
-     omitted proto3 `credit_usage_percent` is treated as zero usage. This keeps
-     billing visible when `grok agent stdio` returns `Method not found`.
+     omitted proto3 `credit_usage_percent` is treated as zero usage. When that
+     period also declares a per-period limit (varint fields `[1,4,2]`/`[1,5,2]`
+     with no used amount, the Weekly SuperGrok Heavy limit frame), the zero is
+     wire-published rather than inferred and is eligible for the step-3 adoption
+     rule. This keeps billing visible when `grok agent stdio` returns
+     `Method not found`.
 5) **Local session signals** (informational fallback)
    - Walks `~/.grok/sessions/<encoded-cwd>/<session-id>/signals.json` files (last 30 days).
    - Aggregates `totalTokensBeforeCompaction`, `contextTokensUsed`, `modelsUsed`,


### PR DESCRIPTION
## Summary

Addresses the reported `grpc-status 13` / `Missing request message.` rejection by sending a nonempty `GetGrokCreditsConfigRequest`, while preserving the default billing semantics.

The current official Grok descriptor defines request field 1 as `bool exclude_legacy_monthly_usage`, not a weekly-period enum. The web client requests `{}`. This patch explicitly encodes false (`00 00 00 00 02 08 00`) so the message is nonempty without excluding legacy monthly usage. Decoding with `protoc` confirms empty and `0800` both mean false, whereas the original `0802` means true.

The maintainer repair also restores the 15-second timeout and the displaced `@Test`. Response parsing is unchanged from main. The captured frame's nonzero timestamp nanoseconds are not usage limits, so its inferred zero must not replace an unknown proxy percentage. The fixture now covers that boundary through the real parser, proxy enrichment, and usage snapshot; explicit wire zero/nonzero percentages still work.

The later unified-billing `0/0` inference has also been removed. Its fixtures remain as regression coverage: absent subscription usage stays unknown, and real fallback usage can enrich it without changing the authoritative reset date. Zero on-demand spending does not establish zero subscription usage.

Thanks @CharlieLZ for the report, original request change, and captured regression fixture.

## Protocol evidence

- [Official public billing descriptor](https://cdn.grok.com/_next/static/chunks/32g78bk5hhe1q.js): decoded its embedded protobuf descriptor, including the actual request boolean and timestamp field types.
- [Official public web billing query](https://cdn.grok.com/_next/static/chunks/062ueaj23tfo3.js): requests the default config and reads the returned monthly/weekly period.
- [Protobuf field presence](https://protobuf.dev/programming-guides/field_presence/): explicit false preserves the implicit proto3 default.

Public assets checked September 1, 2026 UTC; downloaded JavaScript was inspected, not executed.

## Verification and merge gate

- The corrected regression tests fail on the submitted implementation: false-zero adoption, request bytes, and lost timeouts are detected.
- Focused billing/proxy tests pass on `10cefdc9c4cbf470ce882d27ef3cc2432b450b69`: 81 tests across two suites, with stubbed HTTP and synthetic credentials. The same compiler was used through SwiftPM's native backend after Xcode's SDK stat-cache tool stalled before compilation.
- Independent Codex autoreview is clean at its configured P0 threshold; maintainer review also checked the request schema, fallback ownership, and lower-severity regressions.
- `make check` passes with zero lint violations across 2,079 Swift files.
- [Current-head CI](https://github.com/steipete/CodexBar/actions/runs/33470597985) passes all eight jobs on `10cefdc9c4cbf470ce882d27ef3cc2432b450b69`, including both macOS test shards and all three Linux builds.
- The earlier full local repository run stopped on a 600-second `StatusMenuTests` timeout, after two timing-sensitive failures recovered on retry. It is not a green full-suite result. The independently diagnosed Sakana cancellation-test race is addressed separately in [#3344](https://github.com/steipete/CodexBar/pull/3344).

**Leave unmerged until the corrected `0800` request is confirmed against the affected account.** No authenticated provider probe, real cookie import, Keychain access, or installed-app relaunch was performed for this repair. The original reported 0% result was produced by the discarded parser heuristic and is not proof of published usage or of this corrected request's live recovery. Unknown percentages intentionally remain unknown.
