### PR TITLE
fix(grok): preserve unknown usage for malformed billing tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Fixed
 - Keychain: limit repeated cache ACL validation and memory growth while preserving recovery after temporary failures or external repairs (#3300, #3301). Thanks @IgorKhramtsov!
 - Grok: restore 0% usage for a validated active billing period with an omitted usage scalar, preserving unknown usage for incomplete responses (#3261, #3325). Thanks @sf-jin-ku and @olddonkey!
-- Grok: keep unknown billing usage from becoming 0% when a response contains invalid protobuf field numbers or overflowing varints.
+- Grok: keep malformed billing responses from turning unknown usage into 0%, while safely ignoring unknown byte fields (#3357).
 - Ollama: restore usage bars for monthly included credits and show matching history tabs while preserving legacy quota parsing and saved history (#3346). Thanks @haixing23!
 - Menu bar: keep status components and website links scoped to their provider when switching cached tabs, preventing Claude status from appearing under Grok or Codex (#3320). Thanks @gianpaj!
 - Usage & Spend: keep stalled or failed Codex catch-up paused until explicit Refresh, preventing background synchronization from restarting CPU-heavy scans (partial fix for #3316). Thanks @heyajulia!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - Keychain: limit repeated cache ACL validation and memory growth while preserving recovery after temporary failures or external repairs (#3300, #3301). Thanks @IgorKhramtsov!
 - Grok: restore 0% usage for a validated active billing period with an omitted usage scalar, preserving unknown usage for incomplete responses (#3261, #3325). Thanks @sf-jin-ku and @olddonkey!
+- Grok: keep unknown billing usage from becoming 0% when a response contains invalid protobuf field numbers or overflowing varints.
 - Ollama: restore usage bars for monthly included credits and show matching history tabs while preserving legacy quota parsing and saved history (#3346). Thanks @haixing23!
 - Menu bar: keep status components and website links scoped to their provider when switching cached tabs, preventing Claude status from appearing under Grok or Codex (#3320). Thanks @gianpaj!
 - Usage & Spend: keep stalled or failed Codex catch-up paused until explicit Refresh, preventing background synchronization from restarting CPU-heavy scans (partial fix for #3316). Thanks @heyajulia!

--- a/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
@@ -498,7 +498,7 @@ public enum GrokWebBillingFetcher {
                 }
                 let start = index
                 let end = index + Int(length)
-                if depth < 4 {
+                if depth < 4, Self.isKnownBillingMessage(path: fieldPath) {
                     let nested = Self.scanProtobuf(
                         Data(bytes[start..<end]),
                         depth: depth + 1,
@@ -532,6 +532,19 @@ public enum GrokWebBillingFetcher {
         }
 
         return (scan, nextOrder)
+    }
+
+    private static func isKnownBillingMessage(path: [UInt64]) -> Bool {
+        // The billing descriptor declares these messages; other length-delimited fields may be opaque bytes.
+        switch path {
+        case [1],
+             [1, 2], [1, 3], [1, 4], [1, 5], [1, 6], [1, 7], [1, 8], [1, 12],
+             [1, 6, 1], [1, 6, 2], [1, 6, 3], [1, 8, 2], [1, 8, 3],
+             [1, 6, 3, 2], [1, 6, 3, 3]:
+            true
+        default:
+            false
+        }
     }
 
     private static func readVarint(_ bytes: [UInt8], index: inout Int) -> UInt64? {

--- a/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
@@ -465,7 +465,7 @@ public enum GrokWebBillingFetcher {
 
         while index < bytes.count {
             let fieldStart = index
-            guard let key = Self.readVarint(bytes, index: &index), key != 0 else {
+            guard let key = Self.readVarint(bytes, index: &index), key >> 3 > 0, key >> 3 <= 536_870_911 else {
                 scan.isComplete = false
                 index = fieldStart + 1
                 continue
@@ -540,6 +540,7 @@ public enum GrokWebBillingFetcher {
         while index < bytes.count, shift < 64 {
             let byte = bytes[index]
             index += 1
+            if shift == 63, byte > 1 { return nil }
             value |= UInt64(byte & 0x7F) << shift
             if byte & 0x80 == 0 {
                 return value

--- a/Tests/CodexBarTests/GrokZeroUsageTests.swift
+++ b/Tests/CodexBarTests/GrokZeroUsageTests.swift
@@ -64,6 +64,42 @@ struct GrokZeroUsageTests {
         #expect(try await Self.resolve(parsed).snapshot.usedPercent == 0)
     }
 
+    @Test(arguments: [false, true], Self.opaquePayloads)
+    func `unknown byte fields cannot invalidate or invent billing values`(
+        atRoot: Bool, bytes: Data) async throws
+    {
+        let opaqueField = Self.message(path: [14], contents: bytes)
+        let payload = atRoot ? Self.payload() + opaqueField : Self.payload(suffix: opaqueField)
+        let parsed = try GrokWebBillingFetcher.parseGRPCWebResponse(payload, now: Self.now)
+
+        #expect(parsed.usedPercent == 0)
+        #expect(parsed.usedPercentIsImplicitZero)
+        #expect(!parsed.usedPercentIsWirePublished)
+        #expect(parsed.resetsAt == Date(timeIntervalSince1970: 1_789_000_000))
+        #expect(try await Self.resolve(parsed).snapshot.usedPercent == 0)
+    }
+
+    @Test(arguments: Self.billingMessagePaths)
+    func `malformed known messages still prevent implicit zero`(path: [UInt64]) async throws {
+        let malformedMessage = Self.message(path: path, contents: Self.fixed64Field(tag: [0x01]))
+        let parsed = try GrokWebBillingFetcher.parseGRPCWebResponse(
+            Self.payload() + malformedMessage, now: Self.now)
+
+        #expect(!parsed.usedPercentIsImplicitZero)
+        #expect(try await Self.resolve(parsed).snapshot.usedPercent == nil)
+    }
+
+    @Test
+    func `historical period timestamps remain readable without becoming current usage`() throws {
+        let timestamp = Data([0x08]) + Self.varint(1_789_000_000)
+        let payload = Self.message(path: [1, 6, 3, 3], contents: timestamp)
+        let parsed = try GrokWebBillingFetcher.parseGRPCWebResponse(payload, now: Self.now)
+
+        #expect(parsed.resetsAt == Date(timeIntervalSince1970: 1_789_000_000))
+        #expect(!parsed.usedPercentIsImplicitZero)
+        #expect(!parsed.usedPercentIsWirePublished)
+    }
+
     @Test(arguments: [0, 3])
     func `unknown period types cannot supply implicit zero`(periodType: UInt8) throws {
         #expect(throws: GrokWebBillingError.self) {
@@ -95,9 +131,28 @@ struct GrokZeroUsageTests {
         // Overflowing varint must not truncate to a valid fixed64 tag.
         Self.fixed64Field(tag: [0x89, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02]),
         Data([0x0D, 0x00]), // Truncated percentage.
-        Data([0x72, 0x04, 0x08]), // Truncated nested message.
+        Data([0x72, 0x04, 0x08]), // Truncated unknown length-delimited field.
         Data([0x70, 0x80]), // Truncated varint.
     ]
+
+    private static let opaquePayloads: [Data] = [
+        Self.fixed64Field(tag: [0x01]), // Valid opaque bytes, not a valid protobuf message.
+        Data([0x0D, 0x00, 0x00, 0x14, 0x42]), // Looks like a published 37% usage field.
+        Data([0x08]) + Self.varint(1_788_500_000), // Looks like an earlier future reset.
+    ]
+
+    private static let billingMessagePaths: [[UInt64]] = [
+        [1],
+        [1, 2], [1, 3], [1, 4], [1, 5], [1, 6], [1, 7], [1, 8], [1, 12],
+        [1, 6, 1], [1, 6, 2], [1, 6, 3], [1, 8, 2], [1, 8, 3],
+        [1, 6, 3, 2], [1, 6, 3, 3],
+    ]
+
+    private static func message(path: [UInt64], contents: Data) -> Data {
+        path.reversed().reduce(contents) { payload, field in
+            Self.varint((field << 3) | 2) + Self.varint(UInt64(payload.count)) + payload
+        }
+    }
 
     private static func fixed64Field(tag: [UInt8]) -> Data {
         Data(tag + [UInt8](repeating: 0, count: 8))

--- a/Tests/CodexBarTests/GrokZeroUsageTests.swift
+++ b/Tests/CodexBarTests/GrokZeroUsageTests.swift
@@ -45,17 +45,23 @@ struct GrokZeroUsageTests {
         #expect(try await Self.resolve(parsed).snapshot.usedPercent == 0)
     }
 
-    @Test(arguments: [
-        Data([0x00]), // Invalid field key.
-        Data([0x0D, 0x00]), // Truncated percentage.
-        Data([0x72, 0x04, 0x08]), // Truncated nested message.
-        Data([0x70, 0x80]), // Truncated varint.
-    ])
+    @Test(arguments: Self.malformedSuffixes)
     func `malformed frames cannot turn unknown usage into zero`(suffix: Data) async throws {
         let parsed = try GrokWebBillingFetcher.parseGRPCWebResponse(Self.payload(suffix: suffix), now: Self.now)
 
         #expect(!parsed.usedPercentIsImplicitZero)
         #expect(try await Self.resolve(parsed).snapshot.usedPercent == nil)
+    }
+
+    @Test(arguments: [
+        Self.fixed64Field(tag: [0xF9, 0xFF, 0xFF, 0xFF, 0x0F]), // Highest valid field number.
+        Data([0x70]) + Self.varint(.max), // A valid UInt64.max scalar.
+    ])
+    func `valid unknown fields preserve implicit zero`(suffix: Data) async throws {
+        let parsed = try GrokWebBillingFetcher.parseGRPCWebResponse(Self.payload(suffix: suffix), now: Self.now)
+
+        #expect(parsed.usedPercentIsImplicitZero)
+        #expect(try await Self.resolve(parsed).snapshot.usedPercent == 0)
     }
 
     @Test(arguments: [0, 3])
@@ -79,6 +85,22 @@ struct GrokZeroUsageTests {
         #expect(throws: GrokWebBillingError.self) {
             try GrokWebBillingFetcher.parseGRPCWebResponse(Self.payload(), now: Self.proxyReset)
         }
+    }
+
+    private static let malformedSuffixes: [Data] = [
+        Data([0x00]), // Invalid field key.
+        Self.fixed64Field(tag: [0x01]), // Invalid field zero with a complete fixed64 value.
+        Data([0x02, 0x00]), // Invalid field zero with an empty length-delimited value.
+        Self.fixed64Field(tag: [0x81, 0x80, 0x80, 0x80, 0x10]), // Field number exceeds 29 bits.
+        // Overflowing varint must not truncate to a valid fixed64 tag.
+        Self.fixed64Field(tag: [0x89, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02]),
+        Data([0x0D, 0x00]), // Truncated percentage.
+        Data([0x72, 0x04, 0x08]), // Truncated nested message.
+        Data([0x70, 0x80]), // Truncated varint.
+    ]
+
+    private static func fixed64Field(tag: [UInt8]) -> Data {
+        Data(tag + [UInt8](repeating: 0, count: 8))
     }
 
     private static let now = Date(timeIntervalSince1970: 1_788_000_000)

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -74,7 +74,9 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
      or malformed response cannot replace unknown proxy usage. Proxy reset and plan
      metadata remain authoritative when the zero is adopted.
      Invalid protobuf field numbers and overflowing varints prevent that response
-     from qualifying as complete; valid unknown fields remain supported.
+     from qualifying as complete. Only schema-declared messages are recursively
+     decoded; valid unknown length-delimited fields are skipped as opaque data,
+     so their contents cannot invalidate the response or invent usage/reset values.
      Grok's public web client also reads its omitted proto3 scalar as zero, and its
      [billing descriptor](https://cdn.grok.com/_next/static/chunks/32g78bk5hhe1q.js)
      declares `credit_usage_percent` as an implicit-presence float (checked

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -73,6 +73,8 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
      from wire-published percentages; a bare inferred zero, historical-only period,
      or malformed response cannot replace unknown proxy usage. Proxy reset and plan
      metadata remain authoritative when the zero is adopted.
+     Invalid protobuf field numbers and overflowing varints prevent that response
+     from qualifying as complete; valid unknown fields remain supported.
      Grok's public web client also reads its omitted proto3 scalar as zero, and its
      [billing descriptor](https://cdn.grok.com/_next/static/chunks/32g78bk5hhe1q.js)
      declares `credit_usage_percent` as an implicit-presence float (checked


### PR DESCRIPTION
## Summary

Prevent a Grok fallback response with invalid protobuf field numbers or overflowing varints from qualifying as a complete implicit-zero reading. This keeps an omitted percentage from incorrectly replacing unknown proxy usage with 0%. It follows up the completeness check in #3325 without changing valid zero-usage behavior, wire-published percentages, request bytes, authentication, or authoritative proxy plan/reset metadata.

The scanner previously checked only whether the encoded key was nonzero. Field zero with a fixed64 or empty length-delimited value passed that check and left the response marked complete. Oversized field numbers did the same; an overflowing varint could also truncate into a valid-looking key.

The repair follows the existing Antigravity reader's validation pattern: enforce the [protobuf field-number range](https://protobuf.dev/programming-guides/proto3/#assigning-field-numbers) and reject overflow in the tenth varint byte. Review caught an important boundary: length-delimited fields can contain opaque bytes, not just nested protobuf messages. The scanner now descends only into the 16 message paths declared by Grok's [billing descriptor](https://cdn.grok.com/_next/static/chunks/32g78bk5hhe1q.js) and [charger types](https://cdn.grok.com/_next/static/chunks/3cik3p2ot7rii.js), freshly checked September 1. Unknown byte fields are skipped entirely after validating their outer length, so they cannot invalidate a valid response or invent percentages/reset dates. Errors in known nested messages still propagate. Changelog and provider documentation are updated.

## Verification

- Baseline regression: four malformed cases produce eight failing assertions because they incorrectly qualify for implicit zero and replace unknown proxy usage. The highest legal field number and a valid `UInt64.max` scalar pass as positive controls.
- Review regression: six opaque-byte cases at root/config levels produce 14 failing assertions before the schema-boundary repair. All six now pass, including fake percentages and reset timestamps. All 16 known message paths retain malformed-message rejection, and historical timestamps remain readable.
- Repaired decoder: the serial Grok/architecture run passes 191 tests across 15 suites on the first run, including flat legacy and captured billing fixtures.
- An earlier candidate's broader run encountered initialization timeouts in two unchanged synthetic RPC-process tests; an unchanged serial rerun passed. No deadlines or assertions were relaxed. Fixture construction was moved into a typed helper after Swift's test macro hit a type-checking limit.
- Independent Codex autoreview is scoped-clean at its configured P0 threshold on the repaired candidate; maintainer review also checked tag/varint boundaries, the schema descriptor, and related decoder behavior. The valid inline P2 finding is fixed, not waived.
- `make check` passes with zero violations across 2,082 Swift files and all 95 process-cleanup checks (one expected Linux-only skip on macOS).
- Full `make test` passes on the repaired commit: 988 selections across 83 groups, all first-pass successful, zero failures/retries/timeouts (937.1 seconds).
- Exact-head [CI run 33500594291](https://github.com/steipete/CodexBar/actions/runs/33500594291) succeeds on `c9832713f4901ed551722665efbc6326b8723c5d`: both macOS shards, all three Linux jobs, lint, the aggregate check, and GitGuardian are green.

All verification is offline with synthetic responses, credential/session-file isolation, and Keychain access suppressed. No real-account probe or production occurrence is claimed. This is independent of the live-request proof still pending on #3336.
