### PR TITLE
fix(menu): reject non-finite saved status item positions

### DIFF
--- a/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
+++ b/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
@@ -35,7 +35,7 @@ enum MenuBarStatusItemPlacementPreflight {
     static func shouldClearPreferredPosition(_ value: Any, maximumPreferredPosition: Double?) -> Bool {
         guard let number = value as? NSNumber else { return true }
         let position = number.doubleValue
-        if position <= 0 {
+        if !position.isFinite || position <= 0 {
             return true
         }
         guard let maximumPreferredPosition else { return false }

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -409,6 +409,43 @@ struct StatusItemControllerSplitLifecycleTests {
         #expect(defaults.double(forKey: key) == 42)
     }
 
+    @Test(arguments: [Double.nan, .infinity, -.infinity], [Double?.none, .some(3000)])
+    func `status item placement preflight clears nonfinite positions`(
+        position: Double,
+        maximumPreferredPosition: Double?) throws
+    {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-nonfinite-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-codex")
+        let legacyKey = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "Item-1")
+        let unrelatedKey = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "Item-0")
+        defaults.set(position, forKey: key)
+        defaults.set(position, forKey: legacyKey)
+        defaults.set(42, forKey: unrelatedKey)
+        #expect(try #require(defaults.object(forKey: key) as? NSNumber).doubleValue.isFinite == false)
+
+        #expect(MenuBarStatusItemPlacementPreflight.prepare(
+            defaults: defaults,
+            autosaveName: "codexbar-codex",
+            legacyDefaultItemIndex: 1,
+            maximumPreferredPosition: maximumPreferredPosition))
+
+        #expect(defaults.object(forKey: key) == nil)
+        #expect(defaults.object(forKey: legacyKey) == nil)
+        #expect(defaults.double(forKey: unrelatedKey) == 42)
+    }
+
+    @Test(arguments: [42.0, 2500.0], [Double?.none, .some(3000)])
+    func `status item placement preflight preserves finite positions without requiring a display bound`(
+        position: Double,
+        maximumPreferredPosition: Double?)
+    {
+        #expect(!MenuBarStatusItemPlacementPreflight.shouldClearPreferredPosition(
+            NSNumber(value: position),
+            maximumPreferredPosition: maximumPreferredPosition))
+    }
+
     @Test
     func `status item placement preflight preserves large display position`() throws {
         let suite = "StatusItemControllerSplitLifecycleTests-placement-preserve-large-\(UUID().uuidString)"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -127,6 +127,14 @@ See the canonical [provider authoring guide](provider.md#adding-a-new-provider) 
    - Filter: `subsystem:com.steipete.codexbar category:augment`
    - Importer messages include the `[augment-cookie]` prefix
 
+### Debug Menu Bar Placement
+
+Status-item creation checks the item's saved preferred position and its matching legacy key before assigning the
+autosave name. Malformed, non-finite, non-positive, and out-of-bounds positions are removed; unrelated items are
+untouched. When no display bound is available, finite positive positions are preserved. Isolated placement tests
+cover this cleanup without creating status items or changing the user's saved preferences. Passing these tests does
+not establish the cause of a position that changes again after launch; that requires runtime placement evidence.
+
 ### Run Tests Only
 ```bash
 make test


### PR DESCRIPTION
## Summary

Reject non-finite saved menu-bar positions before status-item creation. NaN bypassed both numeric comparisons, and positive infinity was retained when no display bound was available. A single finite-value check closes those holes for both the current autosave key and its matching legacy key.

Finite positions, screen-bound calculation, padding, missing keys, unrelated items, and visibility policy are unchanged. The tests use isolated defaults suites and explicitly verify that the non-finite values survive the defaults round-trip before cleanup.

This was found while investigating #3355, but does **not** establish or fix that report's recurrence involving a finite position. That issue must remain open for runtime evidence. No user preferences were reset, no live status items were created, and no provider or Keychain access was used.

## Verification

- Baseline regression: three invalid-value cases produce nine expected assertion failures; finite controls pass.
- `swift test --no-parallel --filter 'status item placement preflight|ProviderArchitectureGatekeeperTests'`: 53 tests across two suites pass (43.399 seconds), including six non-finite cases and four finite controls.
- Codex autoreview is scoped-clean at its configured P0 threshold; maintainer review and an independent feasibility check agree with the narrow owner-level change.
- `make check`: passed with zero violations across 2,083 Swift files; all 95 process-cleanup tests passed with one expected Linux-only skip.
- Exact-head [CI run 33537432141](https://github.com/steipete/CodexBar/actions/runs/33537432141) passed on `fa8625d6bf415887b6d801075f0933555bd13382`: both complete macOS shards, Linux x64/arm64 builds and tests, Linux musl build, lint, and the aggregate gate. Hosted macOS discovered 988 selections; the full-suite merge gate is this hosted run, not a claim that the local full run passed. Both plugin engines also passed their 79-test golden suites.
- The first full run timed out in group 1 after 600 seconds; a process sample showed an unrelated Antigravity fixture blocked in a filesystem rename during an atomic temporary-file write. The automatic retry sequence was interrupted through the runner's cleanup path and all observed owned processes exited. An unchanged Antigravity diagnostic later passed all seven tests in 1.978 seconds, but it did **not** prove an internal-disk recovery: the task-local Swift launcher was still overriding the requested `TMPDIR`. That launcher override has now been corrected. No product source or test deadline was changed for this environment repair.
- A subsequent full run reached group 4 and reproduced the Poe golden failure twice. Hosted CI reproduced that same failure on both Linux architectures and one macOS shard. Main independently fixed the Poe clock in a0d5d2f66794e0ec4210d020d5ba12e52a7dbeb5; this branch now incorporates that base. The integrated focused run passes all 65 tests across eight suites (76.420 seconds), including the unchanged main Poe implementation and both-engine regression. Post-integration `make check` passes with zero violations and 95 process-cleanup tests (57.273 seconds, one Linux-only skip); the final scoped autoreview has no accepted findings.
- Local full-run caveat: the final local `make test` discovered 989 selections with the local beta toolchain but stopped in group 5 after the adaptive scan's 250 ms timing assertion failed on both attempts. Group 3 had timed out at 600 seconds, then all 12 isolated retries passed, including 7,070 scanner comparisons in 61.943 seconds. Process sampling and host I/O measurements showed widespread filesystem contention; no tests, limits, or product code were changed to conceal these failures. All owned test processes exited. Exact-head hosted CI supplies the complete passing suite independently.

## Release-note context

Menu bar: discard invalid non-finite saved icon positions while preserving valid placements. No changelog edit; release generation owns that work.
