### PR TITLE
fix(test): isolate app-group migration from user state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 - After any code change, run `make check` and fix all reported format/lint issues before handoff.
 - Prefer CLI/focused tests over app-bundle live tests when behavior can be verified without relaunching CodexBar.
 - Never run tests/checks or ad-hoc validation that can display macOS Keychain prompts. Live provider probes, browser-cookie imports, `codexbar usage` against real accounts, and real SecItem reads must be explicitly requested; otherwise use parser tests, stubs, test stores, or `KeychainNoUIQuery`.
+- App-group migration tests must inject dictionary-backed defaults, both snapshot URLs, a synthetic home, and a contained recording FileManager. UUID defaults suites and Keychain isolation flags do not isolate defaults search domains or filesystem access. Ordinary SettingsStore tests must not discover shared defaults or run app-group migration.
 - macOS CI is brittle around headless AppKit status/menu tests. Prefer covering menu behavior through stable state/model seams (`MenuDescriptor`, `ProvidersPane`, `CodexAccountsSectionState`, etc.) instead of constructing live `NSStatusBar`/`NSMenu` flows unless the AppKit wiring itself is the thing under test.
 
 ## Commit & PR Guidelines

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -80,7 +80,7 @@ extension SettingsStore {
             if Self.shouldBridgeSharedDefaults(for: self.userDefaults) {
                 Self.sharedDefaults?.set(newValue, forKey: "debugDisableKeychainAccess")
             }
-            KeychainAccessGate.isDisabled = newValue
+            self.keychainAccessPolicy.setDisabled(newValue)
             self.noteBackgroundWorkSettingsChanged()
         }
     }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -224,24 +224,27 @@ enum CodexAccountMenuProjectionRevalidationResult: Equatable {
 }
 
 @MainActor
+struct SettingsStoreKeychainAccessPolicy {
+    let setDisabled: (Bool) -> Void
+    let isExplicitlyDisabled: () -> Bool
+
+    static var live: Self {
+        Self(
+            setDisabled: { KeychainAccessGate.isDisabled = $0 },
+            isExplicitlyDisabled: { KeychainAccessGate.isExplicitlyDisabled })
+    }
+}
+
+@MainActor
 @Observable
 final class SettingsStore {
     static let sharedDefaults = SettingsStore.resolveSharedDefaults()
     static let mergedOverviewProviderLimit = 6
     static let productionCodexAccountReconciliationSnapshotCacheInterval: TimeInterval = 2
-    static let isRunningTests: Bool = {
-        let env = ProcessInfo.processInfo.environment
-        if env["XCTestConfigurationFilePath"] != nil {
-            return true
-        }
-        if env["TESTING_LIBRARY_VERSION"] != nil {
-            return true
-        }
-        if env["SWIFT_TESTING"] != nil {
-            return true
-        }
-        return NSClassFromString("XCTestCase") != nil
-    }()
+    static let isRunningTests = SettingsStore.resolveIsRunningTests(
+        processName: ProcessInfo.processInfo.processName,
+        environment: ProcessInfo.processInfo.environment,
+        hasLoadedXCTestCase: NSClassFromString("XCTestCase") != nil)
 
     #if DEBUG
     static var codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting: TimeInterval?
@@ -250,6 +253,7 @@ final class SettingsStore {
     @ObservationIgnored let userDefaults: UserDefaults
     @ObservationIgnored let configStore: CodexBarConfigStore
     @ObservationIgnored let antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore
+    @ObservationIgnored let keychainAccessPolicy: SettingsStoreKeychainAccessPolicy
     @ObservationIgnored var config: CodexBarConfig
     @ObservationIgnored var configPersistTask: Task<Void, Never>?
     @ObservationIgnored var configFileWatcher: ConfigFileWatcher?
@@ -276,6 +280,17 @@ final class SettingsStore {
     @ObservationIgnored var providerEnablementRevisions: [ProviderInstanceID: UInt64] = [:]
     @ObservationIgnored var providerConfigRevisions: [ProviderInstanceID: UInt64] = [:]
     @ObservationIgnored var providerConfigFingerprints: [ProviderInstanceID: Data] = [:]
+
+    static func resolveIsRunningTests(
+        processName: String,
+        environment: [String: String],
+        hasLoadedXCTestCase: Bool) -> Bool
+    {
+        TestProcessSafety.isRunningUnderTests(
+            processName: processName,
+            environment: environment,
+            hasLoadedXCTestCase: hasLoadedXCTestCase)
+    }
 
     static func resolveSharedDefaults(
         _ resolve: () -> UserDefaults? = { AppGroupSupport.sharedDefaults() }) -> UserDefaults?
@@ -320,10 +335,11 @@ final class SettingsStore {
         copilotTokenStore: any CopilotTokenStoring = KeychainCopilotTokenStore(),
         tokenAccountStore: any ProviderTokenAccountStoring = FileTokenAccountStore(),
         antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore = AntigravityOAuthCredentialsStore(),
+        keychainAccessPolicy: SettingsStoreKeychainAccessPolicy = .live,
         performInitialProviderDetection: Bool = !SettingsStore.isRunningTests)
     {
         // Legacy credential migration must see the saved policy, including shared-defaults fallback.
-        KeychainAccessGate.isDisabled = Self.loadDebugDisableKeychainAccess(userDefaults: userDefaults)
+        keychainAccessPolicy.setDisabled(Self.loadDebugDisableKeychainAccess(userDefaults: userDefaults))
         if !Self.isRunningTests {
             _ = UserProviderPluginRegistry.refresh()
         }
@@ -371,11 +387,12 @@ final class SettingsStore {
         let config = CodexBarConfigMigrator.loadOrMigrate(
             configStore: configStore,
             userDefaults: userDefaults,
-            keychainAccessDisabled: KeychainAccessGate.isExplicitlyDisabled,
+            keychainAccessDisabled: keychainAccessPolicy.isExplicitlyDisabled(),
             stores: legacyStores)
         self.userDefaults = userDefaults
         self.configStore = configStore
         self.antigravityOAuthCredentialsStore = antigravityOAuthCredentialsStore
+        self.keychainAccessPolicy = keychainAccessPolicy
         self.config = config
         self.configLoading = true
         let defaultsState = Self.loadDefaultsState(
@@ -414,7 +431,7 @@ final class SettingsStore {
         } else {
             self.defaultsState.openAIWebAccessEnabled = resolvedOpenAIWebAccessEnabled
         }
-        KeychainAccessGate.isDisabled = self.debugDisableKeychainAccess
+        self.keychainAccessPolicy.setDisabled(self.debugDisableKeychainAccess)
         self.startConfigFileWatcher()
         self.observeSystemPowerStateChanges()
     }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -226,7 +226,7 @@ enum CodexAccountMenuProjectionRevalidationResult: Equatable {
 @MainActor
 @Observable
 final class SettingsStore {
-    static let sharedDefaults = AppGroupSupport.sharedDefaults()
+    static let sharedDefaults = SettingsStore.resolveSharedDefaults()
     static let mergedOverviewProviderLimit = 6
     static let productionCodexAccountReconciliationSnapshotCacheInterval: TimeInterval = 2
     static let isRunningTests: Bool = {
@@ -277,17 +277,15 @@ final class SettingsStore {
     @ObservationIgnored var providerConfigRevisions: [ProviderInstanceID: UInt64] = [:]
     @ObservationIgnored var providerConfigFingerprints: [ProviderInstanceID: Data] = [:]
 
-    static func shouldBridgeSharedDefaults(for userDefaults: UserDefaults) -> Bool {
-        if !self.isRunningTests {
-            return true
-        }
-        if userDefaults === UserDefaults.standard {
-            return true
-        }
-        if let shared = sharedDefaults, userDefaults === shared {
-            return true
-        }
-        return false
+    static func resolveSharedDefaults(
+        _ resolve: () -> UserDefaults? = { AppGroupSupport.sharedDefaults() }) -> UserDefaults?
+    {
+        guard !self.isRunningTests else { return nil }
+        return resolve()
+    }
+
+    static func shouldBridgeSharedDefaults(for _: UserDefaults) -> Bool {
+        !self.isRunningTests
     }
 
     init(
@@ -332,16 +330,12 @@ final class SettingsStore {
         // Capture this before app-group/config migrations can create prior-installation state.
         let hadExistingConfig = (try? configStore.load()) != nil
         let hadPreviousInstallationState = hadExistingConfig || Self.hadPreviousAppLaunch(userDefaults: userDefaults)
-        let appGroupID = AppGroupSupport.currentGroupID()
-        let appGroupMigration: AppGroupSupport.MigrationResult
-        if Self.isRunningTests {
-            appGroupMigration = AppGroupSupport.migrateLegacyDataIfNeeded(standardDefaults: userDefaults)
-        } else {
-            Self.scheduleAppGroupMigration()
-            appGroupMigration = AppGroupSupport.MigrationResult(status: .targetUnavailable)
-        }
-        let sharedDefaultsAvailable = Self.sharedDefaults != nil
+        // Migration tests inject every dependency directly; ordinary settings tests must not discover user state.
         if !Self.isRunningTests {
+            let appGroupID = AppGroupSupport.currentGroupID()
+            Self.scheduleAppGroupMigration()
+            let appGroupMigration = AppGroupSupport.MigrationResult(status: .targetUnavailable)
+            let sharedDefaultsAvailable = Self.sharedDefaults != nil
             CodexBarLog.logger(LogCategories.settings).info(
                 "App group resolved",
                 metadata: [

--- a/Sources/CodexBarCore/KeychainAccessGate.swift
+++ b/Sources/CodexBarCore/KeychainAccessGate.swift
@@ -45,9 +45,7 @@ public enum KeychainAccessGate {
         if let storedOverrideForTesting { return storedOverrideForTesting }
         #endif
         if let overrideValue { return overrideValue }
-        if UserDefaults.standard.bool(forKey: Self.flagKey) { return true }
-        if let shared = AppGroupSupport.sharedDefaults(), shared.bool(forKey: Self.flagKey) { return true }
-        return false
+        return self.defaultsDisableAccess()
     }
 
     /// True when Keychain access was turned off by the user, environment, or an explicit test override.
@@ -65,8 +63,23 @@ public enum KeychainAccessGate {
         if let storedOverrideForTesting { return storedOverrideForTesting }
         #endif
         if let overrideValue { return overrideValue }
-        if UserDefaults.standard.bool(forKey: Self.flagKey) { return true }
-        if let shared = AppGroupSupport.sharedDefaults(), shared.bool(forKey: Self.flagKey) { return true }
+        return self.defaultsDisableAccess()
+    }
+
+    static func defaultsDisableAccess(
+        processName: String = ProcessInfo.processInfo.processName,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        standardDefaults: () -> UserDefaults = { .standard },
+        sharedDefaults: () -> UserDefaults? = { AppGroupSupport.sharedDefaults() }) -> Bool
+    {
+        // The first setter reads the old explicit policy before installing its override. Automatic
+        // test suppression is not an explicit disable and must not bootstrap real defaults here.
+        guard !KeychainTestSafety.resolveShouldBlockRealKeychainAccess(
+            processName: processName,
+            environment: environment)
+        else { return false }
+        if standardDefaults().bool(forKey: self.flagKey) { return true }
+        if let shared = sharedDefaults(), shared.bool(forKey: Self.flagKey) { return true }
         return false
     }
 

--- a/Sources/CodexBarCore/KeychainSecurity.swift
+++ b/Sources/CodexBarCore/KeychainSecurity.swift
@@ -59,15 +59,9 @@ enum KeychainTestSafety {
         processName: String,
         environment: [String: String]) -> Bool
     {
-        processName == "swiftpm-testing-helper"
-            || processName.hasSuffix("PackageTests")
-            || processName.hasSuffix(".xctest")
-            || environment["XCTestConfigurationFilePath"] != nil
-            || environment["XCTestBundlePath"] != nil
-            || environment["XCTestSessionIdentifier"] != nil
-            || environment["TESTING_LIBRARY_VERSION"] != nil
-            || environment["SWIFT_TESTING"] != nil
-            || environment["SWIFT_TESTING_ENABLED"] != nil
+        TestProcessSafety.isRunningUnderTests(
+            processName: processName,
+            environment: environment)
     }
 }
 

--- a/Sources/CodexBarCore/TestProcessSafety.swift
+++ b/Sources/CodexBarCore/TestProcessSafety.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+package enum TestProcessSafety {
+    package static func isRunningUnderTests(
+        processName: String = ProcessInfo.processInfo.processName,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        hasLoadedXCTestCase: Bool = false) -> Bool
+    {
+        hasLoadedXCTestCase
+            || processName == "swiftpm-testing-helper"
+            || processName.hasSuffix("PackageTests")
+            || processName.hasSuffix(".xctest")
+            || environment["XCTestConfigurationFilePath"] != nil
+            || environment["XCTestBundlePath"] != nil
+            || environment["XCTestSessionIdentifier"] != nil
+            || environment["TESTING_LIBRARY_VERSION"] != nil
+            || environment["SWIFT_TESTING"] != nil
+            || environment["SWIFT_TESTING_ENABLED"] != nil
+    }
+}

--- a/Tests/CodexBarTests/AppGroupSupportTests.swift
+++ b/Tests/CodexBarTests/AppGroupSupportTests.swift
@@ -33,89 +33,229 @@ struct AppGroupSupportTests {
 
     @Test
     func `legacy migration copies snapshot once`() throws {
-        let fileManager = FileManager.default
-        let root = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
-        defer { try? fileManager.removeItem(at: root) }
+        let fixture = try MigrationFixture()
+        defer { fixture.cleanUp() }
+        fixture.legacyDefaults.set(true, forKey: "debugDisableKeychainAccess")
+        fixture.legacyDefaults.set(UsageProvider.cursor.rawValue, forKey: "widgetSelectedProvider")
+        try fixture.writeSnapshot("legacy-snapshot", to: fixture.legacySnapshotURL)
 
-        let standardSuite = "AppGroupSupportTests-standard-\(UUID().uuidString)"
-        let currentSuite = "AppGroupSupportTests-current-\(UUID().uuidString)"
-        let legacySuite = "AppGroupSupportTests-legacy-\(UUID().uuidString)"
-
-        let standardDefaults = try #require(UserDefaults(suiteName: standardSuite))
-        let currentDefaults = try #require(UserDefaults(suiteName: currentSuite))
-        let legacyDefaults = try #require(UserDefaults(suiteName: legacySuite))
-        standardDefaults.removePersistentDomain(forName: standardSuite)
-        currentDefaults.removePersistentDomain(forName: currentSuite)
-        legacyDefaults.removePersistentDomain(forName: legacySuite)
-
-        legacyDefaults.set(true, forKey: "debugDisableKeychainAccess")
-        legacyDefaults.set(UsageProvider.cursor.rawValue, forKey: "widgetSelectedProvider")
-
-        let legacySnapshotURL = root.appendingPathComponent(
-            "legacy/widget-snapshot.json",
-            isDirectory: false)
-        try fileManager.createDirectory(
-            at: legacySnapshotURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true)
-        try Data("legacy-snapshot".utf8).write(to: legacySnapshotURL)
-
-        let currentSnapshotURL = root.appendingPathComponent("current/widget-snapshot.json", isDirectory: false)
-        let result = AppGroupSupport.migrateLegacyDataIfNeeded(
-            bundleID: "com.steipete.codexbar",
-            standardDefaults: standardDefaults,
-            currentDefaultsOverride: currentDefaults,
-            legacyDefaultsOverride: legacyDefaults,
-            currentSnapshotURLOverride: currentSnapshotURL,
-            legacySnapshotURLOverride: legacySnapshotURL)
+        let result = fixture.migrate()
 
         #expect(result.status == .migrated)
         #expect(result.copiedSnapshot)
         #expect(result.copiedDefaults == 2)
-        #expect(currentDefaults.bool(forKey: "debugDisableKeychainAccess"))
-        #expect(currentDefaults.string(forKey: "widgetSelectedProvider") == UsageProvider.cursor.rawValue)
-        #expect(fileManager.fileExists(atPath: currentSnapshotURL.path))
+        #expect(fixture.currentDefaults.bool(forKey: "debugDisableKeychainAccess"))
+        #expect(fixture.currentDefaults.string(forKey: "widgetSelectedProvider") == UsageProvider.cursor.rawValue)
+        #expect(try Data(contentsOf: fixture.currentSnapshotURL) == Data("legacy-snapshot".utf8))
         #expect(
-            standardDefaults.integer(forKey: AppGroupSupport.migrationVersionKey)
+            fixture.standardDefaults.integer(forKey: AppGroupSupport.migrationVersionKey)
                 == AppGroupSupport.migrationVersion)
+        #expect(fixture.fileManager.operations == [
+            .exists(fixture.currentSnapshotURL.path),
+            .exists(fixture.legacySnapshotURL.path),
+            .createDirectory(fixture.currentSnapshotURL.deletingLastPathComponent()),
+            .copy(fixture.legacySnapshotURL, fixture.currentSnapshotURL),
+        ])
 
-        let secondResult = AppGroupSupport.migrateLegacyDataIfNeeded(
-            bundleID: "com.steipete.codexbar",
-            standardDefaults: standardDefaults,
-            currentDefaultsOverride: currentDefaults,
-            legacyDefaultsOverride: legacyDefaults,
-            currentSnapshotURLOverride: currentSnapshotURL,
-            legacySnapshotURLOverride: legacySnapshotURL)
+        try fixture.writeSnapshot("changed-legacy-snapshot", to: fixture.legacySnapshotURL)
+        fixture.fileManager.operations.removeAll()
+        let secondResult = fixture.migrate()
         #expect(secondResult.status == .alreadyCompleted)
+        #expect(!secondResult.copiedSnapshot)
+        #expect(secondResult.copiedDefaults == 0)
+        #expect(fixture.fileManager.operations.isEmpty)
+        #expect(try Data(contentsOf: fixture.currentSnapshotURL) == Data("legacy-snapshot".utf8))
     }
 
     @Test
     func `legacy migration preserves existing target shared defaults`() throws {
-        let standardSuite = "AppGroupSupportTests-standard-existing-\(UUID().uuidString)"
-        let currentSuite = "AppGroupSupportTests-current-existing-\(UUID().uuidString)"
-        let legacySuite = "AppGroupSupportTests-legacy-existing-\(UUID().uuidString)"
+        let fixture = try MigrationFixture()
+        defer { fixture.cleanUp() }
+        fixture.currentDefaults.set(false, forKey: "debugDisableKeychainAccess")
+        fixture.currentDefaults.set(UsageProvider.codex.rawValue, forKey: "widgetSelectedProvider")
+        fixture.legacyDefaults.set(true, forKey: "debugDisableKeychainAccess")
+        fixture.legacyDefaults.set(UsageProvider.cursor.rawValue, forKey: "widgetSelectedProvider")
 
-        let standardDefaults = try #require(UserDefaults(suiteName: standardSuite))
-        let currentDefaults = try #require(UserDefaults(suiteName: currentSuite))
-        let legacyDefaults = try #require(UserDefaults(suiteName: legacySuite))
-        standardDefaults.removePersistentDomain(forName: standardSuite)
-        currentDefaults.removePersistentDomain(forName: currentSuite)
-        legacyDefaults.removePersistentDomain(forName: legacySuite)
-
-        currentDefaults.set(false, forKey: "debugDisableKeychainAccess")
-        currentDefaults.set(UsageProvider.codex.rawValue, forKey: "widgetSelectedProvider")
-        legacyDefaults.set(true, forKey: "debugDisableKeychainAccess")
-        legacyDefaults.set(UsageProvider.cursor.rawValue, forKey: "widgetSelectedProvider")
-
-        let result = AppGroupSupport.migrateLegacyDataIfNeeded(
-            bundleID: "com.steipete.codexbar",
-            standardDefaults: standardDefaults,
-            currentDefaultsOverride: currentDefaults,
-            legacyDefaultsOverride: legacyDefaults)
+        let result = fixture.migrate()
 
         #expect(result.status == .noChangesNeeded)
+        #expect(!result.copiedSnapshot)
         #expect(result.copiedDefaults == 0)
-        #expect(!currentDefaults.bool(forKey: "debugDisableKeychainAccess"))
-        #expect(currentDefaults.string(forKey: "widgetSelectedProvider") == UsageProvider.codex.rawValue)
+        #expect(!fixture.currentDefaults.bool(forKey: "debugDisableKeychainAccess"))
+        #expect(fixture.currentDefaults.string(forKey: "widgetSelectedProvider") == UsageProvider.codex.rawValue)
+        #expect(!FileManager.default.fileExists(atPath: fixture.currentSnapshotURL.path))
+        #expect(fixture.fileManager.operations == [
+            .exists(fixture.currentSnapshotURL.path),
+            .exists(fixture.legacySnapshotURL.path),
+        ])
+    }
+
+    @Test
+    func `legacy migration preserves existing target snapshot bytes`() throws {
+        let fixture = try MigrationFixture()
+        defer { fixture.cleanUp() }
+        try fixture.writeSnapshot("current-snapshot", to: fixture.currentSnapshotURL)
+        try fixture.writeSnapshot("legacy-snapshot", to: fixture.legacySnapshotURL)
+
+        let result = fixture.migrate()
+
+        #expect(result.status == .noChangesNeeded)
+        #expect(!result.copiedSnapshot)
+        #expect(result.copiedDefaults == 0)
+        #expect(try Data(contentsOf: fixture.currentSnapshotURL) == Data("current-snapshot".utf8))
+        #expect(fixture.fileManager.operations == [.exists(fixture.currentSnapshotURL.path)])
+    }
+
+    @Test
+    func `legacy migration completes when synthetic legacy data is absent`() throws {
+        let fixture = try MigrationFixture()
+        defer { fixture.cleanUp() }
+
+        let result = fixture.migrate()
+
+        #expect(result.status == .noChangesNeeded)
+        #expect(!result.copiedSnapshot)
+        #expect(result.copiedDefaults == 0)
+        #expect(fixture.currentDefaults.dictionaryRepresentation().isEmpty)
+        #expect(
+            fixture.standardDefaults.integer(forKey: AppGroupSupport.migrationVersionKey)
+                == AppGroupSupport.migrationVersion)
+        #expect(fixture.fileManager.operations == [
+            .exists(fixture.currentSnapshotURL.path),
+            .exists(fixture.legacySnapshotURL.path),
+        ])
+    }
+
+    @Test
+    func `unavailable synthetic target does not mark migration complete`() throws {
+        let fixture = try MigrationFixture()
+        defer { fixture.cleanUp() }
+
+        let result = fixture.migrate(currentDefaultsAvailable: false)
+
+        #expect(result.status == .targetUnavailable)
+        #expect(!result.copiedSnapshot)
+        #expect(result.copiedDefaults == 0)
+        #expect(fixture.standardDefaults.object(forKey: AppGroupSupport.migrationVersionKey) == nil)
+        #expect(fixture.fileManager.operations == [.containerLookup])
+    }
+}
+
+private struct MigrationFixture {
+    let root: URL
+    let standardDefaults = InMemoryUserDefaults()
+    let currentDefaults = InMemoryUserDefaults()
+    let legacyDefaults = InMemoryUserDefaults()
+    let fileManager: MigrationFileManager
+
+    var currentSnapshotURL: URL {
+        self.root.appendingPathComponent("current/widget-snapshot.json")
+    }
+
+    var legacySnapshotURL: URL {
+        self.root.appendingPathComponent("legacy/widget-snapshot.json")
+    }
+
+    init() throws {
+        self.root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppGroupSupportTests-\(UUID().uuidString)", isDirectory: true)
+        self.fileManager = MigrationFileManager(root: self.root)
+        try FileManager.default.createDirectory(at: self.root, withIntermediateDirectories: true)
+    }
+
+    func writeSnapshot(_ value: String, to url: URL) throws {
+        try self.fileManager.requireContained(url)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(value.utf8).write(to: url)
+    }
+
+    func migrate(currentDefaultsAvailable: Bool = true) -> AppGroupSupport.MigrationResult {
+        // nil is intentional only for the unavailable-target case: container lookup is stubbed to nil.
+        AppGroupSupport.migrateLegacyDataIfNeeded(
+            bundleID: "com.steipete.codexbar",
+            standardDefaults: self.standardDefaults,
+            fileManager: self.fileManager,
+            homeDirectory: self.root.appendingPathComponent("home", isDirectory: true),
+            currentDefaultsOverride: currentDefaultsAvailable ? self.currentDefaults : nil,
+            legacyDefaultsOverride: self.legacyDefaults,
+            currentSnapshotURLOverride: self.currentSnapshotURL,
+            legacySnapshotURLOverride: self.legacySnapshotURL)
+    }
+
+    func cleanUp() {
+        do {
+            try FileManager.default.removeItem(at: self.root)
+        } catch {
+            Issue.record("Could not remove synthetic migration fixture: \(error)")
+        }
+    }
+}
+
+private final class MigrationFileManager: FileManager, @unchecked Sendable {
+    enum Operation: Equatable {
+        case containerLookup
+        case homeLookup
+        case searchPathLookup
+        case exists(String)
+        case createDirectory(URL)
+        case copy(URL, URL)
+    }
+
+    let root: URL
+    private let backing = FileManager()
+    var operations: [Operation] = []
+
+    init(root: URL) {
+        self.root = root
+        super.init()
+    }
+
+    override func containerURL(forSecurityApplicationGroupIdentifier _: String) -> URL? {
+        self.operations.append(.containerLookup)
+        return nil
+    }
+
+    override var homeDirectoryForCurrentUser: URL {
+        self.operations.append(.homeLookup)
+        return self.root.appendingPathComponent("home", isDirectory: true)
+    }
+
+    override func urls(for _: SearchPathDirectory, in _: SearchPathDomainMask) -> [URL] {
+        self.operations.append(.searchPathLookup)
+        return []
+    }
+
+    override func fileExists(atPath path: String) -> Bool {
+        self.operations.append(.exists(path))
+        guard (try? self.requireContained(URL(fileURLWithPath: path))) != nil else { return false }
+        return self.backing.fileExists(atPath: path)
+    }
+
+    override func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]? = nil) throws
+    {
+        self.operations.append(.createDirectory(url))
+        try self.requireContained(url)
+        try self.backing.createDirectory(
+            at: url,
+            withIntermediateDirectories: createIntermediates,
+            attributes: attributes)
+    }
+
+    override func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        self.operations.append(.copy(srcURL, dstURL))
+        try self.requireContained(srcURL)
+        try self.requireContained(dstURL)
+        try self.backing.copyItem(at: srcURL, to: dstURL)
+    }
+
+    func requireContained(_ url: URL) throws {
+        let path = url.standardizedFileURL.path
+        guard path == self.root.path || path.hasPrefix(self.root.path + "/") else {
+            Issue.record("Migration attempted an operation outside its synthetic root: \(url)")
+            throw CocoaError(.fileReadNoPermission)
+        }
     }
 }

--- a/Tests/CodexBarTests/KeychainAccessGateDefaultsTests.swift
+++ b/Tests/CodexBarTests/KeychainAccessGateDefaultsTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct KeychainAccessGateDefaultsTests {
+    @Test(arguments: [
+        ("swiftpm-testing-helper", [:]),
+        ("CodexBarPackageTests", [:]),
+        ("test-child", ["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS": "1"]),
+        ("test-child", ["SWIFT_TESTING": "1"]),
+    ] as [(String, [String: String])])
+    func `uninitialized gate fallback never resolves defaults under automatic test safety`(
+        processName: String,
+        environment: [String: String])
+    {
+        var resolutions: [String] = []
+        let defaults = InMemoryUserDefaults()
+        defaults.set(true, forKey: "debugDisableKeychainAccess")
+
+        let explicitlyDisabled = KeychainAccessGate.defaultsDisableAccess(
+            processName: processName,
+            environment: environment,
+            standardDefaults: {
+                resolutions.append("standard")
+                return defaults
+            },
+            sharedDefaults: {
+                resolutions.append("shared")
+                return defaults
+            })
+
+        #expect(!explicitlyDisabled)
+        #expect(resolutions.isEmpty)
+    }
+
+    @Test(arguments: [nil, false, true] as [Bool?], [nil, false, true] as [Bool?])
+    func `deliberate live opt in retains defaults fallback without accessing live stores`(
+        standardValue: Bool?, sharedValue: Bool?)
+    {
+        let standard = InMemoryUserDefaults()
+        let shared = InMemoryUserDefaults()
+        if let standardValue {
+            standard.set(standardValue, forKey: "debugDisableKeychainAccess")
+        }
+        if let sharedValue {
+            shared.set(sharedValue, forKey: "debugDisableKeychainAccess")
+        }
+        var resolutions: [String] = []
+
+        let explicitlyDisabled = KeychainAccessGate.defaultsDisableAccess(
+            processName: "swiftpm-testing-helper",
+            environment: [
+                "CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS": "1",
+                "CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS": "1",
+            ],
+            standardDefaults: {
+                resolutions.append("standard")
+                return standard
+            },
+            sharedDefaults: {
+                resolutions.append("shared")
+                return shared
+            })
+
+        #expect(explicitlyDisabled == (standardValue == true || sharedValue == true))
+        #expect(resolutions == (standardValue == true ? ["standard"] : ["standard", "shared"]))
+    }
+
+    @Test
+    func `production fallback still uses the supplied defaults`() {
+        let shared = InMemoryUserDefaults()
+        shared.set(true, forKey: "debugDisableKeychainAccess")
+
+        #expect(KeychainAccessGate.defaultsDisableAccess(
+            processName: "CodexBar",
+            environment: [:],
+            standardDefaults: { InMemoryUserDefaults() },
+            sharedDefaults: { shared }))
+    }
+
+    @Test(arguments: [false, true])
+    func `automatic suppression is distinct from an explicit stored override`(disabled: Bool) throws {
+        try self.requireOrdinaryTestSafety()
+        KeychainAccessGate.withStoredOverrideForTesting(disabled) {
+            #expect(KeychainAccessGate.isDisabled)
+            #expect(KeychainAccessGate.isExplicitlyDisabled == disabled)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `task override keeps precedence over automatic safety and stored overrides`(disabled: Bool) {
+        KeychainAccessGate.withStoredOverrideForTesting(!disabled) {
+            KeychainAccessGate.withTaskOverrideForTesting(disabled) {
+                #expect(KeychainAccessGate.isDisabled == disabled)
+                #expect(KeychainAccessGate.isExplicitlyDisabled == disabled)
+            }
+        }
+    }
+
+    private func requireOrdinaryTestSafety() throws {
+        try #require(KeychainTestSafety.resolveShouldBlockRealKeychainAccess(
+            processName: ProcessInfo.processInfo.processName,
+            environment: ProcessInfo.processInfo.environment))
+        try #require(!KeychainAccessGate.isDisabledByEnvironment())
+        try #require(KeychainAccessGate.processDisableReason == nil)
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2336,7 +2336,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1192,
+            line: 1203,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,

--- a/Tests/CodexBarTests/SettingsStoreKeychainPreferenceTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreKeychainPreferenceTests.swift
@@ -1,21 +1,17 @@
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
+@Suite(.serialized)
 @MainActor
 struct SettingsStoreKeychainPreferenceTests {
     @Test(arguments: [nil, false, true] as [Bool?], [nil, false, true] as [Bool?])
     func `local keychain preference wins and shared defaults fill only an absent value`(
-        localValue: Bool?, sharedValue: Bool?) throws
+        localValue: Bool?, sharedValue: Bool?)
     {
-        let localSuite = "SettingsStoreKeychainPreferenceTests-local-\(UUID().uuidString)"
-        let sharedSuite = "SettingsStoreKeychainPreferenceTests-shared-\(UUID().uuidString)"
-        let local = try #require(UserDefaults(suiteName: localSuite))
-        let shared = try #require(UserDefaults(suiteName: sharedSuite))
-        defer {
-            local.removePersistentDomain(forName: localSuite)
-            shared.removePersistentDomain(forName: sharedSuite)
-        }
+        let local = InMemoryUserDefaults()
+        let shared = InMemoryUserDefaults()
         if let localValue {
             local.set(localValue, forKey: "debugDisableKeychainAccess")
         }
@@ -26,6 +22,111 @@ struct SettingsStoreKeychainPreferenceTests {
         let disabled = SettingsStore.loadDebugDisableKeychainAccess(userDefaults: local, sharedDefaults: shared)
 
         #expect(disabled == (localValue ?? sharedValue ?? false))
+        #expect(local.object(forKey: "debugDisableKeychainAccess") as? Bool == (localValue ?? sharedValue))
         #expect(shared.object(forKey: "debugDisableKeychainAccess") as? Bool == sharedValue)
+    }
+
+    @Test
+    func `ordinary tests never invoke the shared defaults resolver`() throws {
+        try #require(SettingsStore.isRunningTests)
+        var resolutions = 0
+        let shared = SettingsStore.resolveSharedDefaults {
+            resolutions += 1
+            return InMemoryUserDefaults()
+        }
+
+        #expect(shared == nil)
+        #expect(resolutions == 0)
+        #expect(SettingsStore.sharedDefaults == nil)
+        let local = InMemoryUserDefaults()
+        #expect(!SettingsStore.shouldBridgeSharedDefaults(for: local))
+        #expect(!SettingsStore.loadDebugDisableKeychainAccess(userDefaults: local))
+        #expect(local.dictionaryRepresentation().isEmpty)
+    }
+
+    @Test
+    func `settings initialization leaves app group migration untouched and fresh defaults adaptive`() throws {
+        let local = InMemoryUserDefaults()
+        try self.withSettingsStore(defaults: local) { store in
+            #expect(local.object(forKey: AppGroupSupport.migrationVersionKey) == nil)
+            #expect(local.object(forKey: "widgetSelectedProvider") == nil)
+            #expect(!store.debugDisableKeychainAccess)
+            #expect(store.refreshFrequency == .adaptive)
+            // Config/secret migration remains independent of app-group migration.
+            #expect(local.bool(forKey: "codexbar.legacySecretsMigrationCompleted"))
+
+            store.debugDisableKeychainAccess = true
+            #expect(local.bool(forKey: "debugDisableKeychainAccess"))
+            store.debugDisableKeychainAccess = false
+            #expect(!local.bool(forKey: "debugDisableKeychainAccess"))
+            #expect(local.object(forKey: AppGroupSupport.migrationVersionKey) == nil)
+            #expect(SettingsStore.sharedDefaults == nil)
+        }
+    }
+
+    @Test(arguments: ["providerDetectionCompleted", AppGroupSupport.migrationVersionKey])
+    func `existing launch markers still keep the legacy refresh default`(marker: String) throws {
+        let local = InMemoryUserDefaults()
+        local.set(1, forKey: marker)
+        try self.withSettingsStore(defaults: local) { store in
+            #expect(store.refreshFrequency == .fiveMinutes)
+            #expect(local.integer(forKey: marker) == 1)
+            if marker != AppGroupSupport.migrationVersionKey {
+                #expect(local.object(forKey: AppGroupSupport.migrationVersionKey) == nil)
+            }
+        }
+    }
+
+    private func withSettingsStore(
+        defaults: InMemoryUserDefaults,
+        operation: (SettingsStore) throws -> Void) throws
+    {
+        // Fail before constructing settings if the caller deliberately opted into live user state.
+        try #require(SettingsStore.isRunningTests)
+        try #require(KeychainTestSafety.resolveShouldBlockRealKeychainAccess(
+            processName: ProcessInfo.processInfo.processName,
+            environment: ProcessInfo.processInfo.environment))
+        try #require(!KeychainAccessGate.isDisabledByEnvironment())
+        try #require(KeychainAccessGate.processDisableReason == nil)
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SettingsStoreKeychainPreferenceTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            do {
+                try FileManager.default.removeItem(at: root)
+            } catch {
+                Issue.record("Could not remove synthetic settings fixture: \(error)")
+            }
+        }
+        let previousOverride = KeychainAccessGate.currentOverrideForTesting
+        defer {
+            if let previousOverride {
+                KeychainAccessGate.isDisabled = previousOverride
+            } else {
+                KeychainAccessGate.resetOverrideForTesting()
+            }
+        }
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: CodexBarConfigStore(fileURL: root.appendingPathComponent("config.json")),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore(fileURL: root.appendingPathComponent("accounts.json")),
+            antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore(
+                fileURL: root.appendingPathComponent("antigravity.json")),
+            performInitialProviderDetection: false)
+        defer { store.configFileWatcher?.stop() }
+        try operation(store)
     }
 }

--- a/Tests/CodexBarTests/SettingsStoreKeychainPreferenceTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreKeychainPreferenceTests.swift
@@ -45,22 +45,47 @@ struct SettingsStoreKeychainPreferenceTests {
     }
 
     @Test
-    func `settings initialization leaves app group migration untouched and fresh defaults adaptive`() throws {
+    func `settings test detection uses the shared runner detector and XCTest fallback`() {
+        #expect(SettingsStore.resolveIsRunningTests(
+            processName: "swiftpm-testing-helper",
+            environment: [:],
+            hasLoadedXCTestCase: false))
+        #expect(SettingsStore.resolveIsRunningTests(
+            processName: "CodexBar",
+            environment: [:],
+            hasLoadedXCTestCase: true))
+        #expect(!SettingsStore.resolveIsRunningTests(
+            processName: "CodexBar",
+            environment: [:],
+            hasLoadedXCTestCase: false))
+    }
+
+    @Test(arguments: [false, true])
+    func `settings initialization isolates app group migration and keychain policy`(disabled: Bool) throws {
         let local = InMemoryUserDefaults()
-        try self.withSettingsStore(defaults: local) { store in
+        local.set(disabled, forKey: "debugDisableKeychainAccess")
+        var keychainAccessValues: [Bool] = []
+        let keychainAccessPolicy = SettingsStoreKeychainAccessPolicy(
+            setDisabled: { keychainAccessValues.append($0) },
+            isExplicitlyDisabled: { keychainAccessValues.last ?? false })
+        try self.withSettingsStore(
+            defaults: local,
+            keychainAccessPolicy: keychainAccessPolicy)
+        { store in
             #expect(local.object(forKey: AppGroupSupport.migrationVersionKey) == nil)
             #expect(local.object(forKey: "widgetSelectedProvider") == nil)
-            #expect(!store.debugDisableKeychainAccess)
+            #expect(store.debugDisableKeychainAccess == disabled)
             #expect(store.refreshFrequency == .adaptive)
             // Config/secret migration remains independent of app-group migration.
-            #expect(local.bool(forKey: "codexbar.legacySecretsMigrationCompleted"))
+            #expect(local.bool(forKey: "codexbar.legacySecretsMigrationCompleted") == !disabled)
 
-            store.debugDisableKeychainAccess = true
-            #expect(local.bool(forKey: "debugDisableKeychainAccess"))
-            store.debugDisableKeychainAccess = false
-            #expect(!local.bool(forKey: "debugDisableKeychainAccess"))
+            store.debugDisableKeychainAccess = !disabled
+            #expect(local.bool(forKey: "debugDisableKeychainAccess") == !disabled)
+            store.debugDisableKeychainAccess = disabled
+            #expect(local.bool(forKey: "debugDisableKeychainAccess") == disabled)
             #expect(local.object(forKey: AppGroupSupport.migrationVersionKey) == nil)
             #expect(SettingsStore.sharedDefaults == nil)
+            #expect(keychainAccessValues == [disabled, disabled, !disabled, disabled])
         }
     }
 
@@ -79,6 +104,9 @@ struct SettingsStoreKeychainPreferenceTests {
 
     private func withSettingsStore(
         defaults: InMemoryUserDefaults,
+        keychainAccessPolicy: SettingsStoreKeychainAccessPolicy = SettingsStoreKeychainAccessPolicy(
+            setDisabled: { _ in },
+            isExplicitlyDisabled: { false }),
         operation: (SettingsStore) throws -> Void) throws
     {
         // Fail before constructing settings if the caller deliberately opted into live user state.
@@ -96,14 +124,6 @@ struct SettingsStoreKeychainPreferenceTests {
                 try FileManager.default.removeItem(at: root)
             } catch {
                 Issue.record("Could not remove synthetic settings fixture: \(error)")
-            }
-        }
-        let previousOverride = KeychainAccessGate.currentOverrideForTesting
-        defer {
-            if let previousOverride {
-                KeychainAccessGate.isDisabled = previousOverride
-            } else {
-                KeychainAccessGate.resetOverrideForTesting()
             }
         }
         let store = SettingsStore(
@@ -125,6 +145,7 @@ struct SettingsStoreKeychainPreferenceTests {
             tokenAccountStore: InMemoryTokenAccountStore(fileURL: root.appendingPathComponent("accounts.json")),
             antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore(
                 fileURL: root.appendingPathComponent("antigravity.json")),
+            keychainAccessPolicy: keychainAccessPolicy,
             performInitialProviderDetection: false)
         defer { store.configFileWatcher?.stop() }
         try operation(store)

--- a/Tests/CodexBarTests/TestProcessSafetyTests.swift
+++ b/Tests/CodexBarTests/TestProcessSafetyTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import CodexBarCore
+
+struct TestProcessSafetyTests {
+    @Test(arguments: [
+        ("swiftpm-testing-helper", [:]),
+        ("CodexBarPackageTests", [:]),
+        ("CodexBarPackageTests.xctest", [:]),
+        ("CodexBar", ["XCTestConfigurationFilePath": "fixture"]),
+        ("CodexBar", ["XCTestBundlePath": "fixture"]),
+        ("CodexBar", ["XCTestSessionIdentifier": "fixture"]),
+        ("CodexBar", ["TESTING_LIBRARY_VERSION": "fixture"]),
+        ("CodexBar", ["SWIFT_TESTING": "fixture"]),
+        ("CodexBar", ["SWIFT_TESTING_ENABLED": "fixture"]),
+    ] as [(String, [String: String])])
+    func `recognizes every supported runner signal`(
+        processName: String,
+        environment: [String: String])
+    {
+        #expect(TestProcessSafety.isRunningUnderTests(
+            processName: processName,
+            environment: environment))
+    }
+
+    @Test
+    func `recognizes the loaded XCTest fallback without class lookup side effects`() {
+        #expect(TestProcessSafety.isRunningUnderTests(
+            processName: "CodexBar",
+            environment: [:],
+            hasLoadedXCTestCase: true))
+    }
+
+    @Test
+    func `does not classify an ordinary app process as a test runner`() {
+        #expect(!TestProcessSafety.isRunningUnderTests(
+            processName: "CodexBar",
+            environment: [:]))
+    }
+}

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -5,6 +5,93 @@ import Foundation
 import AppKit
 #endif
 
+/// No Foundation search-domain fallback or persistent writes, including for absent keys.
+final class InMemoryUserDefaults: UserDefaults, @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String: Any]
+
+    init(values: [String: Any] = [:]) {
+        self.values = values
+        super.init(suiteName: "InMemoryUserDefaults-\(UUID().uuidString)")!
+    }
+
+    override func object(forKey defaultName: String) -> Any? {
+        self.lock.withLock { self.values[defaultName] }
+    }
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        self.lock.withLock { self.values[defaultName] = value }
+    }
+
+    override func removeObject(forKey defaultName: String) {
+        self.set(nil as Any?, forKey: defaultName)
+    }
+
+    override func bool(forKey defaultName: String) -> Bool {
+        (self.object(forKey: defaultName) as? NSNumber)?.boolValue ?? false
+    }
+
+    override func integer(forKey defaultName: String) -> Int {
+        (self.object(forKey: defaultName) as? NSNumber)?.intValue ?? 0
+    }
+
+    override func float(forKey defaultName: String) -> Float {
+        (self.object(forKey: defaultName) as? NSNumber)?.floatValue ?? 0
+    }
+
+    override func double(forKey defaultName: String) -> Double {
+        (self.object(forKey: defaultName) as? NSNumber)?.doubleValue ?? 0
+    }
+
+    override func string(forKey defaultName: String) -> String? {
+        self.object(forKey: defaultName) as? String
+    }
+
+    override func array(forKey defaultName: String) -> [Any]? {
+        self.object(forKey: defaultName) as? [Any]
+    }
+
+    override func dictionary(forKey defaultName: String) -> [String: Any]? {
+        self.object(forKey: defaultName) as? [String: Any]
+    }
+
+    override func data(forKey defaultName: String) -> Data? {
+        self.object(forKey: defaultName) as? Data
+    }
+
+    override func stringArray(forKey defaultName: String) -> [String]? {
+        self.object(forKey: defaultName) as? [String]
+    }
+
+    override func url(forKey defaultName: String) -> URL? {
+        self.object(forKey: defaultName) as? URL
+    }
+
+    override func set(_ value: Bool, forKey defaultName: String) {
+        self.set(value as Any, forKey: defaultName)
+    }
+
+    override func set(_ value: Int, forKey defaultName: String) {
+        self.set(value as Any, forKey: defaultName)
+    }
+
+    override func set(_ value: Float, forKey defaultName: String) {
+        self.set(value as Any, forKey: defaultName)
+    }
+
+    override func set(_ value: Double, forKey defaultName: String) {
+        self.set(value as Any, forKey: defaultName)
+    }
+
+    override func set(_ url: URL?, forKey defaultName: String) {
+        self.set(url as Any?, forKey: defaultName)
+    }
+
+    override func dictionaryRepresentation() -> [String: Any] {
+        self.lock.withLock { self.values }
+    }
+}
+
 final class InMemoryCookieHeaderStore: CookieHeaderStoring, @unchecked Sendable {
     var value: String?
 


### PR DESCRIPTION
## Summary

Prevent app-group and settings tests from discovering or copying real user state. This is a test-safety fix found during the cached-menu-render timing investigation in #3360, not a rendering change.

- Skip app-group discovery, shared-defaults bridging, and migration during ordinary `SettingsStore` test initialization. Production migration scheduling and logic remain unchanged.
- Share one complete test-runner detector between settings isolation and Keychain safety, including Swift Testing and XCTest process/environment variants.
- Keep automatic test suppression separate from explicit Keychain policy, preserve deliberate live-test opt-in, and inject a paired read/write policy so fixtures never race through process-global Keychain state.
- Use dictionary-backed defaults, explicit synthetic home and snapshot URLs, and a recording `FileManager` that rejects operations outside the migration fixture.
- Document the durable isolation contract in `AGENTS.md`.

## Regression coverage

Covers every supported runner signal, automatic suppression versus deliberate live opt-in, stored Keychain policy in both states, snapshot copying once, preservation of existing target defaults and snapshot bytes, missing legacy data, unavailable targets, settings initialization leaving app-group migration untouched, and fresh versus existing-install refresh defaults.

## Validation

- `make check` passed, including SwiftFormat and strict SwiftLint.
- Focused settings, app-group, Keychain, detector, and architecture-gate suites passed.
- Full local `make test` passed all 994 selections in 83 groups on the first attempt, with zero retries or timeouts. The run used a task-owned SwiftPM scratch path and a 300-second local group ceiling to accommodate this machine's slower AppKit and cost-history groups.
- Exact-head CI passed all jobs on `7e86e9aa48a6e1cdac21c2d900dfaa1c551ec665`: lint, both macOS shards, Linux x64/arm64, Linux musl, path detection, and aggregate verification ([run 33598496755](https://github.com/steipete/CodexBar/actions/runs/33598496755)).
- Final branch autoreview found no actionable P0-P2 issues.

No live provider, browser-cookie, or real Keychain validation was run; all proof used contained fixtures and explicit test isolation.
