### PR TITLE
feat: icloud device removal

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,6 +25,11 @@ _Avoid_: Device ID, install ID, client ID
 The set of Devices syncing under a single iCloud account.
 _Avoid_: Cluster, group, network
 
+**Fleet Cache**:
+This Mac's copy of the Fleet, as of its last fetch. It is authoritative up to that moment and
+no further: anything published afterwards is missing from it until the next fetch.
+_Avoid_: Local state, mirror, replica
+
 **Usage Snapshot**:
 What one provider account's usage was at one moment, as seen on one Device. Snapshots are
 per-Device: two Devices reporting the same account hold separate Snapshots.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,32 @@
+# CodexBar
+
+Menu bar app that reports AI provider usage and credits. This glossary covers terms whose
+meaning is specific to CodexBar and easy to confuse with a neighbouring concept.
+
+## Language
+
+### iCloud Sync
+
+**Device**:
+One physical Mac in the user's fleet. A Device outlives reinstalls of CodexBar: reinstalling
+does not produce a second Device.
+_Avoid_: Machine, installation, node, client
+
+**Device Record**:
+The CloudKit record that represents a Device. One per Device.
+_Avoid_: Mac record, host record
+
+**Fleet**:
+The set of Devices syncing under a single iCloud account.
+_Avoid_: Cluster, group, network
+
+**Usage Snapshot**:
+A point-in-time usage reading for one provider account, taken on one Device. Snapshots are
+per-Device: two Devices reporting the same account hold separate Snapshots.
+_Avoid_: Usage record, sample, reading
+
+**Stale Device**:
+A Device Record that no live Mac will ever refresh, because the installation that created it
+is gone. Its Usage Snapshots keep being projected into the menu even though nothing updates
+them.
+_Avoid_: Orphan, ghost, dead device, duplicate

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,7 +8,7 @@ meaning is specific to CodexBar and easy to confuse with a neighbouring concept.
 ### iCloud Sync
 
 **Device**:
-One physical Mac in the user's fleet. A Device outlives reinstalls of CodexBar: reinstalling
+One physical Mac in the user's Fleet. A Device outlives reinstalls of CodexBar: reinstalling
 does not produce a second Device.
 _Avoid_: Machine, installation, node, client
 
@@ -16,17 +16,21 @@ _Avoid_: Machine, installation, node, client
 The CloudKit record that represents a Device. One per Device.
 _Avoid_: Mac record, host record
 
+**Device Identifier**:
+The value by which a Mac claims its Device Record. Two Macs never share one, and one Mac keeps
+the same one across reinstalls of CodexBar.
+_Avoid_: Device ID, install ID, client ID
+
 **Fleet**:
 The set of Devices syncing under a single iCloud account.
 _Avoid_: Cluster, group, network
 
 **Usage Snapshot**:
-A point-in-time usage reading for one provider account, taken on one Device. Snapshots are
+What one provider account's usage was at one moment, as seen on one Device. Snapshots are
 per-Device: two Devices reporting the same account hold separate Snapshots.
 _Avoid_: Usage record, sample, reading
 
 **Stale Device**:
-A Device Record that no live Mac will ever refresh, because the installation that created it
-is gone. Its Usage Snapshots keep being projected into the menu even though nothing updates
-them.
+A Device Record no live Mac will ever refresh, because no Mac claims its Device Identifier any
+more. Its Usage Snapshots keep being projected into the menu even though nothing updates them.
 _Avoid_: Orphan, ghost, dead device, duplicate

--- a/Sources/CodexBar/PreferencesICloudSyncPane.swift
+++ b/Sources/CodexBar/PreferencesICloudSyncPane.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct ICloudSyncPane: View {
     @Bindable var settings: SettingsStore
     @Bindable var state: CloudSyncState
+    @State private var deviceToRemove: DeviceSyncPayload?
     private static let securityFootnote =
         "Secrets use iCloud end-to-end encryption via encryptedValues. " +
         "Hooks and machine-local paths never sync."
@@ -68,7 +69,9 @@ struct ICloudSyncPane: View {
                     ForEach(self.devices, id: \.deviceID) { device in
                         ICloudSyncDeviceRow(
                             device: device,
-                            isCurrentDevice: device.deviceID == self.settings.iCloudSyncDeviceID)
+                            isCurrentDevice: device.deviceID == self.settings.iCloudSyncDeviceID,
+                            canRemove: self.settings.iCloudSyncEnabled && self.syncCanRun,
+                            remove: { self.deviceToRemove = device })
                     }
                 }
             } header: {
@@ -78,6 +81,34 @@ struct ICloudSyncPane: View {
             }
         }
         .formStyle(.grouped)
+        .confirmationDialog(
+            self.removalPrompt,
+            isPresented: self.removalPromptBinding,
+            titleVisibility: .visible)
+        {
+            Button(L("Remove"), role: .destructive) {
+                if let device = self.deviceToRemove {
+                    self.state.removeDevice?(device.deviceID)
+                }
+                self.deviceToRemove = nil
+            }
+            Button(L("Cancel"), role: .cancel) { self.deviceToRemove = nil }
+        }
+    }
+
+    private var removalPrompt: String {
+        guard let device = self.deviceToRemove else { return "" }
+        return L("Remove %@ and its usage snapshots from iCloud?", device.hostName)
+    }
+
+    private var removalPromptBinding: Binding<Bool> {
+        Binding(
+            get: { self.deviceToRemove != nil },
+            set: { presented in
+                if !presented {
+                    self.deviceToRemove = nil
+                }
+            })
     }
 
     private var syncCanBeEnabled: Bool {
@@ -147,6 +178,8 @@ struct ICloudSyncPane: View {
 private struct ICloudSyncDeviceRow: View {
     let device: DeviceSyncPayload
     let isCurrentDevice: Bool
+    let canRemove: Bool
+    let remove: () -> Void
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -165,6 +198,12 @@ private struct ICloudSyncDeviceRow: View {
                     .padding(.vertical, 2)
                     .background(.quaternary, in: Capsule())
             }
+            Button(action: self.remove) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .disabled(!self.canRemove)
+            .help(L("Remove"))
         }
     }
 }

--- a/Sources/CodexBar/PreferencesICloudSyncPane.swift
+++ b/Sources/CodexBar/PreferencesICloudSyncPane.swift
@@ -58,6 +58,12 @@ struct ICloudSyncPane: View {
                     value: self.relativeTime(self.state.status.lastSuccessfulPushAt))
             } header: {
                 Text(L("Status"))
+            } footer: {
+                if let lastError = self.state.status.lastError {
+                    SettingsSectionFooter {
+                        Text(lastError).foregroundStyle(.red)
+                    }
+                }
             }
 
             Section {
@@ -71,13 +77,13 @@ struct ICloudSyncPane: View {
                             device: device,
                             isCurrentDevice: device.deviceID == self.settings.iCloudSyncDeviceID,
                             canRemove: self.settings.iCloudSyncEnabled && self.syncCanRun,
-                            remove: { self.deviceToRemove = device })
+                            onRemove: { self.deviceToRemove = device })
                     }
                 }
             } header: {
                 Text(L("Macs"))
             } footer: {
-                SettingsSectionFooter(L(Self.securityFootnote))
+                SettingsSectionFooter(self.macsFootnote)
             }
         }
         .formStyle(.grouped)
@@ -93,7 +99,26 @@ struct ICloudSyncPane: View {
                 self.deviceToRemove = nil
             }
             Button(L("Cancel"), role: .cancel) { self.deviceToRemove = nil }
+        } message: {
+            // Two Macs can share a host name, which is the case this issue is about, so the
+            // dialog has to say which row it means. Relative dates collide; absolute ones do not.
+            if let device = self.deviceToRemove {
+                Text(String(
+                    format: L("Last seen %@"),
+                    device.lastSeen.formatted(date: .abbreviated, time: .shortened)))
+            }
         }
+    }
+
+    /// A device row stays visible with syncing off, so the footer has to say why its remove
+    /// button is dead: the delete has to reach CloudKit, which needs the engine running. The
+    /// other two reasons a row cannot be removed — a paused sync and an unavailable iCloud
+    /// account — already show their own message further up, so this covers only the setting.
+    private var macsFootnote: String {
+        guard !self.settings.iCloudSyncEnabled, !self.devices.isEmpty else {
+            return L(Self.securityFootnote)
+        }
+        return L(Self.securityFootnote) + " " + L("Turn on iCloud Sync to remove a Mac.")
     }
 
     private var removalPrompt: String {
@@ -179,7 +204,7 @@ private struct ICloudSyncDeviceRow: View {
     let device: DeviceSyncPayload
     let isCurrentDevice: Bool
     let canRemove: Bool
-    let remove: () -> Void
+    let onRemove: () -> Void
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -198,7 +223,7 @@ private struct ICloudSyncDeviceRow: View {
                     .padding(.vertical, 2)
                     .background(.quaternary, in: Capsule())
             }
-            Button(action: self.remove) {
+            Button(action: self.onRemove) {
                 Image(systemName: "trash")
             }
             .buttonStyle(.borderless)

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "المزامنة لا تعمل بعد. حاول مرة أخرى بعد قليل.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "شغّل iCloud Sync لإزالة جهاز Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "إزالة %@ ولقطات الاستخدام الخاصة به من iCloud؟";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -294,7 +297,6 @@
 "Refresh cadence" = "وتيرة التحديث";
 "Remote" = "البعيد";
 "Remove" = "إزالة";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "هل تحذف Codex الحساب؟";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "إزالة \\(account.email) من CodexBar؟ سيتم حذف Codex المنزل الذي يديره.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "إزالة \\(email) من CodexBar؟ سيتم حذف Codex المنزل الذي يديره.";

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 "Refresh cadence" = "وتيرة التحديث";
 "Remote" = "البعيد";
 "Remove" = "إزالة";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "هل تحذف Codex الحساب؟";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "إزالة \\(account.email) من CodexBar؟ سيتم حذف Codex المنزل الذي يديره.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "إزالة \\(email) من CodexBar؟ سيتم حذف Codex المنزل الذي يديره.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 "Refresh cadence" = "Freqüència d'actualització";
 "Remote" = "Remot";
 "Remove" = "Elimineu";
+"Remove %@ and its usage snapshots from iCloud?" = "Vols eliminar %@ i les seves instantànies d'ús d'iCloud?";
 "Remove Codex account?" = "Voleu eliminar el compte de Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Voleu eliminar \\(account.email) del CodexBar? El seu directori Codex gestionat s'esborrarà.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Voleu eliminar \\(email) del CodexBar? El seu directori Codex gestionat s'esborrarà.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Inicieu la sessió d'iCloud a Configuració del Sistema per activar la sincronització.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "La sincronització està aturada: un altre Mac utilitza una versió més recent de CodexBar. Actualitzeu per reprendre-la.";
+"Sync is not running yet. Try again in a moment." = "La sincronització encara no s'està executant. Torna-ho a provar d'aquí a un moment.";
 "Last successful fetch" = "Última baixada correcta";
 "Last successful push" = "Última pujada correcta";
 "Never" = "Mai";
 "Macs" = "Macs";
 "No synced Macs yet." = "Encara no hi ha cap Mac sincronitzat.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Els secrets utilitzen el xifratge d'extrem a extrem d'iCloud (encryptedValues). Els hooks i les rutes locals del Mac mai no se sincronitzen.";
+"Turn on iCloud Sync to remove a Mac." = "Activeu la Sincronització amb iCloud per eliminar un Mac.";
 "Last seen %@" = "Última connexió: %@";
 "This Mac" = "Aquest Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Vols eliminar %@ i les seves instantànies d'ús d'iCloud?";
 "another Mac" = "un altre Mac";
 "%dm ago" = "fa %dm";
 "%dh ago" = "fa %dh";
@@ -294,7 +297,6 @@
 "Refresh cadence" = "Freqüència d'actualització";
 "Remote" = "Remot";
 "Remove" = "Elimineu";
-"Remove %@ and its usage snapshots from iCloud?" = "Vols eliminar %@ i les seves instantànies d'ús d'iCloud?";
 "Remove Codex account?" = "Voleu eliminar el compte de Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Voleu eliminar \\(account.email) del CodexBar? El seu directori Codex gestionat s'esborrarà.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Voleu eliminar \\(email) del CodexBar? El seu directori Codex gestionat s'esborrarà.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "Die Synchronisierung läuft noch nicht. Versuche es gleich noch einmal.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Aktiviere iCloud Sync, um einen Mac zu entfernen.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "%@ und dessen Nutzungs-Snapshots aus iCloud entfernen?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -307,7 +310,6 @@
 "Refresh cadence" = "Trittfrequenz aktualisieren";
 "Remote" = "Remote";
 "Remove" = "Entfernen";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Codex-Konto entfernen?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "\\\\(account.email) aus CodexBar entfernen? Das verwaltete Codex-Heim wird gelöscht.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "\\\\(email) aus CodexBar entfernen? Das verwaltete Codex-Heim wird gelöscht.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "Refresh cadence" = "Trittfrequenz aktualisieren";
 "Remote" = "Remote";
 "Remove" = "Entfernen";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Codex-Konto entfernen?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "\\\\(account.email) aus CodexBar entfernen? Das verwaltete Codex-Heim wird gelöscht.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "\\\\(email) aus CodexBar entfernen? Das verwaltete Codex-Heim wird gelöscht.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -274,7 +274,6 @@
 "Refresh cadence" = "Refresh cadence";
 "Remote" = "Remote";
 "Remove" = "Remove";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Remove Codex account?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Remove \\(email) from CodexBar? Its managed Codex home will be deleted.";
@@ -1449,14 +1448,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "Sync is not running yet. Try again in a moment.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Turn on iCloud Sync to remove a Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -274,6 +274,7 @@
 "Refresh cadence" = "Refresh cadence";
 "Remote" = "Remote";
 "Remove" = "Remove";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Remove Codex account?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Remove \\(email) from CodexBar? Its managed Codex home will be deleted.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -309,6 +309,7 @@
 "Refresh cadence" = "Frecuencia de actualización";
 "Remote" = "Remoto";
 "Remove" = "Eliminar";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "¿Eliminar la cuenta de Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "¿Eliminar \\(account.email) de CodexBar? Su directorio Codex gestionado se borrará.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "¿Eliminar \\(email) de CodexBar? Su directorio Codex gestionado se borrará.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "La sincronización aún no está en marcha. Inténtalo de nuevo en un momento.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Activa iCloud Sync para eliminar un Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "¿Eliminar %@ y sus instantáneas de uso de iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -309,7 +312,6 @@
 "Refresh cadence" = "Frecuencia de actualización";
 "Remote" = "Remoto";
 "Remove" = "Eliminar";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "¿Eliminar la cuenta de Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "¿Eliminar \\(account.email) de CodexBar? Su directorio Codex gestionado se borrará.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "¿Eliminar \\(email) de CodexBar? Su directorio Codex gestionado se borrará.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 "Refresh cadence" = "کادانس تازه سازی";
 "Remote" = "دورافتاده";
 "Remove" = "حذف";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "حساب Codex حذف کنم؟";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "حذف \\(account.email) از CodexBar؟ مدیریت Codex خانه آن حذف خواهد شد.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "حذف \\(email) از CodexBar؟ مدیریت Codex خانه آن حذف خواهد شد.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "همگام‌سازی هنوز اجرا نشده است. لحظه‌ای بعد دوباره تلاش کنید.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "برای حذف یک Mac، iCloud Sync را روشن کنید.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "حذف %@ و عکس‌های استفاده آن از iCloud؟";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -294,7 +297,6 @@
 "Refresh cadence" = "کادانس تازه سازی";
 "Remote" = "دورافتاده";
 "Remove" = "حذف";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "حساب Codex حذف کنم؟";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "حذف \\(account.email) از CodexBar؟ مدیریت Codex خانه آن حذف خواهد شد.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "حذف \\(email) از CodexBar؟ مدیریت Codex خانه آن حذف خواهد شد.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "La synchronisation n'est pas encore active. Réessayez dans un instant.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Activez iCloud Sync pour supprimer un Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Supprimer %@ et ses instantanés d'utilisation d'iCloud ?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -309,7 +312,6 @@
 "Refresh cadence" = "Cadence de rafraîchissement";
 "Remote" = "Distant";
 "Remove" = "Supprimer";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Supprimer le compte Codex ?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Supprimer \\(account.email) de CodexBar ? Sa maison Codex gérée sera supprimée.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Supprimer \\(email) de CodexBar ? Sa maison Codex gérée sera supprimée.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -309,6 +309,7 @@
 "Refresh cadence" = "Cadence de rafraîchissement";
 "Remote" = "Distant";
 "Remove" = "Supprimer";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Supprimer le compte Codex ?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Supprimer \\(account.email) de CodexBar ? Sa maison Codex gérée sera supprimée.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Supprimer \\(email) de CodexBar ? Sa maison Codex gérée sera supprimée.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -291,6 +291,7 @@
 "Refresh cadence" = "Frecuencia de actualización";
 "Remote" = "Remoto";
 "Remove" = "Eliminar";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Queres eliminar a conta de Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Queres eliminar \\(account.email) de CodexBar? O seu directorio de Codex xestionado eliminarase.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Queres eliminar \\(email) de CodexBar? O seu directorio de Codex xestionado eliminarase.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "A sincronización aínda non se está executando. Téntao de novo nun momento.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Activa iCloud Sync para eliminar un Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Queres eliminar %@ e as súas instantáneas de uso de iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -291,7 +294,6 @@
 "Refresh cadence" = "Frecuencia de actualización";
 "Remote" = "Remoto";
 "Remove" = "Eliminar";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Queres eliminar a conta de Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Queres eliminar \\(account.email) de CodexBar? O seu directorio de Codex xestionado eliminarase.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Queres eliminar \\(email) de CodexBar? O seu directorio de Codex xestionado eliminarase.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "Sinkronisasi belum berjalan. Coba lagi sebentar lagi.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Aktifkan iCloud Sync untuk menghapus Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Hapus %@ dan snapshot penggunaannya dari iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -294,7 +297,6 @@
 "Refresh cadence" = "Frekuensi penyegaran";
 "Remote" = "Jarak jauh";
 "Remove" = "Hapus";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Hapus akun Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Hapus \\(account.email) dari CodexBar? Home Codex terkelolanya akan dihapus.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Hapus \\(email) dari CodexBar? Home Codex terkelolanya akan dihapus.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 "Refresh cadence" = "Frekuensi penyegaran";
 "Remote" = "Jarak jauh";
 "Remove" = "Hapus";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Hapus akun Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Hapus \\(account.email) dari CodexBar? Home Codex terkelolanya akan dihapus.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Hapus \\(email) dari CodexBar? Home Codex terkelolanya akan dihapus.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 "Refresh cadence" = "Frequenza aggiornamento";
 "Remote" = "Remoto";
 "Remove" = "Rimuovi";
+"Remove %@ and its usage snapshots from iCloud?" = "Rimuovere %@ e le sue istantanee di utilizzo da iCloud?";
 "Remove Codex account?" = "Rimuovere l'account Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Rimuovere \\(account.email) da CodexBar? La sua home Codex gestita verrà eliminata.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Rimuovere \\(email) da CodexBar? La sua home Codex gestita verrà eliminata.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Accedi a iCloud in Impostazioni di Sistema per abilitare la sincronizzazione.";
 "iCloud access is restricted on this Mac." = "L’accesso a iCloud è limitato su questo Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "La sincronizzazione è in pausa: un altro Mac usa una versione più recente di CodexBar. Aggiorna per riprendere.";
+"Sync is not running yet. Try again in a moment." = "La sincronizzazione non è ancora attiva. Riprova tra un momento.";
 "Last successful fetch" = "Ultimo recupero riuscito";
 "Last successful push" = "Ultimo invio riuscito";
 "Never" = "Mai";
 "Macs" = "Computer Mac";
 "No synced Macs yet." = "Nessun Mac sincronizzato.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "I segreti usano la crittografia end-to-end di iCloud tramite encryptedValues. Gli hook e i percorsi locali non vengono mai sincronizzati.";
+"Turn on iCloud Sync to remove a Mac." = "Attiva la Sincronizzazione iCloud per rimuovere un Mac.";
 "Last seen %@" = "Ultima attività: %@";
 "This Mac" = "Questo Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Rimuovere %@ e le sue istantanee di utilizzo da iCloud?";
 "another Mac" = "un altro Mac";
 "%dm ago" = "%dm fa";
 "%dh ago" = "%dh fa";
@@ -294,7 +297,6 @@
 "Refresh cadence" = "Frequenza aggiornamento";
 "Remote" = "Remoto";
 "Remove" = "Rimuovi";
-"Remove %@ and its usage snapshots from iCloud?" = "Rimuovere %@ e le sue istantanee di utilizzo da iCloud?";
 "Remove Codex account?" = "Rimuovere l'account Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Rimuovere \\(account.email) da CodexBar? La sua home Codex gestita verrà eliminata.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Rimuovere \\(email) da CodexBar? La sua home Codex gestita verrà eliminata.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -309,6 +309,7 @@
 "Refresh cadence" = "更新間隔";
 "Remote" = "リモート";
 "Remove" = "削除";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Codex アカウントを削除しますか？";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "\\(account.email) を CodexBar から削除しますか？管理対象の Codex ホームは削除されます。";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "\\(email) を CodexBar から削除しますか？管理対象の Codex ホームは削除されます。";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "同期はまだ実行されていません。しばらくしてからもう一度お試しください。";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Mac を削除するには iCloud Sync をオンにしてください。";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "%@ とその使用状況スナップショットを iCloud から削除しますか？";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -309,7 +312,6 @@
 "Refresh cadence" = "更新間隔";
 "Remote" = "リモート";
 "Remove" = "削除";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Codex アカウントを削除しますか？";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "\\(account.email) を CodexBar から削除しますか？管理対象の Codex ホームは削除されます。";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "\\(email) を CodexBar から削除しますか？管理対象の Codex ホームは削除されます。";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -310,6 +310,7 @@
 "Refresh cadence" = "새로 고침 주기";
 "Remote" = "원격";
 "Remove" = "제거";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Codex 계정을 제거하시겠습니까?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "CodexBar에서 \\(account.email)을(를) 제거하시겠습니까? 관리되는 Codex 홈이 삭제됩니다.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "CodexBar에서 \\(email)을(를) 제거하시겠습니까? 관리되는 Codex 홈이 삭제됩니다.";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "동기화가 아직 실행되지 않았습니다. 잠시 후 다시 시도하세요.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Mac을 제거하려면 iCloud Sync를 켜세요.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "%@과(와) 사용량 스냅샷을 iCloud에서 제거하시겠습니까?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -310,7 +313,6 @@
 "Refresh cadence" = "새로 고침 주기";
 "Remote" = "원격";
 "Remove" = "제거";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Codex 계정을 제거하시겠습니까?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "CodexBar에서 \\(account.email)을(를) 제거하시겠습니까? 관리되는 Codex 홈이 삭제됩니다.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "CodexBar에서 \\(email)을(를) 제거하시겠습니까? 관리되는 Codex 홈이 삭제됩니다.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "Synchronisatie is nog niet actief. Probeer het zo meteen opnieuw.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Schakel iCloud Sync in om een Mac te verwijderen.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "%@ en de bijbehorende gebruikssnapshots uit iCloud verwijderen?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -309,7 +312,6 @@
 "Refresh cadence" = "Cadans vernieuwen";
 "Remote" = "Op afstand";
 "Remove" = "Verwijderen";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Codex-account verwijderen?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "\\(account.email) verwijderen uit CodexBar? Het beheerde Codex-huis wordt verwijderd.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "\\(email) verwijderen uit CodexBar? Het beheerde Codex-huis wordt verwijderd.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -309,6 +309,7 @@
 "Refresh cadence" = "Cadans vernieuwen";
 "Remote" = "Op afstand";
 "Remove" = "Verwijderen";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Codex-account verwijderen?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "\\(account.email) verwijderen uit CodexBar? Het beheerde Codex-huis wordt verwijderd.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "\\(email) verwijderen uit CodexBar? Het beheerde Codex-huis wordt verwijderd.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 "Refresh cadence" = "Częstotliwość odświeżania";
 "Remote" = "Zdalne";
 "Remove" = "Usuń";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Usunąć konto Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Usunąć \\(account.email) z CodexBar? Jego zarządzony katalog domowy Codex zostanie usunięty.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Usunąć \\(email) z CodexBar? Jego zarządzony katalog domowy Codex zostanie usunięty.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "Synchronizacja jeszcze nie działa. Spróbuj ponownie za chwilę.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Włącz iCloud Sync, aby usunąć Maca.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Usunąć %@ i jego migawki użycia z iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -294,7 +297,6 @@
 "Refresh cadence" = "Częstotliwość odświeżania";
 "Remote" = "Zdalne";
 "Remove" = "Usuń";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Usunąć konto Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Usunąć \\(account.email) z CodexBar? Jego zarządzony katalog domowy Codex zostanie usunięty.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Usunąć \\(email) z CodexBar? Jego zarządzony katalog domowy Codex zostanie usunięty.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -309,6 +309,7 @@
 "Refresh cadence" = "Cadência de atualização";
 "Remote" = "Remoto";
 "Remove" = "Remover";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Remover conta Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Remover \\(account.email) do CodexBar? O diretório Codex gerenciado será apagado.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Remover \\(email) do CodexBar? O diretório Codex gerenciado será apagado.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "A sincronização ainda não está em execução. Tente novamente em instantes.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Ative o iCloud Sync para remover um Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Remover %@ e seus instantâneos de uso do iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -309,7 +312,6 @@
 "Refresh cadence" = "Cadência de atualização";
 "Remote" = "Remoto";
 "Remove" = "Remover";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Remover conta Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Remover \\(account.email) do CodexBar? O diretório Codex gerenciado será apagado.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Remover \\(email) do CodexBar? O diretório Codex gerenciado será apagado.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -311,6 +311,7 @@
 "Refresh cadence" = "Частота обновления";
 "Remote" = "Удалённо";
 "Remove" = "Удалить";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Удалить аккаунт Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Удалить \\(account.email) из CodexBar? Его управляемый каталог Codex будет удалён.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Удалить \\(email) из CodexBar? Его управляемый каталог Codex будет удалён.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "Синхронизация ещё не запущена. Повторите попытку через мгновение.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Включите iCloud Sync, чтобы удалить Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Удалить %@ и его снимки использования из iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -311,7 +314,6 @@
 "Refresh cadence" = "Частота обновления";
 "Remote" = "Удалённо";
 "Remove" = "Удалить";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Удалить аккаунт Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Удалить \\(account.email) из CodexBar? Его управляемый каталог Codex будет удалён.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Удалить \\(email) из CodexBar? Его управляемый каталог Codex будет удалён.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -310,6 +310,7 @@
 "Refresh cadence" = "Uppdateringsintervall";
 "Remote" = "Fjärr";
 "Remove" = "Ta bort";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Ta bort Codex-konto?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Ta bort \\(account.email) från CodexBar? Dess hanterade Codex-hem tas bort.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Ta bort \\(email) från CodexBar? Dess hanterade Codex-hem tas bort.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "Synkroniseringen har inte startat än. Försök igen om en stund.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Slå på iCloud Sync för att ta bort en Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Vill du ta bort %@ och dess användningsögonblicksbilder från iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -310,7 +313,6 @@
 "Refresh cadence" = "Uppdateringsintervall";
 "Remote" = "Fjärr";
 "Remove" = "Ta bort";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Ta bort Codex-konto?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Ta bort \\(account.email) från CodexBar? Dess hanterade Codex-hem tas bort.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Ta bort \\(email) från CodexBar? Dess hanterade Codex-hem tas bort.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "การซิงค์ยังไม่ทำงาน ลองอีกครั้งในอีกสักครู่";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "เปิด iCloud Sync เพื่อลบ Mac";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "ลบ %@ และสแนปช็อตการใช้งานออกจาก iCloud ไหม";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -294,7 +297,6 @@
 "Refresh cadence" = "จังหวะการรีเฟรช";
 "Remote" = "ระยะไกล";
 "Remove" = "ลบ";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "ลบบัญชี Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "ลบ \\(account.email) ออกจาก CodexBar? ระบบจะลบหน้าแรก Codex ที่มีการจัดการ";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "ลบ \\(email) ออกจาก CodexBar? ระบบจะลบหน้าแรก Codex ที่มีการจัดการ";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 "Refresh cadence" = "จังหวะการรีเฟรช";
 "Remote" = "ระยะไกล";
 "Remove" = "ลบ";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "ลบบัญชี Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "ลบ \\(account.email) ออกจาก CodexBar? ระบบจะลบหน้าแรก Codex ที่มีการจัดการ";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "ลบ \\(email) ออกจาก CodexBar? ระบบจะลบหน้าแรก Codex ที่มีการจัดการ";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Eşzamanlamayı etkinleştirmek için Sistem Ayarları'nda iCloud'a giriş yapın.";
 "iCloud access is restricted on this Mac." = "Bu Mac'te iCloud erişimi kısıtlı.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Eşzamanlama duraklatıldı: başka bir Mac daha yeni bir CodexBar sürümü kullanıyor. Devam etmek için güncelleyin.";
+"Sync is not running yet. Try again in a moment." = "Eşitleme henüz çalışmıyor. Birazdan tekrar deneyin.";
 "Last successful fetch" = "Son başarılı veri alma";
 "Last successful push" = "Son başarılı gönderme";
 "Never" = "Asla";
 "Macs" = "Mac'ler";
 "No synced Macs yet." = "Henüz eşzamanlanan Mac yok.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Gizli bilgiler encryptedValues aracılığıyla iCloud uçtan uca şifrelemesiyle korunur. Kancalar ve makineye özgü yollar hiçbir zaman eşzamanlanmaz.";
+"Turn on iCloud Sync to remove a Mac." = "Bir Mac’i kaldırmak için iCloud eşzamanlamayı açın.";
 "Last seen %@" = "Son görülme: %@";
 "This Mac" = "Bu Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "%@ ve kullanım anlık görüntüleri iCloud'dan kaldırılsın mı?";
 "another Mac" = "başka bir Mac";
 "%dm ago" = "%d dk önce";
 "%dh ago" = "%d sa önce";
@@ -294,7 +297,6 @@
 "Refresh cadence" = "Yenileme sıklığı";
 "Remote" = "Uzak";
 "Remove" = "Kaldır";
-"Remove %@ and its usage snapshots from iCloud?" = "%@ ve kullanım anlık görüntüleri iCloud'dan kaldırılsın mı?";
 "Remove Codex account?" = "Codex hesabı kaldırılsın mı?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "\\(account.email) CodexBar'dan kaldırılsın mı? Yönetilen Codex ana dizini silinecek.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "\\(email) CodexBar'dan kaldırılsın mı? Yönetilen Codex ana dizini silinecek.";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 "Refresh cadence" = "Yenileme sıklığı";
 "Remote" = "Uzak";
 "Remove" = "Kaldır";
+"Remove %@ and its usage snapshots from iCloud?" = "%@ ve kullanım anlık görüntüleri iCloud'dan kaldırılsın mı?";
 "Remove Codex account?" = "Codex hesabı kaldırılsın mı?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "\\(account.email) CodexBar'dan kaldırılsın mı? Yönetilen Codex ana dizini silinecek.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "\\(email) CodexBar'dan kaldırılsın mı? Yönetilen Codex ana dizini silinecek.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "Синхронізація ще не запущена. Спробуйте ще раз за мить.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Увімкніть iCloud Sync, щоб вилучити Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Вилучити %@ і його знімки використання з iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -309,7 +312,6 @@
 "Refresh cadence" = "Оновити каденцію";
 "Remote" = "Дистанційний";
 "Remove" = "Видалити";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Видалити обліковий запис Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Видалити \\(account.email) з CodexBar? Його керовану домашню сторінку Codex буде видалено.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Видалити \\(email) з CodexBar? Його керовану домашню сторінку Codex буде видалено.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -309,6 +309,7 @@
 "Refresh cadence" = "Оновити каденцію";
 "Remote" = "Дистанційний";
 "Remove" = "Видалити";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Видалити обліковий запис Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Видалити \\(account.email) з CodexBar? Його керовану домашню сторінку Codex буде видалено.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Видалити \\(email) з CodexBar? Його керовану домашню сторінку Codex буде видалено.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "Đồng bộ chưa chạy. Hãy thử lại sau giây lát.";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "Bật iCloud Sync để xóa một máy Mac.";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "Xóa %@ và các ảnh chụp mức sử dụng của nó khỏi iCloud?";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -309,7 +312,6 @@
 "Refresh cadence" = "Nhịp làm mới";
 "Remote" = "Từ xa";
 "Remove" = "Xóa";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Xóa tài khoản Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Xóa \\(account.email) khỏi CodexBar ? Trang chủ Codex được quản lý của nó sẽ bị xóa.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Xóa \\(email) khỏi CodexBar ? Trang chủ Codex được quản lý của nó sẽ bị xóa.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -309,6 +309,7 @@
 "Refresh cadence" = "Nhịp làm mới";
 "Remote" = "Từ xa";
 "Remove" = "Xóa";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "Xóa tài khoản Codex?";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "Xóa \\(account.email) khỏi CodexBar ? Trang chủ Codex được quản lý của nó sẽ bị xóa.";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "Xóa \\(email) khỏi CodexBar ? Trang chủ Codex được quản lý của nó sẽ bị xóa.";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "同步尚未运行。请稍后再试。";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "打开 iCloud Sync 以移除 Mac。";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "要从 iCloud 中移除 %@ 及其用量快照吗？";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -319,7 +322,6 @@
 "Refresh cadence" = "刷新频率";
 "Remote" = "远程";
 "Remove" = "移除";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "移除 Codex 账户？";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "要从 CodexBar 中移除 \\(account.email) 吗？其托管的 Codex 主目录将被删除。";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "要从 CodexBar 中移除 \\(email) 吗？其托管的 Codex 主目录将被删除。";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -319,6 +319,7 @@
 "Refresh cadence" = "刷新频率";
 "Remote" = "远程";
 "Remove" = "移除";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "移除 Codex 账户？";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "要从 CodexBar 中移除 \\(account.email) 吗？其托管的 Codex 主目录将被删除。";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "要从 CodexBar 中移除 \\(email) 吗？其托管的 Codex 主目录将被删除。";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -317,6 +317,7 @@
 "Refresh cadence" = "重新整理頻率";
 "Remote" = "遠端";
 "Remove" = "移除";
+"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "移除 Codex 帳號？";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "要從 CodexBar 中移除 \\(account.email) 嗎？其託管的 Codex 主目錄將被刪除。";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "要從 CodexBar 中移除 \\(email) 嗎？其託管的 Codex 主目錄將被刪除。";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -18,14 +18,17 @@
 "Sign in to iCloud in System Settings to enable sync." = "Sign in to iCloud in System Settings to enable sync.";
 "iCloud access is restricted on this Mac." = "iCloud access is restricted on this Mac.";
 "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume." = "Sync is paused: another Mac uses a newer version of CodexBar. Update to resume.";
+"Sync is not running yet. Try again in a moment." = "同步尚未執行。請稍後再試。";
 "Last successful fetch" = "Last successful fetch";
 "Last successful push" = "Last successful push";
 "Never" = "Never";
 "Macs" = "Macs";
 "No synced Macs yet." = "No synced Macs yet.";
 "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync." = "Secrets use iCloud end-to-end encryption via encryptedValues. Hooks and machine-local paths never sync.";
+"Turn on iCloud Sync to remove a Mac." = "開啟 iCloud Sync 以移除 Mac。";
 "Last seen %@" = "Last seen %@";
 "This Mac" = "This Mac";
+"Remove %@ and its usage snapshots from iCloud?" = "要從 iCloud 移除 %@ 及其用量快照嗎？";
 "another Mac" = "another Mac";
 "%dm ago" = "%dm ago";
 "%dh ago" = "%dh ago";
@@ -317,7 +320,6 @@
 "Refresh cadence" = "重新整理頻率";
 "Remote" = "遠端";
 "Remove" = "移除";
-"Remove %@ and its usage snapshots from iCloud?" = "Remove %@ and its usage snapshots from iCloud?";
 "Remove Codex account?" = "移除 Codex 帳號？";
 "Remove \\(account.email) from CodexBar? Its managed Codex home will be deleted." = "要從 CodexBar 中移除 \\(account.email) 嗎？其託管的 Codex 主目錄將被刪除。";
 "Remove \\(email) from CodexBar? Its managed Codex home will be deleted." = "要從 CodexBar 中移除 \\(email) 嗎？其託管的 Codex 主目錄將被刪除。";

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -642,8 +642,11 @@ extension SettingsStore {
         let iCloudSyncIncludeSecrets = userDefaults.object(forKey: "iCloudSyncIncludeSecrets") as? Bool ?? true
         let iCloudSyncSnapshotsEnabled = userDefaults.object(forKey: "iCloudSyncSnapshotsEnabled") as? Bool ?? true
         let iCloudSyncShowFleetAccounts = userDefaults.object(forKey: "iCloudSyncShowFleetAccounts") as? Bool ?? true
-        let iCloudSyncDeviceID = userDefaults.string(forKey: "iCloudSyncDeviceID") ?? UUID().uuidString.lowercased()
-        if userDefaults.string(forKey: "iCloudSyncDeviceID") == nil {
+        let persistedDeviceID = userDefaults.string(forKey: "iCloudSyncDeviceID")
+        let iCloudSyncDeviceID = CloudSyncDeviceIdentity.resolve(
+            persisted: persistedDeviceID,
+            hardwareUUID: CloudSyncDeviceIdentity.hardwareUUID())
+        if persistedDeviceID != iCloudSyncDeviceID {
             userDefaults.set(iCloudSyncDeviceID, forKey: "iCloudSyncDeviceID")
         }
         return SettingsDefaultsState(

--- a/Sources/CodexBar/Sync/CloudSyncCoordinator.swift
+++ b/Sources/CodexBar/Sync/CloudSyncCoordinator.swift
@@ -14,6 +14,7 @@ final class CloudSyncCoordinator {
     private var snapshotObserver: NSObjectProtocol?
     private var accountObserver: NSObjectProtocol?
     private var resumeTask: Task<Void, Never>?
+    private var rehydrateTask: Task<Void, Never>?
     private var observedEnabled: Bool
 
     init(
@@ -35,6 +36,9 @@ final class CloudSyncCoordinator {
 
     func start() {
         self.observeSettings()
+        // The Macs list has to render with syncing off, or there is nothing to remove a stale
+        // device from. Local persistence only; the fleet menu cards stay gated on the setting.
+        self.rehydrateTask = Task { await self.engine.rehydrateFleetStateIfNeeded() }
         self.state.removeDevice = { [weak self] deviceID in
             guard let self else { return }
             Task { await self.engine.removeDevice(deviceID: deviceID) }
@@ -106,6 +110,7 @@ final class CloudSyncCoordinator {
             NotificationCenter.default.removeObserver(accountObserver)
         }
         self.resumeTask?.cancel()
+        self.rehydrateTask?.cancel()
         self.state.removeDevice = nil
         self.configObserver = nil
         self.localFileConfigObserver = nil

--- a/Sources/CodexBar/Sync/CloudSyncCoordinator.swift
+++ b/Sources/CodexBar/Sync/CloudSyncCoordinator.swift
@@ -35,6 +35,10 @@ final class CloudSyncCoordinator {
 
     func start() {
         self.observeSettings()
+        self.state.removeDevice = { [weak self] deviceID in
+            guard let self else { return }
+            Task { await self.engine.removeDevice(deviceID: deviceID) }
+        }
         self.configObserver = NotificationCenter.default.addObserver(
             forName: .codexbarProviderConfigDidChange,
             object: self.settings,
@@ -102,6 +106,7 @@ final class CloudSyncCoordinator {
             NotificationCenter.default.removeObserver(accountObserver)
         }
         self.resumeTask?.cancel()
+        self.state.removeDevice = nil
         self.configObserver = nil
         self.localFileConfigObserver = nil
         self.snapshotObserver = nil

--- a/Sources/CodexBar/Sync/CloudSyncDeviceIdentity.swift
+++ b/Sources/CodexBar/Sync/CloudSyncDeviceIdentity.swift
@@ -1,0 +1,35 @@
+import CryptoKit
+import Foundation
+
+/// How a Mac identifies itself to the fleet. See `docs/adr/0001-stable-device-identity.md`.
+enum CloudSyncDeviceIdentity {
+    /// A persisted identifier always wins, so fleets created before stable identity keep addressing
+    /// their existing device records. Only a fresh install derives an identifier from the machine,
+    /// which is what stops a reinstall from stranding the previous device record.
+    static func resolve(persisted: String?, hardwareUUID: String?) -> String {
+        if let persisted, !persisted.isEmpty {
+            return persisted
+        }
+        guard let hardwareUUID, !hardwareUUID.isEmpty else {
+            return UUID().uuidString.lowercased()
+        }
+        return self.derive(from: hardwareUUID)
+    }
+
+    /// The machine's hardware UUID, which survives reinstalling CodexBar and macOS.
+    static func hardwareUUID() -> String? {
+        var size = 0
+        guard sysctlbyname("kern.uuid", nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("kern.uuid", &buffer, &size, nil, 0) == 0 else { return nil }
+        let bytes = buffer.prefix { $0 != 0 }.map(UInt8.init(bitPattern:))
+        return String(bytes: bytes, encoding: .utf8)
+    }
+
+    /// Hashed so the raw hardware identifier never reaches CloudKit, and shaped as a UUID because
+    /// every identifier issued before this change is one.
+    private static func derive(from hardwareUUID: String) -> String {
+        SHA256.hash(data: Data(hardwareUUID.utf8))
+            .withUnsafeBytes { UUID(uuid: $0.load(as: uuid_t.self)).uuidString.lowercased() }
+    }
+}

--- a/Sources/CodexBar/Sync/CloudSyncDeviceIdentity.swift
+++ b/Sources/CodexBar/Sync/CloudSyncDeviceIdentity.swift
@@ -1,11 +1,11 @@
 import CryptoKit
 import Foundation
 
-/// How a Mac identifies itself to the fleet. See `docs/adr/0001-stable-device-identity.md`.
+/// How a Mac identifies itself to the Fleet. See `docs/adr/0001-stable-device-identity.md`.
 enum CloudSyncDeviceIdentity {
-    /// A persisted identifier always wins, so fleets created before stable identity keep addressing
-    /// their existing device records. Only a fresh install derives an identifier from the machine,
-    /// which is what stops a reinstall from stranding the previous device record.
+    /// A persisted Device Identifier always wins, so a Fleet created before stable identity keeps
+    /// addressing its existing Device Records. Only a Mac with none derives one, which is what stops
+    /// a reinstall from stranding the previous Device Record.
     static func resolve(persisted: String?, hardwareUUID: String?) -> String {
         if let persisted, !persisted.isEmpty {
             return persisted
@@ -16,20 +16,26 @@ enum CloudSyncDeviceIdentity {
         return self.derive(from: hardwareUUID)
     }
 
-    /// The machine's hardware UUID, which survives reinstalling CodexBar and macOS.
+    /// The Mac's hardware UUID, which survives reinstalling CodexBar and macOS.
     static func hardwareUUID() -> String? {
-        var size = 0
-        guard sysctlbyname("kern.uuid", nil, &size, nil, 0) == 0, size > 0 else { return nil }
-        var buffer = [CChar](repeating: 0, count: size)
-        guard sysctlbyname("kern.uuid", &buffer, &size, nil, 0) == 0 else { return nil }
-        let bytes = buffer.prefix { $0 != 0 }.map(UInt8.init(bitPattern:))
-        return String(bytes: bytes, encoding: .utf8)
+        Sysctl.string("kern.uuid")
     }
 
     /// Hashed so the raw hardware identifier never reaches CloudKit, and shaped as a UUID because
-    /// every identifier issued before this change is one.
+    /// every Device Identifier issued before this change is one.
     private static func derive(from hardwareUUID: String) -> String {
         SHA256.hash(data: Data(hardwareUUID.utf8))
             .withUnsafeBytes { UUID(uuid: $0.load(as: uuid_t.self)).uuidString.lowercased() }
+    }
+}
+
+enum Sysctl {
+    static func string(_ name: String) -> String? {
+        var size = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else { return nil }
+        let bytes = buffer.prefix { $0 != 0 }.map(UInt8.init(bitPattern:))
+        return String(bytes: bytes, encoding: .utf8)
     }
 }

--- a/Sources/CodexBar/Sync/CloudSyncEngine.swift
+++ b/Sources/CodexBar/Sync/CloudSyncEngine.swift
@@ -178,7 +178,9 @@ enum CloudSyncSnapshotMigration {
             knownRecordNames: Set(hashes.keys).union(envelope.fleetSnapshots.keys))
     }
 
-    static func drop(
+    /// Stops pushing these records and hands back the IDs to delete. The fleet rows are left
+    /// alone: they go when CloudKit confirms the delete, not when it is queued.
+    static func dropPushState(
         _ names: Set<String>,
         hashes: inout [String: String],
         envelope: inout CloudSyncPersistence.Envelope,
@@ -189,8 +191,6 @@ enum CloudSyncSnapshotMigration {
             let recordID = CKRecord.ID(recordName: name, zoneID: zoneID)
             desiredRecords.removeValue(forKey: recordID)
             hashes.removeValue(forKey: name)
-            envelope.fleetDevices.removeValue(forKey: name)
-            envelope.fleetSnapshots.removeValue(forKey: name)
             envelope.encodedSystemFields.removeValue(forKey: name)
             envelope.recordMetadata.removeValue(forKey: name)
             return recordID
@@ -275,20 +275,31 @@ enum CloudSyncSnapshotMigration {
         Set(pendingRecordNames).union(storedRecordNames)
     }
 
+    /// Whether a failed delete gets another go. A Device Record never does: a retry would race
+    /// the Mac that owns it re-registering itself, and delete the fresh record it just published.
+    /// CloudKit has already dropped the change from its pending set by the time this is asked,
+    /// so "no retry" means the engine simply does not queue it again.
+    static func isRetryableDelete(_ recordID: CKRecord.ID, error: CKError) -> Bool {
+        self.retryDelay(for: error) != nil && !DeviceSyncPayload.isRecordName(recordID.recordName)
+    }
+
     static func retryableFailedDeletes(
         _ failures: [CKRecord.ID: CKError],
         liveNames: Set<String> = []) -> [CKRecord.ID]
     {
         failures.compactMap { recordID, error in
-            guard self.retryDelay(for: error) != nil else { return nil }
+            guard self.isRetryableDelete(recordID, error: error) else { return nil }
             guard !liveNames.contains(recordID.recordName) else { return nil }
             return recordID
         }
     }
 
+    /// Failures the user has to hear about, because nothing else will fix them: anything that
+    /// gets no retry. `unknownItem` never counts, since that record is already gone.
     static func reportableFailedDeletes(_ failures: [CKRecord.ID: CKError]) -> [CKError] {
-        failures.values.filter { error in
-            error.code != .unknownItem && self.retryDelay(for: error) == nil
+        failures.compactMap { recordID, error in
+            guard error.code != .unknownItem else { return nil }
+            return self.isRetryableDelete(recordID, error: error) ? nil : error
         }
     }
 
@@ -307,16 +318,21 @@ enum CloudSyncSnapshotMigration {
         }
     }
 
+    /// Names the engine stops tracking after a failed delete: everything that gets no retry.
     static func finishedFailedDeleteNames(_ failures: [CKRecord.ID: CKError]) -> Set<String> {
         Set(failures.compactMap { recordID, error in
-            self.retryDelay(for: error) == nil ? recordID.recordName : nil
+            self.isRetryableDelete(recordID, error: error) ? nil : recordID.recordName
         })
     }
 
-    /// Terminal failures that left the record in place. `unknownItem` is excluded: that record is
-    /// already gone, so the delete succeeded in every way the caller cares about.
-    static func restorableFailedDeleteNames(_ failures: [CKRecord.ID: CKError]) -> Set<String> {
-        self.finishedFailedDeleteNames(failures).subtracting(
+    /// Names CloudKit no longer holds: confirmed deletes, plus records that were already gone.
+    /// Fleet rows go on this signal alone, so a failed delete leaves the Mac in the list rather
+    /// than hiding a Device Record that is still there.
+    static func confirmedDeletedNames(
+        deletedIDs: [CKRecord.ID],
+        failures: [CKRecord.ID: CKError]) -> Set<String>
+    {
+        Set(deletedIDs.map(\.recordName)).union(
             failures.compactMap { $0.value.code == .unknownItem ? $0.key.recordName : nil })
     }
 
@@ -421,8 +437,6 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
     private var persistenceEnvelope: CloudSyncPersistence.Envelope
     private var engine: CKSyncEngine?
     private var desiredRecords: [CKRecord.ID: CKRecord] = [:]
-    private var removedDevices: [String: DeviceSyncPayload] = [:]
-    private var removedSnapshots: [String: AccountSnapshotSyncPayload] = [:]
     private var enabled = false
     private var configPushTask: Task<Void, Never>?
     private var snapshotPushTask: Task<Void, Never>?
@@ -762,8 +776,7 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
         let recordID = self.recordID(named: payload.recordName)
         // This Mac may have been removed before quitting. Re-registering supersedes that removal,
         // so drop the pending delete rather than letting it retire the record we are about to save.
-        self.cancelPendingSnapshotDeletes([payload.recordName])
-        self.forgetOptimisticRemoval([payload.recordName])
+        self.cancelPendingRecordDeletes([payload.recordName])
         let record = self.record(type: .device, id: recordID)
         record["schemaVersion"] = payload.schemaVersion as CKRecordValue
         record["deviceID"] = payload.deviceID as CKRecordValue
@@ -802,19 +815,7 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
             }
         case let .fetchedRecordZoneChanges(changes):
             await self.applyFetchedRecords(changes.modifications.map(\.record))
-            let deletedRecordNames = changes.deletions.map(\.recordID.recordName)
-            for deletion in changes.deletions {
-                self.persistenceEnvelope.encodedSystemFields.removeValue(forKey: deletion.recordID.recordName)
-                self.persistenceEnvelope.recordMetadata.removeValue(forKey: deletion.recordID.recordName)
-                self.persistenceEnvelope.fleetDevices.removeValue(forKey: deletion.recordID.recordName)
-                self.persistenceEnvelope.fleetSnapshots.removeValue(forKey: deletion.recordID.recordName)
-            }
-            await MainActor.run {
-                for recordName in deletedRecordNames {
-                    self.state.fleetDevices.removeValue(forKey: recordName)
-                    self.state.fleetSnapshots.removeValue(forKey: recordName)
-                }
-            }
+            await self.forgetFleetRecords(Set(changes.deletions.map(\.recordID.recordName)))
             self.persistEnvelope()
             await MainActor.run { self.state.status.lastSuccessfulFetchAt = Date() }
         case let .sentRecordZoneChanges(changes):
@@ -842,6 +843,13 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
             self.persistEnvelope()
             if !changes.savedRecords.isEmpty {
                 await MainActor.run { self.state.status.lastSuccessfulPushAt = Date() }
+            }
+            // Only a push with nothing failing in it retires the banner. A batch that saved one
+            // record and failed a delete has not fixed the delete, and a fetch never does.
+            if changes.failedRecordSaves.isEmpty, changes.failedRecordDeletes.isEmpty,
+               !changes.savedRecords.isEmpty || !changes.deletedRecordIDs.isEmpty
+            {
+                await MainActor.run { self.state.status.lastError = nil }
             }
             if !self.pendingSnapshots.isEmpty {
                 Task { [weak self] in
@@ -1173,7 +1181,7 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
         }
     }
 
-    private func rehydrateFleetStateIfNeeded() async {
+    func rehydrateFleetStateIfNeeded() async {
         guard !self.didRehydrateFleetState else { return }
         self.didRehydrateFleetState = true
         let devices = self.persistenceEnvelope.fleetDevices
@@ -1270,12 +1278,7 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
     }
 
     private static func deviceModel() -> String {
-        var size = 0
-        guard sysctlbyname("hw.model", nil, &size, nil, 0) == 0, size > 0 else { return "unknown" }
-        var buffer = [CChar](repeating: 0, count: size)
-        guard sysctlbyname("hw.model", &buffer, &size, nil, 0) == 0 else { return "unknown" }
-        let bytes = buffer.prefix { $0 != 0 }.map(UInt8.init(bitPattern:))
-        return String(bytes: bytes, encoding: .utf8) ?? "unknown"
+        Sysctl.string("hw.model") ?? "unknown"
     }
 }
 
@@ -1283,31 +1286,29 @@ extension CloudSyncEngine {
     /// Removes a device from the fleet on every Mac on the account. The current Mac re-registers
     /// itself the next time sync starts, which is why removal is offered for it too.
     func removeDevice(deviceID: String) async {
+        guard let engine = self.engine else {
+            await MainActor.run {
+                self.state.status.lastError = L("Sync is not running yet. Try again in a moment.")
+            }
+            return
+        }
         let names = CloudSyncDeviceRemoval.recordNames(
             forDeviceID: deviceID,
             snapshots: self.persistenceEnvelope.fleetSnapshots)
-        for name in names {
-            self.removedDevices[name] = self.persistenceEnvelope.fleetDevices[name]
-            self.removedSnapshots[name] = self.persistenceEnvelope.fleetSnapshots[name]
-        }
-        let recordIDs = CloudSyncSnapshotMigration.drop(
+        let recordIDs = CloudSyncSnapshotMigration.dropPushState(
             names,
             hashes: &self.lastSnapshotHashes,
             envelope: &self.persistenceEnvelope,
             desiredRecords: &self.desiredRecords,
             zoneID: Self.zoneID)
-        self.rememberPendingSnapshotDeletes(names)
-        await MainActor.run {
-            for name in names {
-                self.state.fleetDevices.removeValue(forKey: name)
-                self.state.fleetSnapshots.removeValue(forKey: name)
-            }
-        }
-        guard let engine = self.engine else { return }
+        self.rememberPendingRecordDeletes(names)
         engine.state.add(pendingRecordZoneChanges: recordIDs.map { .deleteRecord($0) })
         do {
             try await engine.sendChanges(.init(scope: .recordIDs(recordIDs)))
         } catch {
+            // The send never left this Mac, so stop tracking the names: nothing would drain them
+            // from the pending set, which only the snapshot push requeues.
+            self.forgetPendingRecordDeletes(names)
             await self.record(error: error)
         }
     }
@@ -1331,7 +1332,7 @@ extension CloudSyncEngine {
                 fleetSnapshots: self.persistenceEnvelope.fleetSnapshots,
                 lastSnapshotHashes: self.lastSnapshotHashes))
         guard !toDrop.isEmpty else { return }
-        let recordIDs = CloudSyncSnapshotMigration.drop(
+        let recordIDs = CloudSyncSnapshotMigration.dropPushState(
             toDrop,
             hashes: &self.lastSnapshotHashes,
             envelope: &self.persistenceEnvelope,
@@ -1340,7 +1341,10 @@ extension CloudSyncEngine {
         for recordID in recordIDs {
             syncEngine.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
         }
-        self.rememberPendingSnapshotDeletes(toDrop)
+        self.rememberPendingRecordDeletes(toDrop)
+        // Unlike a device removal, the replacement snapshot is already saved, so the superseded
+        // record is retired now rather than waiting for its delete to land.
+        toDrop.forEach { self.persistenceEnvelope.fleetSnapshots.removeValue(forKey: $0) }
         await MainActor.run {
             toDrop.forEach { self.state.fleetSnapshots.removeValue(forKey: $0) }
         }
@@ -1349,10 +1353,9 @@ extension CloudSyncEngine {
     private func handleSentRecordDeletes(deletedIDs: [CKRecord.ID], failures: [CKRecord.ID: CKError]) async {
         var finished = Set(deletedIDs.map(\.recordName))
         finished.formUnion(CloudSyncSnapshotMigration.finishedFailedDeleteNames(failures))
-        self.forgetPendingSnapshotDeletes(finished)
-        await self.restoreOptimisticallyRemoved(
-            CloudSyncSnapshotMigration.restorableFailedDeleteNames(failures))
-        self.forgetOptimisticRemoval(finished)
+        self.forgetPendingRecordDeletes(finished)
+        await self.forgetFleetRecords(
+            CloudSyncSnapshotMigration.confirmedDeletedNames(deletedIDs: deletedIDs, failures: failures))
         for error in CloudSyncSnapshotMigration.reportableFailedDeletes(failures) {
             await self.record(error: error)
         }
@@ -1361,67 +1364,64 @@ extension CloudSyncEngine {
                 self.desiredRecords.keys.map(\.recordName),
             storedRecordNames: self.lastSnapshotHashes.keys)
         for recordID in CloudSyncSnapshotMigration.retryableFailedDeletes(failures, liveNames: liveNames) {
-            self.rememberPendingSnapshotDeletes([recordID.recordName])
+            self.rememberPendingRecordDeletes([recordID.recordName])
             let delay = failures[recordID].flatMap(CloudSyncSnapshotMigration.retryDelay(for:)) ?? 1
             self.scheduleDeleteRetry(recordID: recordID, after: delay)
         }
     }
 
-    /// A terminal delete failure means the record is still in CloudKit, so the row goes back
-    /// instead of hiding a device that was never removed.
-    private func restoreOptimisticallyRemoved(_ names: Set<String>) async {
-        var devices: [String: DeviceSyncPayload] = [:]
-        var snapshots: [String: AccountSnapshotSyncPayload] = [:]
+    /// Drops every trace of records CloudKit no longer holds, so the Macs list and the fleet
+    /// menu stop showing them. Both the local delete and a remote one land here.
+    private func forgetFleetRecords(_ names: Set<String>) async {
+        guard !names.isEmpty else { return }
         for name in names {
-            devices[name] = self.removedDevices[name]
-            snapshots[name] = self.removedSnapshots[name]
+            self.persistenceEnvelope.encodedSystemFields.removeValue(forKey: name)
+            self.persistenceEnvelope.recordMetadata.removeValue(forKey: name)
+            self.persistenceEnvelope.fleetDevices.removeValue(forKey: name)
+            self.persistenceEnvelope.fleetSnapshots.removeValue(forKey: name)
         }
-        guard !devices.isEmpty || !snapshots.isEmpty else { return }
-        self.persistenceEnvelope.fleetDevices.merge(devices) { _, restored in restored }
-        self.persistenceEnvelope.fleetSnapshots.merge(snapshots) { _, restored in restored }
         await MainActor.run {
-            self.state.fleetDevices.merge(devices) { _, restored in restored }
-            self.state.fleetSnapshots.merge(snapshots) { _, restored in restored }
+            for name in names {
+                self.state.fleetDevices.removeValue(forKey: name)
+                self.state.fleetSnapshots.removeValue(forKey: name)
+            }
         }
-    }
-
-    private func forgetOptimisticRemoval(_ names: Set<String>) {
-        for name in names {
-            self.removedDevices.removeValue(forKey: name)
-            self.removedSnapshots.removeValue(forKey: name)
-        }
-    }
-
-    private func rememberPendingSnapshotDeletes(_ names: Set<String>) {
-        guard !names.isEmpty else { return }
-        self.persistenceEnvelope.pendingSnapshotDeletes.formUnion(names)
         self.persistEnvelope()
     }
 
-    private func forgetPendingSnapshotDeletes(_ names: Set<String>) {
-        let remaining = self.persistenceEnvelope.pendingSnapshotDeletes.subtracting(names)
-        guard remaining != self.persistenceEnvelope.pendingSnapshotDeletes else { return }
-        self.persistenceEnvelope.pendingSnapshotDeletes = remaining
+    private func rememberPendingRecordDeletes(_ names: Set<String>) {
+        guard !names.isEmpty else { return }
+        self.persistenceEnvelope.pendingRecordDeletes.formUnion(names)
         self.persistEnvelope()
     }
 
-    private func cancelPendingSnapshotDeletes(_ names: Set<String>) {
+    private func forgetPendingRecordDeletes(_ names: Set<String>) {
+        let remaining = self.persistenceEnvelope.pendingRecordDeletes.subtracting(names)
+        guard remaining != self.persistenceEnvelope.pendingRecordDeletes else { return }
+        self.persistenceEnvelope.pendingRecordDeletes = remaining
+        self.persistEnvelope()
+    }
+
+    private func cancelPendingRecordDeletes(_ names: Set<String>) {
         guard !names.isEmpty else { return }
-        self.forgetPendingSnapshotDeletes(names)
+        self.forgetPendingRecordDeletes(names)
         guard let engine = self.engine else { return }
         engine.state.remove(pendingRecordZoneChanges: names.map { name in
             .deleteRecord(self.recordID(named: name))
         })
     }
 
-    private func requeuePendingSnapshotDeletes() {
+    /// Deletes that never reached CloudKit, requeued once. Device Records are included, unlike
+    /// in `retryableFailedDeletes`: a delete CloudKit rejected is abandoned, but one that was
+    /// never attempted is still the removal the user asked for.
+    private func requeuePendingRecordDeletes() {
         guard let engine = self.engine else { return }
         let liveNames = CloudSyncSnapshotMigration.liveSnapshotRecordNames(
             pendingRecordNames: self.pendingSnapshots.map(\.recordName) +
                 self.desiredRecords.keys.map(\.recordName),
             storedRecordNames: self.lastSnapshotHashes.keys)
         let names = CloudSyncSnapshotMigration.pendingDeletesToRequeue(
-            pendingDeletes: self.persistenceEnvelope.pendingSnapshotDeletes,
+            pendingDeletes: self.persistenceEnvelope.pendingRecordDeletes,
             liveNames: liveNames)
         for name in names {
             engine.state.add(pendingRecordZoneChanges: [.deleteRecord(self.recordID(named: name))])
@@ -1454,7 +1454,7 @@ extension CloudSyncEngine {
                 }
                 await Task.yield()
                 guard let self, await self.enabled else { return }
-                guard await self.persistenceEnvelope.pendingSnapshotDeletes.contains(recordID.recordName) else {
+                guard await self.persistenceEnvelope.pendingRecordDeletes.contains(recordID.recordName) else {
                     return
                 }
                 guard let engine = await self.engine,
@@ -1474,7 +1474,7 @@ extension CloudSyncEngine {
 
     private func pushPendingSnapshots() async {
         guard let engine = self.engine else { return }
-        guard !self.pendingSnapshots.isEmpty || !self.persistenceEnvelope.pendingSnapshotDeletes.isEmpty else {
+        guard !self.pendingSnapshots.isEmpty || !self.persistenceEnvelope.pendingRecordDeletes.isEmpty else {
             return
         }
         guard await MainActor.run(body: { !self.state.status.needsAppUpdate }) else { return }
@@ -1487,13 +1487,13 @@ extension CloudSyncEngine {
                 CloudSyncSnapshotMigration.retainingObsoletePredecessors(
                     in: &self.persistenceEnvelope.pendingPredecessorDeletes,
                     obsoleteNames: obsoleteNames)
-                self.cancelPendingSnapshotDeletes(
+                self.cancelPendingRecordDeletes(
                     CloudSyncSnapshotMigration.cancelledPersistedDeletes(
-                        pendingDeletes: self.persistenceEnvelope.pendingSnapshotDeletes,
+                        pendingDeletes: self.persistenceEnvelope.pendingRecordDeletes,
                         liveNames: Set(self.pendingSnapshots.map(\.recordName))))
                 self.hasReconciledLiveSnapshots = true
             }
-            self.requeuePendingSnapshotDeletes()
+            self.requeuePendingRecordDeletes()
             var stillPending: [AccountSnapshotSyncPayload] = []
             for payload in self.pendingSnapshots {
                 let hash = try CanonicalSyncJSON.hash(payload)

--- a/Sources/CodexBar/Sync/CloudSyncEngine.swift
+++ b/Sources/CodexBar/Sync/CloudSyncEngine.swift
@@ -636,13 +636,18 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
         }
     }
 
-    func fetchChanges() async {
-        guard self.enabled, let engine = self.engine else { return }
+    /// Reports whether the fleet cache is current. A caller about to act on that cache
+    /// destructively has no grounds to when this comes back false.
+    @discardableResult
+    func fetchChanges() async -> Bool {
+        guard self.enabled, let engine = self.engine else { return false }
         do {
             try await engine.fetchChanges(.init(scope: .zoneIDs([Self.zoneID])))
             await MainActor.run { self.state.status.lastSuccessfulFetchAt = Date() }
+            return true
         } catch {
             await self.record(error: error)
+            return false
         }
     }
 
@@ -1311,6 +1316,10 @@ extension CloudSyncEngine {
             }
             return
         }
+        // The delete set is built from the fleet cache, so the cache has to be current: a usage
+        // snapshot published since the last fetch would otherwise outlive the device record it
+        // belongs to. A fetch that fails leaves no grounds to delete anything, and reports itself.
+        guard await self.fetchChanges() else { return }
         let names = CloudSyncDeviceRemoval.recordNames(
             forDeviceID: deviceID,
             snapshots: self.persistenceEnvelope.fleetSnapshots)

--- a/Sources/CodexBar/Sync/CloudSyncEngine.swift
+++ b/Sources/CodexBar/Sync/CloudSyncEngine.swift
@@ -25,6 +25,8 @@ final class CloudSyncState {
     var status = SyncStatus()
     var fleetDevices: [String: DeviceSyncPayload] = [:]
     var fleetSnapshots: [String: AccountSnapshotSyncPayload] = [:]
+    /// Wired by `CloudSyncCoordinator`; the settings pane's only route into the sync engine.
+    @ObservationIgnored var removeDevice: ((String) -> Void)?
 }
 
 struct CloudSyncQuotaRetryState: Equatable, Sendable {
@@ -150,6 +152,21 @@ enum CloudSyncDirtyState {
     }
 }
 
+enum CloudSyncDeviceRemoval {
+    /// Everything a device owns in the sync zone: its device record plus every usage snapshot it
+    /// published. Snapshots outlive the device record otherwise, and the menu keeps projecting them.
+    static func recordNames(
+        forDeviceID deviceID: String,
+        snapshots: [String: AccountSnapshotSyncPayload]) -> Set<String>
+    {
+        var names: Set<String> = [DeviceSyncPayload.recordName(for: deviceID)]
+        for (name, snapshot) in snapshots where snapshot.deviceID == deviceID {
+            names.insert(name)
+        }
+        return names
+    }
+}
+
 enum CloudSyncSnapshotMigration {
     static func obsoleteRecordNames(
         liveSnapshots: [AccountSnapshotSyncPayload],
@@ -172,6 +189,7 @@ enum CloudSyncSnapshotMigration {
             let recordID = CKRecord.ID(recordName: name, zoneID: zoneID)
             desiredRecords.removeValue(forKey: recordID)
             hashes.removeValue(forKey: name)
+            envelope.fleetDevices.removeValue(forKey: name)
             envelope.fleetSnapshots.removeValue(forKey: name)
             envelope.encodedSystemFields.removeValue(forKey: name)
             envelope.recordMetadata.removeValue(forKey: name)
@@ -295,6 +313,13 @@ enum CloudSyncSnapshotMigration {
         })
     }
 
+    /// Terminal failures that left the record in place. `unknownItem` is excluded: that record is
+    /// already gone, so the delete succeeded in every way the caller cares about.
+    static func restorableFailedDeleteNames(_ failures: [CKRecord.ID: CKError]) -> Set<String> {
+        self.finishedFailedDeleteNames(failures).subtracting(
+            failures.compactMap { $0.value.code == .unknownItem ? $0.key.recordName : nil })
+    }
+
     static func abandonedReplacementNames(
         failures: [String: CKError],
         pendingReplacements: Set<String>) -> Set<String>
@@ -396,6 +421,8 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
     private var persistenceEnvelope: CloudSyncPersistence.Envelope
     private var engine: CKSyncEngine?
     private var desiredRecords: [CKRecord.ID: CKRecord] = [:]
+    private var removedDevices: [String: DeviceSyncPayload] = [:]
+    private var removedSnapshots: [String: AccountSnapshotSyncPayload] = [:]
     private var enabled = false
     private var configPushTask: Task<Void, Never>?
     private var snapshotPushTask: Task<Void, Never>?
@@ -733,6 +760,10 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
             appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
             lastSeen: Date())
         let recordID = self.recordID(named: payload.recordName)
+        // This Mac may have been removed before quitting. Re-registering supersedes that removal,
+        // so drop the pending delete rather than letting it retire the record we are about to save.
+        self.cancelPendingSnapshotDeletes([payload.recordName])
+        self.forgetOptimisticRemoval([payload.recordName])
         let record = self.record(type: .device, id: recordID)
         record["schemaVersion"] = payload.schemaVersion as CKRecordValue
         record["deviceID"] = payload.deviceID as CKRecordValue
@@ -1249,6 +1280,38 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
 }
 
 extension CloudSyncEngine {
+    /// Removes a device from the fleet on every Mac on the account. The current Mac re-registers
+    /// itself the next time sync starts, which is why removal is offered for it too.
+    func removeDevice(deviceID: String) async {
+        let names = CloudSyncDeviceRemoval.recordNames(
+            forDeviceID: deviceID,
+            snapshots: self.persistenceEnvelope.fleetSnapshots)
+        for name in names {
+            self.removedDevices[name] = self.persistenceEnvelope.fleetDevices[name]
+            self.removedSnapshots[name] = self.persistenceEnvelope.fleetSnapshots[name]
+        }
+        let recordIDs = CloudSyncSnapshotMigration.drop(
+            names,
+            hashes: &self.lastSnapshotHashes,
+            envelope: &self.persistenceEnvelope,
+            desiredRecords: &self.desiredRecords,
+            zoneID: Self.zoneID)
+        self.rememberPendingSnapshotDeletes(names)
+        await MainActor.run {
+            for name in names {
+                self.state.fleetDevices.removeValue(forKey: name)
+                self.state.fleetSnapshots.removeValue(forKey: name)
+            }
+        }
+        guard let engine = self.engine else { return }
+        engine.state.add(pendingRecordZoneChanges: recordIDs.map { .deleteRecord($0) })
+        do {
+            try await engine.sendChanges(.init(scope: .recordIDs(recordIDs)))
+        } catch {
+            await self.record(error: error)
+        }
+    }
+
     private func finishConfirmedSnapshotMigrations(
         savedRecordNames: [String],
         syncEngine: CKSyncEngine) async
@@ -1287,6 +1350,9 @@ extension CloudSyncEngine {
         var finished = Set(deletedIDs.map(\.recordName))
         finished.formUnion(CloudSyncSnapshotMigration.finishedFailedDeleteNames(failures))
         self.forgetPendingSnapshotDeletes(finished)
+        await self.restoreOptimisticallyRemoved(
+            CloudSyncSnapshotMigration.restorableFailedDeleteNames(failures))
+        self.forgetOptimisticRemoval(finished)
         for error in CloudSyncSnapshotMigration.reportableFailedDeletes(failures) {
             await self.record(error: error)
         }
@@ -1298,6 +1364,31 @@ extension CloudSyncEngine {
             self.rememberPendingSnapshotDeletes([recordID.recordName])
             let delay = failures[recordID].flatMap(CloudSyncSnapshotMigration.retryDelay(for:)) ?? 1
             self.scheduleDeleteRetry(recordID: recordID, after: delay)
+        }
+    }
+
+    /// A terminal delete failure means the record is still in CloudKit, so the row goes back
+    /// instead of hiding a device that was never removed.
+    private func restoreOptimisticallyRemoved(_ names: Set<String>) async {
+        var devices: [String: DeviceSyncPayload] = [:]
+        var snapshots: [String: AccountSnapshotSyncPayload] = [:]
+        for name in names {
+            devices[name] = self.removedDevices[name]
+            snapshots[name] = self.removedSnapshots[name]
+        }
+        guard !devices.isEmpty || !snapshots.isEmpty else { return }
+        self.persistenceEnvelope.fleetDevices.merge(devices) { _, restored in restored }
+        self.persistenceEnvelope.fleetSnapshots.merge(snapshots) { _, restored in restored }
+        await MainActor.run {
+            self.state.fleetDevices.merge(devices) { _, restored in restored }
+            self.state.fleetSnapshots.merge(snapshots) { _, restored in restored }
+        }
+    }
+
+    private func forgetOptimisticRemoval(_ names: Set<String>) {
+        for name in names {
+            self.removedDevices.removeValue(forKey: name)
+            self.removedSnapshots.removeValue(forKey: name)
         }
     }
 

--- a/Sources/CodexBar/Sync/CloudSyncEngine.swift
+++ b/Sources/CodexBar/Sync/CloudSyncEngine.swift
@@ -165,6 +165,19 @@ enum CloudSyncDeviceRemoval {
         }
         return names
     }
+
+    /// Usage Snapshots left behind by a Device Record that is already gone. CloudKit can confirm
+    /// the device delete and terminally reject one of its snapshot deletes in the same batch, and
+    /// the leftover snapshot would otherwise keep projecting into the fleet menu with no Macs row
+    /// left to remove it from.
+    static func orphanedSnapshotNames(
+        removedNames: Set<String>,
+        snapshots: [String: AccountSnapshotSyncPayload]) -> Set<String>
+    {
+        Set(snapshots.compactMap { name, snapshot in
+            removedNames.contains(DeviceSyncPayload.recordName(for: snapshot.deviceID)) ? name : nil
+        })
+    }
 }
 
 enum CloudSyncSnapshotMigration {
@@ -844,10 +857,16 @@ actor CloudSyncEngine: CKSyncEngineDelegate {
             if !changes.savedRecords.isEmpty {
                 await MainActor.run { self.state.status.lastSuccessfulPushAt = Date() }
             }
-            // Only a push with nothing failing in it retires the banner. A batch that saved one
-            // record and failed a delete has not fixed the delete, and a fetch never does.
-            if changes.failedRecordSaves.isEmpty, changes.failedRecordDeletes.isEmpty,
-               !changes.savedRecords.isEmpty || !changes.deletedRecordIDs.isEmpty
+            // Only a push with nothing the user has to hear about retires the banner. A batch that
+            // saved one record and reported a failed delete has not fixed it, and a fetch never
+            // does. Records CloudKit no longer holds are removals that landed, so they clear the
+            // banner rather than block it.
+            let landedDeletes = CloudSyncSnapshotMigration.confirmedDeletedNames(
+                deletedIDs: changes.deletedRecordIDs,
+                failures: changes.failedRecordDeletes)
+            if changes.failedRecordSaves.isEmpty,
+               CloudSyncSnapshotMigration.reportableFailedDeletes(changes.failedRecordDeletes).isEmpty,
+               !changes.savedRecords.isEmpty || !landedDeletes.isEmpty
             {
                 await MainActor.run { self.state.status.lastError = nil }
             }
@@ -1374,6 +1393,9 @@ extension CloudSyncEngine {
     /// menu stop showing them. Both the local delete and a remote one land here.
     private func forgetFleetRecords(_ names: Set<String>) async {
         guard !names.isEmpty else { return }
+        let names = names.union(CloudSyncDeviceRemoval.orphanedSnapshotNames(
+            removedNames: names,
+            snapshots: self.persistenceEnvelope.fleetSnapshots))
         for name in names {
             self.persistenceEnvelope.encodedSystemFields.removeValue(forKey: name)
             self.persistenceEnvelope.recordMetadata.removeValue(forKey: name)

--- a/Sources/CodexBar/Sync/CloudSyncPersistence.swift
+++ b/Sources/CodexBar/Sync/CloudSyncPersistence.swift
@@ -19,7 +19,7 @@ struct CloudSyncPersistence: Sendable {
         var preferencesDirty: Bool
         var fleetDevices: [String: DeviceSyncPayload]
         var fleetSnapshots: [String: AccountSnapshotSyncPayload]
-        var pendingSnapshotDeletes: Set<String>
+        var pendingRecordDeletes: Set<String>
         var pendingPredecessorDeletes: [String: Set<String>]
 
         init(
@@ -31,7 +31,7 @@ struct CloudSyncPersistence: Sendable {
             preferencesDirty: Bool = false,
             fleetDevices: [String: DeviceSyncPayload] = [:],
             fleetSnapshots: [String: AccountSnapshotSyncPayload] = [:],
-            pendingSnapshotDeletes: Set<String> = [],
+            pendingRecordDeletes: Set<String> = [],
             pendingPredecessorDeletes: [String: Set<String>] = [:])
         {
             self.stateSerialization = stateSerialization
@@ -42,7 +42,7 @@ struct CloudSyncPersistence: Sendable {
             self.preferencesDirty = preferencesDirty
             self.fleetDevices = fleetDevices
             self.fleetSnapshots = fleetSnapshots
-            self.pendingSnapshotDeletes = pendingSnapshotDeletes
+            self.pendingRecordDeletes = pendingRecordDeletes
             self.pendingPredecessorDeletes = pendingPredecessorDeletes
         }
 
@@ -55,7 +55,7 @@ struct CloudSyncPersistence: Sendable {
             case preferencesDirty
             case fleetDevices
             case fleetSnapshots
-            case pendingSnapshotDeletes
+            case pendingRecordDeletes = "pendingSnapshotDeletes"
             case pendingPredecessorDeletes
         }
 
@@ -85,9 +85,9 @@ struct CloudSyncPersistence: Sendable {
             self.fleetSnapshots = try container.decodeIfPresent(
                 [String: AccountSnapshotSyncPayload].self,
                 forKey: .fleetSnapshots) ?? [:]
-            self.pendingSnapshotDeletes = try container.decodeIfPresent(
+            self.pendingRecordDeletes = try container.decodeIfPresent(
                 Set<String>.self,
-                forKey: .pendingSnapshotDeletes) ?? []
+                forKey: .pendingRecordDeletes) ?? []
             self.pendingPredecessorDeletes = try container.decodeIfPresent(
                 [String: Set<String>].self,
                 forKey: .pendingPredecessorDeletes) ?? [:]

--- a/Sources/CodexBarCore/Sync/SyncModels.swift
+++ b/Sources/CodexBarCore/Sync/SyncModels.swift
@@ -166,8 +166,16 @@ public struct DeviceSyncPayload: Codable, Sendable {
         self.lastSeen = lastSeen
     }
 
+    private static let recordNamePrefix = "device-"
+
     public static func recordName(for deviceID: String) -> String {
-        "device-\(deviceID)"
+        self.recordNamePrefix + deviceID
+    }
+
+    /// A Device Record delete is attempted once and never retried, so the delete paths have to
+    /// tell a Device Record apart from a Usage Snapshot by record name alone.
+    public static func isRecordName(_ recordName: String) -> Bool {
+        recordName.hasPrefix(self.recordNamePrefix)
     }
 
     public var recordName: String {

--- a/Sources/CodexBarCore/Sync/SyncModels.swift
+++ b/Sources/CodexBarCore/Sync/SyncModels.swift
@@ -166,8 +166,12 @@ public struct DeviceSyncPayload: Codable, Sendable {
         self.lastSeen = lastSeen
     }
 
+    public static func recordName(for deviceID: String) -> String {
+        "device-\(deviceID)"
+    }
+
     public var recordName: String {
-        "device-\(self.deviceID)"
+        Self.recordName(for: self.deviceID)
     }
 }
 

--- a/Tests/CodexBarTests/CloudSyncDeviceIdentityTests.swift
+++ b/Tests/CodexBarTests/CloudSyncDeviceIdentityTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CloudSyncDeviceIdentityTests {
+    @Test
+    func `a persisted identifier is kept so existing fleets stay addressable`() {
+        let resolved = CloudSyncDeviceIdentity.resolve(
+            persisted: "kept",
+            hardwareUUID: Self.hardwareUUID)
+
+        #expect(resolved == "kept")
+    }
+
+    @Test
+    func `a fresh install derives the same identifier from the same hardware`() {
+        let first = CloudSyncDeviceIdentity.resolve(persisted: nil, hardwareUUID: Self.hardwareUUID)
+        let second = CloudSyncDeviceIdentity.resolve(persisted: "", hardwareUUID: Self.hardwareUUID)
+
+        #expect(first == second)
+        #expect(first != CloudSyncDeviceIdentity.resolve(persisted: nil, hardwareUUID: "OTHER-HARDWARE"))
+        #expect(first != Self.hardwareUUID.lowercased())
+        #expect(UUID(uuidString: first) != nil)
+    }
+
+    @Test
+    func `a missing hardware UUID falls back to a random identifier`() {
+        let first = CloudSyncDeviceIdentity.resolve(persisted: nil, hardwareUUID: nil)
+        let second = CloudSyncDeviceIdentity.resolve(persisted: nil, hardwareUUID: nil)
+
+        #expect(first != second)
+        #expect(UUID(uuidString: first) != nil)
+    }
+
+    private static let hardwareUUID = "3F7964F9-C5A6-39D4-942D-02750C0980E0"
+}

--- a/Tests/CodexBarTests/CloudSyncDeviceRemovalTests.swift
+++ b/Tests/CodexBarTests/CloudSyncDeviceRemovalTests.swift
@@ -1,0 +1,58 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CloudSyncDeviceRemovalTests {
+    @Test
+    func `removing a device targets its record and every snapshot it published`() {
+        let stale = Self.snapshot(deviceID: "stale", accountKey: "a")
+        let alsoStale = Self.snapshot(deviceID: "stale", accountKey: "b")
+        let other = Self.snapshot(deviceID: "other", accountKey: "a")
+
+        let names = CloudSyncDeviceRemoval.recordNames(
+            forDeviceID: "stale",
+            snapshots: Self.byRecordName([stale, alsoStale, other]))
+
+        #expect(names == Set([
+            DeviceSyncPayload.recordName(for: "stale"),
+            stale.recordName,
+            alsoStale.recordName,
+        ]))
+    }
+
+    @Test
+    func `removing a device spares snapshots published by other devices`() {
+        let other = Self.snapshot(deviceID: "other", accountKey: "a")
+
+        let names = CloudSyncDeviceRemoval.recordNames(
+            forDeviceID: "stale",
+            snapshots: Self.byRecordName([other]))
+
+        #expect(names == Set([DeviceSyncPayload.recordName(for: "stale")]))
+    }
+
+    private static func byRecordName(
+        _ snapshots: [AccountSnapshotSyncPayload]) -> [String: AccountSnapshotSyncPayload]
+    {
+        Dictionary(uniqueKeysWithValues: snapshots.map { ($0.recordName, $0) })
+    }
+
+    private static func snapshot(deviceID: String, accountKey: String) -> AccountSnapshotSyncPayload {
+        let fetchedAt = Date(timeIntervalSince1970: 100)
+        return AccountSnapshotSyncPayload(
+            provider: .codex,
+            deviceID: deviceID,
+            accountKey: accountKey,
+            fetchedAt: fetchedAt,
+            displayLabel: "person@example.com",
+            usage: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 25,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: fetchedAt))
+    }
+}

--- a/Tests/CodexBarTests/CloudSyncSettingsTests.swift
+++ b/Tests/CodexBarTests/CloudSyncSettingsTests.swift
@@ -162,7 +162,7 @@ struct CloudSyncSettingsTests {
 
         #expect(envelope.dirtyProviders.isEmpty)
         #expect(!envelope.preferencesDirty)
-        #expect(envelope.pendingSnapshotDeletes.isEmpty)
+        #expect(envelope.pendingRecordDeletes.isEmpty)
     }
 
     @Test
@@ -173,10 +173,10 @@ struct CloudSyncSettingsTests {
         let fileURL = directory.appendingPathComponent("engine-state.json")
         let persistence = CloudSyncPersistence(fileURL: fileURL)
         var envelope = CloudSyncPersistence.Envelope(stateSerialization: nil, encodedSystemFields: [:])
-        envelope.pendingSnapshotDeletes = ["snap-claude-old-device-id"]
+        envelope.pendingRecordDeletes = ["snap-claude-old-device-id"]
         try persistence.save(envelope)
 
-        #expect(persistence.load().pendingSnapshotDeletes == ["snap-claude-old-device-id"])
+        #expect(persistence.load().pendingRecordDeletes == ["snap-claude-old-device-id"])
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2325,7 +2325,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1192,
+            line: 1195,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,

--- a/Tests/CodexBarTests/SyncModelTests.swift
+++ b/Tests/CodexBarTests/SyncModelTests.swift
@@ -421,6 +421,93 @@ struct CloudSyncSnapshotMigrationDeleteRetryTests {
         #expect(retryable == ["snap-obsolete"])
     }
 
+    @Test
+    func `a failed Device Record delete is not retried`() {
+        let zoneID = CloudSyncEngine.zoneID
+        func recordID(_ name: String) -> CKRecord.ID {
+            CKRecord.ID(recordName: name, zoneID: zoneID)
+        }
+        let stale = DeviceSyncPayload.recordName(for: "stale")
+        let gone = DeviceSyncPayload.recordName(for: "gone")
+
+        let failures: [CKRecord.ID: CKError] = [
+            recordID(stale): Self.cloudKitError(.networkFailure),
+            recordID(gone): Self.cloudKitError(.unknownItem),
+            recordID("snapshot-stale"): Self.cloudKitError(.networkFailure),
+        ]
+
+        #expect(
+            CloudSyncSnapshotMigration.retryableFailedDeletes(failures).map(\.recordName) ==
+                ["snapshot-stale"])
+        #expect(CloudSyncSnapshotMigration.finishedFailedDeleteNames(failures) == [stale, gone])
+    }
+
+    @Test
+    func `a device row goes only when CloudKit confirms the delete`() {
+        let zoneID = CloudSyncEngine.zoneID
+        func recordID(_ name: String) -> CKRecord.ID {
+            CKRecord.ID(recordName: name, zoneID: zoneID)
+        }
+        let confirmed = DeviceSyncPayload.recordName(for: "confirmed")
+        let alreadyGone = DeviceSyncPayload.recordName(for: "already-gone")
+        let refused = DeviceSyncPayload.recordName(for: "refused")
+
+        let names = CloudSyncSnapshotMigration.confirmedDeletedNames(
+            deletedIDs: [recordID(confirmed)],
+            failures: [
+                recordID(alreadyGone): Self.cloudKitError(.unknownItem),
+                recordID(refused): Self.cloudKitError(.permissionFailure),
+                recordID("snapshot-offline"): Self.cloudKitError(.networkFailure),
+            ])
+
+        #expect(names == [confirmed, alreadyGone])
+    }
+
+    @Test
+    func `queueing a delete leaves the fleet row until the delete lands`() {
+        let recordName = DeviceSyncPayload.recordName(for: "stale")
+        var envelope = CloudSyncPersistence.Envelope(stateSerialization: nil, encodedSystemFields: [:])
+        envelope.fleetDevices[recordName] = DeviceSyncPayload(
+            deviceID: "stale",
+            hostName: "Old Mac",
+            model: "Mac16,1",
+            appVersion: "1.0",
+            lastSeen: .distantPast)
+        envelope.encodedSystemFields[recordName] = Data()
+        var hashes = [recordName: "hash"]
+        var desiredRecords: [CKRecord.ID: CKRecord] = [:]
+
+        let recordIDs = CloudSyncSnapshotMigration.dropPushState(
+            [recordName],
+            hashes: &hashes,
+            envelope: &envelope,
+            desiredRecords: &desiredRecords,
+            zoneID: CloudSyncEngine.zoneID)
+
+        #expect(recordIDs.map(\.recordName) == [recordName])
+        #expect(hashes.isEmpty)
+        #expect(envelope.encodedSystemFields[recordName] == nil)
+        #expect(envelope.fleetDevices[recordName] != nil)
+    }
+
+    @Test
+    func `a Device Record delete that will not be retried is reported`() {
+        let zoneID = CloudSyncEngine.zoneID
+        func recordID(_ name: String) -> CKRecord.ID {
+            CKRecord.ID(recordName: name, zoneID: zoneID)
+        }
+
+        let failures: [CKRecord.ID: CKError] = [
+            recordID(DeviceSyncPayload.recordName(for: "stale")): Self.cloudKitError(.networkFailure),
+            recordID(DeviceSyncPayload.recordName(for: "gone")): Self.cloudKitError(.unknownItem),
+            recordID("snapshot-stale"): Self.cloudKitError(.networkFailure),
+        ]
+
+        #expect(
+            CloudSyncSnapshotMigration.reportableFailedDeletes(failures).map(\.code) ==
+                [.networkFailure])
+    }
+
     private static func cloudKitError(_ code: CKError.Code, retryAfter: TimeInterval? = nil) -> CKError {
         var userInfo: [String: Any] = [:]
         if let retryAfter {

--- a/Tests/CodexBarTests/SyncModelTests.swift
+++ b/Tests/CodexBarTests/SyncModelTests.swift
@@ -464,6 +464,32 @@ struct CloudSyncSnapshotMigrationDeleteRetryTests {
     }
 
     @Test
+    func `snapshots of a removed device go with it`() {
+        func snapshot(deviceID: String) -> AccountSnapshotSyncPayload {
+            AccountSnapshotSyncPayload(
+                provider: .codex,
+                deviceID: deviceID,
+                accountIdentity: "acct",
+                displayLabel: "owner@example.com",
+                usage: UsageSnapshot(
+                    primary: nil,
+                    secondary: nil,
+                    updatedAt: Date(timeIntervalSince1970: 100),
+                    identity: nil))
+        }
+        let removed = snapshot(deviceID: "removed")
+        let kept = snapshot(deviceID: "kept")
+
+        // CloudKit can confirm the Device Record delete and terminally reject one of its snapshot
+        // deletes in the same batch, leaving a snapshot with no Macs row to remove it from.
+        let orphans = CloudSyncDeviceRemoval.orphanedSnapshotNames(
+            removedNames: [DeviceSyncPayload.recordName(for: "removed")],
+            snapshots: [removed.recordName: removed, kept.recordName: kept])
+
+        #expect(orphans == [removed.recordName])
+    }
+
+    @Test
     func `queueing a delete leaves the fleet row until the delete lands`() {
         let recordName = DeviceSyncPayload.recordName(for: "stale")
         var envelope = CloudSyncPersistence.Envelope(stateSerialization: nil, encodedSystemFields: [:])

--- a/docs/adr/0001-stable-device-identity.md
+++ b/docs/adr/0001-stable-device-identity.md
@@ -1,0 +1,21 @@
+# Device identity is derived from the machine, not the installation
+
+`iCloudSyncDeviceID` was a random UUID minted into `UserDefaults` on first launch, so a
+reinstall produced a new identity and left the previous Device Record and its Usage Snapshots
+in CloudKit with nothing alive to refresh them (issue #3234). Device identity is now derived
+from a hashed `kern.uuid`, which survives reinstalls, so one Mac stays one Device.
+
+## Considered Options
+
+The new derivation applies **only when no identifier is already persisted**. Existing installs
+keep the random UUID they have.
+
+Migrating every install to the hashed identifier was rejected: it would strand a Device Record
+for every current sync user at once, inflicting the reported bug on all of them to fix it for
+the few who reinstall.
+
+## Consequences
+
+A Mac that already reinstalled before this change carries a random UUID and still shows one
+legacy duplicate. That duplicate must be removed by hand, once; subsequent reinstalls no
+longer create one.

--- a/docs/adr/0001-stable-device-identity.md
+++ b/docs/adr/0001-stable-device-identity.md
@@ -1,21 +1,26 @@
-# Device identity is derived from the machine, not the installation
+# A Device Identifier belongs to the Mac, not to CodexBar's local state
 
-`iCloudSyncDeviceID` was a random UUID minted into `UserDefaults` on first launch, so a
-reinstall produced a new identity and left the previous Device Record and its Usage Snapshots
-in CloudKit with nothing alive to refresh them (issue #3234). Device identity is now derived
-from a hashed `kern.uuid`, which survives reinstalls, so one Mac stays one Device.
+The Device Identifier was a random UUID minted into `UserDefaults` on first launch, so it
+identified CodexBar's local state rather than the Mac. Reinstalling produced a second Device
+Identifier, and the Fleet gained a Stale Device holding Usage Snapshots nothing would ever
+refresh (issue #3234). It is now derived from a hashed `kern.uuid`, which the Mac keeps across
+reinstalls, so one Mac claims one Device Record.
 
 ## Considered Options
 
-The new derivation applies **only when no identifier is already persisted**. Existing installs
-keep the random UUID they have.
+The derivation applies **only when no Device Identifier is already persisted**. A Mac that
+already has one keeps it.
 
-Migrating every install to the hashed identifier was rejected: it would strand a Device Record
-for every current sync user at once, inflicting the reported bug on all of them to fix it for
-the few who reinstall.
+Re-keying every Mac to the derived Device Identifier at once was rejected. It does not avoid a
+Stale Device, it only moves when one appears: either way each Mac in the Fleet strands its
+random Device Identifier exactly once. Re-keying strands it on the update that ships this
+change, with the user having done nothing to invite it; waiting strands it on the next
+reinstall, an act the user took and can connect the Stale Device to. A Mac that never
+reinstalls again is never charged at all.
 
 ## Consequences
 
-A Mac that already reinstalled before this change carries a random UUID and still shows one
-legacy duplicate. That duplicate must be removed by hand, once; subsequent reinstalls no
-longer create one.
+Every Mac syncing today creates one more Stale Device, at its next reinstall, where the derived
+Device Identifier replaces the random one. Reinstalls after that strand nothing. Stale Devices
+from before this change stay in the Fleet. All of them are removed by hand from
+Settings → iCloud Sync (see ADR 0002), which is what makes deferring the cost acceptable.

--- a/docs/adr/0002-removal-is-offered-for-the-current-device.md
+++ b/docs/adr/0002-removal-is-offered-for-the-current-device.md
@@ -1,0 +1,22 @@
+# Removal is offered for the current Device too
+
+Issue #3234 asked for a way to remove a Stale Device, and the triage note scoped that to
+"a selected non-current device". CodexBar offers it for every Device in the Fleet, including
+the one running the app.
+
+## Considered Options
+
+Hiding the control on the current Device's row was rejected. It is the only way to reset this
+Mac's own Device Record and Usage Snapshots, and a Fleet that has accumulated a Stale Device
+usually wants that reset available on the Mac the user is sitting at.
+
+Removal is not permanent for a live Device, and that is what makes offering it safe: the next
+time syncing starts, `queueDeviceRecord` re-registers this Mac and cancels the queued delete
+for its own record, so the Device Record comes back and its Usage Snapshots repopulate as they
+are read again.
+
+## Consequences
+
+Removing the current Device reads as a reset rather than a deletion. The row disappears, the
+Usage Snapshots stop being projected into the menu, and both return on the next sync start.
+A user who wants the record gone for good has to turn syncing off after removing it.


### PR DESCRIPTION
Closes #3234.
**This is not completely verified. see below: Verification**
**Generated by Claude, Reviewed by kwnms04 and Claude.**


## What this does

Settings → iCloud Sync → **Macs** now lists every synced Mac and lets you remove one, with confirmation. Removing a Mac deletes its Device Record and every Usage Snapshot it published, on every Mac on the account.

The list renders from local persistence, so it is visible even with syncing off — otherwise there is nothing to remove a stale device *from*, which is the state the issue reports.

## Why the row does not disappear immediately

An earlier revision removed the row optimistically and put it back on failure. That machinery was the source of most review findings, so it is gone. The row now goes on one signal: CloudKit confirmed the delete, or reported the record was already gone. That is the same path a delete made on another Mac already took, so both cases share one code path.

A Device Record delete is attempted **once**. Retrying would race the Mac that owns it re-registering itself and delete the record it just published. Failures that get no retry are surfaced in the pane instead of being dropped, and clear when a push completes with nothing failing in it.

## Scope

Two deliberate departures, both recorded as ADRs:

- **ADR 0002** — removal is offered for the current Mac too, though triage scoped this to "a selected non-current device". The current Mac re-registers on the next sync start, and `queueDeviceRecord` cancels its own pending delete, so the removal is self-healing rather than destructive.
- **ADR 0001** — the Device Identifier is derived from the Mac's hardware UUID rather than minted per install, so a reinstall stops stranding a duplicate. This is beyond what the issue asked for. **It has a cost the ADR states plainly: every Mac syncing today creates one more Stale Device at its next reinstall.** Existing duplicates are not merged — the issue lists auto-merge as out of scope, and triage confirmed "without automatic hostname merging".

Also out of scope, as the issue notes: "reset icloud data".

## Duplicates are the point

The confirmation dialog shows the device's absolute last-seen time, because the case this issue is about is two rows with the *same host name*. On the machine this was developed on, `kwnmbp.local` currently has four Device Records (0.49.4 → 0.55.1 → 0.55.1 → 0.56.1). Host name alone cannot tell them apart.

## Verification

- `make check` — swiftformat clean, swiftlint `--strict` 0 violations across 2075 files, locales 22 catalogs / 1494 keys, packaging and signing checks pass.
- `make test` — all 82 groups run green except `ClaudeOAuthCredentialsStoreNeverPromptCacheTests`, which shells out to `/usr/bin/defaults`; that tool cannot write any domain on this machine, so those two tests fail for reasons unrelated to this change. The other 11 suites in that group were run separately and pass.
- New tests cover the confirmed-delete rule, the no-retry policy for Device Records, the reporting rule, and that queueing a delete leaves the fleet row in place.

**Not verified locally:** the removal itself, the confirmation dialog, and the failure banner. iCloud entitlements are only embedded in identity-signed release builds of `com.steipete.codexbar`, and this machine has no signing identity. What was verified against a running build is that the Macs list renders with syncing off and the remove controls are correctly disabled without the entitlement.

## Follow-ups, not addressed here

1. `CloudSyncState.removeDevice` is a closure on an `@Observable` state object — behaviour where state belongs.
2. `CloudSyncSnapshotMigration` now owns Device Record delete policy as well as snapshot migration; it has two reasons to change.
3. Record kind is carried as a `"device-"` name prefix rather than a type.
4. Snapshots the local cache never saw are not deleted, since removal reads the local envelope rather than querying CloudKit.
5. Removal stays unavailable while syncing is off; the footer says so, but the issue's original complaint is only partly answered.
6. A delete queued but not sent before the app quits is only requeued through the snapshot push, which is gated on snapshot syncing being on.
7. `macsFootnote` concatenates two localized sentences, which is not translatable as a unit.
