### PR TITLE
test: fix MiMo cache publication hooks across Python versions

### DIFF
--- a/Scripts/test_mimo_usage.py
+++ b/Scripts/test_mimo_usage.py
@@ -2,7 +2,6 @@
 
 import importlib.util
 import json
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 import tempfile
@@ -25,19 +24,36 @@ class MiMoUsageCacheTests(unittest.TestCase):
     def test_concurrent_writers_publish_without_colliding(self):
         module = load_mimo_usage()
         original_cache_path = module.CACHE_PATH
-        original_replace = os.replace
-        replace_barrier = threading.Barrier(2)
+        original_replace = Path.replace
         failures = []
         payloads = []
-
-        def synchronized_replace(source, destination):
-            replace_barrier.wait(timeout=10)
-            return original_replace(source, destination)
+        temporary_paths = []
+        staged_payloads = []
 
         with tempfile.TemporaryDirectory(prefix="codexbar-mimo-cache-") as root:
             cache_path = Path(root) / "usage.json"
             module.CACHE_PATH = cache_path
             try:
+                def inspect_staged_payloads():
+                    self.assertEqual(len(temporary_paths), 2)
+                    self.assertEqual(len(set(temporary_paths)), 2)
+                    for path in temporary_paths:
+                        self.assertEqual(path.parent, cache_path.parent)
+                        self.assertTrue(path.name.startswith(f".{cache_path.name}."))
+                        self.assertEqual(path.suffix, ".tmp")
+                        staged_payloads.append(json.loads(path.read_text()))
+                    self.assertCountEqual([payload["sessions_scanned"] for payload in staged_payloads], [1, 2])
+                    self.assertFalse(cache_path.exists())
+
+                # The action runs while both writers are blocked, before either can publish.
+                replace_barrier = threading.Barrier(2, action=inspect_staged_payloads)
+
+                def synchronized_replace(source, destination):
+                    self.assertEqual(destination, cache_path)
+                    temporary_paths.append(source)
+                    replace_barrier.wait(timeout=10)
+                    return original_replace(source, destination)
+
                 def write_cache(writer_id):
                     try:
                         usage = {
@@ -53,7 +69,7 @@ class MiMoUsageCacheTests(unittest.TestCase):
                     except Exception as error:
                         failures.append(error)
 
-                with patch.object(os, "replace", synchronized_replace):
+                with patch.object(Path, "replace", synchronized_replace):
                     writers = [threading.Thread(target=write_cache, args=(index,)) for index in (1, 2)]
                     for writer in writers:
                         writer.start()
@@ -62,7 +78,9 @@ class MiMoUsageCacheTests(unittest.TestCase):
 
                 self.assertTrue(all(not writer.is_alive() for writer in writers))
                 self.assertEqual(failures, [])
+                self.assertEqual(len(temporary_paths), 2, "Both writers must reach the publication hook")
                 self.assertEqual(len(payloads), 2)
+                self.assertCountEqual(staged_payloads, payloads)
                 self.assertIn(json.loads(cache_path.read_text()), payloads)
                 self.assertEqual(list(Path(root).iterdir()), [cache_path])
             finally:
@@ -78,24 +96,44 @@ class MiMoUsageCacheTests(unittest.TestCase):
             ) as root:
                 cache_path = Path(root) / "usage.json"
                 other_writer = Path(root) / ".usage.json.other-writer.tmp"
-                cache_path.write_text('{"previous": "complete cache"}')
-                other_writer.write_text("another writer owns this file")
+                previous_cache = b'{"previous": "complete cache"}\n'
+                other_writer_contents = b"another writer owns this file"
+                cache_path.write_bytes(previous_cache)
+                other_writer.write_bytes(other_writer_contents)
+                failed_temporary_paths = []
 
                 def partial_write_then_fail(path, text, *args, **kwargs):
+                    failed_temporary_paths.append(path)
                     original_write_text(path, text[:10], *args, **kwargs)
+                    self.assertEqual(path.read_text(), text[:10])
                     raise OSError("synthetic write failure")
+
+                def fail_replace(path, destination):
+                    failed_temporary_paths.append(path)
+                    self.assertEqual(destination, cache_path)
+                    staged_payload = json.loads(path.read_text())
+                    self.assertEqual(staged_payload["windows"], {})
+                    self.assertEqual(staged_payload["sessions_scanned"], 0)
+                    raise OSError("synthetic replace failure")
 
                 failure = (
                     patch.object(Path, "write_text", partial_write_then_fail)
                     if failure_stage == "write"
-                    else patch.object(os, "replace", side_effect=OSError("synthetic replace failure"))
+                    else patch.object(Path, "replace", fail_replace)
                 )
                 with patch.object(module, "CACHE_PATH", cache_path), failure:
                     with self.assertRaisesRegex(OSError, f"synthetic {failure_stage} failure"):
                         module.write_cache({}, 0, None)
 
-                self.assertEqual(json.loads(cache_path.read_text()), {"previous": "complete cache"})
-                self.assertEqual(other_writer.read_text(), "another writer owns this file")
+                self.assertEqual(len(failed_temporary_paths), 1, "The failure hook must run exactly once")
+                failed_path = failed_temporary_paths[0]
+                self.assertEqual(failed_path.parent, cache_path.parent)
+                self.assertTrue(failed_path.name.startswith(f".{cache_path.name}."))
+                self.assertEqual(failed_path.suffix, ".tmp")
+                self.assertNotEqual(failed_path, other_writer)
+                self.assertFalse(failed_path.exists())
+                self.assertEqual(cache_path.read_bytes(), previous_cache)
+                self.assertEqual(other_writer.read_bytes(), other_writer_contents)
                 self.assertEqual(set(Path(root).iterdir()), {cache_path, other_writer})
 
 


### PR DESCRIPTION
## Summary

Fix the interpreter-dependent MiMo cache tests without changing production cache behavior. Python 3.9's `Path.replace` calls a prebound filesystem accessor, so patching `os.replace` neither injected the publication failure nor reliably synchronized concurrent writers.

The tests now patch `Path.replace`, the boundary actually invoked by the writer. Concurrent writers rendezvous with distinct, complete temporary payloads before delegating to the real replacement method. Explicit assertions reject a bypassed hook or barrier. Both partial-write and publication-failure cases verify that the previous cache and another writer's temporary file remain byte-for-byte intact, while the failed writer's temporary file is removed.

Only `Scripts/test_mimo_usage.py` changes; `Scripts/mimo-usage.py` is unchanged.

## Validation

- Reproduced the original `stage='replace': AssertionError: OSError not raised` under Xcode Python 3.9.6.
- Both focused tests pass with Python 3.9.6, 3.12.14, 3.13.15, and 3.14.7 using `PYTHONDONTWRITEBYTECODE=1 <interpreter> Scripts/test_mimo_usage.py -v`.
- Twenty concurrency repetitions pass per interpreter (80 total).
- Twelve synthetic negative controls are rejected as expected: bypassed publication hook, skipped barrier, and no-op publication on each interpreter.
- `make check` passes with Homebrew Python 3.14.7. On Xcode Python 3.9.6 it now passes the MiMo tests, then encounters the separate existing Swift-runner requirement for `os.waitid` with `WNOWAIT`.
- Local full `make test` was deliberately not run: this checkout's test initialization can run app-group migration against real saved data. All task-specific runtime proof uses temporary directories and synthetic data; no live provider probes, real-cache reads, or Keychain tests were used.
