### PR TITLE
test: isolate cached menu render measurement

### DIFF
--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CodexBarCore
 import Foundation
+import os
 import Testing
 @testable import CodexBar
 
@@ -485,7 +486,10 @@ struct MenuBarLayoutRendererTests {
         let renderer = MenuBarLayoutRenderer()
         let layout = MenuBarLayout(lines: [[.icon, .percent(window: .automatic), .separatorDot, .resetCountdown]])
         let icon = NSImage(size: NSSize(width: 16, height: 16))
-        let first = renderer.render(layout: layout, data: self.data(), icon: icon, options: self.options())
+        // Fixture construction is not part of the renderer's cached path.
+        let data = self.data()
+        let options = self.options()
+        let first = renderer.render(layout: layout, data: data, icon: icon, options: options)
         var last = first
         var fastest = Duration.seconds(10)
 
@@ -493,13 +497,54 @@ struct MenuBarLayoutRendererTests {
         for _ in 0..<3 {
             let startedAt = ContinuousClock.now
             for _ in 0..<1000 {
-                last = renderer.render(layout: layout, data: self.data(), icon: icon, options: self.options())
+                last = renderer.render(layout: layout, data: data, icon: icon, options: options)
             }
             fastest = min(fastest, ContinuousClock.now - startedAt)
         }
 
         #expect(first.attributedTitle === last.attributedTitle)
         #expect(fastest < .milliseconds(50), "Fastest cached batch took \(fastest)")
+    }
+
+    @Test
+    func `cached renders skip icon layout for equivalent rebuilt inputs`() {
+        let cache = MenuBarLayoutTitleCache()
+        let renderer = MenuBarLayoutRenderer(cache: cache)
+        let layout = MenuBarLayout(lines: [[.icon, .percent(window: .automatic), .separatorDot, .resetCountdown]])
+        let icon = MenuBarLayoutSizeCountingImage(size: NSSize(width: 16, height: 16))
+        let first = renderer.render(layout: layout, data: self.data(), icon: icon, options: self.options())
+        let initialSizeReads = icon.sizeReadCount
+        #expect(initialSizeReads > 0)
+
+        // Uncached rendering reads the icon size even when it returns the original image.
+        for _ in 0..<1000 {
+            let cached = renderer.render(layout: layout, data: self.data(), icon: icon, options: self.options())
+            #expect(cached.attributedTitle === first.attributedTitle)
+            #expect(cached.leadingIcon === icon)
+        }
+        #expect(icon.sizeReadCount == initialSizeReads)
+        #expect(cache.count == 1)
+
+        let changed = renderer.render(
+            layout: layout,
+            data: self.data(automaticUsedPercent: 75),
+            icon: icon,
+            options: self.options())
+        #expect(changed.attributedTitle !== first.attributedTitle)
+        #expect(changed.attributedTitle.string.contains("75%"))
+        #expect(icon.sizeReadCount > initialSizeReads)
+        #expect(cache.count == 2)
+
+        let sizeReadsBeforeClear = icon.sizeReadCount
+        renderer.removeAll()
+        // The cache has no isEmpty property.
+        // swiftlint:disable:next empty_count
+        #expect(cache.count == 0)
+        let rebuilt = renderer.render(layout: layout, data: self.data(), icon: icon, options: self.options())
+        #expect(rebuilt.attributedTitle !== first.attributedTitle)
+        #expect(rebuilt.attributedTitle.string == first.attributedTitle.string)
+        #expect(icon.sizeReadCount > sizeReadsBeforeClear)
+        #expect(cache.count == 1)
     }
 
     @Test
@@ -1479,5 +1524,23 @@ struct MenuBarLayoutRendererTests {
             return CGFloat(truncating: value)
         }
         return nil
+    }
+}
+
+private final class MenuBarLayoutSizeCountingImage: NSImage {
+    private let sizeReads = OSAllocatedUnfairLock(initialState: 0)
+
+    var sizeReadCount: Int {
+        self.sizeReads.withLock { $0 }
+    }
+
+    override var size: NSSize {
+        get {
+            self.sizeReads.withLock { $0 += 1 }
+            return super.size
+        }
+        set {
+            super.size = newValue
+        }
     }
 }


### PR DESCRIPTION
## Summary

Keep the cached-render performance test focused on the renderer: construct its unchanged synthetic data and options before warmup/timing, rather than rebuilding them in every measured iteration. Preserve the 50 ms threshold, existing best-of-three sampling, 1,000 full render calls per batch, and attributed-title identity assertion. No production code or fixture values change.

Add a deterministic regression that rebuilds equivalent inputs 1,000 times and checks every cached title/icon identity, cache entry count, and absence of repeated icon-layout work. It also verifies invalidation for changed usage and an explicit cache clear. The test-only image counter is synchronized to respect NSImage's Sendable contract.

## Why

[CI run 33469117913](https://github.com/steipete/CodexBar/actions/runs/33469117913) failed this assertion with a fastest batch of 56.409875 ms. An unchanged failed-job rerun on the same head passed. This is separate from [the containment change](https://github.com/steipete/CodexBar/pull/3343).

The production caller constructs data/options upstream of `render`. The old test instead included synthetic fixture preparation in its renderer-only budget. All real renderer work—reset formatting, conditional evaluation, key construction/hashing, and cache lookup—remains measured.

A single debug diagnostic on macOS 27 / Swift 6.4 recorded three predetermined interleaved batches of 1,000 iterations:

| Work | Batch 1 | Batch 2 | Batch 3 |
| --- | ---: | ---: | ---: |
| Original fixtures + render | 25.39 ms | 32.20 ms | 18.03 ms |
| Fixture preparation only | 119.97 ms | 36.48 ms | 11.69 ms |
| Full cached render with prebuilt inputs | 11.44 ms | 7.73 ms | 8.09 ms |

These independently scheduled wall times are not exact CPU accounting and do not establish the precise cause of the historical CI failure. They support correcting the test boundary without a production optimization or a relaxed gate. Temporary diagnostic code is not included in the patch.

## Validation

- Unchanged `MenuBarLayoutRendererTests`: 50 tests passed.
- Corrected `MenuBarLayoutRendererTests`: 51 tests passed, including the unchanged 50 ms gate and the deterministic cache-work regression.
- Repository-pinned SwiftFormat 0.61.1 and SwiftLint 0.65.0 pass for the changed file; `git diff --check` passes.
- Local `make check` stopped in the unrelated MiMo cache-publication test on Python 3.9.6: `Path.replace` bypasses that test's `os.replace` mock. This is being handled separately; no retry or unrelated fix is included here.
- Local full `make test` was not run because unrelated app-group migration tests can reach real user snapshot paths. Focused tests ran with Keychain suppression and session/Codex file isolation enabled.
- No app launch, live provider probe, credential access, UI change, or changelog edit.

The first PR CI run failed the same Poe history golden on both Linux architectures and macOS shard 0; the renderer's shard passed. The branch was rebased onto main's [Poe refresh-clock fix](https://github.com/steipete/CodexBar/commit/a0d5d2f66794e0ec4210d020d5ba12e52a7dbeb5), preserving this PR's patch byte-for-byte. The updated head receives a fresh full CI run; no same-head rerun or deadline change was used.
