### PR TITLE
fix(claude): recover background refresh after access repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Grok: restore 0% usage for a validated active billing period with an omitted usage scalar, preserving unknown usage for incomplete responses (#3261, #3325). Thanks @sf-jin-ku and @olddonkey!
 - Menu bar: keep status components and website links scoped to their provider when switching cached tabs, preventing Claude status from appearing under Grok or Codex (#3320). Thanks @gianpaj!
 - Usage & Spend: keep stalled or failed Codex catch-up paused until explicit Refresh, preventing background synchronization from restarting CPU-heavy scans (partial fix for #3316). Thanks @heyajulia!
+- Claude: resume scheduled browser-cookie refreshes when no-UI Keychain access recovers, while preserving non-interactive reads and user-initiated denial cooldowns (#3287). Thanks @ehmo!
 - Xiaomi MiMo: prevent overlapping local usage tracker updates from colliding on a shared temporary cache file, preserving atomic publication (#3321). Thanks @Lucenx9!
 - Claude: avoid duplicated “Resets Reset” labels when CLI usage supplies a singular reset description (#3317). Thanks @Aternus!
 

--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -95,7 +95,7 @@ public enum BrowserCookieAccessGate {
         guard browser.usesKeychainForCookieDecryption else { return true }
         guard !KeychainAccessGate.isDisabled else { return false }
         guard ProviderInteractionContext.current == .userInitiated else {
-            return self.shouldAttemptInBackground(browser, now: now)
+            return self.shouldAttemptInBackground(browser)
         }
         if self.deniedBrowsersForTesting?.contains(browser) == true {
             return self.isExplicitRetryAllowed(for: browser)
@@ -312,15 +312,9 @@ public enum BrowserCookieAccessGate {
     /// grants access (an explicit `.allowed`), a scheduled refresh can read cookies without any prompt,
     /// so background usage stays in sync instead of only updating when the menu is opened. Anything else
     /// — interaction required, not found, or a query failure — keeps the no-surprise boundary and skips.
-    /// An active per-browser or Chromium-family denial cooldown is still honored.
-    private static func shouldAttemptInBackground(_ browser: Browser, now: Date) -> Bool {
+    /// A current grant can recover background refresh without clearing the user-initiated denial cooldown.
+    private static func shouldAttemptInBackground(_ browser: Browser) -> Bool {
         if self.deniedBrowsersForTesting?.contains(browser) == true {
-            return false
-        }
-        if self.hasActiveDenialCooldown(for: browser, now: now) {
-            self.log.debug(
-                "Skipping background Chromium cookie import; denial cooldown active",
-                metadata: ["browser": browser.displayName])
             return false
         }
         guard self.chromiumKeychainAccessIsAllowed(for: browser) else {
@@ -333,22 +327,6 @@ public enum BrowserCookieAccessGate {
             "Background Chromium cookie import allowed by no-UI Keychain preflight",
             metadata: ["browser": browser.displayName])
         return true
-    }
-
-    /// Read-only check for an active per-browser or Chromium-family denial cooldown. Mirrors the
-    /// suppression window enforced on the user-initiated path without mutating persisted state, so a
-    /// scheduled refresh stays side-effect free.
-    private static func hasActiveDenialCooldown(for browser: Browser, now: Date) -> Bool {
-        self.lock.withLock { state in
-            self.loadIfNeeded(&state)
-            if let blockedUntil = state.deniedUntilByBrowser[browser.rawValue], blockedUntil > now {
-                return true
-            }
-            if let familyBlockedUntil = state.chromiumFamilyDeniedUntil, familyBlockedUntil > now {
-                return true
-            }
-            return false
-        }
     }
 
     /// Returns true only when the no-UI Safe Storage preflight explicitly reports `.allowed` for one of

--- a/Tests/CodexBarTests/BrowserCookieAccessGateTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieAccessGateTests.swift
@@ -20,10 +20,11 @@ struct BrowserCookieAccessGateTests {
         _ browser: Browser,
         preflight: KeychainAccessPreflight.Outcome,
         interaction: ProviderInteraction,
+        keychainDisabled: Bool = false,
         now: Date = Date()) -> Bool
     {
         var result = false
-        KeychainAccessGate.withTaskOverrideForTesting(false) {
+        KeychainAccessGate.withTaskOverrideForTesting(keychainDisabled) {
             ProviderInteractionContext.$current.withValue(interaction) {
                 KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in preflight } operation: {
                     result = BrowserCookieAccessGate.shouldAttempt(browser, now: now)
@@ -62,30 +63,74 @@ struct BrowserCookieAccessGateTests {
         #expect(self.evaluate(.chrome, preflight: .failure(-25293), interaction: .background) == false)
     }
 
-    @Test
-    func `an active denial cooldown suppresses background refresh even when the ACL is allowed`() {
+    @Test(arguments: [Browser.chrome, .brave])
+    func `background refresh recovers during browser and family cooldowns when access becomes allowed`(
+        browser: Browser)
+    {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
         let start = Date(timeIntervalSince1970: 2000)
         BrowserCookieAccessGate.recordDenied(for: .chrome, now: start)
 
-        // Within the six-hour cooldown the background gate stays suppressed regardless of a now-allowed
-        // preflight, matching the suppression the user-initiated path honors.
         #expect(self.evaluate(
-            .chrome,
+            browser,
             preflight: .allowed,
             interaction: .background,
+            now: start.addingTimeInterval(60)))
+
+        // A background success does not clear the interactive path's persisted denial policy.
+        #expect(BrowserCookieAccessGate.hasActiveDenial(for: .chrome, now: start.addingTimeInterval(60)))
+        #expect(self.evaluate(
+            browser,
+            preflight: .allowed,
+            interaction: .userInitiated,
             now: start.addingTimeInterval(60)) == false)
 
-        // Once the six-hour cooldown lapses, an allowed preflight lets the background refresh proceed
-        // again.
         let sixHours: TimeInterval = 6 * 60 * 60
         #expect(self.evaluate(
-            .chrome,
+            browser,
             preflight: .allowed,
             interaction: .background,
             now: start.addingTimeInterval(sixHours + 60)))
+    }
+
+    @Test(arguments: [Browser.chrome, .brave], [
+        KeychainAccessPreflight.Outcome.interactionRequired,
+        .notFound,
+        .failure(-25293),
+    ])
+    func `background recovery still requires explicitly allowed access during a denial cooldown`(
+        browser: Browser,
+        preflight: KeychainAccessPreflight.Outcome)
+    {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let start = Date(timeIntervalSince1970: 2000)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: start)
+
+        #expect(self.evaluate(
+            browser,
+            preflight: preflight,
+            interaction: .background,
+            now: start.addingTimeInterval(60)) == false)
+    }
+
+    @Test
+    func `background recovery cannot override disabled Keychain access`() {
+        BrowserCookieAccessGate.resetForTesting()
+        defer { BrowserCookieAccessGate.resetForTesting() }
+
+        let start = Date(timeIntervalSince1970: 2000)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: start)
+
+        #expect(self.evaluate(
+            .chrome,
+            preflight: .allowed,
+            interaction: .background,
+            keychainDisabled: true,
+            now: start.addingTimeInterval(60)) == false)
     }
 
     @Test

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -371,7 +371,7 @@ struct BrowserDetectionTests {
     }
 
     @Test
-    func `recorded browser denial suppresses automatic family and permits explicit source retry`() {
+    func `recorded browser denial permits background recovery and preserves explicit source retry`() {
         BrowserCookieAccessGate.resetForTesting()
         defer { BrowserCookieAccessGate.resetForTesting() }
 
@@ -387,8 +387,8 @@ struct BrowserDetectionTests {
                 return .allowed
             } operation: {
                 ProviderInteractionContext.$current.withValue(.background) {
-                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(1)) == false)
-                    #expect(BrowserCookieAccessGate.shouldAttempt(.edge, now: start.addingTimeInterval(1)) == false)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.chrome, now: start.addingTimeInterval(1)) == true)
+                    #expect(BrowserCookieAccessGate.shouldAttempt(.edge, now: start.addingTimeInterval(1)) == true)
                     #expect(BrowserCookieAccessGate.shouldAttempt(.safari, now: start.addingTimeInterval(1)) == true)
                 }
                 BrowserCookieAccessGate.withExplicitRetry {
@@ -406,7 +406,7 @@ struct BrowserDetectionTests {
             }
         }
 
-        #expect(preflightCount == 2)
+        #expect(preflightCount == 4)
     }
 
     @Test

--- a/docs/keychain-prompts.md
+++ b/docs/keychain-prompts.md
@@ -28,6 +28,11 @@ A user-initiated import or acknowledged Claude repair may attempt interactive au
 chosen to continue. Denials temporarily suppress repeated Chromium-family attempts so one browser cannot lead to a
 prompt storm across the others.
 
+Scheduled Chromium imports can recover during that denial cooldown when the current no-UI Safe Storage preflight
+explicitly confirms access. Interaction-required, missing, or failed preflights still suppress the import, and the
+actual read remains non-interactive. This recovery does not clear the user-initiated denial cooldown or override
+disabled Keychain access.
+
 Provider-owned child processes are a separate boundary. CodexBar may intentionally launch a provider CLI such as
 Claude for usage. That executable owns its credential behavior, which CodexBar cannot constrain or fully inspect.
 


### PR DESCRIPTION
Scheduled Claude browser refresh could remain blocked for six hours after browser Safe Storage access had been repaired. The background gate checked an old browser/family denial cooldown before asking the current noninteractive Keychain preflight whether access was allowed.

A fresh explicit allowed result now permits background refresh during that cooldown. Disabled Keychain access and every non-allowed preflight still block the read; actual cookie access remains noninteractive. The user-initiated cooldown and explicit retry behavior are preserved.

Fixes #3287. Regression tests reproduce the old failure for Chrome and a Chromium-family browser, then cover recovery, non-allowed results, disabled access, and the interactive retry policy. Documentation and changelog are updated.

Validation on a84b931e9b84100d3e94c30267db52c7b80db563: 56 focused tests across BrowserCookieAccessGateTests, BrowserDetectionTests, ClaudeWebBackgroundRecoveryTests, and KeychainPromptSafetyAuditTests passed; make check passed with zero lint violations; independent Codex review found no actionable issues. Full local make test passed all 985 selections in 83 groups on the first attempt, with zero failures, retries, or timeouts (1,474 seconds total). [Exact-head GitHub CI](https://github.com/steipete/CodexBar/actions/runs/33480052130) passed all nine checks, including both full macOS shards, all Linux builds, lint, and the security check. All tests use isolated stores and preflight stubs; no real account, browser, or Keychain probes were performed.
