### PR TITLE
fix(antigravity): get token history on Linux from SQLite logs

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -104,7 +104,7 @@ extension AntigravityLocalReader {
         let supported = try self.hasSupportedSQLiteTable(database, budget: budget)
         if let failure = progress.failure { throw failure }
         guard supported else { return SourceResult(isComplete: false) }
-        let sessionTimestamp = try self.readSessionTimestamp(database, budget: budget)
+        let sessionTimestampMs = try self.readSessionTimestamp(database, budget: budget)
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -120,14 +120,11 @@ extension AntigravityLocalReader {
         if let failure = progress.failure { throw failure }
         guard prepared == SQLITE_OK, let statement else { return SourceResult(isComplete: false) }
         sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
-        let rows = try self.readRows(
+        return try self.readRows(
             statement,
             session: url.deletingPathExtension().lastPathComponent,
-            sessionTimestampMs: sessionTimestamp.timestampMs,
+            sessionTimestampMs: sessionTimestampMs,
             progress: progress)
-        var result = rows
-        result.isComplete = result.isComplete && sessionTimestamp.isComplete
-        return result
         #else
         return SourceResult(isComplete: false)
         #endif
@@ -201,7 +198,7 @@ extension AntigravityLocalReader {
 
     private static func readSessionTimestamp(
         _ database: OpaquePointer,
-        budget: Budget) throws -> (timestampMs: Int64?, isComplete: Bool)
+        budget: Budget) throws -> Int64?
     {
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -215,28 +212,24 @@ extension AntigravityLocalReader {
             nil) == SQLITE_OK,
             let statement
         else {
-            return (nil, true)
+            return nil
         }
         let step = sqlite3_step(statement)
-        guard step == SQLITE_ROW else {
-            return step == SQLITE_DONE ? (nil, true) : (nil, false)
-        }
+        guard step == SQLITE_ROW else { return nil }
         guard sqlite3_column_type(statement, 0) == SQLITE_BLOB,
               let pointer = sqlite3_column_blob(statement, 0)
         else {
-            return (nil, false)
+            return nil
         }
         let count = Int(sqlite3_column_bytes(statement, 0))
-        guard count > 0 else { return (nil, false) }
+        guard count > 0 else { return nil }
         try budget.chargeBytes(count)
         let bytes = Array(UnsafeBufferPointer(
             start: pointer.assumingMemoryBound(to: UInt8.self), count: count))
         do {
-            return try (
-                AntigravityProtoReader.sessionCreatedTimestampMs(bytes, checkCancellation: budget.check),
-                true)
+            return try AntigravityProtoReader.sessionCreatedTimestampMs(bytes, checkCancellation: budget.check)
         } catch AntigravityLocalReader.ScanFailure.invalid {
-            return (nil, false)
+            return nil
         }
     }
     #endif

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -104,6 +104,7 @@ extension AntigravityLocalReader {
         let supported = try self.hasSupportedSQLiteTable(database, budget: budget)
         if let failure = progress.failure { throw failure }
         guard supported else { return SourceResult(isComplete: false) }
+        let sessionTimestamp = try self.readSessionTimestamp(database, budget: budget)
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -119,8 +120,14 @@ extension AntigravityLocalReader {
         if let failure = progress.failure { throw failure }
         guard prepared == SQLITE_OK, let statement else { return SourceResult(isComplete: false) }
         sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
-        return try self.readRows(
-            statement, session: url.deletingPathExtension().lastPathComponent, progress: progress)
+        let rows = try self.readRows(
+            statement,
+            session: url.deletingPathExtension().lastPathComponent,
+            sessionTimestampMs: sessionTimestamp.timestampMs,
+            progress: progress)
+        var result = rows
+        result.isComplete = result.isComplete && sessionTimestamp.isComplete
+        return result
         #else
         return SourceResult(isComplete: false)
         #endif
@@ -130,6 +137,7 @@ extension AntigravityLocalReader {
     private static func readRows(
         _ statement: OpaquePointer,
         session: String,
+        sessionTimestampMs: Int64?,
         progress: SQLProgress) throws -> SourceResult
     {
         let budget = progress.budget
@@ -173,16 +181,63 @@ extension AntigravityLocalReader {
                 continue
             }
             // Validate exactly once while the single SQL snapshot is held; buffer only typed events.
-            guard let turn = try AntigravityProtoReader.parseTurn(bytes, checkCancellation: budget.check),
-                  let event = Event(
-                      session: session, row: row, turn: turn, cacheWrite: 0)
+            guard let turn = try AntigravityProtoReader.parseTurn(
+                bytes,
+                sessionTimestampMs: sessionTimestampMs,
+                checkCancellation: budget.check)
             else {
+                result.isComplete = false
+                continue
+            }
+            if turn.isConversationAggregate { continue }
+            guard let event = Event(session: session, row: row, turn: turn, cacheWrite: 0) else {
                 result.isComplete = false
                 continue
             }
             result.events.append(event)
         }
         return result
+    }
+
+    private static func readSessionTimestamp(
+        _ database: OpaquePointer,
+        budget: Budget) throws -> (timestampMs: Int64?, isComplete: Bool)
+    {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        // This table is absent in older Antigravity databases. Its timestamp is only a
+        // session-start fallback for the newer opaque per-turn timestamp layout.
+        guard sqlite3_prepare_v2(
+            database,
+            "SELECT data FROM main.trajectory_metadata_blob LIMIT 1",
+            -1,
+            &statement,
+            nil) == SQLITE_OK,
+            let statement
+        else {
+            return (nil, true)
+        }
+        let step = sqlite3_step(statement)
+        guard step == SQLITE_ROW else {
+            return step == SQLITE_DONE ? (nil, true) : (nil, false)
+        }
+        guard sqlite3_column_type(statement, 0) == SQLITE_BLOB,
+              let pointer = sqlite3_column_blob(statement, 0)
+        else {
+            return (nil, false)
+        }
+        let count = Int(sqlite3_column_bytes(statement, 0))
+        guard count > 0 else { return (nil, false) }
+        try budget.chargeBytes(count)
+        let bytes = Array(UnsafeBufferPointer(
+            start: pointer.assumingMemoryBound(to: UInt8.self), count: count))
+        do {
+            return try (
+                AntigravityProtoReader.sessionCreatedTimestampMs(bytes, checkCancellation: budget.check),
+                true)
+        } catch AntigravityLocalReader.ScanFailure.invalid {
+            return (nil, false)
+        }
     }
     #endif
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Decodes only the independently recorded generation layout; no inferred opaque timestamps.
+/// Decodes the independently recorded generation layout and recognizes the opaque modern fallback.
 struct AntigravityProtoReader {
     private let bytes: ArraySlice<UInt8>
     private var offset: Int
@@ -29,6 +29,7 @@ struct AntigravityProtoReader {
         var timestampMs: Int64?
         var model: String?
         var label: String?
+        var isConversationAggregate = false
     }
 
     private struct Timestamp {
@@ -42,6 +43,27 @@ struct AntigravityProtoReader {
             else { throw AntigravityLocalReader.ScanFailure.invalid }
             return seconds * 1000 + nanos / 1_000_000
         }
+    }
+
+    private struct GenerationTimestamp {
+        var legacy = Timestamp()
+        var sawEnvelope = false
+        var sawLegacy = false
+        var hasModernSentinel = false
+        var hasModernOpaqueBytes = false
+    }
+
+    static func sessionCreatedTimestampMs(
+        _ rootBytes: [UInt8],
+        checkCancellation: () throws -> Void = {}) throws -> Int64?
+    {
+        var timestamp = Timestamp()
+        try self.fields(rootBytes[...], checkCancellation: checkCancellation) { field in
+            guard field.number == 2 else { return }
+            try self.parseTimestamp(
+                field.message(), timestamp: &timestamp, checkCancellation: checkCancellation)
+        }
+        return try timestamp.milliseconds()
     }
 
     struct Field {
@@ -134,10 +156,11 @@ struct AntigravityProtoReader {
 
     static func parseTurn(
         _ rootBytes: [UInt8],
+        sessionTimestampMs: Int64? = nil,
         checkCancellation: () throws -> Void = {}) throws -> ParsedTurn?
     {
         var turn = ParsedTurn()
-        var time = Timestamp()
+        var generation = GenerationTimestamp()
         var foundChat = false
         do {
             // Repeated singular messages merge, scalars use last-one-wins. Every occurrence is validated.
@@ -145,10 +168,23 @@ struct AntigravityProtoReader {
                 guard field.number == 1 else { return }
                 foundChat = true
                 try self.parseChat(
-                    field.message(), turn: &turn, time: &time, checkCancellation: checkCancellation)
+                    field.message(),
+                    turn: &turn,
+                    generation: &generation,
+                    checkCancellation: checkCancellation)
             }
             guard foundChat else { return nil }
-            turn.timestampMs = try time.milliseconds()
+            turn.isConversationAggregate = turn.isConversationAggregate && !generation.sawEnvelope
+            if generation.sawLegacy {
+                guard let timestampMs = try generation.legacy.milliseconds() else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                turn.timestampMs = timestampMs
+            } else if generation.hasModernSentinel, generation.hasModernOpaqueBytes {
+                turn.timestampMs = sessionTimestampMs
+            } else if generation.sawEnvelope {
+                throw AntigravityLocalReader.ScanFailure.invalid
+            }
             return turn
         } catch AntigravityLocalReader.ScanFailure.invalid {
             return nil
@@ -158,17 +194,27 @@ struct AntigravityProtoReader {
     private static func parseChat(
         _ bytes: ArraySlice<UInt8>,
         turn: inout ParsedTurn,
-        time: inout Timestamp,
+        generation: inout GenerationTimestamp,
         checkCancellation: () throws -> Void) throws
     {
         try self.fields(bytes, checkCancellation: checkCancellation) { field in
             switch field.number {
+            case 1, 2:
+                // The final row in current CLI databases contains the accumulated conversation
+                // alongside generation rows in the same table. It has a usage envelope but is not a turn.
+                if try self.isConversationAggregateMarker(field, checkCancellation: checkCancellation) {
+                    turn.isConversationAggregate = true
+                }
             case 4:
                 var usage = turn.usage ?? ParsedUsage()
                 try self.parseUsage(field.message(), usage: &usage, checkCancellation: checkCancellation)
                 turn.usage = usage
             case 9:
-                try self.parseGeneration(field.message(), time: &time, checkCancellation: checkCancellation)
+                generation.sawEnvelope = true
+                try self.parseGeneration(
+                    field.message(),
+                    generation: &generation,
+                    checkCancellation: checkCancellation)
             case 19: turn.model = try field.string()
             case 21: turn.label = try field.string()
             default: break
@@ -196,25 +242,66 @@ struct AntigravityProtoReader {
 
     private static func parseGeneration(
         _ bytes: ArraySlice<UInt8>,
-        time: inout Timestamp,
+        generation: inout GenerationTimestamp,
         checkCancellation: () throws -> Void) throws
     {
         try self.fields(bytes, checkCancellation: checkCancellation) { field in
-            guard field.number == 4 else { return }
-            try self.fields(field.message(), checkCancellation: checkCancellation) { stamp in
-                switch stamp.number {
-                case 1:
-                    let seconds = try stamp.integer()
-                    guard seconds > 0, seconds <= 253_402_300_799 else {
-                        throw AntigravityLocalReader.ScanFailure.invalid
-                    }
-                    time.seconds = seconds
-                case 2:
-                    let nanos = try stamp.integer()
-                    guard nanos <= 999_999_999 else { throw AntigravityLocalReader.ScanFailure.invalid }
-                    time.nanos = nanos
-                default: break
+            switch field.number {
+            case 4:
+                generation.sawLegacy = true
+                try self.parseTimestamp(
+                    field.message(),
+                    timestamp: &generation.legacy,
+                    checkCancellation: checkCancellation)
+            case 2:
+                guard field.wire == 0, field.value == UInt64.max else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
                 }
+                generation.hasModernSentinel = true
+            case 10:
+                guard field.wire == 2, field.data?.count == 8 else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                generation.hasModernOpaqueBytes = true
+            default: break
+            }
+        }
+    }
+
+    private static func isConversationAggregateMarker(
+        _ field: Field,
+        checkCancellation: () throws -> Void) throws -> Bool
+    {
+        guard field.wire == 2 else { throw AntigravityLocalReader.ScanFailure.invalid }
+        var hasConversationID = false
+        try self.fields(field.message(), checkCancellation: checkCancellation) { child in
+            if child.number == 1 {
+                guard child.wire == 0 else { throw AntigravityLocalReader.ScanFailure.invalid }
+                _ = try child.integer()
+                hasConversationID = true
+            }
+        }
+        return hasConversationID
+    }
+
+    private static func parseTimestamp(
+        _ bytes: ArraySlice<UInt8>,
+        timestamp: inout Timestamp,
+        checkCancellation: () throws -> Void) throws
+    {
+        try self.fields(bytes, checkCancellation: checkCancellation) { field in
+            switch field.number {
+            case 1:
+                let seconds = try field.integer()
+                guard seconds > 0, seconds <= 253_402_300_799 else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                timestamp.seconds = seconds
+            case 2:
+                let nanos = try field.integer()
+                guard nanos <= 999_999_999 else { throw AntigravityLocalReader.ScanFailure.invalid }
+                timestamp.nanos = nanos
+            default: break
             }
         }
     }

--- a/Tests/CodexBarTests/AntigravityLocalFixture.swift
+++ b/Tests/CodexBarTests/AntigravityLocalFixture.swift
@@ -10,7 +10,7 @@ import CSQLite3
 /// Synthetic, not a private capture. Independent schema and JSONL producer provenance:
 /// https://github.com/junhoyeo/tokscale/tree/62ca1eb1677556972ba963fdfa3a41ab23c1eb4b
 /// crates/tokscale-core/src/sessions/antigravity_cli.rs records six DBs / 140 turns:
-/// usage #9 text + #10 thinking == #3 total output. The opaque 1.1.18 time inference is NOT used.
+/// usage #9 text + #10 thinking == #3 total output. The opaque 1.1.18 payload is never decoded.
 /// The separate producer in crates/tokscale-cli/src/antigravity.rs emits sessionId and retry usage.
 final class AntigravityLocalFixture: Sendable {
     static let now = Date(timeIntervalSince1970: 1_787_832_000) // 2026-08-27 12:00 UTC
@@ -64,7 +64,8 @@ final class AntigravityLocalFixture: Sendable {
     func database(
         _ session: String = "session-a",
         rootIndex: Int = 0,
-        blobs: [[UInt8]] = []) throws -> URL
+        blobs: [[UInt8]] = [],
+        createdSeconds: UInt64? = nil) throws -> URL
     {
         let directory = self.context.databaseRoots[rootIndex]
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -74,6 +75,12 @@ final class AntigravityLocalFixture: Sendable {
         try Self.execute(database, "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB)")
         for (index, blob) in blobs.enumerated() {
             try Self.insert(database, row: Int64(index), blob: blob)
+        }
+        if let createdSeconds {
+            try Self.execute(
+                database,
+                "CREATE TABLE trajectory_metadata_blob (id TEXT PRIMARY KEY, data BLOB)")
+            try Self.insertSessionMetadata(database, createdSeconds: createdSeconds)
         }
         return url
     }
@@ -112,6 +119,24 @@ final class AntigravityLocalFixture: Sendable {
         sqlite3_bind_int64(statement, 1, row)
         let result = blob.withUnsafeBytes { bytes in
             sqlite3_bind_blob(statement, 2, bytes.baseAddress, Int32(blob.count), nil)
+            return sqlite3_step(statement)
+        }
+        guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
+    }
+
+    private static func insertSessionMetadata(_ database: OpaquePointer, createdSeconds: UInt64) throws {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(
+            database,
+            "INSERT INTO trajectory_metadata_blob (id, data) VALUES (?, ?)",
+            -1,
+            &statement,
+            nil) == SQLITE_OK else { throw AntigravityLocalReader.ScanFailure.invalid }
+        sqlite3_bind_text(statement, 1, "main", -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        let metadata = self.message(2, self.varint(1, createdSeconds))
+        let result = metadata.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, 2, bytes.baseAddress, Int32(metadata.count), nil)
             return sqlite3_step(statement)
         }
         guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
@@ -157,6 +182,40 @@ final class AntigravityLocalFixture: Sendable {
         if let model { chat += self.message(19, Array(model.utf8)) }
         if let label { chat += self.message(21, Array(label.utf8)) }
         return self.message(1, chat)
+    }
+
+    static func modernBlob(
+        model: String? = "fixture-modern-model",
+        label: String? = "Fixture modern model",
+        response: String? = "modern-response",
+        timestampMarker: UInt64 = UInt64.max,
+        timestampPayload: [UInt8] = [8, 1, 2, 3, 4, 5, 6, 7]) -> [UInt8]
+    {
+        var usage = self.varint(1, 11) + self.varint(2, 100) + self.varint(5, 50)
+            + self.varint(9, 30) + self.varint(10, 7)
+        if let response { usage += self.message(11, Array(response.utf8)) }
+        var chat = self.message(4, usage)
+        // agy 1.1.18 keeps #2 as an unset sentinel and stores an opaque eight-byte
+        // timestamp payload in #10. The production reader dates this at session start.
+        chat += self.message(9, self.varint(2, timestampMarker) + self.message(10, timestampPayload))
+        if let model { chat += self.message(19, Array(model.utf8)) }
+        if let label { chat += self.message(21, Array(label.utf8)) }
+        return self.message(1, chat)
+    }
+
+    static func conversationMarkerBlob(
+        marker: [UInt8]? = nil,
+        includeGeneration: Bool = false) -> [UInt8]
+    {
+        let markerField = marker ?? self.message(1, self.varint(1, 1))
+        var conversation = markerField + self.message(4, self.varint(1, 11))
+        if includeGeneration {
+            let usage = self.varint(1, 11) + self.varint(2, 100) + self.varint(5, 50)
+                + self.varint(9, 30) + self.varint(10, 7)
+            let generation = self.varint(2, UInt64.max) + self.message(10, [8, 1, 2, 3, 4, 5, 6, 7])
+            conversation += self.message(4, usage) + self.message(9, generation)
+        }
+        return self.message(1, conversation)
     }
 
     static let cacheUsage =

--- a/Tests/CodexBarTests/AntigravityLocalFixture.swift
+++ b/Tests/CodexBarTests/AntigravityLocalFixture.swift
@@ -65,7 +65,8 @@ final class AntigravityLocalFixture: Sendable {
         _ session: String = "session-a",
         rootIndex: Int = 0,
         blobs: [[UInt8]] = [],
-        createdSeconds: UInt64? = nil) throws -> URL
+        createdSeconds: UInt64? = nil,
+        sessionMetadataBlob: [UInt8]? = nil) throws -> URL
     {
         let directory = self.context.databaseRoots[rootIndex]
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -76,11 +77,12 @@ final class AntigravityLocalFixture: Sendable {
         for (index, blob) in blobs.enumerated() {
             try Self.insert(database, row: Int64(index), blob: blob)
         }
-        if let createdSeconds {
+        let metadata = sessionMetadataBlob ?? createdSeconds.map { Self.message(2, Self.varint(1, $0)) }
+        if let metadata {
             try Self.execute(
                 database,
                 "CREATE TABLE trajectory_metadata_blob (id TEXT PRIMARY KEY, data BLOB)")
-            try Self.insertSessionMetadata(database, createdSeconds: createdSeconds)
+            try Self.insertSessionMetadata(database, metadata: metadata)
         }
         return url
     }
@@ -124,7 +126,7 @@ final class AntigravityLocalFixture: Sendable {
         guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
     }
 
-    private static func insertSessionMetadata(_ database: OpaquePointer, createdSeconds: UInt64) throws {
+    private static func insertSessionMetadata(_ database: OpaquePointer, metadata: [UInt8]) throws {
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
         guard sqlite3_prepare_v2(
@@ -134,7 +136,6 @@ final class AntigravityLocalFixture: Sendable {
             &statement,
             nil) == SQLITE_OK else { throw AntigravityLocalReader.ScanFailure.invalid }
         sqlite3_bind_text(statement, 1, "main", -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
-        let metadata = self.message(2, self.varint(1, createdSeconds))
         let result = metadata.withUnsafeBytes { bytes in
             sqlite3_bind_blob(statement, 2, bytes.baseAddress, Int32(metadata.count), nil)
             return sqlite3_step(statement)

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -127,6 +127,30 @@ struct AntigravityLocalReaderTests {
     }
 
     @Test
+    func `malformed fallback metadata does not invalidate legacy timestamps`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.blob()],
+            sessionMetadataBlob: [0x12, 0x02, 0x08])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
+    }
+
+    @Test
+    func `modern rows with malformed fallback metadata remain partial`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.modernBlob()],
+            sessionMetadataBlob: [0x12, 0x02, 0x08])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
     func `legacy event timestamps take precedence over session creation time`() throws {
         let fixture = try Fixture()
         try fixture.database(

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -25,6 +25,8 @@ struct AntigravityLocalReaderTests {
         #expect(report.report.data.first?.date == "2026-08-27")
         #expect(report.report.data.first?.inputTokens == 111)
         #expect(report.report.data.first?.outputTokens == 30)
+        #expect(report.report.data.first?.cacheReadTokens == 50)
+        #expect(report.report.data.first?.cacheCreationTokens == 0)
         #expect(report.report.data.first?.reasoningTokens == 7)
         #expect(report.report.data.first?.modelBreakdowns?.first?.modelName == "unknown")
         #expect(try await fixture.snapshot().last30DaysTokens == 198)
@@ -88,6 +90,115 @@ struct AntigravityLocalReaderTests {
         #expect(snapshot.costProvenance == .unknown)
         #expect(snapshot.daily.allSatisfy { $0.costUSD == nil })
         #expect(snapshot.daily.flatMap { $0.modelBreakdowns ?? [] }.allSatisfy { $0.costUSD == nil })
+    }
+
+    @Test
+    func `modern opaque timestamp rows use the trusted session creation time`() async throws {
+        let fixture = try Fixture()
+        #expect(try AntigravityProtoReader.parseTurn(Fixture.modernBlob())?.timestampMs == nil)
+        try fixture.database(
+            blobs: [Fixture.modernBlob()],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
+        #expect(report.report.data.first?.inputTokens == 111)
+        #expect(report.report.data.first?.outputTokens == 30)
+        #expect(report.report.data.first?.cacheReadTokens == 50)
+        #expect(report.report.data.first?.cacheCreationTokens == 0)
+        #expect(report.report.data.first?.reasoningTokens == 7)
+        #expect(report.report.data.first?.date == "2026-08-27")
+
+        let snapshot = try await fixture.snapshot()
+        #expect(snapshot.historyCoverageIsEstablished)
+        #expect(snapshot.last30DaysTokens == 198)
+        #expect(snapshot.last30DaysCostUSD == nil)
+    }
+
+    @Test
+    func `modern rows without a trusted session timestamp remain partial`() throws {
+        let fixture = try Fixture()
+        try fixture.database(blobs: [Fixture.modernBlob()])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
+    func `legacy event timestamps take precedence over session creation time`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.blob(seconds: UInt64(Fixture.now.timeIntervalSince1970) - 86400)],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.date == "2026-08-26")
+    }
+
+    @Test
+    func `unrecognized generation timestamp shapes produce partial coverage`() throws {
+        let fixture = try Fixture()
+        let wrongMarker = Fixture.modernBlob(
+            response: "unrecognized-timestamp-shape",
+            timestampMarker: 2,
+            timestampPayload: [1, 2, 3, 4, 5, 6, 7, 8])
+        let shortPayload = Fixture.modernBlob(
+            response: "short-timestamp-payload",
+            timestampPayload: [1, 2, 3, 4, 5, 6, 7])
+        let longPayload = Fixture.modernBlob(
+            response: "long-timestamp-payload",
+            timestampPayload: [1, 2, 3, 4, 5, 6, 7, 8, 9])
+        try fixture.database(
+            blobs: [wrongMarker, shortPayload, longPayload],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
+    func `conversation aggregate rows do not invalidate generation history`() throws {
+        let fixture = try Fixture()
+        let usage = Fixture.message(4, Fixture.varint(1, 11))
+        let aggregates = [1, 2].map { field in
+            Fixture.message(1, Fixture.message(field, Fixture.varint(1, 1)) + usage)
+        }
+        try fixture.database(blobs: [Fixture.blob()] + aggregates)
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
+    }
+
+    @Test(arguments: [1, 2])
+    func `wrong wire conversation fields produce partial coverage`(field: Int) throws {
+        let fixture = try Fixture()
+        try fixture.database(blobs: [Fixture.conversationMarkerBlob(marker: Fixture.varint(field, 1))])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
+    func `conversation marker with generation evidence remains token history`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.conversationMarkerBlob(includeGeneration: true)],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        let entry = try #require(report.report.data.first)
+        #expect(entry.inputTokens == 111)
+        #expect(entry.outputTokens == 30)
+        #expect(entry.cacheReadTokens == 50)
+        #expect(entry.cacheCreationTokens == 0)
+        #expect(entry.reasoningTokens == 7)
     }
 
     @Test

--- a/TestsLinux/AntigravityLocalSQLiteLinuxTests.swift
+++ b/TestsLinux/AntigravityLocalSQLiteLinuxTests.swift
@@ -1,0 +1,131 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(CSQLite3)
+import CSQLite3
+#elseif canImport(SQLite3)
+import SQLite3
+#endif
+
+#if canImport(CSQLite3) || canImport(SQLite3)
+struct AntigravityLocalSQLiteLinuxTests {
+    @Test
+    func `reads current CLI conversation rows using session creation fallback`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-linux-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let context = AntigravityLocalReader.Context(environment: ["HOME": root.path])
+        let directory = context.databaseRoots[0]
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let path = directory.appendingPathComponent("linux-session.db")
+
+        do {
+            var database: OpaquePointer?
+            let opened = sqlite3_open_v2(
+                path.path,
+                &database,
+                SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                nil)
+            guard opened == SQLITE_OK, let database else {
+                if let database { sqlite3_close(database) }
+                throw AntigravityLocalReader.ScanFailure.invalid
+            }
+            defer { sqlite3_close(database) }
+            guard sqlite3_exec(
+                database,
+                "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);" +
+                    "CREATE TABLE trajectory_metadata_blob (id TEXT PRIMARY KEY, data BLOB)",
+                nil,
+                nil,
+                nil) == SQLITE_OK else { throw AntigravityLocalReader.ScanFailure.invalid }
+            try Self.insert(database, table: "gen_metadata", id: "0", data: Self.modernTurn())
+            try Self.insert(database, table: "gen_metadata", id: "1", data: Self.aggregateRecord())
+            try Self.insert(
+                database,
+                table: "trajectory_metadata_blob",
+                id: "main",
+                data: Self.sessionMetadata(createdSeconds: 1_787_832_000))
+        }
+
+        var limits = AntigravityLocalReader.Limits()
+        limits.duration = 60
+        let report = try AntigravityLocalReader.makeDailyReportWithStatus(
+            context: context,
+            calendar: CostUsageBucketTimeZone.calendar(identifier: "UTC"),
+            limits: limits)
+        #expect(report.coverage == .complete)
+        let entry = try #require(report.report.data.first)
+        #expect(entry.date == "2026-08-27")
+        #expect(entry.inputTokens == 111)
+        #expect(entry.outputTokens == 30)
+        #expect(entry.cacheReadTokens == 50)
+        #expect(entry.cacheCreationTokens == 0)
+        #expect(entry.reasoningTokens == 7)
+        #expect(entry.totalTokens == 198)
+    }
+
+    private static func insert(
+        _ database: OpaquePointer,
+        table: String,
+        id: String,
+        data: [UInt8]) throws
+    {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        let idColumn = table == "gen_metadata" ? "idx" : "id"
+        let sql = "INSERT INTO \(table) (\(idColumn), data) VALUES (?, ?)"
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else { throw AntigravityLocalReader.ScanFailure.invalid }
+        if let integer = Int64(String(id)) {
+            sqlite3_bind_int64(statement, 1, integer)
+        } else {
+            sqlite3_bind_text(statement, 1, String(id), -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+        let result = data.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, 2, bytes.baseAddress, Int32(data.count), nil)
+            return sqlite3_step(statement)
+        }
+        guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
+    }
+
+    private static func varint(_ field: Int, _ value: UInt64) -> [UInt8] {
+        self.unsigned(UInt64(field << 3)) + self.unsigned(value)
+    }
+
+    private static func message(_ field: Int, _ bytes: [UInt8]) -> [UInt8] {
+        self.unsigned(UInt64(field << 3 | 2)) + self.unsigned(UInt64(bytes.count)) + bytes
+    }
+
+    private static func modernTurn() -> [UInt8] {
+        let usage = self.varint(1, 11) + self.varint(2, 100) + self.varint(5, 50)
+            + self.varint(9, 30) + self.varint(10, 7) + self.message(11, Array("response".utf8))
+        let generation = self.varint(2, UInt64.max) + self.message(10, [8, 1, 2, 3, 4, 5, 6, 7])
+        let chat = self.message(4, usage) + self.message(9, generation)
+            + self.message(19, Array("gemini-3-flash".utf8))
+        return self.message(1, chat)
+    }
+
+    private static func aggregateRecord() -> [UInt8] {
+        let usage = self.message(4, self.varint(1, 11))
+        let conversation = self.message(1, self.varint(1, 1)) + usage
+        return self.message(1, conversation)
+    }
+
+    private static func sessionMetadata(createdSeconds: UInt64) -> [UInt8] {
+        self.message(2, self.varint(1, createdSeconds))
+    }
+
+    private static func unsigned(_ value: UInt64) -> [UInt8] {
+        var value = value
+        var result: [UInt8] = []
+        while value >= 128 {
+            result.append(UInt8(value & 127) | 128)
+            value >>= 7
+        }
+        result.append(UInt8(value))
+        return result
+    }
+}
+#endif
+#endif

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -278,17 +278,22 @@ Overflowed aggregate totals remain unknown rather than becoming saturated or wra
 
 The schema evidence is [Tokscale's pinned SQLite parser](https://github.com/junhoyeo/tokscale/blob/62ca1eb1677556972ba963fdfa3a41ab23c1eb4b/crates/tokscale-core/src/sessions/antigravity_cli.rs),
 whose header records six databases and 140 turns. SQLite usage fields 1 + 2 are input, 5 is cache read,
-9 is text output, and 10 is thinking output: text and thinking are separate counts. Historical model IDs are retained;
-missing models stay unknown unless an unambiguous raw label maps to a model within the same session.
+9 is text output, and 10 is reasoning output: text and reasoning are separate counts. SQLite has no independently
+verified cache-write field, so cache write remains 0/unknown and no value is inferred. Historical model IDs are
+retained; missing models stay unknown unless an unambiguous raw label maps to a model within the same session.
 Conflicting mappings remain unresolved. Every repeated known protobuf envelope is validated and merged.
 The supported database layout is an ordinary `gen_metadata` table with stored `idx` and `data` columns.
 Extra ordinary columns and `WITHOUT ROWID` tables are supported; views, virtual tables, and generated/hidden columns
 are rejected before querying payloads. Schema inspection and the payload scan share one read transaction.
 Inspection uses `sqlite_master` and `table_xinfo`; SQLite builds without that pragma cannot establish coverage.
+Current CLI databases may also contain a validated aggregate conversation row; it is ignored as non-generation data.
 
-Supported SQLite event time is `chatModel.#9.#4` containing protobuf seconds/nanos. Session creation, file modification,
-and refresh time are never substitutes. The opaque agy 1.1.18 timestamp layout remains unsupported: the pinned parser
-explicitly labels its newer interpretation an inference. See [the session-start misattribution report](https://github.com/junhoyeo/tokscale/issues/1184).
+Supported SQLite event time is the legacy `chatModel.#9.#4` protobuf seconds/nanos timestamp. The narrowly recognized
+modern fallback is `chatModel.#9.#2 == UInt64.max` with exactly eight opaque bytes in `chatModel.#9.#10`; it uses
+`trajectory_metadata_blob.#2` as the session-created timestamp. The opaque bytes are never decoded. Unknown timestamp
+layouts remain unsupported and make coverage partial. Fallback daily placement is approximate for sessions spanning
+multiple days. File modification and refresh time are never substitutes. See
+[the session-start misattribution report](https://github.com/junhoyeo/tokscale/issues/1184).
 
 SQLite session identity is the original database filename stem, with `gen_metadata.idx` identifying rows. Copies
 retaining that session name deduplicate across recognized roots; ID-less rows at different indices remain distinct.


### PR DESCRIPTION
## Summary

- Read Antigravity SQLite token history on Linux.
- Parse input, output, cache-read, and reasoning token buckets.
- Support legacy per-turn timestamps and the current opaque timestamp layout.
- Ignore validated accumulated-conversation rows instead of counting them as generations.
- Keep cache-write tokens represented as 0/unknown.
- Clearly label `codexbar cost --provider antigravity` as token history, with dollar costs unavailable.

## Implementation notes

Current Antigravity databases may no longer expose the legacy protobuf timestamp. The reader narrowly recognizes the current layout only when both the expected sentinel and exactly eight opaque timestamp bytes are present.

Those opaque bytes are not decoded. The reader instead uses the trusted session-created timestamp from `trajectory_metadata_blob`. Unknown layouts remain partial rather than being guessed.

Because the fallback is session-level, daily placement is approximate for sessions spanning multiple days.

Reference: https://github.com/junhoyeo/tokscale/issues/1184

## Testing

- `make test`
  - 989 selections passed
  - 83/83 groups passed on the first attempt
  - 0 failures, retries, or timeouts
- `make check`
  - 0 lint violations
- Added a Linux CSQLite integration fixture and focused parser tests.

No UI changes; screenshots are not applicable.