### PR TITLE
fix(codex): distinguish same-email workspace labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Codex: avoid repeated full scans after trace-log pruning, while retaining the latest validated cost history through temporary trace-database failures (#3318). Thanks @brzvsk!
 
 ### Fixed
+- Codex: distinguish same-email workspaces with stable, privacy-safe labels across account settings, system selection, and menu switchers (#3282). Thanks @Dknightsure!
 - Menu bar: keep status components and website links scoped to their provider when switching cached tabs, preventing Claude status from appearing under Grok or Codex (#3320). Thanks @gianpaj!
 - Usage & Spend: keep stalled or failed Codex catch-up paused until explicit Refresh, preventing background synchronization from restarting CPU-heavy scans (partial fix for #3316). Thanks @heyajulia!
 - Xiaomi MiMo: prevent overlapping local usage tracker updates from colliding on a shared temporary cache file, preserving atomic publication (#3321). Thanks @Lucenx9!

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -1443,6 +1443,12 @@ final class CodexAccountSwitcherView: NSView {
             return account.menuDisplayName
         }
 
+        if let discriminator = account.displayDiscriminator {
+            let suffix = "|\(discriminator)"
+            let emailWidth = max(0, availableTextWidth - self.textWidth(suffix))
+            return "\(self.truncateMiddle(account.email, toFit: emailWidth))\(suffix)"
+        }
+
         guard let workspace = account.menuWorkspaceLabel else {
             return self.truncateMiddle(account.email, toFit: availableTextWidth)
         }

--- a/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
@@ -1,9 +1,15 @@
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
 import Foundation
 
 public struct CodexVisibleAccount: Equatable, Identifiable, Sendable {
     public let id: String
     public let email: String
     public let workspaceLabel: String?
+    public private(set) var displayDiscriminator: String?
     public let workspaceAccountID: String?
     public let authFingerprint: String?
     public let storedAccountID: UUID?
@@ -40,8 +46,8 @@ public struct CodexVisibleAccount: Equatable, Identifiable, Sendable {
     }
 
     public var displayName: String {
-        guard let workspaceLabel else { return self.email }
-        return "\(self.email) — \(workspaceLabel)"
+        guard let label = self.disambiguatedWorkspaceLabel ?? self.workspaceLabel else { return self.email }
+        return "\(self.email) — \(label)"
     }
 
     public var menuDisplayName: String {
@@ -50,10 +56,38 @@ public struct CodexVisibleAccount: Equatable, Identifiable, Sendable {
     }
 
     public var menuWorkspaceLabel: String? {
+        if let disambiguatedWorkspaceLabel {
+            return disambiguatedWorkspaceLabel
+        }
         guard let workspaceLabel, workspaceLabel.compare("Personal", options: [.caseInsensitive]) != .orderedSame else {
             return nil
         }
         return workspaceLabel
+    }
+
+    private var disambiguatedWorkspaceLabel: String? {
+        guard let displayDiscriminator else { return nil }
+        return "\(self.workspaceLabel ?? "Workspace") · \(displayDiscriminator)"
+    }
+
+    static func disambiguating(_ accounts: [Self]) -> [Self] {
+        let unlabeled = accounts.map { account in
+            var result = account
+            result.displayDiscriminator = nil
+            return result
+        }
+        let groups = Dictionary(grouping: unlabeled, by: { $0.menuDisplayName.lowercased() })
+        return unlabeled.map { account in
+            var result = account
+            guard (groups[account.menuDisplayName.lowercased()]?.count ?? 0) > 1 else { return result }
+            // Workspace identity survives active-account changes and promotion to the system account.
+            // Hash it rather than exposing any part of the provider ID or a profile's filesystem path.
+            let identity = ManagedCodexAccount.normalizeWorkspaceAccountID(account.workspaceAccountID)
+                ?? account.storedAccountID?.uuidString.lowercased() ?? account.id
+            result.displayDiscriminator = SHA256.hash(data: Data(identity.utf8))
+                .prefix(4).map { String(format: "%02x", $0) }.joined()
+            return result
+        }
     }
 
     public var authenticationHealthLabel: String? {
@@ -81,7 +115,7 @@ public struct CodexVisibleAccountProjection: Equatable, Sendable {
         liveVisibleAccountID: String?,
         hasUnreadableAddedAccountStore: Bool)
     {
-        self.visibleAccounts = visibleAccounts
+        self.visibleAccounts = CodexVisibleAccount.disambiguating(visibleAccounts)
         self.activeVisibleAccountID = activeVisibleAccountID
         self.liveVisibleAccountID = liveVisibleAccountID
         self.hasUnreadableAddedAccountStore = hasUnreadableAddedAccountStore

--- a/Tests/CodexBarTests/CodexWorkspaceDisplayScreenshotTests.swift
+++ b/Tests/CodexBarTests/CodexWorkspaceDisplayScreenshotTests.swift
@@ -1,0 +1,85 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+import XCTest
+@testable import CodexBar
+
+@MainActor
+final class CodexWorkspaceDisplayScreenshotTests: XCTestCase {
+    func test_renderSyntheticWorkspaceLabels() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["CODEXBAR_WORKSPACE_LABEL_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_WORKSPACE_LABEL_PROOF_DIR for synthetic account-label proof.")
+        }
+        guard environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment["CODEXBAR_TEST_CODEX_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1"
+        else {
+            return XCTFail("Screenshot proof requires credential and session isolation.")
+        }
+        let directory = URL(fileURLWithPath: path, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let original = CodexWorkspaceDisplayTests.accounts(label: nil)
+        let projected = CodexWorkspaceDisplayTests.project(original).visibleAccounts
+        for (name, accounts) in [("before", original), ("after", projected)] {
+            let state = CodexAccountsSectionState(
+                visibleAccounts: accounts,
+                activeVisibleAccountID: accounts[0].id,
+                liveVisibleAccountID: accounts[0].id,
+                hasUnreadableManagedAccountStore: false,
+                isAuthenticatingManagedAccount: false,
+                authenticatingManagedAccountID: nil,
+                isRemovingManagedAccount: false,
+                isAuthenticatingLiveAccount: false,
+                isPromotingSystemAccount: false,
+                notice: nil)
+            let content = VStack(alignment: .leading, spacing: 18) {
+                Text("Synthetic Codex workspace accounts").font(.title2.bold())
+                CodexAccountsSectionView(
+                    state: state,
+                    setActiveVisibleAccount: { _ in },
+                    reauthenticateAccount: { _ in },
+                    removeAccount: { _ in },
+                    requestSystemVisibleAccount: { _ in },
+                    addAccount: {})
+                Divider()
+                Text("Menu account switcher").font(.headline)
+                WorkspaceProofSwitcher(accounts: accounts).frame(width: 310, height: 26)
+            }
+            .padding(24)
+            .frame(width: 640)
+            .background(Color(nsColor: .windowBackgroundColor))
+            .environment(\.colorScheme, .light)
+            let hosting = NSHostingView(rootView: content)
+            hosting.appearance = NSAppearance(named: .aqua)
+            hosting.frame = CGRect(origin: .zero, size: hosting.fittingSize)
+            let window = NSWindow(
+                contentRect: hosting.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+            window.isReleasedWhenClosed = false
+            window.contentView = hosting
+            defer {
+                window.contentView = nil
+                window.close()
+            }
+            window.layoutIfNeeded()
+            hosting.layoutSubtreeIfNeeded()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            let representation = try XCTUnwrap(hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds))
+            hosting.cacheDisplay(in: hosting.bounds, to: representation)
+            let data = try XCTUnwrap(representation.representation(using: .png, properties: [:]))
+            try data.write(to: directory.appendingPathComponent("workspace-labels-\(name).png"))
+        }
+    }
+}
+
+private struct WorkspaceProofSwitcher: NSViewRepresentable {
+    let accounts: [CodexVisibleAccount]
+
+    func makeNSView(context: Context) -> CodexAccountSwitcherView {
+        CodexAccountSwitcherView(
+            accounts: self.accounts, selectedAccountID: self.accounts[0].id, width: 310, onSelect: { _ in })
+    }
+
+    func updateNSView(_ nsView: CodexAccountSwitcherView, context: Context) {}
+}

--- a/Tests/CodexBarTests/CodexWorkspaceDisplayTests.swift
+++ b/Tests/CodexBarTests/CodexWorkspaceDisplayTests.swift
@@ -1,0 +1,137 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct CodexWorkspaceDisplayTests {
+    @Test(arguments: [nil, "", " \n\t ", "Personal", "Business", " Team Alpha "] as [String?])
+    func `same email workspace collisions have stable opaque display labels`(label: String?) throws {
+        let accounts = Self.accounts(label: label)
+        let projection = Self.project(accounts)
+        let displayed = projection.visibleAccounts
+        #expect(Set(displayed.map(\.displayName)).count == 2)
+        #expect(Set(displayed.map(\.menuDisplayName)).count == 2)
+        for (raw, account) in zip(accounts, displayed) {
+            let discriminator = try #require(account.displayDiscriminator)
+            #expect(discriminator.count == 8)
+            #expect(account.displayName == account.menuDisplayName)
+            #expect(account.displayName.contains(discriminator))
+            #expect(try !account.displayName.contains(#require(account.workspaceAccountID)))
+            #expect(account.workspaceLabel == raw.workspaceLabel)
+            #expect(account.selectionSource == raw.selectionSource)
+            #expect(account.authFingerprint == raw.authFingerprint)
+            #expect(PersonalInfoRedactor.redactEmail(account.menuDisplayName, isEnabled: true).isEmpty)
+            #expect(PersonalInfoRedactor.redactEmail(account.menuDisplayName, isEnabled: false) == account.displayName)
+        }
+        #expect(Self.project(displayed).visibleAccounts == displayed)
+        #expect(Self.project(Array(accounts.reversed())).visibleAccounts.map(\.displayName) == displayed.reversed()
+            .map(\.displayName))
+    }
+
+    @Test
+    func `nil and Personal labels collide only when their menu names match`() {
+        let personal = Self.account(id: 0, label: "Personal")
+        let unnamed = Self.account(id: 1, label: nil)
+        let named = Self.account(id: 2, label: "Engineering")
+        let displayed = Self.project([personal, unnamed, named]).visibleAccounts
+        #expect(displayed[0].displayDiscriminator != nil)
+        #expect(displayed[1].displayDiscriminator != nil)
+        #expect(displayed[2].displayDiscriminator == nil)
+        #expect(displayed[2].displayName == "user@example.com — Engineering")
+        #expect(Self.project([personal]).visibleAccounts.first?.menuDisplayName == "user@example.com")
+    }
+
+    @Test
+    func `workspace discriminator survives active selection and system promotion`() throws {
+        let managed = (0..<2).map { index in
+            ManagedCodexAccount(
+                id: Self.accountID(index),
+                email: "user@example.com",
+                providerAccountID: "workspace-\(index)",
+                workspaceLabel: "Business",
+                workspaceAccountID: "workspace-\(index)",
+                managedHomePath: "/tmp/synthetic-codex-\(index)",
+                createdAt: 1,
+                updatedAt: 2,
+                lastAuthenticatedAt: 3)
+        }
+        func project(activeIndex: Int, liveIndex: Int?) -> [CodexVisibleAccount] {
+            let live = liveIndex.map { index in
+                ObservedSystemCodexAccount(
+                    email: "user@example.com",
+                    workspaceLabel: "Business",
+                    workspaceAccountID: "workspace-\(index)",
+                    codexHomePath: "/tmp/synthetic-codex-system",
+                    observedAt: Date(),
+                    identity: .providerAccount(id: "workspace-\(index)"))
+            }
+            return CodexVisibleAccountProjection.make(from: CodexAccountReconciliationSnapshot(
+                storedAccounts: managed,
+                activeStoredAccount: managed[activeIndex],
+                liveSystemAccount: live,
+                matchingStoredAccountForLiveSystemAccount: liveIndex.map { managed[$0] },
+                activeSource: .managedAccount(id: managed[activeIndex].id),
+                hasUnreadableAddedAccountStore: false,
+                storedAccountRuntimeIdentities: Dictionary(uniqueKeysWithValues: managed.enumerated().map {
+                    ($0.element.id, .providerAccount(id: "workspace-\($0.offset)"))
+                }))).visibleAccounts
+        }
+        let original = project(activeIndex: 0, liveIndex: nil)
+        for accounts in [project(activeIndex: 1, liveIndex: nil), project(activeIndex: 1, liveIndex: 1)] {
+            for expected in original {
+                let actual = try #require(accounts.first { $0.workspaceAccountID == expected.workspaceAccountID })
+                #expect(actual.displayName == expected.displayName)
+                #expect(actual.menuDisplayName == expected.menuDisplayName)
+                #expect(actual.storedAccountID == expected.storedAccountID)
+            }
+        }
+    }
+
+    @Test
+    func `compact switcher keeps the workspace discriminator visible`() throws {
+        let accounts = Self.project(Self.accounts(label: "Same long Business workspace name")).visibleAccounts
+        let view = CodexAccountSwitcherView(
+            accounts: accounts,
+            selectedAccountID: accounts[0].id,
+            width: 220,
+            onSelect: { _ in })
+        let titles = view._test_buttonTitles()
+        #expect(Set(titles).count == 2)
+        for (account, title) in zip(accounts, titles) {
+            #expect(try title.hasSuffix(#require(account.displayDiscriminator)))
+        }
+        #expect(view._test_buttonToolTips() == accounts.map(\.menuDisplayName))
+    }
+
+    static func project(_ accounts: [CodexVisibleAccount]) -> CodexVisibleAccountProjection {
+        CodexVisibleAccountProjection(
+            visibleAccounts: accounts,
+            activeVisibleAccountID: accounts.first?.id,
+            liveVisibleAccountID: nil,
+            hasUnreadableAddedAccountStore: false)
+    }
+
+    static func accounts(label: String?) -> [CodexVisibleAccount] {
+        (0..<2).map { self.account(id: $0, label: label) }
+    }
+
+    private static func accountID(_ index: Int) -> UUID {
+        UUID(uuidString: "00000000-0000-0000-0000-00000000000\(index)")!
+    }
+
+    private static func account(id: Int, label: String?) -> CodexVisibleAccount {
+        CodexVisibleAccount(
+            id: "synthetic-\(id)",
+            email: "user@example.com",
+            workspaceLabel: label,
+            workspaceAccountID: "synthetic-workspace-\(id)",
+            storedAccountID: self.accountID(id),
+            selectionSource: .managedAccount(id: self.accountID(id)),
+            isActive: id == 0,
+            isLive: false,
+            canReauthenticate: true,
+            canRemove: true)
+    }
+}

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -92,6 +92,14 @@ Example:
 }
 ```
 
+### Same-email workspace labels
+
+Account settings, the System Account picker, and the menu switcher retain the workspace name when it is available.
+If the same email and workspace label would appear more than once (including missing names or the “Personal” fallback),
+CodexBar adds a stable eight-character hash of the workspace identity. The hash stays the same when selecting or promoting
+that workspace and never exposes the full provider identifier. This is display-only; stored account metadata and
+credential selection are unchanged. Compact switcher buttons keep the discriminator visible when space is limited.
+
 ### OpenAI web dashboard (optional, off by default)
 - Enable it in Preferences -> Providers -> Codex -> OpenAI web extras.
 - It exists for dashboard-only extras such as code review remaining, usage breakdown, and credits history.


### PR DESCRIPTION
Distinct Codex workspaces can have the same email and the same visible workspace label, leaving users unable to tell them apart when switching accounts. Resolve those display collisions once in the visible-account projection by adding a short, stable hash of workspace identity. Preserve unambiguous supplied labels and keep the discriminator visible when compact buttons truncate the email.

This is a presentation change: credential selection, stored workspace labels, account identity, and authentication are unchanged. Regressions cover missing/Personal/duplicate labels, active-account changes, system-account promotion, and redacted presentation. The synthetic settings/switcher captures below exercise production rendering with fictional accounts.

Fixes #3282. Thanks @Dknightsure for the report.

Validation on 40a62d5d0a0aa20377607423b3919a3a91132639: 63 focused tests across six suites and the synthetic XCTest renderer passed, alongside make check and independent Codex review. Additional read-only review confirmed both repeated-workspace profile identities and crowded button widths are addressed. Full local make test passed all 987 selections in 83 groups on the first attempt, with zero failures, retries, or timeouts (1,156 seconds total). [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33480769668) passed all nine checks, including both full macOS shards, Linux builds, lint, and the security check. All proof uses fictional accounts; no live account, browser, or Keychain probes were used.

Before:

![Synthetic workspace labels before](https://github.com/user-attachments/assets/c07a06d8-8fa4-4d0d-a5aa-7801a0f0b469)

After:

![Synthetic workspace labels after](https://github.com/user-attachments/assets/cf4573b3-eb8b-4ebe-be1c-69f7b2ea2738)

Crowded switcher, with all eight identifiers visible:

![Synthetic eight-account switcher](https://github.com/user-attachments/assets/ab31ef5b-b954-4811-a127-72128687542d)
