### PR TITLE
fix(codex): preserve selected workspaces in stacked refresh

### DIFF
--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -428,7 +428,7 @@ extension UsageStore {
                         authFingerprint: authFingerprint ?? (requiresLiveAuth ? nil : account.authFingerprint),
                         workspaceAccountID: authFingerprint == nil && requiresLiveAuth
                             ? nil
-                            : (workspaceAccountID ?? account.workspaceAccountID)))
+                            : (account.workspaceAccountID ?? workspaceAccountID)))
             })
         let visibleAccounts = projection.visibleAccounts.map { account in
             guard case let .managedAccount(id) = account.selectionSource else { return account }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -413,7 +413,7 @@ extension UsageStore {
     {
         let managedRuntimeStates = Dictionary(
             uniqueKeysWithValues: snapshot.storedAccounts.map { account in
-                let workspaceAccountID: String? =
+                let authWorkspaceAccountID: String? =
                     switch snapshot.runtimeIdentity(for: account) {
                     case let .providerAccount(id):
                         id
@@ -428,7 +428,7 @@ extension UsageStore {
                         authFingerprint: authFingerprint ?? (requiresLiveAuth ? nil : account.authFingerprint),
                         workspaceAccountID: authFingerprint == nil && requiresLiveAuth
                             ? nil
-                            : (account.workspaceAccountID ?? workspaceAccountID)))
+                            : (account.workspaceAccountID ?? account.providerAccountID ?? authWorkspaceAccountID)))
             })
         let visibleAccounts = projection.visibleAccounts.map { account in
             guard case let .managedAccount(id) = account.selectionSource else { return account }

--- a/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
@@ -165,7 +165,9 @@ extension CodexVisibleAccountProjection {
             drafts.append(VisibleAccountDraft(
                 email: normalizedEmail,
                 workspaceLabel: Self.normalizeWorkspaceLabel(storedAccount.workspaceLabel),
-                workspaceAccountID: storedAccount.workspaceAccountID ?? runtimeWorkspaceAccountID,
+                workspaceAccountID: storedAccount.workspaceAccountID
+                    ?? storedAccount.providerAccountID
+                    ?? runtimeWorkspaceAccountID,
                 authFingerprint: storedAccount.authFingerprint,
                 storedAccountID: storedAccount.id,
                 selectionSource: .managedAccount(id: storedAccount.id),

--- a/Tests/CodexBarTests/CodexManagedWorkspaceRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexManagedWorkspaceRefreshTests.swift
@@ -1,0 +1,116 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test(arguments: [false, true])
+    func `stacked refresh keeps selected managed workspace separate from auth default`(
+        switchesWorkspaceDuringRefresh: Bool) async throws
+    {
+        let suite = "CodexManagedWorkspaceRefreshTests-\(switchesWorkspaceDuringRefresh)"
+        let root = CodexCredentialFixtures.root
+            .appendingPathComponent("managed-workspace-refresh-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let targetHome = root.appendingPathComponent("target", isDirectory: true)
+        let siblingHome = root.appendingPathComponent("sibling", isDirectory: true)
+        let authenticatedTarget = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: UUID(),
+            email: "workspace-member@example.com",
+            workspaceID: "auth-default-workspace",
+            workspaceLabel: "Default",
+            homeURL: targetHome)
+        let target = ManagedCodexAccount(
+            id: authenticatedTarget.id,
+            email: authenticatedTarget.email,
+            providerAccountID: "selected-team-workspace",
+            workspaceLabel: "Selected Team",
+            workspaceAccountID: "selected-team-workspace",
+            authFingerprint: authenticatedTarget.authFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let sibling = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: UUID(),
+            email: "sibling-member@example.com",
+            workspaceID: "sibling-workspace",
+            workspaceLabel: "Sibling",
+            homeURL: siblingHome)
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [target, sibling])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: target.id)
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = self.makeCodexWeeklyPublicationStore(
+            settings: settings,
+            suite: suite,
+            snapshotStore: snapshotStore)
+        let targetSnapshot = self.codexSnapshot(email: target.email, usedPercent: 64)
+        let siblingSnapshot = self.codexSnapshot(email: sibling.email, usedPercent: 22)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == targetHome.path {
+                #expect(context.codexWorkspaceID == "selected-team-workspace")
+                return try await blocker.awaitResult()
+            }
+            #expect(context.env["CODEX_HOME"] == siblingHome.path)
+            #expect(context.codexWorkspaceID == "sibling-workspace")
+            return siblingSnapshot
+        }
+
+        let refresh = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        if switchesWorkspaceDuringRefresh {
+            let replacement = ManagedCodexAccount(
+                id: target.id,
+                email: target.email,
+                providerAccountID: "replacement-team-workspace",
+                workspaceLabel: "Replacement Team",
+                workspaceAccountID: "replacement-team-workspace",
+                authFingerprint: target.authFingerprint,
+                managedHomePath: target.managedHomePath,
+                createdAt: target.createdAt,
+                updatedAt: 3,
+                lastAuthenticatedAt: target.lastAuthenticatedAt)
+            try FileManagedCodexAccountStore(fileURL: storeURL).storeAccounts(ManagedCodexAccountSet(
+                version: FileManagedCodexAccountStore.currentVersion,
+                accounts: [replacement, sibling]))
+        }
+        await blocker.resume(with: .success(targetSnapshot))
+        await refresh.value
+
+        let menuProjection = try #require(settings.codexVisibleAccountProjectionForMenuDisplay)
+        let displayedSnapshots = store.codexAccountSnapshots.filter { row in
+            menuProjection.visibleAccounts.contains { account in
+                account.id == row.id && UsageStore.codexPriorSnapshotAccountMatches(row.account, account: account)
+            }
+        }
+        #expect(displayedSnapshots.contains {
+            $0.account.storedAccountID == sibling.id && $0.snapshot?.primary?.usedPercent == 22
+        })
+        if switchesWorkspaceDuringRefresh {
+            #expect(store.snapshots[.codex] == nil)
+            #expect(!store.codexAccountSnapshots.contains { $0.account.storedAccountID == target.id })
+            #expect(!snapshotStore.storedSnapshots.contains { $0.account.storedAccountID == target.id })
+        } else {
+            #expect(displayedSnapshots.count == 2)
+            let targetRow = try #require(displayedSnapshots.first { $0.account.storedAccountID == target.id })
+            #expect(targetRow.account.workspaceAccountID == "selected-team-workspace")
+            #expect(targetRow.snapshot?.primary?.usedPercent == 64)
+            #expect(store.snapshots[.codex]?.primary?.usedPercent == 64)
+            #expect(snapshotStore.storedSnapshots.contains {
+                $0.account.storedAccountID == target.id && $0.account.workspaceAccountID == "selected-team-workspace"
+            })
+        }
+        let auth = try CodexOAuthCredentialsStore.load(env: ["CODEX_HOME": targetHome.path])
+        #expect(auth.accountId == "auth-default-workspace")
+    }
+}

--- a/Tests/CodexBarTests/CodexManagedWorkspaceRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexManagedWorkspaceRefreshTests.swift
@@ -5,11 +5,13 @@ import Testing
 
 @MainActor
 extension CodexAccountScopedRefreshTests {
-    @Test(arguments: [false, true])
+    @Test(arguments: [false, true], [false, true])
     func `stacked refresh keeps selected managed workspace separate from auth default`(
-        switchesWorkspaceDuringRefresh: Bool) async throws
+        switchesWorkspaceDuringRefresh: Bool,
+        usesProviderAccountIDFallback: Bool) async throws
     {
-        let suite = "CodexManagedWorkspaceRefreshTests-\(switchesWorkspaceDuringRefresh)"
+        let suite = "CodexManagedWorkspaceRefreshTests-\(switchesWorkspaceDuringRefresh)-" +
+            "\(usesProviderAccountIDFallback)"
         let root = CodexCredentialFixtures.root
             .appendingPathComponent("managed-workspace-refresh-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -26,7 +28,7 @@ extension CodexAccountScopedRefreshTests {
             email: authenticatedTarget.email,
             providerAccountID: "selected-team-workspace",
             workspaceLabel: "Selected Team",
-            workspaceAccountID: "selected-team-workspace",
+            workspaceAccountID: usesProviderAccountIDFallback ? nil : "selected-team-workspace",
             authFingerprint: authenticatedTarget.authFingerprint,
             managedHomePath: targetHome.path,
             createdAt: 1,
@@ -48,6 +50,9 @@ extension CodexAccountScopedRefreshTests {
         }
         settings._test_managedCodexAccountStoreURL = storeURL
         settings.codexActiveSource = .managedAccount(id: target.id)
+        let initialProjection = settings.codexVisibleAccountProjection
+        let initialTarget = try #require(initialProjection.visibleAccounts.first { $0.storedAccountID == target.id })
+        #expect(initialTarget.workspaceAccountID == "selected-team-workspace")
         let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
         let store = self.makeCodexWeeklyPublicationStore(
             settings: settings,
@@ -74,7 +79,7 @@ extension CodexAccountScopedRefreshTests {
                 email: target.email,
                 providerAccountID: "replacement-team-workspace",
                 workspaceLabel: "Replacement Team",
-                workspaceAccountID: "replacement-team-workspace",
+                workspaceAccountID: usesProviderAccountIDFallback ? nil : "replacement-team-workspace",
                 authFingerprint: target.authFingerprint,
                 managedHomePath: target.managedHomePath,
                 createdAt: target.createdAt,

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -68,6 +68,9 @@ Usage source picker:
   Automatic mode also suppresses unscoped CLI fallback whenever a managed workspace is selected. Explicit
   managed-account workspace selection is stored in CodexBar's private managed-account metadata; it never edits the
   source `auth.json` or publishes an `account_id` change back to another application's credential file.
+- Stacked account refreshes retain each managed account's selected workspace through usage publication and menu
+  matching, even when its auth file names a different default workspace. Changing the selected workspace while a
+  refresh is running discards the old workspace's result.
 - Reusing OpenCode OAuth enables remote account quota, not OpenCode session token/cost ingestion. See
   [OpenCode with Codex or OpenAI](opencode.md#using-opencode-with-codex-or-openai) for the current history boundary.
 


### PR DESCRIPTION
## Summary

A managed Codex account can explicitly select a workspace while its `auth.json` still names the login's default workspace. Stacked refresh fetched the selected workspace but projected and published its row under the auth file's workspace identity, so menu ownership checks rejected the successful result and left one account at “Not fetched yet.” A workspace change during an in-flight refresh could also admit stale results.

Use one workspace precedence across fetch routing, visible-account projection, refresh publication, and menu matching: explicit managed workspace, legacy stored provider account ID, then the runtime auth workspace. This keeps upgraded/provider-ID-only records working as well as current records. Existing email, credential-fingerprint, and freshness checks remain in force, and changing the selected workspace while a refresh is running discards the old workspace's result.

Fixes #3347. Thanks @krevoit for the report and live confirmation.

## Verification

- All 133 `CodexAccountScopedRefreshTests` pass on the rebased head, including current and legacy managed-account shapes, two visible accounts, and an in-flight workspace change.
- All 39 provider-architecture gatekeeper tests pass without changing the allowlist or its source anchors.
- `make check` passes: all 95 process-control tests pass (one expected platform skip), documentation links pass, and SwiftFormat/SwiftLint report zero violations across 2,086 Swift files.
- Independent code-path review found and drove the legacy provider-ID fallback; the final Codex autoreview is scoped-clean through P2.
- The local full runner completed 72 of 83 groups before shared-storage I/O stalled a menu group. The affected 43-test menu suite passes independently in 50 seconds; no assertion failed in the full run.
- [Exact-head CI run 33589321446](https://github.com/steipete/CodexBar/actions/runs/33589321446) is fully green across both macOS shards, Linux x64/ARM64, musl, lint, security, and the aggregate gate.

Validation uses synthetic auth files, isolated managed-account stores, and stub fetch strategies. No real credential, Keychain read, provider request, browser-cookie import, or WebView is used.

## Release-note context

Codex: keep selected managed workspaces attached to their stacked usage rows instead of replacing them with the auth file's default workspace; changing a selection mid-refresh discards the stale result. Credit @krevoit. No changelog edit before release.
