### PR TITLE
fix(antigravity): update Antigravity sessions token history reader

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -104,7 +104,7 @@ extension AntigravityLocalReader {
         let supported = try self.hasSupportedSQLiteTable(database, budget: budget)
         if let failure = progress.failure { throw failure }
         guard supported else { return SourceResult(isComplete: false) }
-        let trajectoryStartTimestampMs = try self.readTrajectoryStartTimestamp(database, budget: budget)
+        let trajectoryStartTimestampMs = try self.readTrajectoryStartTimestamp(database, progress: progress)
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -198,8 +198,9 @@ extension AntigravityLocalReader {
 
     private static func readTrajectoryStartTimestamp(
         _ database: OpaquePointer,
-        budget: Budget) throws -> Int64?
+        progress: SQLProgress) throws -> Int64?
     {
+        let budget = progress.budget
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
         // This table is absent in older Antigravity databases. Its timestamp is the base for
@@ -222,8 +223,13 @@ extension AntigravityLocalReader {
             return nil
         }
         let count = Int(sqlite3_column_bytes(statement, 0))
-        guard count > 0 else { return nil }
+        guard count > 0, count <= budget.limits.blobBytes else { return nil }
         try budget.chargeBytes(count)
+        guard count <= budget.limits.databaseBytes - progress.databaseBytes else {
+            throw ScanFailure.exhausted
+        }
+        progress.databaseBytes += count
+        budget.statistics.materializedPayloadBytes += count
         let bytes = Array(UnsafeBufferPointer(
             start: pointer.assumingMemoryBound(to: UInt8.self), count: count))
         do {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -104,6 +104,7 @@ extension AntigravityLocalReader {
         let supported = try self.hasSupportedSQLiteTable(database, budget: budget)
         if let failure = progress.failure { throw failure }
         guard supported else { return SourceResult(isComplete: false) }
+        let trajectoryStartTimestampMs = try self.readTrajectoryStartTimestamp(database, budget: budget)
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -120,7 +121,10 @@ extension AntigravityLocalReader {
         guard prepared == SQLITE_OK, let statement else { return SourceResult(isComplete: false) }
         sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
         return try self.readRows(
-            statement, session: url.deletingPathExtension().lastPathComponent, progress: progress)
+            statement,
+            session: url.deletingPathExtension().lastPathComponent,
+            trajectoryStartTimestampMs: trajectoryStartTimestampMs,
+            progress: progress)
         #else
         return SourceResult(isComplete: false)
         #endif
@@ -130,6 +134,7 @@ extension AntigravityLocalReader {
     private static func readRows(
         _ statement: OpaquePointer,
         session: String,
+        trajectoryStartTimestampMs: Int64?,
         progress: SQLProgress) throws -> SourceResult
     {
         let budget = progress.budget
@@ -173,16 +178,59 @@ extension AntigravityLocalReader {
                 continue
             }
             // Validate exactly once while the single SQL snapshot is held; buffer only typed events.
-            guard let turn = try AntigravityProtoReader.parseTurn(bytes, checkCancellation: budget.check),
-                  let event = Event(
-                      session: session, row: row, turn: turn, cacheWrite: 0)
+            guard let turn = try AntigravityProtoReader.parseTurn(
+                bytes,
+                trajectoryStartTimestampMs: trajectoryStartTimestampMs,
+                checkCancellation: budget.check)
             else {
+                result.isComplete = false
+                continue
+            }
+            if turn.isConversationAggregate { continue }
+            guard let event = Event(session: session, row: row, turn: turn, cacheWrite: 0) else {
                 result.isComplete = false
                 continue
             }
             result.events.append(event)
         }
         return result
+    }
+
+    private static func readTrajectoryStartTimestamp(
+        _ database: OpaquePointer,
+        budget: Budget) throws -> Int64?
+    {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        // This table is absent in older Antigravity databases. Its timestamp is the base for
+        // the relative per-turn timestamp used by current Antigravity databases.
+        guard sqlite3_prepare_v2(
+            database,
+            "SELECT data FROM main.trajectory_metadata_blob ORDER BY id LIMIT 1",
+            -1,
+            &statement,
+            nil) == SQLITE_OK,
+            let statement
+        else {
+            return nil
+        }
+        let step = sqlite3_step(statement)
+        guard step == SQLITE_ROW else { return nil }
+        guard sqlite3_column_type(statement, 0) == SQLITE_BLOB,
+              let pointer = sqlite3_column_blob(statement, 0)
+        else {
+            return nil
+        }
+        let count = Int(sqlite3_column_bytes(statement, 0))
+        guard count > 0 else { return nil }
+        try budget.chargeBytes(count)
+        let bytes = Array(UnsafeBufferPointer(
+            start: pointer.assumingMemoryBound(to: UInt8.self), count: count))
+        do {
+            return try AntigravityProtoReader.trajectoryStartTimestampMs(bytes, checkCancellation: budget.check)
+        } catch AntigravityLocalReader.ScanFailure.invalid {
+            return nil
+        }
     }
     #endif
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
@@ -16,33 +16,54 @@ extension AntigravityLocalReader {
               let statement else { return false }
         sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.schemaEntries, 128) + 1))
         var entries = 0
+        var foundGenMetadata = false
         while true {
             try budget.check()
-            guard sqlite3_step(statement) == SQLITE_ROW else { return false }
+            let step = sqlite3_step(statement)
+            if step == SQLITE_DONE { break }
+            guard step == SQLITE_ROW else { return false }
             entries += 1
             budget.statistics.schemaEntries += 1
             guard entries <= budget.limits.schemaEntries else { throw ScanFailure.exhausted }
-            let name = try self.schemaText(statement, column: 0, budget: budget)
-            let type = try self.schemaText(statement, column: 1, budget: budget)
-            guard name?.lowercased() == "gen_metadata" else { continue }
-            guard type == "table", sqlite3_column_type(statement, 2) == SQLITE_INTEGER,
-                  sqlite3_column_int64(statement, 2) > 0 else { return false }
-            return try self.hasStoredSQLiteColumns(database, budget: budget)
+            guard let name = try self.schemaText(statement, column: 0, budget: budget)?.lowercased(),
+                  let type = try self.schemaText(statement, column: 1, budget: budget)
+            else { continue }
+            let isOrdinaryTable = type == "table" && sqlite3_column_type(statement, 2) == SQLITE_INTEGER
+                && sqlite3_column_int64(statement, 2) > 0
+            if name == "gen_metadata" {
+                guard isOrdinaryTable else { return false }
+                guard try self.hasStoredSQLiteColumns(
+                    database, table: "gen_metadata", requiredColumns: ["idx", "data"], budget: budget)
+                else { return false }
+                foundGenMetadata = true
+            } else if name == "trajectory_metadata_blob" {
+                guard isOrdinaryTable else { return false }
+                guard try self.hasStoredSQLiteColumns(
+                    database, table: "trajectory_metadata_blob", requiredColumns: ["data"], budget: budget)
+                else { return false }
+            }
         }
+        return foundGenMetadata
     }
 
-    private static func hasStoredSQLiteColumns(_ database: OpaquePointer, budget: Budget) throws -> Bool {
+    private static func hasStoredSQLiteColumns(
+        _ database: OpaquePointer,
+        table: String,
+        requiredColumns: Set<String>,
+        budget: Budget) throws -> Bool
+    {
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
         // table_info omits generated columns. An unknown table_xinfo pragma returns no columns: fail closed.
-        guard sqlite3_prepare_v2(database, "PRAGMA main.table_xinfo('gen_metadata')", -1, &statement, nil) == SQLITE_OK,
+        let sql = "PRAGMA main.table_xinfo('\(table)')"
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
               let statement, sqlite3_column_count(statement) >= 7 else { return false }
         var columns = Set<String>()
         var count = 0
         while true {
             try budget.check()
             let step = sqlite3_step(statement)
-            if step == SQLITE_DONE { return columns.isSuperset(of: ["idx", "data"]) }
+            if step == SQLITE_DONE { return columns.isSuperset(of: requiredColumns) }
             guard step == SQLITE_ROW else { return false }
             count += 1
             budget.statistics.schemaColumns += 1

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// Decodes only the independently recorded generation layout; no inferred opaque timestamps.
+/// Decodes the independently recorded generation layout, including current relative timestamps.
 struct AntigravityProtoReader {
+    private static let maximumTimestampMs: Int64 = 253_402_300_799_999
     private let bytes: ArraySlice<UInt8>
     private var offset: Int
     private(set) var isMalformed = false
@@ -29,6 +30,7 @@ struct AntigravityProtoReader {
         var timestampMs: Int64?
         var model: String?
         var label: String?
+        var isConversationAggregate = false
     }
 
     private struct Timestamp {
@@ -42,6 +44,28 @@ struct AntigravityProtoReader {
             else { throw AntigravityLocalReader.ScanFailure.invalid }
             return seconds * 1000 + nanos / 1_000_000
         }
+    }
+
+    private struct GenerationTimestamp {
+        var legacy = Timestamp()
+        var sawEnvelope = false
+        var sawLegacy = false
+        var hasModernSentinel = false
+        var sawModernRelativeTimestamp = false
+        var relativeElapsedMs: UInt64?
+    }
+
+    static func trajectoryStartTimestampMs(
+        _ rootBytes: [UInt8],
+        checkCancellation: () throws -> Void = {}) throws -> Int64?
+    {
+        var timestamp = Timestamp()
+        try self.fields(rootBytes[...], checkCancellation: checkCancellation) { field in
+            guard field.number == 2 else { return }
+            try self.parseTimestamp(
+                field.message(), timestamp: &timestamp, checkCancellation: checkCancellation)
+        }
+        return try timestamp.milliseconds()
     }
 
     struct Field {
@@ -134,10 +158,11 @@ struct AntigravityProtoReader {
 
     static func parseTurn(
         _ rootBytes: [UInt8],
+        trajectoryStartTimestampMs: Int64? = nil,
         checkCancellation: () throws -> Void = {}) throws -> ParsedTurn?
     {
         var turn = ParsedTurn()
-        var time = Timestamp()
+        var generation = GenerationTimestamp()
         var foundChat = false
         do {
             // Repeated singular messages merge, scalars use last-one-wins. Every occurrence is validated.
@@ -145,10 +170,34 @@ struct AntigravityProtoReader {
                 guard field.number == 1 else { return }
                 foundChat = true
                 try self.parseChat(
-                    field.message(), turn: &turn, time: &time, checkCancellation: checkCancellation)
+                    field.message(),
+                    turn: &turn,
+                    generation: &generation,
+                    checkCancellation: checkCancellation)
             }
             guard foundChat else { return nil }
-            turn.timestampMs = try time.milliseconds()
+            turn.isConversationAggregate = turn.isConversationAggregate && !generation.sawEnvelope
+            if generation.sawLegacy {
+                guard let timestampMs = try generation.legacy.milliseconds() else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                turn.timestampMs = timestampMs
+            } else if generation.hasModernSentinel {
+                guard generation.sawModernRelativeTimestamp, let trajectoryStartTimestampMs else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                guard trajectoryStartTimestampMs > 0,
+                      trajectoryStartTimestampMs <= self.maximumTimestampMs,
+                      let elapsedMs = Int64(exactly: generation.relativeElapsedMs ?? 0)
+                else { throw AntigravityLocalReader.ScanFailure.invalid }
+                let (timestampMs, overflow) = trajectoryStartTimestampMs.addingReportingOverflow(elapsedMs)
+                guard !overflow, timestampMs <= self.maximumTimestampMs else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                turn.timestampMs = timestampMs
+            } else if generation.sawEnvelope {
+                throw AntigravityLocalReader.ScanFailure.invalid
+            }
             return turn
         } catch AntigravityLocalReader.ScanFailure.invalid {
             return nil
@@ -158,17 +207,27 @@ struct AntigravityProtoReader {
     private static func parseChat(
         _ bytes: ArraySlice<UInt8>,
         turn: inout ParsedTurn,
-        time: inout Timestamp,
+        generation: inout GenerationTimestamp,
         checkCancellation: () throws -> Void) throws
     {
         try self.fields(bytes, checkCancellation: checkCancellation) { field in
             switch field.number {
+            case 1, 2:
+                // The final row in current CLI databases contains the accumulated conversation
+                // alongside generation rows in the same table. It has a usage envelope but is not a turn.
+                if try self.isConversationAggregateMarker(field, checkCancellation: checkCancellation) {
+                    turn.isConversationAggregate = true
+                }
             case 4:
                 var usage = turn.usage ?? ParsedUsage()
                 try self.parseUsage(field.message(), usage: &usage, checkCancellation: checkCancellation)
                 turn.usage = usage
             case 9:
-                try self.parseGeneration(field.message(), time: &time, checkCancellation: checkCancellation)
+                generation.sawEnvelope = true
+                try self.parseGeneration(
+                    field.message(),
+                    generation: &generation,
+                    checkCancellation: checkCancellation)
             case 19: turn.model = try field.string()
             case 21: turn.label = try field.string()
             default: break
@@ -196,25 +255,86 @@ struct AntigravityProtoReader {
 
     private static func parseGeneration(
         _ bytes: ArraySlice<UInt8>,
-        time: inout Timestamp,
+        generation: inout GenerationTimestamp,
         checkCancellation: () throws -> Void) throws
     {
         try self.fields(bytes, checkCancellation: checkCancellation) { field in
-            guard field.number == 4 else { return }
-            try self.fields(field.message(), checkCancellation: checkCancellation) { stamp in
-                switch stamp.number {
-                case 1:
-                    let seconds = try stamp.integer()
-                    guard seconds > 0, seconds <= 253_402_300_799 else {
-                        throw AntigravityLocalReader.ScanFailure.invalid
-                    }
-                    time.seconds = seconds
-                case 2:
-                    let nanos = try stamp.integer()
-                    guard nanos <= 999_999_999 else { throw AntigravityLocalReader.ScanFailure.invalid }
-                    time.nanos = nanos
-                default: break
+            switch field.number {
+            case 4:
+                generation.sawLegacy = true
+                try self.parseTimestamp(
+                    field.message(),
+                    timestamp: &generation.legacy,
+                    checkCancellation: checkCancellation)
+            case 2:
+                guard field.wire == 0, field.value == UInt64.max else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
                 }
+                generation.hasModernSentinel = true
+            case 10:
+                generation.sawModernRelativeTimestamp = true
+                if let elapsedMs = try self.parseModernRelativeTimestamp(
+                    field.message(), checkCancellation: checkCancellation)
+                {
+                    generation.relativeElapsedMs = elapsedMs
+                }
+            default: break
+            }
+        }
+    }
+
+    private static func parseModernRelativeTimestamp(
+        _ bytes: ArraySlice<UInt8>,
+        checkCancellation: () throws -> Void) throws -> UInt64?
+    {
+        var elapsedMs: UInt64?
+        try self.fields(bytes, checkCancellation: checkCancellation) { field in
+            switch field.number {
+            case 1:
+                elapsedMs = try field.integer()
+            case 4:
+                // This is separate generation metadata (currently 128000/256000), not time.
+                _ = try field.integer()
+            default: break
+            }
+        }
+        return elapsedMs
+    }
+
+    private static func isConversationAggregateMarker(
+        _ field: Field,
+        checkCancellation: () throws -> Void) throws -> Bool
+    {
+        guard field.wire == 2 else { throw AntigravityLocalReader.ScanFailure.invalid }
+        var hasConversationID = false
+        try self.fields(field.message(), checkCancellation: checkCancellation) { child in
+            if child.number == 1 {
+                guard child.wire == 0 else { throw AntigravityLocalReader.ScanFailure.invalid }
+                _ = try child.integer()
+                hasConversationID = true
+            }
+        }
+        return hasConversationID
+    }
+
+    private static func parseTimestamp(
+        _ bytes: ArraySlice<UInt8>,
+        timestamp: inout Timestamp,
+        checkCancellation: () throws -> Void) throws
+    {
+        try self.fields(bytes, checkCancellation: checkCancellation) { field in
+            switch field.number {
+            case 1:
+                let seconds = try field.integer()
+                guard seconds > 0, seconds <= 253_402_300_799 else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                timestamp.seconds = seconds
+            case 2:
+                let nanos = try field.integer()
+                guard nanos <= 999_999_999 else { throw AntigravityLocalReader.ScanFailure.invalid }
+                timestamp.nanos = nanos
+            default: break
             }
         }
     }

--- a/Tests/CodexBarTests/AntigravityLocalFixture.swift
+++ b/Tests/CodexBarTests/AntigravityLocalFixture.swift
@@ -10,7 +10,9 @@ import CSQLite3
 /// Synthetic, not a private capture. Independent schema and JSONL producer provenance:
 /// https://github.com/junhoyeo/tokscale/tree/62ca1eb1677556972ba963fdfa3a41ab23c1eb4b
 /// crates/tokscale-core/src/sessions/antigravity_cli.rs records six DBs / 140 turns:
-/// usage #9 text + #10 thinking == #3 total output. The opaque 1.1.18 time inference is NOT used.
+/// usage #9 text + #10 thinking == #3 total output. Modern timing evidence:
+/// https://github.com/AstroQore/agent-session-kit/pull/11
+/// path 1.9.10.1 is elapsed milliseconds and 1.9.10.4 is separate context metadata.
 /// The separate producer in crates/tokscale-cli/src/antigravity.rs emits sessionId and retry usage.
 final class AntigravityLocalFixture: Sendable {
     static let now = Date(timeIntervalSince1970: 1_787_832_000) // 2026-08-27 12:00 UTC
@@ -64,7 +66,10 @@ final class AntigravityLocalFixture: Sendable {
     func database(
         _ session: String = "session-a",
         rootIndex: Int = 0,
-        blobs: [[UInt8]] = []) throws -> URL
+        blobs: [[UInt8]] = [],
+        createdSeconds: UInt64? = nil,
+        createdNanos: UInt64? = nil,
+        sessionMetadataBlob: [UInt8]? = nil) throws -> URL
     {
         let directory = self.context.databaseRoots[rootIndex]
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -74,6 +79,15 @@ final class AntigravityLocalFixture: Sendable {
         try Self.execute(database, "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB)")
         for (index, blob) in blobs.enumerated() {
             try Self.insert(database, row: Int64(index), blob: blob)
+        }
+        let metadata = sessionMetadataBlob ?? createdSeconds.map {
+            Self.sessionMetadata(createdSeconds: $0, nanos: createdNanos)
+        }
+        if let metadata {
+            try Self.execute(
+                database,
+                "CREATE TABLE trajectory_metadata_blob (id TEXT PRIMARY KEY, data BLOB)")
+            try Self.insertSessionMetadata(database, metadata: metadata)
         }
         return url
     }
@@ -112,6 +126,23 @@ final class AntigravityLocalFixture: Sendable {
         sqlite3_bind_int64(statement, 1, row)
         let result = blob.withUnsafeBytes { bytes in
             sqlite3_bind_blob(statement, 2, bytes.baseAddress, Int32(blob.count), nil)
+            return sqlite3_step(statement)
+        }
+        guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
+    }
+
+    private static func insertSessionMetadata(_ database: OpaquePointer, metadata: [UInt8]) throws {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(
+            database,
+            "INSERT INTO trajectory_metadata_blob (id, data) VALUES (?, ?)",
+            -1,
+            &statement,
+            nil) == SQLITE_OK else { throw AntigravityLocalReader.ScanFailure.invalid }
+        sqlite3_bind_text(statement, 1, "main", -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        let result = metadata.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, 2, bytes.baseAddress, Int32(metadata.count), nil)
             return sqlite3_step(statement)
         }
         guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
@@ -157,6 +188,73 @@ final class AntigravityLocalFixture: Sendable {
         if let model { chat += self.message(19, Array(model.utf8)) }
         if let label { chat += self.message(21, Array(label.utf8)) }
         return self.message(1, chat)
+    }
+
+    static func modernBlob(
+        model: String? = "fixture-modern-model",
+        label: String? = "Fixture modern model",
+        response: String? = "modern-response",
+        elapsedMilliseconds: UInt64 = 0,
+        contextWindow: UInt64 = 128_000,
+        generationMarker: UInt64 = UInt64.max,
+        legacySeconds: UInt64? = nil,
+        legacyNanos: UInt64 = 0,
+        generationFields: [UInt8]? = nil) -> [UInt8]
+    {
+        var usage = self.varint(1, 11) + self.varint(2, 100) + self.varint(5, 50)
+            + self.varint(9, 30) + self.varint(10, 7)
+        if let response { usage += self.message(11, Array(response.utf8)) }
+        var chat = self.message(4, usage)
+        var generation = self.varint(2, generationMarker)
+        if let generationFields {
+            generation += generationFields
+        } else {
+            generation += self.message(
+                10,
+                self.relativeTimestamp(
+                    elapsedMilliseconds: elapsedMilliseconds,
+                    contextWindow: contextWindow))
+        }
+        if let legacySeconds {
+            var legacy = self.varint(1, legacySeconds)
+            if legacyNanos > 0 { legacy += self.varint(2, legacyNanos) }
+            generation += self.message(4, legacy)
+        }
+        chat += self.message(9, generation)
+        if let model { chat += self.message(19, Array(model.utf8)) }
+        if let label { chat += self.message(21, Array(label.utf8)) }
+        return self.message(1, chat)
+    }
+
+    static func relativeTimestamp(elapsedMilliseconds: UInt64, contextWindow: UInt64) -> [UInt8] {
+        var bytes: [UInt8] = []
+        // Proto3 omits the zero-valued elapsed offset.
+        if elapsedMilliseconds > 0 { bytes += self.varint(1, elapsedMilliseconds) }
+        bytes += self.varint(4, contextWindow)
+        return bytes
+    }
+
+    static func sessionMetadata(createdSeconds: UInt64, nanos: UInt64? = nil) -> [UInt8] {
+        var timestamp = self.varint(1, createdSeconds)
+        if let nanos { timestamp += self.varint(2, nanos) }
+        return self.message(2, timestamp)
+    }
+
+    static func conversationMarkerBlob(
+        marker: [UInt8]? = nil,
+        includeGeneration: Bool = false) -> [UInt8]
+    {
+        let markerField = marker ?? self.message(1, self.varint(1, 1))
+        var conversation = markerField + self.message(4, self.varint(1, 11))
+        if includeGeneration {
+            let usage = self.varint(1, 11) + self.varint(2, 100) + self.varint(5, 50)
+                + self.varint(9, 30) + self.varint(10, 7)
+            let generation = self.varint(2, UInt64.max) + self.message(
+                10,
+                self.relativeTimestamp(elapsedMilliseconds: 0, contextWindow: 128_000))
+            conversation += self.message(4, usage) + self.message(9, generation)
+        }
+        return self.message(1, conversation)
     }
 
     static let cacheUsage =

--- a/Tests/CodexBarTests/AntigravityLocalIntegrityTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalIntegrityTests.swift
@@ -92,6 +92,39 @@ struct AntigravityLocalIntegrityTests {
         #expect(snapshot.daily.isEmpty)
     }
 
+    @Test(arguments: [
+        "view",
+        "virtual",
+        "generated-data",
+    ])
+    func `computed trajectory metadata tables are rejected before querying payloads`(layout: String) async throws {
+        let fixture = try Fixture()
+        let url = try fixture.database(
+            blobs: [Fixture.modernBlob()],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "ALTER TABLE trajectory_metadata_blob RENAME TO backing_metadata")
+        let sql = switch layout {
+        case "view":
+            "CREATE VIEW trajectory_metadata_blob AS SELECT id, data FROM backing_metadata"
+        case "generated-data":
+            """
+            CREATE TABLE trajectory_metadata_blob (id TEXT PRIMARY KEY, payload BLOB, data BLOB AS (payload) VIRTUAL);
+            INSERT INTO trajectory_metadata_blob (id, payload) SELECT id, data FROM backing_metadata;
+            """
+        default:
+            "CREATE VIRTUAL TABLE trajectory_metadata_blob USING fts5(id, data); " +
+                "INSERT INTO trajectory_metadata_blob VALUES ('main', 'invalid')"
+        }
+        try Fixture.execute(database, sql)
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.statistics.rows == 0)
+        #expect(report.statistics.attemptedBytes == 0)
+        #expect(report.statistics.materializedPayloadBytes == 0)
+    }
+
     @Test(arguments: ["ordinary", "extra-column", "without-rowid"])
     func `stored ordinary SQLite tables remain supported`(layout: String) throws {
         let fixture = try Fixture()

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -264,6 +264,23 @@ struct AntigravityLocalReaderTests {
     }
 
     @Test
+    func `trajectory metadata bytes are charged to database and materialized byte limits`() throws {
+        let fixture = try Fixture()
+        let metadata = Fixture.sessionMetadata(createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+        let blob = Fixture.modernBlob()
+        try fixture.database(blobs: [blob], sessionMetadataBlob: metadata)
+
+        var limits = AntigravityLocalReader.Limits()
+        let report = try fixture.report(limits: limits)
+        #expect(report.coverage == .complete)
+        #expect(report.statistics.materializedPayloadBytes == blob.count + metadata.count)
+
+        limits.databaseBytes = metadata.count - 1
+        let exhausted = try fixture.report(limits: limits)
+        #expect(exhausted.coverage == .partial)
+    }
+
+    @Test
     func `complete empty out of window absent and corrupt sources remain distinct`() async throws {
         let fixture = try Fixture()
         #expect(try fixture.report().coverage == .unavailable)

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -25,6 +25,8 @@ struct AntigravityLocalReaderTests {
         #expect(report.report.data.first?.date == "2026-08-27")
         #expect(report.report.data.first?.inputTokens == 111)
         #expect(report.report.data.first?.outputTokens == 30)
+        #expect(report.report.data.first?.cacheReadTokens == 50)
+        #expect(report.report.data.first?.cacheCreationTokens == 0)
         #expect(report.report.data.first?.reasoningTokens == 7)
         #expect(report.report.data.first?.modelBreakdowns?.first?.modelName == "unknown")
         #expect(try await fixture.snapshot().last30DaysTokens == 198)
@@ -88,6 +90,177 @@ struct AntigravityLocalReaderTests {
         #expect(snapshot.costProvenance == .unknown)
         #expect(snapshot.daily.allSatisfy { $0.costUSD == nil })
         #expect(snapshot.daily.flatMap { $0.modelBreakdowns ?? [] }.allSatisfy { $0.costUSD == nil })
+    }
+
+    @Test
+    func `modern relative timestamps add elapsed milliseconds to the trajectory base`() throws {
+        let baseSeconds = UInt64(Fixture.now.timeIntervalSince1970)
+        let metadata = Fixture.sessionMetadata(createdSeconds: baseSeconds, nanos: 456_789_000)
+        let baseMilliseconds = try #require(
+            try AntigravityProtoReader.trajectoryStartTimestampMs(metadata))
+        let turn = try #require(try AntigravityProtoReader.parseTurn(
+            Fixture.modernBlob(elapsedMilliseconds: 1234),
+            trajectoryStartTimestampMs: baseMilliseconds))
+
+        #expect(baseMilliseconds == Int64(baseSeconds) * 1000 + 456)
+        #expect(turn.timestampMs == baseMilliseconds + 1234)
+    }
+
+    @Test
+    func `zero elapsed milliseconds are proto3 elided and date at the trajectory base`() throws {
+        let baseMilliseconds = Int64(Fixture.now.timeIntervalSince1970 * 1000)
+        let relativeTimestamp = Fixture.relativeTimestamp(elapsedMilliseconds: 0, contextWindow: 256_000)
+        #expect(relativeTimestamp == Fixture.varint(4, 256_000))
+        let turn = try #require(try AntigravityProtoReader.parseTurn(
+            Fixture.modernBlob(elapsedMilliseconds: 0, contextWindow: 256_000),
+            trajectoryStartTimestampMs: baseMilliseconds))
+        #expect(turn.timestampMs == baseMilliseconds)
+    }
+
+    @Test
+    func `modern relative timestamp rows are dated from trajectory metadata`() async throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.modernBlob(elapsedMilliseconds: 1234)],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970),
+            createdNanos: 456_789_000)
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
+        #expect(report.report.data.first?.inputTokens == 111)
+        #expect(report.report.data.first?.outputTokens == 30)
+        #expect(report.report.data.first?.cacheReadTokens == 50)
+        #expect(report.report.data.first?.cacheCreationTokens == 0)
+        #expect(report.report.data.first?.reasoningTokens == 7)
+        #expect(report.report.data.first?.date == "2026-08-27")
+
+        let snapshot = try await fixture.snapshot()
+        #expect(snapshot.historyCoverageIsEstablished)
+        #expect(snapshot.last30DaysTokens == 198)
+        #expect(snapshot.last30DaysCostUSD == nil)
+    }
+
+    @Test
+    func `modern rows without a trajectory base remain partial`() throws {
+        let fixture = try Fixture()
+        try fixture.database(blobs: [Fixture.modernBlob()])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
+    func `malformed trajectory metadata does not invalidate legacy timestamps`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.blob()],
+            sessionMetadataBlob: [0x12, 0x02, 0x08])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
+    }
+
+    @Test
+    func `modern rows with malformed trajectory metadata remain partial`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.modernBlob()],
+            sessionMetadataBlob: [0x12, 0x02, 0x08])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
+    func `legacy event timestamps take precedence over modern relative timestamps`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.modernBlob(
+                elapsedMilliseconds: 5000,
+                legacySeconds: UInt64(Fixture.now.timeIntervalSince1970) - 86400)],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.date == "2026-08-26")
+    }
+
+    @Test
+    func `malformed wrong-wire and overflowing relative timestamps fail closed`() throws {
+        let fixture = try Fixture()
+        let malformedOffset = Fixture.modernBlob(
+            response: "malformed-offset",
+            generationFields: Fixture.message(10, [0x08, 0x80]))
+        let wrongWireOffset = Fixture.modernBlob(
+            response: "wrong-wire-offset",
+            generationFields: Fixture.message(10, Fixture.message(1, [1]) + Fixture.varint(4, 128_000)))
+        let wrongWireContext = Fixture.modernBlob(
+            response: "wrong-wire-context",
+            generationFields: Fixture.message(10, Fixture.varint(1, 1) + Fixture.message(4, [1])))
+        let wrongMarker = Fixture.modernBlob(
+            response: "wrong-marker",
+            generationMarker: 2)
+        let overflowingOffset = Fixture.modernBlob(
+            response: "overflowing-offset",
+            elapsedMilliseconds: UInt64.max)
+        try fixture.database(
+            blobs: [
+                malformedOffset,
+                wrongWireOffset,
+                wrongWireContext,
+                wrongMarker,
+                overflowingOffset,
+            ],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
+    func `conversation aggregate rows do not invalidate generation history`() throws {
+        let fixture = try Fixture()
+        let usage = Fixture.message(4, Fixture.varint(1, 11))
+        let aggregates = [1, 2].map { field in
+            Fixture.message(1, Fixture.message(field, Fixture.varint(1, 1)) + usage)
+        }
+        try fixture.database(blobs: [Fixture.blob()] + aggregates)
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
+    }
+
+    @Test(arguments: [1, 2])
+    func `wrong wire conversation fields produce partial coverage`(field: Int) throws {
+        let fixture = try Fixture()
+        try fixture.database(blobs: [Fixture.conversationMarkerBlob(marker: Fixture.varint(field, 1))])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
+    func `conversation marker with generation evidence remains token history`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.conversationMarkerBlob(includeGeneration: true)],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        let entry = try #require(report.report.data.first)
+        #expect(entry.inputTokens == 111)
+        #expect(entry.outputTokens == 30)
+        #expect(entry.cacheReadTokens == 50)
+        #expect(entry.cacheCreationTokens == 0)
+        #expect(entry.reasoningTokens == 7)
     }
 
     @Test

--- a/TestsLinux/AntigravityLocalSQLiteLinuxTests.swift
+++ b/TestsLinux/AntigravityLocalSQLiteLinuxTests.swift
@@ -1,0 +1,132 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(CSQLite3)
+import CSQLite3
+#elseif canImport(SQLite3)
+import SQLite3
+#endif
+
+#if canImport(CSQLite3) || canImport(SQLite3)
+struct AntigravityLocalSQLiteLinuxTests {
+    @Test
+    func `reads current CLI conversation rows using relative timestamps`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-linux-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let context = AntigravityLocalReader.Context(environment: ["HOME": root.path])
+        let directory = context.databaseRoots[0]
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let path = directory.appendingPathComponent("linux-session.db")
+
+        do {
+            var database: OpaquePointer?
+            let opened = sqlite3_open_v2(
+                path.path,
+                &database,
+                SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                nil)
+            guard opened == SQLITE_OK, let database else {
+                if let database { sqlite3_close(database) }
+                throw AntigravityLocalReader.ScanFailure.invalid
+            }
+            defer { sqlite3_close(database) }
+            guard sqlite3_exec(
+                database,
+                "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);" +
+                    "CREATE TABLE trajectory_metadata_blob (id TEXT PRIMARY KEY, data BLOB)",
+                nil,
+                nil,
+                nil) == SQLITE_OK else { throw AntigravityLocalReader.ScanFailure.invalid }
+            try Self.insert(database, table: "gen_metadata", id: "0", data: Self.modernTurn())
+            try Self.insert(database, table: "gen_metadata", id: "1", data: Self.aggregateRecord())
+            try Self.insert(
+                database,
+                table: "trajectory_metadata_blob",
+                id: "main",
+                data: Self.sessionMetadata(createdSeconds: 1_787_832_000, nanos: 456_789_000))
+        }
+
+        var limits = AntigravityLocalReader.Limits()
+        limits.duration = 60
+        let report = try AntigravityLocalReader.makeDailyReportWithStatus(
+            context: context,
+            calendar: CostUsageBucketTimeZone.calendar(identifier: "UTC"),
+            limits: limits)
+        #expect(report.coverage == .complete)
+        let entry = try #require(report.report.data.first)
+        #expect(entry.date == "2026-08-27")
+        #expect(entry.inputTokens == 111)
+        #expect(entry.outputTokens == 30)
+        #expect(entry.cacheReadTokens == 50)
+        #expect(entry.cacheCreationTokens == 0)
+        #expect(entry.reasoningTokens == 7)
+        #expect(entry.totalTokens == 198)
+    }
+
+    private static func insert(
+        _ database: OpaquePointer,
+        table: String,
+        id: String,
+        data: [UInt8]) throws
+    {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        let idColumn = table == "gen_metadata" ? "idx" : "id"
+        let sql = "INSERT INTO \(table) (\(idColumn), data) VALUES (?, ?)"
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else { throw AntigravityLocalReader.ScanFailure.invalid }
+        if let integer = Int64(String(id)) {
+            sqlite3_bind_int64(statement, 1, integer)
+        } else {
+            sqlite3_bind_text(statement, 1, String(id), -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+        let result = data.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, 2, bytes.baseAddress, Int32(data.count), nil)
+            return sqlite3_step(statement)
+        }
+        guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
+    }
+
+    private static func varint(_ field: Int, _ value: UInt64) -> [UInt8] {
+        self.unsigned(UInt64(field << 3)) + self.unsigned(value)
+    }
+
+    private static func message(_ field: Int, _ bytes: [UInt8]) -> [UInt8] {
+        self.unsigned(UInt64(field << 3 | 2)) + self.unsigned(UInt64(bytes.count)) + bytes
+    }
+
+    private static func modernTurn() -> [UInt8] {
+        let usage = self.varint(1, 11) + self.varint(2, 100) + self.varint(5, 50)
+            + self.varint(9, 30) + self.varint(10, 7) + self.message(11, Array("response".utf8))
+        let relativeTimestamp = self.varint(1, 1234) + self.varint(4, 256_000)
+        let generation = self.varint(2, UInt64.max) + self.message(10, relativeTimestamp)
+        let chat = self.message(4, usage) + self.message(9, generation)
+            + self.message(19, Array("gemini-3-flash".utf8))
+        return self.message(1, chat)
+    }
+
+    private static func aggregateRecord() -> [UInt8] {
+        let usage = self.message(4, self.varint(1, 11))
+        let conversation = self.message(1, self.varint(1, 1)) + usage
+        return self.message(1, conversation)
+    }
+
+    private static func sessionMetadata(createdSeconds: UInt64, nanos: UInt64) -> [UInt8] {
+        self.message(2, self.varint(1, createdSeconds) + self.varint(2, nanos))
+    }
+
+    private static func unsigned(_ value: UInt64) -> [UInt8] {
+        var value = value
+        var result: [UInt8] = []
+        while value >= 128 {
+            result.append(UInt8(value & 127) | 128)
+            value >>= 7
+        }
+        result.append(UInt8(value))
+        return result
+    }
+}
+#endif
+#endif

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -292,10 +292,14 @@ The supported database layout is an ordinary `gen_metadata` table with stored `i
 Extra ordinary columns and `WITHOUT ROWID` tables are supported; views, virtual tables, and generated/hidden columns
 are rejected before querying payloads. Schema inspection and the payload scan share one read transaction.
 Inspection uses `sqlite_master` and `table_xinfo`; SQLite builds without that pragma cannot establish coverage.
+Aggregate conversation rows without generation payloads are ignored.
 
-Supported SQLite event time is `chatModel.#9.#4` containing protobuf seconds/nanos. Session creation, file modification,
-and refresh time are never substitutes. The opaque agy 1.1.18 timestamp layout remains unsupported: the pinned parser
-explicitly labels its newer interpretation an inference. See [the session-start misattribution report](https://github.com/junhoyeo/tokscale/issues/1184).
+Supported SQLite event time is either:
+- Legacy absolute timestamps in `chatModel.#9.#4` (`1.9.4`, seconds/nanos).
+- Modern relative elapsed milliseconds in `chatModel.#9.#10` (`1.9.10.1`, 0 when omitted) added to the
+  `trajectory_metadata_blob.#2` (`2.1`/`2.2`) base timestamp, used by `agy` 1.1.18+.
+
+Missing or malformed timestamps mark event coverage partial. File modification and refresh times are never substitutes.
 
 SQLite session identity is the original database filename stem, with `gen_metadata.idx` identifying rows. Copies
 retaining that session name deduplicate across recognized roots; ID-less rows at different indices remain distinct.


### PR DESCRIPTION
## Summary
Starting with antigravity-cli [1.1.18](https://github.com/google-antigravity/antigravity-cli/releases#release-1.1.18), Antigravity CLI SQLite session log changed how event timestamps and conversation rows are stored:
- Event timestamps are now stored as relative elapsed milliseconds (`1.9.10.1`) offset from the trajectory start timestamp in `trajectory_metadata_blob.#2`.
- Databases now include a non-generation aggregate conversation row in `gen_metadata`.

This PR updates the local token history reader to support the new format while keeping backward compatibility.

## Changes
- **Relative timestamps**: Add `1.9.10.1` elapsed milliseconds to `trajectory_metadata_blob.#2` (`2.1`/`2.2`) base timestamp. Proto3 zero-offset elision is handled as`0` ms.
- **Precedence**: Legacy `1.9.4` timestamps continue to take precedence for older databases.
- **Aggregate rows**: Skip non-generation aggregate conversation rows so they don't break turn decoding.
- **Fail-closed safety**: Missing trajectory base metadata or malformed timestamps mark coverage `.partial` rather than corrupting token totals.
- **Tests**: Add unit test coverage and a Linux SQLite parity suite in `TestsLinux/`.

## Evidence & Verification
- Relative clock layout independently documented and verified in other open source projects https://github.com/AstroQore/agent-session-kit/pull/11 and https://github.com/AstroQore/vibe-bar/pull/233.
- All unit and Linux SQLite tests pass.