### PR TITLE
fix: preserve nested process containment during observation

### DIFF
--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -235,9 +235,11 @@ class TestProcessOwnership:
         self.process = process
         self.known = {root.pid: root.birth}
         self.sessions = {root.pid: root.birth} if root.session == root.pid else {}
+        self.pending_members: dict[int, TestProcess] = {}
+        self.pending_sessions: dict[int, set[int]] = {}
 
-    def refresh(self) -> dict[int, TestProcess]:
-        snapshot = test_process_snapshot(self.known.keys() | self.sessions.keys())
+    def refresh(self, *, observing: bool = False) -> dict[int, TestProcess]:
+        snapshot = test_process_snapshot(self.known.keys() | self.sessions.keys() | self.pending_members.keys())
         if self.process is not None:
             if self.process.returncode is not None:
                 raise RuntimeError("Test root was reaped before cleanup completed")
@@ -256,6 +258,7 @@ class TestProcessOwnership:
                 self.root.pid, self.root.parent, self.root.session, self.root.birth, exited)
         owned = {pid: info for pid, info in snapshot.items() if self.known.get(pid) == info.birth}
         checked_sessions = {}
+        replaced_sessions = set()
         while True:
             self.known.update({pid: info.birth for pid, info in owned.items()})
             self.sessions.update({pid: info.birth for pid, info in owned.items() if info.session == pid})
@@ -269,6 +272,8 @@ class TestProcessOwnership:
                 # Recheck AFTER enumeration: the leader might have been reaped during the snapshot.
                 current = test_process(sid) if anchor is not None and anchor.birth == birth else None
                 checked_sessions[sid] = current is not None and current.birth == birth
+                if (anchor is not None and anchor.birth != birth) or (current is not None and current.birth != birth):
+                    replaced_sessions.add(sid)
             additions = {
                 pid: info for pid, info in snapshot.items()
                 if pid not in owned and (
@@ -279,18 +284,53 @@ class TestProcessOwnership:
             if not additions:
                 break
             owned.update(additions)
+        # Uncertain members can change sessions. Retain their births until confirmed gone
+        # or independently attributed; keeping only the old SID could silently lose them.
+        pending_members = {
+            pid: info for pid, info in self.pending_members.items()
+            if pid in snapshot and snapshot[pid].birth == info.birth
+        }
         for sid in list(self.sessions):
             if checked_sessions[sid]:
                 continue
             members = {pid for pid, info in snapshot.items() if info.session == sid and not info.zombie}
             if members - owned.keys():
-                raise RuntimeError(
-                    f"Lost test session continuity for SID {sid}; "
-                    f"cannot attribute PIDs {sorted(members - owned.keys())}")
+                # A nested owner may still be draining its hidden, unreaped child's session.
+                # Observation retains uncertainty; cleanup never adopts or signals these PIDs.
+                if observing and self.process is not None and not exited and sid not in replaced_sessions:
+                    pending_members.update({pid: snapshot[pid] for pid in members - owned.keys()})
+                else:
+                    raise RuntimeError(
+                        f"Lost test session continuity for SID {sid}; "
+                        f"cannot attribute PIDs {sorted(members - owned.keys())}")
             if not members:
                 del self.sessions[sid]
+        pending_members = {pid: info for pid, info in pending_members.items() if pid not in owned}
+        # Uncertainty follows observed ancestry and live pending session leaders, without
+        # granting ownership. Use current sessions after migration; old SIDs are not anchors.
+        while True:
+            additions = {
+                pid: info for pid, info in snapshot.items()
+                if pid not in owned and pid not in pending_members and (
+                    (info.parent in pending_members and info.birth >= pending_members[info.parent].birth)
+                    or (info.session in pending_members and snapshot[info.session].session == info.session
+                        and not snapshot[info.session].zombie and info.birth >= pending_members[info.session].birth)
+                )
+            }
+            if not additions:
+                break
+            pending_members.update(additions)
+        # Matching zombies can still prove ancestry above, but do not themselves need draining.
+        pending_members = {pid: info for pid, info in pending_members.items() if not snapshot[pid].zombie}
+        pending_sessions: dict[int, set[int]] = {}
+        for pid, info in pending_members.items():
+            pending_sessions.setdefault(info.session, set()).add(pid)
+        if pending_sessions and (not observing or self.process is None or exited):
+            raise RuntimeError(f"Lost test session continuity; cannot attribute pending PIDs {sorted(pending_members)}")
         # Confirmed exits/replacements retire; unavailable known metadata raises before reaching here.
         self.known = {pid: info.birth for pid, info in owned.items()}
+        self.pending_members = pending_members
+        self.pending_sessions = pending_sessions
         return {pid: info for pid, info in owned.items() if not info.zombie}
 
     def send(self, info: TestProcess, sig: signal.Signals) -> None:
@@ -413,7 +453,7 @@ def run_command(command: list[str], timeout: int | None = None) -> int:
         ownership = TestProcessOwnership(root, process)
         next_diagnostic = started + 30
         while True:
-            owned = ownership.refresh()
+            owned = ownership.refresh(observing=True)
             result = unreaped_exit_code(process)
             if result is not None:
                 return result

--- a/Scripts/test_swift_test_process_cleanup.py
+++ b/Scripts/test_swift_test_process_cleanup.py
@@ -105,6 +105,133 @@ def fixture(mode, directory, ready_delay=0):
         time.sleep(0.05)
 
 
+def nested_fixture(directory):
+    root = Path(directory)
+    child = root / "child"
+    original_refresh = runner.TestProcessOwnership.refresh
+    original_drain = runner.TestProcessOwnership.drain
+    def refresh(ownership, **kwargs):
+        owned = original_refresh(ownership, **kwargs)
+        if (child / "ready").exists() and not (child / "observed").exists():
+            identity = json.loads((child / "ready").read_text())
+            info = owned.get(identity["pid"])
+            if info is None or info.birth != tuple(identity["birth"]):
+                return owned
+            ready = root / "leader-ready.tmp"
+            ready.write_text(str(ownership.root.pid))
+            ready.replace(root / "leader-ready")
+            wait_until(lambda: (root / "allow-exit").exists() or (child / "stop").exists())
+            release_observed_fixture(child, owned)
+        return owned
+    def drain(ownership, process):
+        try:
+            assert runner.unreaped_exit_code(process) == 23
+            assert process.returncode is None
+            (root / "before-drain").touch()
+            wait_until(lambda: (root / "allow-drain").exists() or (child / "stop").exists())
+        finally:
+            original_drain(ownership, process)
+    with patch.object(runner.TestProcessOwnership, "refresh", refresh), \
+            patch.object(runner.TestProcessOwnership, "drain", drain):
+        result = runner.run_command([sys.executable, __file__, "--fixture", "failure", str(child)], timeout=5)
+        assert result == 23
+    (root / "complete").touch()
+
+
+class NestedProcessCleanupTests(unittest.TestCase):
+    def test_outer_observation_defers_unknown_orphan_until_inner_owner_drains(self):
+        with tempfile.TemporaryDirectory(prefix="codexbar-nested-cleanup-") as directory:
+            root = Path(directory)
+            child_root = root / "child"
+            sentinel_root = root / "sentinel"
+            child_root.mkdir()
+            sentinel_root.mkdir()
+            sentinel = subprocess.Popen(
+                [sys.executable, __file__, "--fixture", "sentinel", str(sentinel_root)], start_new_session=True)
+            original_snapshot = runner.test_process_snapshot
+            original_refresh = runner.TestProcessOwnership.refresh
+            original_send = runner.TestProcessOwnership.send
+            observations = []
+            signaled = []
+            attempts = 0
+            def snapshot(required=()):
+                if attempts == 0:
+                    wait_until(lambda: (root / "leader-ready").exists())
+                    leader = int((root / "leader-ready").read_text())
+                    # First outer poll sees the live leader, but misses its child's birth.
+                    infos = original_snapshot(required)
+                    self.assertFalse(infos[leader].zombie)
+                    child = int((child_root / "pid").read_text())
+                    infos.pop(child, None)
+                    return infos
+                if attempts == 1:
+                    wait_until(lambda: (root / "before-drain").exists())
+                    leader = int((root / "leader-ready").read_text())
+                    child = int((child_root / "pid").read_text())
+                    wait_until(lambda: runner.test_process(child).parent != leader)
+                    infos = original_snapshot(required)
+                    # Model Darwin's hidden exited leader even on hosts exposing zombie metadata.
+                    infos.pop(leader, None)
+                    self.assertIn(child, infos)
+                    return infos
+                wait_until(lambda: (root / "complete").exists())
+                return original_snapshot(required)
+            def refresh(ownership, **kwargs):
+                nonlocal attempts
+                phase = attempts
+                try:
+                    owned = original_refresh(ownership, **kwargs)
+                    if phase < 2:
+                        leader = int((root / "leader-ready").read_text())
+                        child = int((child_root / "pid").read_text())
+                        self.assertNotIn(child, ownership.known, "outer must not adopt an uncertain orphan")
+                        self.assertIn(leader, ownership.sessions)
+                        if phase == 1:
+                            self.assertEqual(ownership.pending_sessions, {leader: {child}})
+                        observations.append(phase)
+                        if phase == 0:
+                            (root / "allow-exit").touch()
+                    return owned
+                finally:
+                    attempts += 1
+                    if phase == 1:
+                        (root / "allow-drain").touch()
+            def send(ownership, info, sig):
+                signaled.append(info.pid)
+                original_send(ownership, info, sig)
+            try:
+                wait_until(lambda: (sentinel_root / "ready").exists())
+                with patch.object(runner, "test_process_snapshot", side_effect=snapshot), \
+                        patch.object(runner.TestProcessOwnership, "refresh", refresh), \
+                        patch.object(runner.TestProcessOwnership, "send", send):
+                    self.assertEqual(runner.run_command(
+                        [sys.executable, __file__, "--nested-fixture", directory], timeout=5), 0)
+                self.assertEqual(observations, [0, 1])
+                self.assertNotIn(int((child_root / "pid").read_text()), signaled)
+                self.assertNotIn(sentinel.pid, signaled)
+                for name in ("pid", "parent-pid"):
+                    self.assertFalse(running(int((child_root / name).read_text())))
+                self.assertIsNone(runner.unreaped_exit_code(sentinel))
+                print(json.dumps(dict(nested_observations=observations, uncertain_orphan_adopted=False,
+                                      outer_signaled=signaled, inner_exit=23, owned_children_drained=True,
+                                      unrelated_sentinel_alive=True)), flush=True)
+            finally:
+                sentinel_alive = runner.unreaped_exit_code(sentinel) is None
+                (root / "allow-exit").touch()
+                (root / "allow-drain").touch()
+                (child_root / "stop").touch()
+                (sentinel_root / "stop").touch()
+                runner.stop_unreaped_child(sentinel)
+                for name in ("pid", "parent-pid"):
+                    path = child_root / name
+                    if path.exists():
+                        pid = int(path.read_text())
+                        wait_until(lambda: not running(pid))
+                self.assertTrue(sentinel_alive, "unrelated sentinel was terminated before fixture teardown")
+                print(json.dumps(dict(nested_teardown_complete=True,
+                                      unrelated_sentinel_alive_before_teardown=sentinel_alive)), flush=True)
+
+
 class ProcessCleanupTests(unittest.TestCase):
     def exercise(self, mode, expected, interrupt=False, ready_delay=0):
         with tempfile.TemporaryDirectory(prefix="codexbar-process-cleanup-") as directory:
@@ -129,9 +256,9 @@ class ProcessCleanupTests(unittest.TestCase):
                 original_drain = runner.TestProcessOwnership.drain
                 acknowledged = False
                 draining = False
-                def refresh(ownership):
+                def refresh(ownership, **kwargs):
                     nonlocal acknowledged
-                    owned = original_refresh(ownership)
+                    owned = original_refresh(ownership, **kwargs)
                     if not acknowledged and not draining:
                         acknowledged = release_observed_fixture(
                             child_root, owned, include_grandchild=mode == "success-session-tree")
@@ -1037,6 +1164,280 @@ class SessionOwnershipTests(unittest.TestCase):
         self.assertNotIn(30, ownership.known)
 
 
+class PendingSessionTests(unittest.TestCase):
+    root = runner.TestProcess(10, 1, 10, (100, 0))
+    leader = runner.TestProcess(20, 10, 20, (101, 0))
+    orphan = runner.TestProcess(30, 1, 20, (102, 0))
+
+    def setUp(self):
+        self.process = Mock(pid=10, returncode=None)
+        self.ownership = runner.TestProcessOwnership(self.root, self.process)
+        self.ownership.known[20] = self.leader.birth
+        self.ownership.sessions[20] = self.leader.birth
+
+    def refresh(self, *infos, exited=None, observing=True):
+        snapshot = {info.pid: info for info in infos}
+        with patch.object(runner, "test_process_snapshot", return_value=snapshot), \
+                patch.object(runner, "test_process", side_effect=snapshot.get), \
+                patch.object(runner, "unreaped_exit_code", return_value=exited):
+            return self.ownership.refresh(observing=observing)
+
+    def test_live_command_observes_uncertainty_without_adopting_then_retires_empty_session(self):
+        self.assertEqual(set(self.refresh(self.root, self.orphan)), {10})
+        self.assertEqual(self.ownership.pending_sessions, {20: {30}})
+        self.assertNotIn(30, self.ownership.known)
+        self.assertEqual(set(self.refresh(self.root)), {10})
+        self.assertEqual(self.ownership.pending_sessions, {})
+        self.assertNotIn(20, self.ownership.sessions)
+        self.assertEqual(self.refresh(exited=0), {})
+
+    def test_command_exit_cannot_defer_uncertainty(self):
+        self.refresh(self.root, self.orphan)
+        with self.assertRaisesRegex(RuntimeError, "session continuity"):
+            self.refresh(self.orphan, exited=0)
+        self.assertNotIn(30, self.ownership.known)
+
+    def test_pending_member_cannot_escape_uncertainty_by_changing_sessions(self):
+        self.refresh(self.root, self.orphan)
+        moved = runner.TestProcess(30, 1, 30, self.orphan.birth)
+        self.assertEqual(set(self.refresh(self.root, moved)), {10})
+        self.assertNotIn(20, self.ownership.sessions)
+        self.assertEqual(self.ownership.pending_sessions, {20: {30}})
+        with self.assertRaisesRegex(RuntimeError, "cannot attribute pending PIDs"):
+            self.refresh(self.root, moved, observing=False)
+        self.assertNotIn(30, self.ownership.known)
+        self.assertEqual(self.refresh(exited=0), {})
+        self.assertEqual(self.ownership.pending_members, {})
+
+    def test_pending_birth_replacement_retires_without_claiming_replacement(self):
+        self.refresh(self.root, self.orphan)
+        replacement = runner.TestProcess(30, 1, 30, (200, 0))
+        self.assertEqual(set(self.refresh(self.root, replacement)), {10})
+        self.assertEqual(self.ownership.pending_members, {})
+        self.assertNotIn(30, self.ownership.known)
+
+    def test_pending_child_survives_parent_session_migration_and_disappearance(self):
+        self.refresh(self.root, self.orphan)
+        moved = runner.TestProcess(30, 1, 30, self.orphan.birth)
+        child = runner.TestProcess(31, 30, 30, (103, 0))
+        self.assertEqual(set(self.refresh(self.root, moved, child)), {10})
+        orphaned_child = runner.TestProcess(31, 1, 30, child.birth)
+        with self.assertRaisesRegex(RuntimeError, "cannot attribute pending PIDs"):
+            self.refresh(orphaned_child, exited=0)
+        self.assertEqual(set(self.ownership.pending_members), {30, 31})
+        self.assertEqual(self.ownership.known, {10: self.root.birth})
+
+    def test_new_pending_ancestry_is_recursive_and_survives_further_migration(self):
+        child = runner.TestProcess(31, 30, 31, (103, 0))
+        grandchild = runner.TestProcess(32, 31, 32, (104, 0))
+        self.assertEqual(set(self.refresh(self.root, grandchild, child, self.orphan)), {10})
+        self.assertEqual(set(self.ownership.pending_members), {30, 31, 32})
+        moved_child = runner.TestProcess(31, 1, 40, child.birth)
+        moved_grandchild = runner.TestProcess(32, 1, 50, grandchild.birth)
+        self.refresh(self.root, moved_grandchild, moved_child)
+        self.assertEqual(set(self.ownership.pending_members), {31, 32})
+        self.refresh(self.root, moved_grandchild)
+        self.assertEqual(set(self.ownership.pending_members), {32})
+        with self.assertRaisesRegex(RuntimeError, "cannot attribute pending PIDs"):
+            self.refresh(moved_grandchild, exited=0)
+
+    def test_live_pending_session_leader_retains_orphaned_peers_and_their_children(self):
+        self.refresh(self.root, self.orphan)
+        moved = runner.TestProcess(30, 1, 30, self.orphan.birth)
+        peer = runner.TestProcess(31, 1, 30, (103, 0))
+        child = runner.TestProcess(32, 31, 32, (104, 0))
+        self.assertEqual(set(self.refresh(self.root, child, peer, moved)), {10})
+        self.assertEqual(set(self.ownership.pending_members), {30, 31, 32})
+        self.assertEqual(self.ownership.known, {10: self.root.birth})
+        self.assertNotIn(30, self.ownership.sessions)
+        self.refresh(self.root, peer)
+        self.assertEqual(set(self.ownership.pending_members), {31})
+        with self.assertRaisesRegex(RuntimeError, "cannot attribute pending PIDs"):
+            self.refresh(self.root, peer, observing=False)
+
+    def test_pending_nonleader_does_not_seed_peers_in_its_current_or_former_session(self):
+        self.refresh(self.root, self.orphan)
+        moved = runner.TestProcess(30, 1, 30, self.orphan.birth)
+        self.refresh(self.root, moved)
+        moved_again = runner.TestProcess(30, 1, 40, self.orphan.birth)
+        former_peer = runner.TestProcess(31, 1, 30, (103, 0))
+        current_peer = runner.TestProcess(32, 1, 40, (104, 0))
+        self.assertEqual(set(self.refresh(self.root, moved_again, former_peer, current_peer)), {10})
+        self.assertEqual(set(self.ownership.pending_members), {30})
+        self.assertEqual(self.refresh(former_peer, current_peer, exited=0), {})
+
+    def test_pending_ancestry_and_session_edges_require_compatible_birth_order(self):
+        for parent in (1, 30):
+            for birth, expected in (((102, 0), False), ((102, 1), True), ((102, 2), True)):
+                with self.subTest(parent=parent, birth=birth):
+                    self.setUp()
+                    pending = runner.TestProcess(30, 1, 20, (102, 1))
+                    self.refresh(self.root, pending)
+                    moved = runner.TestProcess(30, 1, 30, pending.birth)
+                    candidate = runner.TestProcess(31, parent, 31 if parent == 30 else 30, birth)
+                    descendant = runner.TestProcess(32, 31, 32, (103, 0))
+                    self.assertEqual(set(self.refresh(self.root, descendant, candidate, moved)), {10})
+                    self.assertEqual(set(self.ownership.pending_members), {30, 31, 32} if expected else {30})
+                    self.assertEqual(self.ownership.known, {10: self.root.birth})
+
+    def test_pending_zombie_ancestry_retains_live_descendants_without_retaining_exits(self):
+        self.refresh(self.root, self.orphan)
+        zombie = runner.TestProcess(30, 1, 0, self.orphan.birth, True)
+        child = runner.TestProcess(31, 30, 0, (103, 0), True)
+        grandchild = runner.TestProcess(32, 31, 32, (104, 0))
+        unrelated = runner.TestProcess(33, 1, 30, (105, 0))
+        self.assertEqual(set(self.refresh(self.root, grandchild, child, zombie, unrelated)), {10})
+        self.assertEqual(set(self.ownership.pending_members), {32})
+        with self.assertRaisesRegex(RuntimeError, "cannot attribute pending PIDs"):
+            self.refresh(grandchild, unrelated, exited=0)
+
+    def test_replaced_pending_leader_does_not_seed_replacement_children_or_peers(self):
+        self.refresh(self.root, self.orphan)
+        moved = runner.TestProcess(30, 1, 30, self.orphan.birth)
+        self.refresh(self.root, moved)
+        replacement = runner.TestProcess(30, 1, 30, (200, 0))
+        child = runner.TestProcess(31, 30, 31, (201, 0))
+        peer = runner.TestProcess(32, 1, 30, (202, 0))
+        self.assertEqual(self.refresh(replacement, child, peer, exited=0), {})
+        self.assertEqual(self.ownership.pending_members, {})
+        self.assertEqual(self.ownership.known, {10: self.root.birth})
+
+    def test_replaced_pending_child_retires_but_previously_observed_grandchild_remains(self):
+        child = runner.TestProcess(31, 30, 31, (103, 0))
+        grandchild = runner.TestProcess(32, 31, 32, (104, 0))
+        self.refresh(self.root, self.orphan, child, grandchild)
+        replacement = runner.TestProcess(31, 1, 31, (200, 0))
+        new_child = runner.TestProcess(33, 31, 33, (201, 0))
+        orphaned_grandchild = runner.TestProcess(32, 1, 32, grandchild.birth)
+        self.refresh(self.root, replacement, new_child, orphaned_grandchild)
+        self.assertEqual(set(self.ownership.pending_members), {32})
+        self.assertEqual(self.ownership.known, {10: self.root.birth})
+        with self.assertRaisesRegex(RuntimeError, "cannot attribute pending PIDs"):
+            self.refresh(replacement, new_child, orphaned_grandchild, exited=0)
+
+    def test_confirmed_pending_descendant_exit_or_replacement_retires_old_birth(self):
+        child = runner.TestProcess(31, 30, 31, (103, 0))
+        for remaining in ((), (runner.TestProcess(31, 1, 0, child.birth, True),),
+                          (runner.TestProcess(31, 1, 31, (200, 0)),)):
+            with self.subTest(remaining=remaining):
+                self.setUp()
+                self.refresh(self.root, self.orphan, child)
+                self.assertIn(31, self.ownership.pending_members)
+                self.assertEqual(self.refresh(*remaining, exited=0), {})
+                self.assertEqual(self.ownership.pending_members, {})
+                self.assertNotIn(31, self.ownership.known)
+
+    def test_pending_descendant_metadata_stays_required_after_ancestry_disappears(self):
+        child = runner.TestProcess(31, 30, 31, (103, 0))
+        self.refresh(self.root, self.orphan, child)
+        moved = runner.TestProcess(31, 1, 40, child.birth)
+        self.refresh(self.root, moved)
+        for error in (errno.EPERM, errno.EACCES, errno.EIO):
+            with self.subTest(errno=error):
+                def lookup(pid):
+                    if pid == 31:
+                        raise OSError(error, "pending descendant unavailable")
+                    return self.root if pid == 10 else None
+                with patch.object(runner, "test_process_ids", return_value={10}), \
+                        patch.object(runner, "test_process", side_effect=lookup), \
+                        patch.object(runner, "unreaped_exit_code", return_value=None):
+                    with self.assertRaisesRegex(OSError, "pending descendant unavailable") as raised:
+                        self.ownership.refresh(observing=True)
+                self.assertEqual(raised.exception.errno, error)
+                self.assertEqual(set(self.ownership.pending_members), {31})
+                self.assertNotIn(31, self.ownership.known)
+
+    def test_pending_descendant_becomes_owned_only_through_independent_lineage_or_session(self):
+        child = runner.TestProcess(31, 30, 31, (103, 0))
+        for parent, session in ((10, 31), (1, 10)):
+            with self.subTest(parent=parent, session=session):
+                self.setUp()
+                self.refresh(self.root, self.orphan, child)
+                self.assertIn(31, self.ownership.pending_members)
+                proven = runner.TestProcess(31, parent, session, child.birth)
+                self.assertEqual(set(self.refresh(self.root, proven, observing=False)), {10, 31})
+                self.assertEqual(self.ownership.pending_members, {})
+                self.assertEqual(self.ownership.known[31], child.birth)
+
+    def test_pending_descendants_and_unrelated_peers_never_gain_signal_authority(self):
+        child = runner.TestProcess(31, 30, 31, (103, 0))
+        grandchild = runner.TestProcess(32, 31, 32, (104, 0))
+        peer = runner.TestProcess(40, 1, 40, (105, 0))
+        self.refresh(self.root, self.orphan, child, grandchild, peer)
+        self.assertEqual(set(self.ownership.pending_members), {30, 31, 32})
+        orphaned = runner.TestProcess(32, 1, 32, grandchild.birth)
+        self.refresh(self.root, orphaned, peer)
+        snapshot = {10: self.root, 32: orphaned, 40: peer}
+        with patch.object(runner, "test_process_snapshot", return_value=snapshot), \
+                patch.object(runner, "test_process", side_effect=snapshot.get), \
+                patch.object(runner, "unreaped_exit_code", return_value=None), \
+                patch.object(self.ownership, "send") as send, \
+                patch.object(runner, "stop_unreaped_child") as stop:
+            with self.assertRaisesRegex(RuntimeError, "cannot attribute pending PIDs"):
+                self.ownership.drain(self.process)
+        self.assertEqual([call.args[0].pid for call in send.call_args_list], [10])
+        stop.assert_called_once_with(self.process)
+        with patch.object(runner, "test_process", side_effect=snapshot.get), \
+                patch.object(runner.sys, "platform", "darwin"), \
+                patch.object(runner, "darwin_signal_process") as native, \
+                patch.object(runner.os, "kill") as kill:
+            for info in (orphaned, peer):
+                self.ownership.send(info, signal.SIGKILL)
+        native.assert_not_called()
+        kill.assert_not_called()
+        self.assertEqual(self.ownership.known, {10: self.root.birth})
+
+    def test_pending_member_metadata_stays_required_even_after_session_changes(self):
+        self.refresh(self.root, self.orphan)
+        def lookup(pid):
+            if pid == 30:
+                raise PermissionError(errno.EACCES, "pending identity unavailable")
+            return self.root if pid == 10 else None
+        with patch.object(runner, "test_process_ids", return_value={10}), \
+                patch.object(runner, "test_process", side_effect=lookup):
+            with self.assertRaisesRegex(PermissionError, "pending identity unavailable"):
+                self.ownership.refresh(observing=True)
+        self.assertNotIn(30, self.ownership.known)
+
+    def test_observation_without_direct_wait_ownership_cannot_defer_uncertainty(self):
+        self.ownership.process = None
+        with self.assertRaisesRegex(RuntimeError, "session continuity"):
+            self.refresh(self.root, self.orphan)
+        self.assertNotIn(30, self.ownership.known)
+
+    def test_reused_session_birth_still_fails_during_observation(self):
+        replacement = runner.TestProcess(20, 1, 20, (200, 0))
+        with self.assertRaisesRegex(RuntimeError, "session continuity"):
+            self.refresh(self.root, replacement, self.orphan)
+        self.assertEqual(self.ownership.known[20], self.leader.birth)
+        self.assertNotIn(30, self.ownership.known)
+
+    def test_reused_session_birth_after_enumeration_still_fails_during_observation(self):
+        replacement = runner.TestProcess(20, 1, 20, (200, 0))
+        with patch.object(runner, "test_process_snapshot", return_value={10: self.root, 20: self.leader, 30: self.orphan}), \
+                patch.object(runner, "test_process", return_value=replacement), \
+                patch.object(runner, "unreaped_exit_code", return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "session continuity"):
+                self.ownership.refresh(observing=True)
+        self.assertNotIn(30, self.ownership.known)
+
+    def test_cleanup_of_live_command_fails_without_signaling_uncertain_or_unrelated_pid(self):
+        peer = runner.TestProcess(40, 1, 40, (103, 0))
+        self.refresh(self.root, self.orphan, peer)
+        snapshot = {10: self.root, 30: self.orphan, 40: peer}
+        with patch.object(runner, "test_process_snapshot", return_value=snapshot), \
+                patch.object(runner, "test_process", side_effect=snapshot.get), \
+                patch.object(runner, "unreaped_exit_code", return_value=None), \
+                patch.object(self.ownership, "send") as send, \
+                patch.object(runner, "stop_unreaped_child") as stop:
+            with self.assertRaisesRegex(RuntimeError, "session continuity"):
+                self.ownership.drain(self.process)
+        self.assertEqual([call.args[0].pid for call in send.call_args_list], [10])
+        stop.assert_called_once_with(self.process)
+        self.assertNotIn(30, self.ownership.known)
+        self.assertNotIn(40, self.ownership.known)
+
+
 @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux /proc and pthread_exit semantics")
 class LinuxThreadGroupTests(unittest.TestCase):
     def test_native_zombie_leader_with_live_worker_is_killed_and_reaped(self):
@@ -1103,5 +1504,7 @@ int main(int argc, char **argv) {
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "--fixture":
         fixture(sys.argv[2], sys.argv[3], float(sys.argv[4]) if len(sys.argv) > 4 else 0)
+    elif len(sys.argv) > 1 and sys.argv[1] == "--nested-fixture":
+        nested_fixture(sys.argv[2])
     else:
         unittest.main()

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -141,7 +141,16 @@ finishes (`waitid` with `WNOWAIT`), preventing reuse of its PID/session. Observe
 leaders can establish ownership of orphaned session members only while a matching live or unreaped
 birth identity still anchors that session. Known descendants retain their identities after reparenting;
 empty completed sessions retire. If an observed session loses its anchor while unaccounted live members
-remain, cleanup fails without adopting or signaling those uncertain PIDs. Unavailable metadata for a
+remain, observation may retain that session as pending only while the direct command is still wait-owned
+and running. A nested runner can then finish draining its own child: its unreaped wait handle is not
+signal authority for the outer observer, and macOS may hide the exited leader's metadata. Pending members
+remain birth-checked even if they change sessions. Uncertainty also follows observed descendants and peers
+of a live matching pending session leader, with compatible birth ordering; those identities remain pending
+after reparenting or session migration. Unreadable pending metadata fails closed; confirmed exits or replaced
+pending births retire without claiming replacements. Pending status grants no ownership or signal authority.
+Command exit and every cleanup path require session continuity and fail if uncertainty remains; a detected
+replacement session-leader birth still fails immediately, even during observation.
+No observation or cleanup deadline is extended. Unavailable metadata for a
 known identity also fails cleanup; an unreadable unrelated peer does not abort enumeration.
 For the direct child, confirmed metadata absence (ESRCH/ENOENT) can precede a waitable exit on
 Darwin. Its unreaped wait handle retains ownership while ordinary polling continues within the
@@ -173,9 +182,14 @@ files and self-expiry, with final cleanup restricted to their unreaped direct ch
 
 Process-cleanup fixtures keep ancestry alive until the real ownership refresh observes matching ready
 child identities (and the session-tree grandchild), then acknowledges a private fixture gate before drain.
-The direct `waitid` fixture uses the same handshake without reaping its root. Immediate cases and a controlled
-one-second readiness delay retain the two-second command budget; startup no longer adds a fixed 1.2-second
-ancestry sleep. Gate waits are bounded and stop-file aware; helper self-expiry remains 20 seconds.
+The direct `waitid` fixture uses the same handshake without reaping its root. Success/failure fixtures keep
+their five-second command budget; timeout fixtures keep two seconds. A virtual-clock readiness test proves
+one-second startup adds no fixed ancestry sleep. Gate waits are bounded and stop-file aware; helper
+self-expiry remains 20 seconds.
+The nested failure regression gates the inner drain and controls outer snapshots: the outer observer
+sees a live session leader first, then its previously unseen orphan with the exited leader hidden.
+Only the inner wait owner drains that orphan; the outer runner must complete without claiming it.
+Contract tests also require unresolved sessions to fail at cleanup and reject reused leader births.
 
 Cost performance and fair-scheduling corpora use exclusive initial fixture creation: the scanner only
 reads after setup has closed each file. This avoids per-file atomic publication and durability work


### PR DESCRIPTION
## Summary

Fix intermittent process-containment failures when `make check` runs inside `ci_swift_test_by_suite.run_command`. A nested runner can still own its fixture's unreaped wait handle while macOS hides the exited session leader's metadata from an outer observer. The outer runner previously treated that temporary missing anchor as an immediate failure, interrupting the inner owner's cleanup.

Separate ordinary observation from strict cleanup. While its direct command remains running and wait-owned, an observer retains unresolved identities as pending without adopting or signaling them. Pending births and observed descendants remain tracked across reparenting, session migration, and parent exit. Command exit and cleanup still reject unresolved uncertainty; replaced owned session-leader births and unreadable required metadata still fail closed.

Add a deterministic nested regression that forces the exact missing-anchor observation order, plus pending-descendant, PID-replacement, metadata-error, and no-signal safety tests. Update the development guide to describe the ownership boundary.

## Validation

- The gated nested regression reproduces the original `Lost test session continuity ... cannot attribute PIDs ...` failure against the original runner.
- Final synthetic cleanup suite, inside a real outer runner: 95 tests successful in 35.590 seconds on macOS 27 / Python 3.14.7, with one existing Linux-native pthread test skipped on macOS. Owned children are drained, the inner failure retains exit code 23, and unrelated sentinels survive.
- Exact `run_command(['make', 'check'], timeout=180)` succeeded in 69.885 seconds in an isolated checkout, including another complete cleanup-suite run and zero SwiftLint violations. Verified source hashes match this patch.
- Native Darwin audit-token fixtures preserve wrong-generation children, then terminate and reap matching identities while unrelated sentinels survive.
- 72 selected synthetic safety tests passed with zero skips. `git diff --check` is clean.

Local verification limitations are explicit: the primary workstation had prolonged filesystem/startup stalls. Local wrapped checks exhausted their unchanged 180-second deadline before the containment fixture, and the full local Swift build was stopped while stalled. No full local Swift-suite pass is claimed.

## Safety and scope

PID birth checks, generation-bound signaling, direct-child wait ownership, cleanup grace periods, fixture budgets, and command deadlines are unchanged. Pending status never grants signal authority. No fixture was disabled, and no app/provider/metadata-performance implementation is changed. The tracker still cannot discover ancestry that disappears entirely between snapshots.
