### PR TITLE
fix(antigravity): recover Linux port discovery after lsof failures

### DIFF
--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -19,11 +19,9 @@ package final class ProcessPipeCapture: @unchecked Sendable {
     private var isStopping = false
     private var continuation: CheckedContinuation<Void, Never>?
     #if os(Linux)
-    private let readerQueue = DispatchQueue(label: "com.steipete.CodexBar.process-pipe-capture.reader")
     private let callbackQueue = DispatchQueue(label: "com.steipete.CodexBar.process-pipe-capture.callback")
-    private var readSource: DispatchSourceRead?
-    private var sourceStarted = false
-    private var sourceCancelled = false
+    private var readerStarted = false
+    private var readerExited = false
     private var callbackScheduled = false
     private var callbackRequested = false
     #endif
@@ -48,6 +46,14 @@ package final class ProcessPipeCapture: @unchecked Sendable {
 
     #if os(Linux)
     package func start(linuxDescriptorSetup: @Sendable (Int32) -> Bool) {
+        self.condition.lock()
+        guard !self.readerStarted, !self.isFinished, !self.isStopping else {
+            self.condition.unlock()
+            return
+        }
+        self.readerStarted = true
+        self.condition.unlock()
+
         let fileDescriptor = self.handle.fileDescriptor
         guard linuxDescriptorSetup(fileDescriptor) else {
             self.finishFailedLinuxStart()
@@ -55,20 +61,14 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         }
 
         // FileHandle.readabilityHandler duplicates the descriptor on Linux and traps if dup(2) returns EMFILE.
-        // A dispatch read source monitors the pipe's existing descriptor, so descriptor exhaustion cannot trigger
-        // Foundation's precondition failure.
-        let source = DispatchSource.makeReadSource(fileDescriptor: fileDescriptor, queue: self.readerQueue)
-        source.setEventHandler { [weak self] in
-            self?.handleLinuxReadableData(fileDescriptor: fileDescriptor)
+        // DispatchSourceRead avoids that duplication, but Swift 6.3's Linux epoll backend can unregister and free
+        // a pipe's shared muxnote on its target queue while the manager queue is still traversing the HUP event.
+        // Poll on an owned thread instead: the reader keeps sole descriptor-close ownership, while the bounded poll
+        // interval keeps stop() responsive without allocating a wakeup descriptor that would break the EMFILE path.
+        Thread.detachNewThread { [self] in
+            Thread.current.name = "CodexBar pipe capture"
+            self.runLinuxReader(fileDescriptor: fileDescriptor)
         }
-        source.setCancelHandler { [weak self] in
-            self?.finishLinuxSourceCancellation()
-        }
-        self.condition.lock()
-        self.readSource = source
-        self.sourceStarted = true
-        self.condition.unlock()
-        source.resume()
     }
     #endif
 
@@ -166,6 +166,42 @@ package final class ProcessPipeCapture: @unchecked Sendable {
     }
 
     #if os(Linux)
+    private func runLinuxReader(fileDescriptor: Int32) {
+        var pollDescriptor = pollfd(fd: fileDescriptor, events: Int16(POLLIN), revents: 0)
+
+        while true {
+            self.condition.lock()
+            let shouldStop = self.isStopping
+            self.condition.unlock()
+            if shouldStop { break }
+
+            pollDescriptor.revents = 0
+            #if canImport(Glibc)
+            let pollResult = Glibc.poll(&pollDescriptor, 1, 25)
+            #elseif canImport(Musl)
+            let pollResult = Musl.poll(&pollDescriptor, 1, 25)
+            #endif
+            if pollResult < 0 {
+                if errno == EINTR { continue }
+                self.finishLinuxRead(reachedEOF: false)
+                break
+            }
+            if pollResult == 0 { continue }
+
+            self.handleLinuxReadableData(fileDescriptor: fileDescriptor)
+            self.condition.lock()
+            let finished = self.isFinished || self.isStopping
+            self.condition.unlock()
+            if finished { break }
+        }
+
+        try? self.handle.close()
+        self.condition.lock()
+        self.readerExited = true
+        self.condition.broadcast()
+        self.condition.unlock()
+    }
+
     private func handleLinuxReadableData(fileDescriptor: Int32) {
         self.condition.lock()
         guard !self.isStopping else {
@@ -215,14 +251,12 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         }
 
         var continuation: CheckedContinuation<Void, Never>?
-        var sourceToCancel: DispatchSourceRead?
         self.condition.lock()
         if reachedEnd {
             self.isFinished = true
             self.didReachEOF = true
             continuation = self.continuation
             self.continuation = nil
-            sourceToCancel = self.readSource
         }
         self.activeCallbacks -= 1
         if self.activeCallbacks == 0 || reachedEnd {
@@ -230,10 +264,25 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         }
         self.condition.unlock()
 
-        sourceToCancel?.cancel()
         if receivedData {
             self.scheduleLinuxDataCallback()
         }
+        continuation?.resume()
+    }
+
+    private func finishLinuxRead(reachedEOF: Bool) {
+        let continuation: CheckedContinuation<Void, Never>?
+        self.condition.lock()
+        if self.isStopping {
+            continuation = nil
+        } else {
+            self.isFinished = true
+            self.didReachEOF = reachedEOF
+            continuation = self.continuation
+            self.continuation = nil
+            self.condition.broadcast()
+        }
+        self.condition.unlock()
         continuation?.resume()
     }
 
@@ -271,20 +320,12 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         try? self.handle.close()
         self.condition.lock()
         self.isFinished = true
+        self.readerExited = true
         let continuation = self.continuation
         self.continuation = nil
         self.condition.broadcast()
         self.condition.unlock()
         continuation?.resume()
-    }
-
-    private func finishLinuxSourceCancellation() {
-        try? self.handle.close()
-        self.condition.lock()
-        self.sourceCancelled = true
-        self.readSource = nil
-        self.condition.broadcast()
-        self.condition.unlock()
     }
     #endif
 
@@ -311,13 +352,17 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         let continuation: CheckedContinuation<Void, Never>?
         let snapshot: Data
         #if os(Linux)
-        let source: DispatchSourceRead?
         self.condition.lock()
         self.isStopping = true
-        source = self.readSource
-        self.readSource = nil
+        let closeUnstartedReader = !self.readerStarted
+        if closeUnstartedReader {
+            self.readerExited = true
+        }
+        self.condition.broadcast()
         self.condition.unlock()
-        source?.cancel()
+        if closeUnstartedReader {
+            try? self.handle.close()
+        }
         #else
         self.handle.readabilityHandler = nil
         #endif
@@ -325,7 +370,7 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         self.condition.lock()
         self.isStopping = true
         #if os(Linux)
-        while self.activeCallbacks > 0 || (self.sourceStarted && !self.sourceCancelled) {
+        while self.activeCallbacks > 0 || (self.readerStarted && !self.readerExited) {
             self.condition.wait()
         }
         #else
@@ -339,11 +384,8 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         snapshot = self.data
         self.condition.unlock()
 
-        // Explicitly close the read-end file descriptor. On Linux
-        // swift-corelibs-foundation, clearing readabilityHandler does not
-        // release the underlying dup'd monitor fd, so the pipe read end leaks
-        // if we rely solely on closeOnDealloc. Closing here prevents the
-        // long-running fd growth that leads to EMFILE/SIGILL (issue #2234).
+        // Linux closes from the reader's single exit path (or the never-started path above). On Darwin,
+        // clearing readabilityHandler does not release its duplicated monitor descriptor immediately.
         #if !os(Linux)
         try? self.handle.close()
         #endif

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -675,6 +675,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         dependencies: SnapshotWaitDependencies) async throws -> AntigravityStatusSnapshot
     {
         var lastFetchError: Error?
+        var lastPortDiscoveryError: Error?
         while dependencies.now() < deadline {
             try await Self.checkAuthenticationPrompt(dependencies)
             let remaining = deadline.timeIntervalSince(dependencies.now())
@@ -682,6 +683,10 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             let ports: [Int]
             do {
                 ports = try await dependencies.listeningPorts(Int(pid), portProbeTimeout)
+            } catch let error as AntigravityPortDiscoveryPendingError {
+                try Task.checkCancellation()
+                lastPortDiscoveryError = error.underlyingError
+                ports = []
             } catch {
                 guard Self.isNoListeningPortsError(error) else {
                     try await Self.checkAuthenticationPrompt(dependencies)
@@ -739,6 +744,9 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         try await Self.checkAuthenticationPrompt(dependencies)
         if let lastFetchError {
             throw lastFetchError
+        }
+        if let lastPortDiscoveryError {
+            throw lastPortDiscoveryError
         }
         Self.log.warning("Antigravity CLI HTTPS: no ports found for pid \(pid)")
         throw AntigravityStatusProbeError.portDetectionFailed(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+PortDetection.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+PortDetection.swift
@@ -53,20 +53,44 @@ extension AntigravityStatusProbe {
         let lsof = ["/usr/sbin/lsof", "/usr/bin/lsof"].first(where: {
             FileManager.default.isExecutableFile(atPath: $0)
         })
+        return try await Self.linuxListeningPorts(pid: pid, timeout: timeout, lsof: lsof)
+        #endif
+    }
 
+    static func linuxListeningPorts(
+        pid: Int,
+        timeout: TimeInterval,
+        lsof: String?,
+        procRoot: String = "/proc") async throws -> [Int]
+    {
+        try Task.checkCancellation()
+        var lsofError: (any Error)?
         if let lsof {
-            return try await Self.lsofListeningPorts(lsof: lsof, pid: pid, timeout: timeout)
+            do {
+                return try await Self.lsofListeningPorts(lsof: lsof, pid: pid, timeout: timeout)
+            } catch let error as SubprocessRunnerError {
+                switch error {
+                case .binaryNotFound, .launchFailed, .nonZeroExit:
+                    lsofError = error
+                case .timedOut, .outputTooLarge:
+                    throw error
+                }
+            } catch let error as AntigravityStatusProbeError {
+                guard case .portDetectionFailed = error else { throw error }
+                lsofError = error
+            }
         }
 
-        // `lsof` is frequently absent on minimal Linux hosts. Fall back to the
-        // kernel's /proc interface, mirroring the /proc/<pid>/cwd fallback that
-        // LocalAgentSessionScanner.cwdByPID already uses when lsof is missing.
-        let ports = Self.procListeningPorts(pid: pid)
+        // Installed lsof can fail on inaccessible mount namespaces. The existing
+        // process-scoped kernel lookup remains usable without broadening socket ownership.
+        try Task.checkCancellation()
+        let ports = Self.procListeningPorts(pid: pid, procRoot: procRoot)
+        try Task.checkCancellation()
         if ports.isEmpty {
+            if let lsofError { throw lsofError }
             throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
         }
         return ports
-        #endif
     }
 
     private static func lsofListeningPorts(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+PortDetection.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+PortDetection.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+/// Readiness polling may retry an empty kernel lookup while retaining the lsof diagnostic.
+struct AntigravityPortDiscoveryPendingError: LocalizedError {
+    let underlyingError: any Error
+
+    var errorDescription: String? {
+        self.underlyingError.localizedDescription
+    }
+}
+
 /// Parses Linux `/proc/<pid>/net/tcp{,6}` output to recover the listening ports
 /// owned by a process. The parsing is platform-independent for focused tests.
 enum ProcNetTCPListeningPortParser {
@@ -64,7 +73,7 @@ extension AntigravityStatusProbe {
         procRoot: String = "/proc") async throws -> [Int]
     {
         try Task.checkCancellation()
-        var lsofError: (any Error)?
+        var lsofError: SubprocessRunnerError?
         if let lsof {
             do {
                 return try await Self.lsofListeningPorts(lsof: lsof, pid: pid, timeout: timeout)
@@ -77,7 +86,6 @@ extension AntigravityStatusProbe {
                 }
             } catch let error as AntigravityStatusProbeError {
                 guard case .portDetectionFailed = error else { throw error }
-                lsofError = error
             }
         }
 
@@ -87,7 +95,7 @@ extension AntigravityStatusProbe {
         let ports = Self.procListeningPorts(pid: pid, procRoot: procRoot)
         try Task.checkCancellation()
         if ports.isEmpty {
-            if let lsofError { throw lsofError }
+            if let lsofError { throw AntigravityPortDiscoveryPendingError(underlyingError: lsofError) }
             throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
         }
         return ports

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -850,6 +850,63 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
+    func `cli HTTPS retains the last pending port diagnostic until the readiness deadline`() async {
+        let attempts = AntigravityCLICounter()
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let clock = AntigravityCLITestClock(date: start)
+        do {
+            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: start.addingTimeInterval(5),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 0,
+                    listeningPorts: { _, _ in
+                        let attempt = attempts.increment()
+                        throw AntigravityPortDiscoveryPendingError(underlyingError:
+                            SubprocessRunnerError.nonZeroExit(code: 1, stderr: "namespace warning \(attempt)"))
+                    },
+                    drainOutput: { Data() },
+                    fetchSnapshot: { _ in
+                        Issue.record("Missing listeners must not fetch usage")
+                        throw AntigravityStatusProbeError.timedOut
+                    },
+                    now: { clock.now() }))
+            Issue.record("Expected the final port discovery diagnostic")
+        } catch let SubprocessRunnerError.nonZeroExit(code, stderr) {
+            #expect(attempts.value == 2)
+            #expect(code == 1)
+            #expect(stderr == "namespace warning 2")
+        } catch {
+            Issue.record("Expected the original diagnostic, got \(error)")
+        }
+    }
+
+    @Test
+    func `cli HTTPS retains endpoint readiness failure over a later port warning`() async {
+        let attempts = AntigravityCLICounter()
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let clock = AntigravityCLITestClock(date: start)
+        await #expect(throws: AntigravityStatusProbeError.apiError("quota service warming")) {
+            try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: start.addingTimeInterval(5),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 0,
+                    listeningPorts: { _, _ in
+                        if attempts.increment() == 1 { return [50080] }
+                        throw AntigravityPortDiscoveryPendingError(underlyingError:
+                            SubprocessRunnerError.nonZeroExit(code: 1, stderr: "namespace warning"))
+                    },
+                    drainOutput: { Data() },
+                    fetchSnapshot: { _ in
+                        throw AntigravityStatusProbeError.apiError("quota service warming")
+                    },
+                    now: { clock.now() }))
+        }
+        #expect(attempts.value == 2)
+    }
+
+    @Test
     func `cli HTTPS preserves non transient port detection errors`() async {
         do {
             _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -850,63 +850,6 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
-    func `cli HTTPS retains the last pending port diagnostic until the readiness deadline`() async {
-        let attempts = AntigravityCLICounter()
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        let clock = AntigravityCLITestClock(date: start)
-        do {
-            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
-                pid: 123,
-                deadline: start.addingTimeInterval(5),
-                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
-                    pollIntervalNanoseconds: 0,
-                    listeningPorts: { _, _ in
-                        let attempt = attempts.increment()
-                        throw AntigravityPortDiscoveryPendingError(underlyingError:
-                            SubprocessRunnerError.nonZeroExit(code: 1, stderr: "namespace warning \(attempt)"))
-                    },
-                    drainOutput: { Data() },
-                    fetchSnapshot: { _ in
-                        Issue.record("Missing listeners must not fetch usage")
-                        throw AntigravityStatusProbeError.timedOut
-                    },
-                    now: { clock.now() }))
-            Issue.record("Expected the final port discovery diagnostic")
-        } catch let SubprocessRunnerError.nonZeroExit(code, stderr) {
-            #expect(attempts.value == 2)
-            #expect(code == 1)
-            #expect(stderr == "namespace warning 2")
-        } catch {
-            Issue.record("Expected the original diagnostic, got \(error)")
-        }
-    }
-
-    @Test
-    func `cli HTTPS retains endpoint readiness failure over a later port warning`() async {
-        let attempts = AntigravityCLICounter()
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        let clock = AntigravityCLITestClock(date: start)
-        await #expect(throws: AntigravityStatusProbeError.apiError("quota service warming")) {
-            try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
-                pid: 123,
-                deadline: start.addingTimeInterval(5),
-                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
-                    pollIntervalNanoseconds: 0,
-                    listeningPorts: { _, _ in
-                        if attempts.increment() == 1 { return [50080] }
-                        throw AntigravityPortDiscoveryPendingError(underlyingError:
-                            SubprocessRunnerError.nonZeroExit(code: 1, stderr: "namespace warning"))
-                    },
-                    drainOutput: { Data() },
-                    fetchSnapshot: { _ in
-                        throw AntigravityStatusProbeError.apiError("quota service warming")
-                    },
-                    now: { clock.now() }))
-        }
-        #expect(attempts.value == 2)
-    }
-
-    @Test
     func `cli HTTPS preserves non transient port detection errors`() async {
         do {
             _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
@@ -1096,6 +1039,65 @@ extension AntigravityCLIHTTPSFetchStrategyTests {
             AntigravityStatusProbeError.apiError("OAuth credentials expired"))
 
         #expect((result as? AntigravityStatusProbeError) == .apiError("OAuth credentials expired"))
+    }
+}
+
+extension AntigravityCLIHTTPSFetchStrategyTests {
+    @Test
+    func `cli HTTPS retains the last pending port diagnostic until the readiness deadline`() async {
+        let attempts = AntigravityCLICounter()
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let clock = AntigravityCLITestClock(date: start)
+        do {
+            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: start.addingTimeInterval(5),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 0,
+                    listeningPorts: { _, _ in
+                        let attempt = attempts.increment()
+                        throw AntigravityPortDiscoveryPendingError(underlyingError:
+                            SubprocessRunnerError.nonZeroExit(code: 1, stderr: "namespace warning \(attempt)"))
+                    },
+                    drainOutput: { Data() },
+                    fetchSnapshot: { _ in
+                        Issue.record("Missing listeners must not fetch usage")
+                        throw AntigravityStatusProbeError.timedOut
+                    },
+                    now: { clock.now() }))
+            Issue.record("Expected the final port discovery diagnostic")
+        } catch let SubprocessRunnerError.nonZeroExit(code, stderr) {
+            #expect(attempts.value == 2)
+            #expect(code == 1)
+            #expect(stderr == "namespace warning 2")
+        } catch {
+            Issue.record("Expected the original diagnostic, got \(error)")
+        }
+    }
+
+    @Test
+    func `cli HTTPS retains endpoint readiness failure over a later port warning`() async {
+        let attempts = AntigravityCLICounter()
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let clock = AntigravityCLITestClock(date: start)
+        await #expect(throws: AntigravityStatusProbeError.apiError("quota service warming")) {
+            try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: start.addingTimeInterval(5),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 0,
+                    listeningPorts: { _, _ in
+                        if attempts.increment() == 1 { return [50080] }
+                        throw AntigravityPortDiscoveryPendingError(underlyingError:
+                            SubprocessRunnerError.nonZeroExit(code: 1, stderr: "namespace warning"))
+                    },
+                    drainOutput: { Data() },
+                    fetchSnapshot: { _ in
+                        throw AntigravityStatusProbeError.apiError("quota service warming")
+                    },
+                    now: { clock.now() }))
+        }
+        #expect(attempts.value == 2)
     }
 }
 

--- a/TestsLinux/AntigravityPortDiscoveryTests.swift
+++ b/TestsLinux/AntigravityPortDiscoveryTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+import Testing
+@testable import CodexBarCore
+
+struct AntigravityPortDiscoveryTests {
+    @Test(arguments: [
+        "printf 'lsof: WARNING: cannot stat namespace filesystem\\n' >&2; exit 1",
+        "exit 1",
+        "exit 0",
+        "printf 'lsof: failed\\n' >&2; exit 2",
+    ])
+    func `failed or empty lsof recovers only process owned proc listeners`(script: String) async throws {
+        let fixture = try Fixture(script: script)
+        defer { fixture.remove() }
+        #expect(try await fixture.ports() == [8080])
+    }
+
+    @Test
+    func `missing lsof executable recovers through proc`() async throws {
+        let fixture = try Fixture(script: "exit 0")
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(at: fixture.lsof)
+        #expect(try await fixture.ports() == [8080])
+    }
+
+    @Test
+    func `successful lsof retains precedence over proc`() async throws {
+        let fixture = try Fixture(script: "printf 'agy 42 user TCP 127.0.0.1:4242 (LISTEN)\\n'")
+        defer { fixture.remove() }
+        #expect(try await fixture.ports() == [4242])
+    }
+
+    @Test
+    func `failed proc fallback preserves lsof diagnostic`() async throws {
+        let fixture = try Fixture(script: "printf 'namespace warning\\n' >&2; exit 1")
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(at: fixture.root.appendingPathComponent("42/fd/7"))
+        do {
+            _ = try await fixture.ports()
+            Issue.record("Expected original lsof failure when neither source has a listener")
+        } catch let SubprocessRunnerError.nonZeroExit(code, stderr) {
+            #expect(code == 1)
+            #expect(stderr == "namespace warning\n")
+        }
+    }
+
+    @Test
+    func `absent lsof and empty proc retains no ports error`() async throws {
+        let fixture = try Fixture(script: "exit 0")
+        defer { fixture.remove() }
+        await #expect(throws: AntigravityStatusProbeError.portDetectionFailed("no listening ports found")) {
+            try await AntigravityStatusProbe.linuxListeningPorts(
+                pid: 999,
+                timeout: 5,
+                lsof: nil,
+                procRoot: fixture.root.path)
+        }
+    }
+
+    @Test
+    func `cancelled discovery cannot recover through proc`() async throws {
+        let fixture = try Fixture(script: "exit 1")
+        defer { fixture.remove() }
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await AntigravityStatusProbe.linuxListeningPorts(
+                pid: 42,
+                timeout: 5,
+                lsof: nil,
+                procRoot: fixture.root.path)
+        }
+        await #expect(throws: CancellationError.self) { try await task.value }
+    }
+
+    @Test
+    func `lsof timeout cannot recover through proc`() async throws {
+        let fixture = try Fixture(script: "exec sleep 10")
+        defer { fixture.remove() }
+        do {
+            _ = try await fixture.ports(timeout: 0.1)
+            Issue.record("Expected lsof deadline to remain authoritative")
+        } catch let SubprocessRunnerError.timedOut(label) {
+            #expect(label == "antigravity-lsof")
+        }
+    }
+
+    #if canImport(Glibc) || canImport(Musl)
+    @Test
+    func `Linux proc recovers a real listener after lsof namespace warnings`() async throws {
+        let fixture = try Fixture(script: "printf 'lsof: WARNING: namespace unavailable\\n' >&2; exit 1")
+        defer { fixture.remove() }
+        #if canImport(Glibc)
+        let streamType = Int32(SOCK_STREAM.rawValue)
+        #else
+        let streamType = SOCK_STREAM
+        #endif
+        let descriptor = socket(AF_INET, streamType, 0)
+        guard descriptor >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        defer { close(descriptor) }
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0, listen(descriptor, 1) == 0 else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let named = withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(descriptor, $0, &length)
+            }
+        }
+        guard named == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        let ports = try await AntigravityStatusProbe.linuxListeningPorts(
+            pid: Int(getpid()), timeout: 5, lsof: fixture.lsof.path)
+        #expect(ports.contains(Int(UInt16(bigEndian: address.sin_port))))
+    }
+    #endif
+
+    private struct Fixture: Sendable {
+        let root: URL
+        let lsof: URL
+
+        init(script: String) throws {
+            self.root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("codexbar-port-discovery-\(UUID().uuidString)")
+            self.lsof = self.root.appendingPathComponent("lsof")
+            let files = FileManager.default
+            try files.createDirectory(at: self.root.appendingPathComponent("42/fd"), withIntermediateDirectories: true)
+            try files.createDirectory(at: self.root.appendingPathComponent("42/net"), withIntermediateDirectories: true)
+            try files.createSymbolicLink(
+                atPath: self.root.appendingPathComponent("42/fd/7").path,
+                withDestinationPath: "socket:[111111]")
+            let table = """
+            sl local_address rem_address st tx_queue rx_queue tr tm->when retrnsmt uid timeout inode
+            0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 111111
+            1: 0100007F:C000 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 999999
+            """
+            try Data(table.utf8).write(to: self.root.appendingPathComponent("42/net/tcp"))
+            try Data("#!/bin/sh\n\(script)\n".utf8).write(to: self.lsof)
+            try files.setAttributes([.posixPermissions: 0o700], ofItemAtPath: self.lsof.path)
+        }
+
+        func ports(timeout: TimeInterval = 5) async throws -> [Int] {
+            try await AntigravityStatusProbe.linuxListeningPorts(
+                pid: 42, timeout: timeout, lsof: self.lsof.path, procRoot: self.root.path)
+        }
+
+        func remove() {
+            try? FileManager.default.removeItem(at: self.root)
+        }
+    }
+}

--- a/TestsLinux/AntigravityPortDiscoveryTests.swift
+++ b/TestsLinux/AntigravityPortDiscoveryTests.swift
@@ -202,8 +202,7 @@ struct AntigravityPortDiscoveryTests {
             1: 0100007F:C000 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 999999
             """
             try Data(table.utf8).write(to: self.root.appendingPathComponent("42/net/tcp"))
-            try Data("#!/bin/sh\n\(script)\n".utf8).write(to: self.lsof)
-            try files.setAttributes([.posixPermissions: 0o700], ofItemAtPath: self.lsof.path)
+            try FakeExecutable.install("#!/bin/sh\n\(script)\n", at: self.lsof)
         }
 
         func ports(timeout: TimeInterval = 5) async throws -> [Int] {

--- a/TestsLinux/AntigravityPortDiscoveryTests.swift
+++ b/TestsLinux/AntigravityPortDiscoveryTests.swift
@@ -29,6 +29,38 @@ struct AntigravityPortDiscoveryTests {
     }
 
     @Test
+    func `CLI readiness retries namespace warnings until the proc listener appears`() async throws {
+        let fixture = try Fixture(script: "printf 'lsof: WARNING: namespace unavailable\\n' >&2; exit 1")
+        defer { fixture.remove() }
+        let socketLink = fixture.root.appendingPathComponent("42/fd/7")
+        try FileManager.default.removeItem(at: socketLink)
+        let attempts = DiscoveryAttempts()
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 42,
+            deadline: Date().addingTimeInterval(15),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, timeout in
+                    if await attempts.next() == 2 {
+                        try FileManager.default.createSymbolicLink(
+                            atPath: socketLink.path, withDestinationPath: "socket:[111111]")
+                    }
+                    return try await fixture.ports(timeout: timeout)
+                },
+                drainOutput: { Data() },
+                fetchSnapshot: { ports in
+                    #expect(ports == [8080])
+                    return AntigravityStatusSnapshot(
+                        modelQuotas: [AntigravityModelQuota(
+                            label: "Gemini Pro", modelId: "gemini-pro", remainingFraction: 0.5,
+                            resetTime: nil, resetDescription: nil)],
+                        accountEmail: "fixture@example.com", accountPlan: "Pro", source: .local)
+                }))
+        #expect(snapshot.accountEmail == "fixture@example.com")
+        #expect(await attempts.count == 2)
+    }
+
+    @Test
     func `successful lsof retains precedence over proc`() async throws {
         let fixture = try Fixture(script: "printf 'agy 42 user TCP 127.0.0.1:4242 (LISTEN)\\n'")
         defer { fixture.remove() }
@@ -43,9 +75,14 @@ struct AntigravityPortDiscoveryTests {
         do {
             _ = try await fixture.ports()
             Issue.record("Expected original lsof failure when neither source has a listener")
-        } catch let SubprocessRunnerError.nonZeroExit(code, stderr) {
+        } catch let error as AntigravityPortDiscoveryPendingError {
+            guard case let SubprocessRunnerError.nonZeroExit(code, stderr) = error.underlyingError else {
+                Issue.record("Expected the original lsof diagnostic")
+                return
+            }
             #expect(code == 1)
             #expect(stderr == "namespace warning\n")
+            #expect(error.localizedDescription == error.underlyingError.localizedDescription)
         }
     }
 
@@ -59,6 +96,16 @@ struct AntigravityPortDiscoveryTests {
                 timeout: 5,
                 lsof: nil,
                 procRoot: fixture.root.path)
+        }
+    }
+
+    @Test(arguments: ["exit 0", "exit 1"])
+    func `ordinary empty discovery retains the existing no ports classification`(script: String) async throws {
+        let fixture = try Fixture(script: script)
+        defer { fixture.remove() }
+        try FileManager.default.removeItem(at: fixture.root.appendingPathComponent("42/fd/7"))
+        await #expect(throws: AntigravityStatusProbeError.portDetectionFailed("no listening ports found")) {
+            try await fixture.ports()
         }
     }
 
@@ -125,6 +172,15 @@ struct AntigravityPortDiscoveryTests {
         #expect(ports.contains(Int(UInt16(bigEndian: address.sin_port))))
     }
     #endif
+
+    private actor DiscoveryAttempts {
+        private(set) var count = 0
+
+        func next() -> Int {
+            self.count += 1
+            return self.count
+        }
+    }
 
     private struct Fixture: Sendable {
         let root: URL

--- a/TestsLinux/ProcessPipeCaptureLinuxTests.swift
+++ b/TestsLinux/ProcessPipeCaptureLinuxTests.swift
@@ -129,6 +129,55 @@ struct ProcessPipeCaptureLinuxTests {
     }
 
     @Test
+    func `buffered pipe tail is drained before hangup completes`() throws {
+        let expected = Data(repeating: 0x5A, count: 256 * 1024)
+        let pipe = Pipe()
+        let capture = ProcessPipeCapture(pipe: pipe, maxBytes: expected.count)
+        capture.start()
+
+        try pipe.fileHandleForWriting.write(contentsOf: expected)
+        try pipe.fileHandleForWriting.close()
+        let captured = capture.finishSynchronously(timeout: 2)
+
+        #expect(captured == expected)
+        #expect(capture.reachedEOF)
+    }
+
+    @Test
+    func `silent open pipe stops promptly without claiming EOF`() throws {
+        let pipe = Pipe()
+        let capture = ProcessPipeCapture(pipe: pipe)
+        capture.start()
+
+        let startedAt = ContinuousClock.now
+        capture.stop()
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(elapsed < .milliseconds(500))
+        #expect(!capture.reachedEOF)
+        try pipe.fileHandleForWriting.close()
+    }
+
+    @Test
+    func `stop before start closes once and prevents a late reader`() throws {
+        let pipe = Pipe()
+        let capture = ProcessPipeCapture(pipe: pipe)
+
+        capture.stop()
+        capture.stop()
+        capture.start()
+
+        var writerPollDescriptor = pollfd(
+            fd: pipe.fileHandleForWriting.fileDescriptor,
+            events: 0,
+            revents: 0)
+        #expect(Glibc.poll(&writerPollDescriptor, 1, 0) == 1)
+        #expect(writerPollDescriptor.revents & Int16(POLLERR) != 0)
+        #expect(!capture.reachedEOF)
+        try pipe.fileHandleForWriting.close()
+    }
+
+    @Test
     func `Linux descriptor setup failure closes the read end immediately`() throws {
         let pipe = Pipe()
         let capture = ProcessPipeCapture(pipe: pipe)

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -121,7 +121,9 @@ When the Antigravity 2.0 app is running:
    - Linux tries `lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>`, then process-scoped `/proc` discovery if
      `lsof` is missing, fails to launch or exits unsuccessfully, or reports no listeners. Namespace warnings from
      `lsof` therefore do not prevent discovery when `/proc` remains readable. Cancellation and hard subprocess limits
-     still propagate; if neither source finds a listener, the original discovery error is retained.
+     still propagate. If neither source finds a listener, CLI readiness polling continues within its existing deadline
+     and retains the last discovery diagnostic if startup never succeeds. An endpoint readiness failure takes
+     precedence once a listener has been reached.
    - `/proc/<pid>/fd` socket inodes are matched only against the same process's `net/tcp` and `net/tcp6` tables.
    - All listening ports are probed.
 

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -117,7 +117,12 @@ When the Antigravity 2.0 app is running:
      - `--extension_server_csrf_token <token>` (preferred HTTP fallback token when present).
 
 2. **Port discovery**
-   - Command: `lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>`.
+   - macOS uses kernel process-socket enumeration.
+   - Linux tries `lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>`, then process-scoped `/proc` discovery if
+     `lsof` is missing, fails to launch or exits unsuccessfully, or reports no listeners. Namespace warnings from
+     `lsof` therefore do not prevent discovery when `/proc` remains readable. Cancellation and hard subprocess limits
+     still propagate; if neither source finds a listener, the original discovery error is retained.
+   - `/proc/<pid>/fd` socket inodes are matched only against the same process's `net/tcp` and `net/tcp6` tables.
    - All listening ports are probed.
 
 3. **Connect port probe (HTTPS)**
@@ -149,7 +154,7 @@ When source mode is `auto` or `cli` and the desktop local probe fails, CodexBar 
 
 CodexBar launches `agy` in a PTY because the CLI exposes its quota server only while the interactive process is alive.
 The implementation still does **not** scrape terminal output; it only keeps the process alive, drains discarded PTY
-rendering, discovers listening ports with `lsof`, and probes the local HTTPS server:
+rendering, uses the same platform-specific port discovery described above, and probes the local HTTPS server:
 
 - First: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary`
 - Fallback 1: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetUserStatus`
@@ -333,7 +338,8 @@ cancellation. The fixtures are synthetic and source-linked, not private captures
 
 ## Constraints
 - Internal protocol; fields may change.
-- Requires `lsof` for local/CLI port detection.
+- Linux local/CLI port detection requires working `lsof` output or readable process-scoped `/proc` socket metadata;
+  macOS uses kernel process-socket enumeration.
 - Local HTTPS uses a self-signed cert; the probe allows insecure TLS only for loopback hosts.
 
 ## Key files


### PR DESCRIPTION
## Summary

Recover Antigravity Linux port discovery when an installed `lsof` exits with namespace warnings or otherwise cannot identify listeners. The existing fallback previously ran only when `lsof` was absent, so the reported systemd refresh failed before any quota endpoint was called.

The Linux resolver now tries the existing process-scoped `/proc` lookup after launch/nonzero/empty-result failures. Successful `lsof` results retain precedence. Cancellation, timeout, and output-limit errors still propagate. If the process has not opened its listener yet, CLI readiness polling retries within its existing deadline and retains the last warning if startup never succeeds; an authentication or endpoint-readiness error takes precedence. Ordinary empty discovery keeps its existing no-listeners classification. Socket inodes must belong to the target PID and match that same PID's TCP tables; discovery does not broaden to unrelated processes or namespaces. macOS kernel enumeration, quota parsing, authentication, and `agy` process ownership are unchanged.

Refs #3362. Thanks @srijits for the precise sanitized trace identifying the failure before endpoint discovery.

## Verification

- Baseline: six expected failures across the warning/empty/missing-executable cases and pre-cancelled fallback; existing success/error/timeout controls passed.
- Cold-start regression was independently red: the production readiness loop stopped after the first empty `/proc` lookup instead of waiting for the second poll's listener. The repair adds a typed pending-discovery state plus deadline-diagnostic, ordinary-empty classification, and endpoint-error precedence controls.
- Candidate `e012297`: focused port/proc/CLI/deadline/warm-reuse coverage passed 181 tests across seven suites; the test-layout follow-up passed all 41 CLI fetch tests. `make check` passed with zero violations across 2,083 Swift files and all 95 process-cleanup tests (one expected Linux-only skip).
- Codex autoreview is scoped-clean at its configured P0 threshold for the final branch; independent feasibility review and maintainer code inspection agree with the bounded repair. The accepted earlier cold-start review finding is fixed.
- [CI run 33548055692](https://github.com/steipete/CodexBar/actions/runs/33548055692) tests the combined candidate and current-main tree. Both macOS shards passed all 989 selections across 248 groups with no failures, timeouts, or retries; both plugin engines passed their 79-test goldens. Linux ARM64 passed all 469 tests, including the actual process-owned loopback listener and delayed-listener regressions. Musl build and lint passed.
- Linux x64's first parallel run crashed inside `libdispatch` without an assertion failure. Its unchanged rerun passed all 469 tests, including real `/proc` listener recovery and cold-start polling; the initial crash has not been attributed to a source defect. A separate AWS diagnostic expired during setup and ran no tests; its lease was released.
- Final fixture hardening `05e39f8` uses the existing fake-executable trampoline to avoid a known concurrent-fork writable-executable race. Assertions and production code are unchanged; this is not claimed as the cause or cure of the `libdispatch` crash. The scoped fixture review is clean, its pinned formatter check passes, and the final focused run passes 50 tests. Final `make check` passes all 95 process-cleanup tests and reports zero Swift violations after serialized validation.
- Linux x64 crashed again in the same `libdispatch` event-loop region in [CI run 33560449029](https://github.com/steipete/CodexBar/actions/runs/33560449029); ARM64 and musl passed. Exact runtime disassembly maps both crashes to adjacent instructions traversing a pipe HUP registration. A standalone correct-API stress case reproduces the crash in the official Swift 6.3.3 Ubuntu 24.04 x86_64 image without any CodexBar code.
- Follow-up `6c93ae6` removes CodexBar's Linux pipe capture from that runtime path: one owned nonblocking polling thread drains and closes each read descriptor, while callbacks stay coalesced on their separate queue. New controls cover buffered data at HUP, silent open-pipe shutdown, and stop-before-start cleanup. Darwin is unchanged. The scoped review is clean; 54 subprocess/readiness tests and final `make check` pass, including all 95 process-cleanup tests and zero violations across 2,083 Swift files.
- Independent clean x64 proof on the exact head passes the affected 20-test Linux slice nine consecutive times and the complete 472-test Linux binary. It used the same pinned official Swift 6.3.3 Ubuntu 24.04 image as the standalone red reproduction. The remote lease was released after success.
- [Exact-head CI run 33570192400](https://github.com/steipete/CodexBar/actions/runs/33570192400) is green on the current-main merge tree: both macOS shards passed all 989 selections across 248 groups without a failure, timeout, or retry; both plugin-engine passes ran 79 goldens. Linux x64 and ARM64 each passed all 472 tests, including the new pipe-lifecycle controls and real `/proc` listener recovery. Musl, lint, security, and the aggregate gate passed.
- Local full-suite attempts are not reported as passing. On the final head, groups 1–13 passed before an existing Claude account-invalidation group timed out at the unchanged 600-second bound; seven isolated controls passed and the Claude suite itself then timed out without an assertion. Earlier attempts encountered existing Claude fake-CLI/PTY failures, a recovered Antigravity timeout, and heavy filesystem contention. All owned processes exited. The task-local launcher disables debug information only; repository settings, assertions, and deadlines are unchanged. Hosted CI uses the normal toolchain and clean runners for the complete gate.

Tests use synthetic scripts, temporary `/proc` fixtures, and local sockets only. No real `agy` account, systemd provider installation, credentials, or quota endpoint was probed. The Linux listener regression establishes port-discovery behavior, not an authenticated provider refresh.

## Release-note context

Antigravity on Linux: retain CLI quota discovery when `lsof` encounters inaccessible mount-namespace warnings, using the existing process-owned `/proc` fallback. Credit @srijits for the report. No changelog edit before release.
