### PR TITLE
fix: keep live forecast text within menu rows

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -587,6 +587,8 @@ private struct MetricRow: View {
             .lineLimit(lineLimit)
             .fixedSize(horizontal: false, vertical: true)
             .hidden()
+            // Freeze the measured height, but let updates use the entire metric row width.
+            .frame(maxWidth: .infinity, alignment: .leading)
             .overlay(alignment: .topLeading) {
                 if let text, !text.isEmpty {
                     Text(text)
@@ -594,7 +596,6 @@ private struct MetricRow: View {
                         .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                         .lineLimit(lineLimit)
                         .truncationMode(.tail)
-                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .clipped()

--- a/Tests/CodexBarTests/MetricTextUpdateLayoutTests.swift
+++ b/Tests/CodexBarTests/MetricTextUpdateLayoutTests.swift
@@ -1,0 +1,158 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct MetricTextUpdateLayoutTests {
+    enum TextKind: String, CaseIterable {
+        case pace
+        case detail
+
+        var initialText: String {
+            switch self {
+            case .pace: "On pace · Lasts until reset"
+            case .detail: "100 credits remaining"
+            }
+        }
+
+        var updatedText: String {
+            switch self {
+            case .pace: "32% in deficit · Runs out in 1d 11m"
+            case .detail: "1234 credits remaining this week"
+            }
+        }
+    }
+
+    private struct RenderedSection {
+        let size: CGSize
+        let pixels: Data
+        let png: Data
+    }
+
+    @Test(arguments: TextKind.allCases)
+    func `longer live metric text renders like a reopened card without changing height`(_ kind: TextKind) throws {
+        let initial = Self.model(kind: kind, text: kind.initialText)
+        let updated = Self.model(kind: kind, text: kind.updatedText)
+        #expect(initial.hasCompatibleTrackedLayout(with: updated))
+
+        let before = try Self.render(model: initial, layoutModel: initial)
+        let live = try Self.render(model: updated, layoutModel: initial)
+        let reopened = try Self.render(model: updated, layoutModel: updated)
+
+        // Optional, synthetic-only artifacts use the same production view and fixture as the regression.
+        try Self.export(before, name: "\(kind.rawValue)-initial")
+        try Self.export(live, name: "\(kind.rawValue)-live")
+        try Self.export(reopened, name: "\(kind.rawValue)-reopened")
+
+        #expect(live.size == before.size)
+        #expect(live.size == reopened.size)
+        #expect(before.pixels != reopened.pixels, "The fixture must visibly update its text.")
+        #expect(live.pixels == reopened.pixels, "Frozen layout must not clip text that fits the card width.")
+    }
+
+    @Test
+    func `live forecast that exceeds the reserved lines keeps the open card height`() throws {
+        let initial = Self.model(kind: .pace, text: TextKind.pace.initialText)
+        let updated = Self.model(
+            kind: .pace,
+            text: "32% in deficit · Runs out in 1 day and 11 minutes at the current usage rate")
+        let before = try Self.render(model: initial, layoutModel: initial)
+        let live = try Self.render(model: updated, layoutModel: initial)
+        let reopened = try Self.render(model: updated, layoutModel: updated)
+
+        #expect(reopened.size.height > before.size.height, "The fixture must require an extra line.")
+        #expect(live.size == before.size)
+        try Self.export(live, name: "pace-overflow-live")
+        try Self.export(reopened, name: "pace-overflow-reopened")
+    }
+
+    private static func model(kind: TextKind, text: String) -> UsageMenuCardView.Model {
+        UsageMenuCardView.Model(
+            provider: .kimi,
+            providerName: "Kimi Code",
+            email: "synthetic@example.test",
+            subtitleText: "Updated just now",
+            subtitleStyle: .info,
+            planText: nil,
+            metrics: [.init(
+                id: "primary",
+                title: "7-day usage",
+                percent: 68,
+                percentStyle: .left,
+                resetText: "Resets in 3d 2h",
+                detailText: kind == .detail ? text : nil,
+                detailLeftText: kind == .pace ? text : nil,
+                detailRightText: nil,
+                pacePercent: 36,
+                detailIsPaceDerived: kind == .pace,
+                paceOnTop: false)],
+            usageNotes: [],
+            openAIAPIUsage: nil,
+            inlineUsageDashboard: nil,
+            creditsText: nil,
+            creditsRemaining: nil,
+            creditsHintText: nil,
+            creditsHintCopyText: nil,
+            providerCost: nil,
+            tokenUsage: nil,
+            placeholder: nil,
+            progressColor: .blue)
+    }
+
+    private static func render(
+        model: UsageMenuCardView.Model,
+        layoutModel: UsageMenuCardView.Model) throws -> RenderedSection
+    {
+        let view = UsageMenuCardUsageSectionView(
+            model: model,
+            layoutModel: layoutModel,
+            showBottomDivider: false,
+            bottomPadding: 6,
+            width: 320)
+            .environment(\.locale, Locale(identifier: "en_US_POSIX"))
+            .environment(\.colorScheme, .light)
+            .environment(\.displayScale, 2)
+            .background(Color.white)
+        let hosting = NSHostingView(rootView: view)
+        hosting.appearance = NSAppearance(named: .aqua)
+        let size = hosting.fittingSize
+        #expect(size.width == 320)
+        #expect(size.height > 0)
+        hosting.frame = CGRect(origin: .zero, size: size)
+        hosting.layoutSubtreeIfNeeded()
+
+        let scale: CGFloat = 2
+        let pixelWidth = Int(ceil(size.width * scale))
+        let pixelHeight = Int(ceil(size.height * scale))
+        let representation = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: pixelWidth,
+            pixelsHigh: pixelHeight,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: pixelWidth * 4,
+            bitsPerPixel: 32))
+        representation.size = size
+        let pixels = try #require(representation.bitmapData)
+        let byteCount = representation.bytesPerRow * pixelHeight
+        pixels.initialize(repeating: 0, count: byteCount)
+        let context = try #require(NSGraphicsContext(bitmapImageRep: representation))
+        hosting.displayIgnoringOpacity(hosting.bounds, in: context)
+        return try RenderedSection(
+            size: size,
+            pixels: Data(bytes: pixels, count: byteCount),
+            png: #require(representation.representation(using: .png, properties: [:])))
+    }
+
+    private static func export(_ rendered: RenderedSection, name: String) throws {
+        guard let path = ProcessInfo.processInfo.environment["CODEXBAR_FORECAST_LAYOUT_PROOF_DIR"] else { return }
+        let directory = URL(fileURLWithPath: NSString(string: path).expandingTildeInPath, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try rendered.png.write(to: directory.appendingPathComponent("\(name).png"), options: .atomic)
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1973,7 +1973,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 665,
+            line: 666,
             anchor: "guard self.model.provider == .doubao else { return nil }",
             expectedProviderIDs: ["doubao"],
             expectedReferenceCount: 1,
@@ -1981,7 +1981,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1053,
+            line: 1054,
             anchor: "if input.provider == .sub2api {",
             expectedProviderIDs: ["sub2api"],
             expectedReferenceCount: 1,
@@ -1989,7 +1989,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "The sub2api menu card localizes and groups provider-owned usage detail rows for display."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1125,
+            line: 1126,
             anchor: "if provider == .kiro,",
             expectedProviderIDs: ["kilo", "kiro"],
             expectedReferenceCount: 2,
@@ -1997,7 +1997,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1148,
+            line: 1149,
             anchor: "if provider == .minimax {",
             expectedProviderIDs: ["codex", "minimax"],
             expectedReferenceCount: 2,
@@ -2005,7 +2005,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1183,
+            line: 1184,
             anchor: "guard let loginMethod = snapshot?.loginMethod(for: .kilo) else {",
             expectedProviderIDs: ["kilo"],
             expectedReferenceCount: 1,
@@ -2013,7 +2013,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1262,
+            line: 1263,
             anchor: "if input.provider == .antigravity {",
             expectedProviderIDs: ["antigravity", "mistral"],
             expectedReferenceCount: 2,
@@ -2021,7 +2021,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1282,
+            line: 1283,
             anchor: "if input.provider == .codex, let codexProjection = input.codexProjection {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2029,7 +2029,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1298,
+            line: 1299,
             anchor: "if input.provider != .codex, let weekly = snapshot.secondary {",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "codex", "perplexity", "sub2api"],
             expectedReferenceCount: 5,
@@ -2043,7 +2043,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1338,
+            line: 1339,
             anchor: "if input.provider == .kilo || input.provider == .kimi,",
             expectedProviderIDs: ["kilo", "kimi"],
             expectedReferenceCount: 2,
@@ -2051,7 +2051,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1395,
+            line: 1396,
             anchor: "if input.provider == .zai, let resetText = Self.localizedZaiPeriodicResetText(primary) {",
             expectedProviderIDs: ["zai"],
             expectedReferenceCount: 1,
@@ -2059,7 +2059,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1439,
+            line: 1440,
             anchor: "var paceDetail = if input.provider == .kimi {",
             expectedProviderIDs: ["kimi"],
             expectedReferenceCount: 1,
@@ -2067,7 +2067,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1455,
+            line: 1456,
             anchor: "if input.provider == .warp,",
             expectedProviderIDs: ["chutes", "kilo", "kiro", "litellm", "sub2api", "warp"],
             expectedReferenceCount: 6,
@@ -2075,7 +2075,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1488,
+            line: 1489,
             anchor: "if input.provider == .alibaba || input.provider == .alibabatokenplan,",
             expectedProviderIDs: ["alibaba", "alibabatokenplan", "copilot", "crof", "manus", "perplexity", "zenmux"],
             expectedReferenceCount: 8,
@@ -2092,7 +2092,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView.swift",
-            line: 1529,
+            line: 1530,
             anchor: "if input.provider == .synthetic,",
             expectedProviderIDs: ["synthetic"],
             expectedReferenceCount: 1,

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -67,6 +67,8 @@ model-generic token label while the rendered menu-bar prefix and accessibility l
   tertiary, and extra windows render when the provider snapshot has data for them.
 - Manual refresh updates the open card subtitle and persistent Refresh-row spinner in place. Repeated clicks share the
   active request, and the existing row geometry remains fixed through success or failure.
+- Live pace and metric detail text use the full row width. Updates that exceed the space reserved when the menu opened
+  show a trailing ellipsis; reopening the menu measures the updated text again.
 - Codex credits can add a separate “Buy Credits…” menu action.
 - Claude capped Extra Usage follows the used/remaining fill preference; spending amounts and “% used” copy stay unchanged.
 - Codex OpenAI web extras: code review remaining and usage breakdown render when dashboard data is attached.


### PR DESCRIPTION
Live usage refreshes could cut off a forecast's duration until the menu was reopened. The text overlay inherited the old label's intrinsic width and could wrap below its frozen height, hiding the end without an ellipsis.

Keep the measured row height while giving updated pace and metric detail labels the full available width. Text that exceeds the reserved space now tail-truncates visibly. This preserves AppKit menu tracking geometry and fixes the shared renderer used by all providers.

Adds pixel-level regression coverage comparing a live update against a freshly opened card for both pace and detail labels, plus a height-stability check for overflow. Both rendering cases fail on the original code and pass with the fix. Updates the menu behavior documentation and the existing architecture-audit line anchors shifted by this edit.

Validation: 50 focused layout and architecture tests pass; `make check` passes with zero violations. Independent review found no accepted findings in the renderer fix or the source-anchor correction. `make test` passed all 990 selections across 83 groups with zero retries or timeouts. The initial full run caught stale architecture-audit anchors; the corrected run is fully green.

Synthetic render from the regression fixture, before:

![Forecast duration clipped before the fix](https://github.com/user-attachments/assets/3b919e55-0548-4434-80d6-224218d0a5fd)

After:

![Full forecast duration visible after the fix](https://github.com/user-attachments/assets/a06186a2-fd07-4291-9554-870c1b602a6c)
