### PR TITLE
test(sakana): await cancellation with a bounded deadline

### DIFF
--- a/Tests/CodexBarTests/SakanaUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/SakanaUsageFetcherTests.swift
@@ -172,10 +172,7 @@ struct SakanaUsageFetcherTests {
         #expect(snapshot.fiveHour?.usedPercent == 92)
         #expect(snapshot.payAsYouGo == nil)
         #expect(startedAt.duration(to: .now) < .milliseconds(500))
-        for _ in 0..<1000 where await !(transport.didCancelPayAsYouGo()) {
-            await Task.yield()
-        }
-        #expect(await transport.didCancelPayAsYouGo())
+        #expect(try await transport.waitForPayAsYouGoCancellation())
     }
 
     @Test
@@ -192,10 +189,7 @@ struct SakanaUsageFetcherTests {
                 session: transport)
         }
 
-        for _ in 0..<1000 where await !(transport.didCancelPayAsYouGo()) {
-            await Task.yield()
-        }
-        #expect(await transport.didCancelPayAsYouGo())
+        #expect(try await transport.waitForPayAsYouGoCancellation())
     }
 
     @Test
@@ -457,8 +451,13 @@ private actor SakanaScriptedTransport: ProviderHTTPTransport {
         self.capturedRequests
     }
 
-    func didCancelPayAsYouGo() -> Bool {
-        self.payAsYouGoWasCancelled
+    func waitForPayAsYouGoCancellation() async throws -> Bool {
+        // Stay below the optional request's five-second fallback timeout.
+        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
+        while !self.payAsYouGoWasCancelled, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        return self.payAsYouGoWasCancelled
     }
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {


### PR DESCRIPTION
## Summary

Fixes a synchronization race in the Sakana cancellation tests, without changing provider behavior.

The full local test run observed the primary quota result within its existing 500ms limit, but the test exhausted 1,000 scheduler yields before the transport actor recorded cancellation. The suite passed on retry. A yield count is not an acknowledgement or a time bound.

Both cancellation checks now share an actor helper with a one-second monotonic deadline and 10ms polling. The primary-response assertion remains before the wait, and the acknowledgement deadline remains below the production optional-request timeout of five seconds. No production deadline is relaxed.

## Verification

- File-scoped SwiftFormat and strict SwiftLint pass; `git diff --check` passes.
- Independent Codex autoreview found no accepted findings at its configured P0 threshold; maintainer review checked actor reentrancy and the production cancellation boundary.
- All 23 Sakana tests pass; repository `make check` passes with zero violations across 2,079 Swift files.
- The fresh full `make test` run passes all 82 groups (984 selections) on this head, with zero failures, retries, or timeouts. It uses the same compiler through SwiftPM's native backend after the SDK stat-cache tool stalled in the default backend.
- Ten additional focused repetitions pass: 230 Sakana test executions with the primary-response latency assertion intact.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33469912103) passes all required checks: both macOS test shards, Linux x64/arm64 builds, lint, and the aggregate gate. The musl build is correctly skipped by the test-only path gate.
- The originating full local run stopped later on an unrelated 600-second `StatusMenuTests` timeout; this PR does not claim to fix that timeout or the separately retried Kiro process-cleanup failure.

Test-only change; no changelog entry or live credentials required.
