### PR TITLE
fix(poe): use the refresh clock for history windows

### DIFF
--- a/Sources/CodexBarCore/Resources/Plugins/poe.js
+++ b/Sources/CodexBarCore/Resources/Plugins/poe.js
@@ -13,6 +13,7 @@ defineProvider({
   ],
 
   async fetchUsage(ctx) {
+    const now = ctx.date.now();
     const balanceResponse = await ctx.http.getJSON("https://api.poe.com/usage/current_balance");
     if (balanceResponse.status === 401 || balanceResponse.status === 403) {
       throw new Error("Invalid or expired Poe API token");
@@ -68,7 +69,7 @@ defineProvider({
     const entries = [];
     try {
       let cursor = null;
-      const cutoff = Date.now() - 30 * 86400000;
+      const cutoff = now.getTime() - 30 * 86400000;
       for (let page = 0; page < 5; page += 1) {
         const query = cursor ? `?limit=100&starting_after=${encodeURIComponent(cursor)}` : "?limit=100";
         const response = await ctx.http.getJSON(`https://api.poe.com/usage/points_history${query}`);
@@ -143,7 +144,6 @@ defineProvider({
       );
     const seven = summarize(7);
     const thirty = summarize(30);
-    const now = new Date(Date.now());
     const todayUTC = now.toISOString().slice(0, 10);
     const todayEntries = entries.filter((entry) => entry.date.toISOString().slice(0, 10) === todayUTC);
     const today = todayEntries.reduce(

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -296,15 +296,8 @@ struct ProviderPluginDetailsParityTests {
 
     @Test
     func `Poe fixture matches the cut-over golden`() async throws {
-        let transport = Self.transport { request in
-            switch request.url?.path {
-            case "/usage/current_balance": Self.poeBalance
-            case "/usage/points_history": Self.poeHistory
-            default: throw FixtureError.unexpectedURL(request.url)
-            }
-        }
         let now = Date(timeIntervalSince1970: 1_785_816_000)
-        let script = try await ProviderPluginRuntime(bundledPlugin: "poe", transport: transport)
+        let script = try await Self.poeRuntime()
             .fetchUsage(secrets: ["POE_API_KEY": "fixture-key"], now: now)
 
         #expect(script.primary == nil)
@@ -328,6 +321,44 @@ struct ProviderPluginDetailsParityTests {
             chart: Self.chart("Daily points", unit: "points", points: [
                 ("2026-08-02", 12.5), ("2026-08-03", 8),
             ]))])
+    }
+
+    @Test
+    func `Poe today follows the supplied refresh date`() async throws {
+        let now = Date(timeIntervalSince1970: 1_785_772_800)
+        let snapshot = try await Self.poeRuntime()
+            .fetchUsage(secrets: ["POE_API_KEY": "fixture-key"], now: now)
+        let section = try #require(snapshot.details.first)
+
+        #expect(try section.rows.contains(Self.row("Today", "8 points", "1 requests · $0.02")))
+        #expect(snapshot.updatedAt == now)
+    }
+
+    @Test(arguments: [0.0, 1.0])
+    func `Poe thirty day cutoff uses the supplied refresh clock`(secondsAfterCutoff: Double) async throws {
+        let now = Date(timeIntervalSince1970: 1_785_686_400 + 30 * 86400 + secondsAfterCutoff)
+        let snapshot = try await Self.poeRuntime()
+            .fetchUsage(secrets: ["POE_API_KEY": "fixture-key"], now: now)
+        let section = try #require(snapshot.details.first)
+        let atBoundary = secondsAfterCutoff == 0
+
+        #expect(try section.rows.contains(Self.row(
+            "Last 30 days",
+            atBoundary ? "20.5 points" : "8 points",
+            atBoundary ? "2 requests · $0.05" : "1 requests · $0.02")))
+        #expect(section.chart?.points.count == (atBoundary ? 2 : 1))
+    }
+
+    @Test
+    func `Poe expired history preserves the balance at the supplied refresh date`() async throws {
+        let now = Date(timeIntervalSince1970: 1_785_772_800 + 30 * 86400 + 1)
+        let snapshot = try await Self.poeRuntime()
+            .fetchUsage(secrets: ["POE_API_KEY": "fixture-key"], now: now)
+
+        #expect(try snapshot.details == [Self.section("Points", rows: [
+            Self.row("Current balance", "2,500 points"),
+        ])])
+        #expect(snapshot.identity?.loginMethod == "Balance: 2,500 points")
     }
 
     @Test
@@ -521,6 +552,17 @@ struct ProviderPluginDetailsParityTests {
                 headerFields: ["Content-Type": "application/json"]))
             return try (Data(body(request).utf8), response)
         }
+    }
+
+    private static func poeRuntime() throws -> ProviderPluginRuntime {
+        let transport = Self.transport { request in
+            switch request.url?.path {
+            case "/usage/current_balance": Self.poeBalance
+            case "/usage/points_history": Self.poeHistory
+            default: throw FixtureError.unexpectedURL(request.url)
+            }
+        }
+        return try ProviderPluginRuntime(bundledPlugin: "poe", transport: transport)
     }
 
     private static func openRouterRuntime(

--- a/docs/poe.md
+++ b/docs/poe.md
@@ -34,6 +34,8 @@ CodexBar requests:
 
 The current balance request is required. Recent points history is best-effort, so a history error does not hide a valid balance.
 
+History filtering and the UTC "Today" row use the same host refresh timestamp. The history cutoff remains a rolling 30-day duration, including entries exactly at the cutoff; it is not a calendar-month filter.
+
 ## Display
 
 The provider shows the current point balance in the menu and menu bar. When available, recent history is grouped by day and shown in the usage detail.


### PR DESCRIPTION
## Summary

Use Poe's supplied host refresh clock consistently for the rolling 30-day history cutoff and UTC Today row. The plugin previously called wall-clock `Date.now()` twice, ignoring the runtime's explicit `now` argument and potentially crossing a time boundary within one refresh.

The existing parity golden exposed this on September 1: its August 2 record aged out under wall-clock time even though the fixture supplied an August 4 refresh date. Keep that golden unchanged, capture `ctx.date.now()` once, and add regressions for Today, exact-cutoff inclusion, exclusion after the cutoff, and expired-history balance retention.

Request endpoints, authentication, pagination bounds, optional-history failure handling, and rolling-duration semantics are unchanged. This is separate from the non-finite placement fix in #3361, whose full-suite gate exposed the problem. No live provider, browser, or credential access was used.

## Verification

- Baseline: existing golden plus new clock cases reproduce five assertion failures across four test functions.
- `swift test --no-parallel --filter 'Poe|ProviderPluginDetailsParityTests|date now'`: all 27 tests across six suites pass under QuickJS (2.721 seconds) and JavaScriptCore (4.384 seconds), including optional-history failure preserving the required balance.
- `make check`: passed with zero lint violations across 2,083 Swift files; all 95 process-cleanup tests passed with one expected Linux-only skip.
- Codex autoreview is scoped-clean at its configured P0 threshold; maintainer review and the independent clock-contract audit found no actionable issue. An initial bundle preparation detected concurrent index staging and refused before review; the completed review used the final stable candidate.
- Full `make test` and exact-head hosted CI: pending completion. Do not merge until green.

## Release-note context

Poe: use one refresh timestamp for recent-history filtering and Today totals. No changelog edit; release generation owns that work.
