### PR TITLE
fix(codex): restore OAuth subscription renewal dates

### DIFF
--- a/Sources/CodexBarCore/OpenAISubscriptionDates.swift
+++ b/Sources/CodexBarCore/OpenAISubscriptionDates.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Renewal/expiry dates from ChatGPT's subscriptions payload.
+/// Kept independent of WebKit so OAuth usage can attach subscription metadata without browser access.
+public struct OpenAISubscriptionDates: Equatable, Sendable {
+    public let expiresAt: Date?
+    public let renewsAt: Date?
+
+    public init(expiresAt: Date?, renewsAt: Date?) {
+        self.expiresAt = expiresAt
+        self.renewsAt = renewsAt
+    }
+
+    public static func parse(data: Data) -> Self? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let activeUntil = json["active_until"] as? String ?? json["activeUntil"] as? String,
+              let willRenew = json["will_renew"] as? Bool ?? json["willRenew"] as? Bool,
+              let periodEnd = self.parseDate(activeUntil)
+        else { return nil }
+
+        return willRenew
+            ? Self(expiresAt: nil, renewsAt: periodEnd)
+            : Self(expiresAt: periodEnd, renewsAt: nil)
+    }
+
+    static func responseShape(data: Data) -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) else { return "non-json" }
+        if let object = json as? [String: Any] {
+            return object.keys.sorted().prefix(20).joined(separator: ",")
+        }
+        if let items = json as? [Any] {
+            return "array(count=\(items.count))"
+        }
+        return String(describing: type(of: json))
+    }
+
+    private static func parseDate(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -392,6 +392,7 @@ public enum CodexOAuthUsageFetcher {
     private static let defaultChatGPTBaseURL = "https://chatgpt.com/backend-api/"
     private static let chatGPTUsagePath = "/wham/usage"
     private static let codexUsagePath = "/api/codex/usage"
+    private static let chatGPTSubscriptionsPath = "/subscriptions"
     private static let rateLimitResetCreditsPath = "/wham/rate-limit-reset-credits"
     private static let spendControlsMonthlyUsagePathSuffix = "/spend-controls/current-user/monthly-usage"
 
@@ -467,6 +468,65 @@ public enum CodexOAuthUsageFetcher {
             env: env,
             timeout: timeout,
             session: CodexAuthenticatedHTTPTransport.current)
+    }
+
+    public static func fetchSubscription(
+        accessToken: String,
+        accountId: String?,
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        timeout: TimeInterval = 3) async -> OpenAISubscriptionDates?
+    {
+        await self.fetchSubscription(
+            accessToken: accessToken,
+            accountId: accountId,
+            env: env,
+            timeout: timeout,
+            session: CodexAuthenticatedHTTPTransport.current)
+    }
+
+    public static func fetchSubscription(
+        accessToken: String,
+        accountId: String?,
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        timeout: TimeInterval = 3,
+        session transport: any ProviderHTTPTransport) async -> OpenAISubscriptionDates?
+    {
+        guard let accountId = accountId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !accountId.isEmpty
+        else { return nil }
+
+        var request = URLRequest(
+            url: self.resolveSubscriptionsURL(env: env, accountId: accountId),
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: timeout)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+
+        let logger = CodexBarLog.logger(LogCategories.provider(.codex, scope: "subscription"))
+        do {
+            let response = try await transport.response(for: request)
+            let metadata = (200...299).contains(response.statusCode)
+                ? OpenAISubscriptionDates.parse(data: response.data)
+                : nil
+            logger.debug(
+                "Codex subscription response",
+                metadata: [
+                    "status": "\(response.statusCode)",
+                    "contentType": response.response.value(forHTTPHeaderField: "Content-Type") ?? "missing",
+                    "bytes": "\(response.data.count)",
+                    "shape": OpenAISubscriptionDates.responseShape(data: response.data),
+                    "parsed": metadata == nil ? "0" : "1",
+                ])
+            return metadata
+        } catch {
+            logger.debug(
+                "Codex subscription request failed",
+                metadata: ["errorType": String(describing: type(of: error))])
+            return nil
+        }
     }
 
     public static func fetchSpendControlsMonthlyUsage(
@@ -605,6 +665,20 @@ public enum CodexOAuthUsageFetcher {
         let path = normalized.contains("/backend-api") ? Self.chatGPTUsagePath : Self.codexUsagePath
         let full = normalized + path
         return URL(string: full) ?? URL(string: Self.defaultChatGPTBaseURL + Self.chatGPTUsagePath)!
+    }
+
+    private static func resolveSubscriptionsURL(
+        env: [String: String],
+        accountId: String,
+        configContents: String? = nil) -> URL
+    {
+        let baseURL = self.resolveChatGPTBaseURL(env: env, configContents: configContents)
+        let normalized = self.normalizeChatGPTBaseURL(baseURL)
+        let full = normalized + Self.chatGPTSubscriptionsPath
+        let endpoint = URL(string: full) ?? URL(string: Self.defaultChatGPTBaseURL + Self.chatGPTSubscriptionsPath)!
+        guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else { return endpoint }
+        components.queryItems = (components.queryItems ?? []) + [URLQueryItem(name: "account_id", value: accountId)]
+        return components.url ?? endpoint
     }
 
     private static func resolveRateLimitResetCreditsURL(env: [String: String]) -> URL {

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -395,10 +395,19 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
                 isAPIKey: credentials.isAPIKey)
         }
 
-        let usage = try await CodexOAuthUsageFetcher.fetchUsage(
-            accessToken: credentials.accessToken,
-            accountId: credentials.accountId,
-            env: context.env)
+        let accessToken = credentials.accessToken
+        let accountId = credentials.accountId
+        let env = context.env
+        async let usageRequest = CodexOAuthUsageFetcher.fetchUsage(
+            accessToken: accessToken,
+            accountId: accountId,
+            env: env)
+        async let subscriptionRequest = CodexOAuthUsageFetcher.fetchSubscription(
+            accessToken: accessToken,
+            accountId: accountId,
+            env: env)
+        let usage = try await usageRequest
+        let subscription = await subscriptionRequest
         let resetCreditsAttempted = Self.shouldFetchResetCredits(context)
         let resetCredits = try await Self.fetchResetCreditsIfRequested(
             context: context,
@@ -408,6 +417,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             usageResponse: usage,
             resetCredits: resetCredits,
             credentials: credentials,
+            subscription: subscription,
             updatedAt: updatedAt,
             allowEmptyUsageForResetCreditEnrichment: Self.defersResetCreditFetchToApp(context),
             codexResetCreditsAttempted: resetCreditsAttempted)
@@ -506,6 +516,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
         usageResponse: CodexUsageResponse,
         resetCredits: CodexRateLimitResetCreditsSnapshot? = nil,
         credentials: CodexOAuthCredentials,
+        subscription: OpenAISubscriptionDates? = nil,
         updatedAt: Date,
         allowEmptyUsageForResetCreditEnrichment: Bool = false,
         codexResetCreditsAttempted: Bool = false) throws -> ProviderFetchResult
@@ -514,6 +525,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
         let reconciled = CodexReconciledState.fromOAuth(
             response: usageResponse,
             credentials: credentials,
+            subscription: subscription,
             updatedAt: updatedAt)
 
         if let reconciled {

--- a/Sources/CodexBarCore/Providers/Codex/CodexReconciledState.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexReconciledState.swift
@@ -40,6 +40,7 @@ public struct CodexReconciledState: Sendable {
     public static func fromOAuth(
         response: CodexUsageResponse,
         credentials: CodexOAuthCredentials,
+        subscription: OpenAISubscriptionDates? = nil,
         updatedAt: Date = Date()) -> CodexReconciledState?
     {
         self.make(
@@ -48,6 +49,8 @@ public struct CodexReconciledState: Sendable {
             extraRateWindows: CodexAdditionalRateLimitMapper.extraRateWindows(
                 from: response.additionalRateLimits,
                 now: updatedAt),
+            subscriptionExpiresAt: subscription?.expiresAt,
+            subscriptionRenewsAt: subscription?.renewsAt,
             identity: self.oauthIdentity(response: response, credentials: credentials),
             updatedAt: updatedAt)
     }

--- a/Tests/CodexBarTests/CodexOAuthRequestTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthRequestTests.swift
@@ -124,6 +124,92 @@ struct CodexOAuthRequestTests {
     #endif
 
     @Test
+    func `subscription request includes account query and maps renewal into usage`() async throws {
+        let expectedRenewal = try #require(ISO8601DateFormatter().date(from: "2026-09-08T09:34:05Z"))
+        let payload = Data(#"{"active_until":"2026-09-08T09:34:05Z","will_renew":true}"#.utf8)
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+            #expect(components.path == "/backend-api/subscriptions")
+            #expect(components.queryItems == [URLQueryItem(name: "account_id", value: "account-a")])
+            #expect(request.httpMethod == "GET")
+            #expect(request.timeoutInterval == 3)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer token-a")
+            #expect(request.value(forHTTPHeaderField: "ChatGPT-Account-Id") == "account-a")
+            #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]))
+            return (payload, response)
+        }
+
+        let subscription = await CodexOAuthUsageFetcher.fetchSubscription(
+            accessToken: "token-a",
+            accountId: "account-a",
+            env: ["CODEX_HOME": "/tmp/codexbar-subscription-request-test"],
+            timeout: 3,
+            session: transport)
+
+        #expect(subscription?.renewsAt == expectedRenewal)
+        #expect(subscription?.expiresAt == nil)
+        #expect(await transport.requests().count == 1)
+
+        let usageResponse = try CodexOAuthUsageFetcher._decodeUsageResponseForTesting(Data(#"""
+        {
+          "rate_limit": {
+            "secondary_window": {
+              "used_percent": 47,
+              "reset_at": 1788272120,
+              "limit_window_seconds": 604800
+            }
+          }
+        }
+        """#.utf8))
+        let credentials = CodexOAuthCredentials(
+            accessToken: "token-a",
+            refreshToken: "refresh-a",
+            idToken: nil,
+            accountId: "account-a",
+            lastRefresh: nil)
+        let state = try #require(CodexReconciledState.fromOAuth(
+            response: usageResponse,
+            credentials: credentials,
+            subscription: subscription,
+            updatedAt: Date(timeIntervalSince1970: 1)))
+        #expect(state.toUsageSnapshot().subscriptionRenewsAt == expectedRenewal)
+    }
+
+    @Test
+    func `nonrenewing subscription maps its period end as expiry`() throws {
+        let expectedExpiry = try #require(ISO8601DateFormatter().date(from: "2026-09-08T09:34:05Z"))
+        let payload = Data(#"{"active_until":"2026-09-08T09:34:05Z","will_renew":false}"#.utf8)
+
+        let subscription = try #require(OpenAISubscriptionDates.parse(data: payload))
+
+        #expect(subscription.expiresAt == expectedExpiry)
+        #expect(subscription.renewsAt == nil)
+    }
+
+    @Test
+    func `subscription request without account id is skipped`() async {
+        let transport = ProviderHTTPTransportStub { _ in
+            Issue.record("Subscription transport should not run without an account ID")
+            throw URLError(.badURL)
+        }
+
+        let subscription = await CodexOAuthUsageFetcher.fetchSubscription(
+            accessToken: "token-a",
+            accountId: "  ",
+            env: ["CODEX_HOME": "/tmp/codexbar-subscription-request-test"],
+            session: transport)
+
+        #expect(subscription == nil)
+        #expect(await transport.requests().isEmpty)
+    }
+
+    @Test
     func `token refresh request uses isolated cache policy`() async throws {
         let transport = ProviderHTTPTransportStub { request in
             #expect(request.url?.absoluteString == "https://auth.openai.com/oauth/token")


### PR DESCRIPTION
## Problem

Codex OAuth-mode usage did not surface subscription renewal/expiry dates: the ChatGPT `subscriptions` payload was parsed only on the web-dashboard path, so OAuth-mode cards lost the renewal metadata (rebased from ad636d819 whose architecture has since moved on; the change applies cleanly to current main).

## Change

- Parse `active_until`/`will_renew` from the subscriptions payload in the Codex OAuth usage fetcher (new `OpenAISubscriptionDates` value kept WebKit-free).
- Attach renewal metadata to the reconciled state so the menu card shows renewal dates like the web mode.
- Tests covering payloads with/without renewal + response shape diagnostics.