### PR TITLE
fix(claude): identify Cloudflare web challenges

### DIFF
--- a/Sources/CodexBar/MenuContent.swift
+++ b/Sources/CodexBar/MenuContent.swift
@@ -142,6 +142,8 @@ struct MenuContent: View {
             CodexWorkspacesPresenter.shared.present()
         case .settings:
             self.actions.openSettings()
+        case let .providerSettings(provider):
+            self.actions.openProviderSettings(provider)
         case .about:
             self.actions.openAbout()
         case .quit:
@@ -165,6 +167,7 @@ struct MenuActions {
     let switchAccount: (UsageProvider) -> Void
     let openTerminal: (String) -> Void
     let openSettings: () -> Void
+    let openProviderSettings: (UsageProvider) -> Void
     let openAbout: () -> Void
     let quit: () -> Void
     let copyError: (String) -> Void

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -75,6 +75,7 @@ struct MenuDescriptor {
         case loginToProvider(url: String)
         case openCodexWorkspaces
         case settings
+        case providerSettings(UsageProvider)
         case about
         case quit
         case copyError(String)
@@ -783,7 +784,7 @@ extension MenuDescriptor.MenuAction {
     var systemImageName: String? {
         switch self {
         case .installUpdate: MenuDescriptor.MenuActionSystemImage.installUpdate.rawValue
-        case .settings: MenuDescriptor.MenuActionSystemImage.settings.rawValue
+        case .settings, .providerSettings: MenuDescriptor.MenuActionSystemImage.settings.rawValue
         case .about: MenuDescriptor.MenuActionSystemImage.about.rawValue
         case .quit: MenuDescriptor.MenuActionSystemImage.quit.rawValue
         case .refresh: MenuDescriptor.MenuActionSystemImage.refresh.rawValue

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -356,6 +356,9 @@ struct ClaudeProviderImplementation: ProviderImplementation {
             // to reading Claude Code's Keychain item or usage arrives via the Claude CLI fallback.
             return ("Allow reading Claude Code's credentials in Settings…", .settings)
         }
+        if self.shouldOpenSettingsForCloudflareChallenge(context: context) {
+            return ("Open Claude Settings…", .settings)
+        }
         if self.shouldOpenBrowserForWebSessionError(context: context) {
             return ("Re-login at claude.ai", .loginToProvider(url: "https://claude.ai/"))
         }
@@ -368,6 +371,14 @@ struct ClaudeProviderImplementation: ProviderImplementation {
             showSingleAccount: context.settings.claudeSwapShowSingleAccount)
         guard !context.hasAccount || swapOwnsAccountPresentation else { return nil }
         return (L("Sign in with Claude Code..."), .switchAccount(.claude))
+    }
+
+    @MainActor
+    private func shouldOpenSettingsForCloudflareChallenge(context: ProviderMenuLoginContext) -> Bool {
+        let source = context.settings.claudeSettingsSnapshot(tokenOverride: nil).usageDataSource
+        guard source == .auto || source == .web else { return false }
+        return context.store.error(for: .claude) ==
+            ClaudeWebAPIFetcher.FetchError.cloudflareChallenge.localizedDescription
     }
 
     @MainActor

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -354,10 +354,10 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         if self.shouldOfferDirectKeychainReadConsent(context: context) {
             // Terminal unreadable state (#2634/#2650): OAuth cannot recover until the user either opts in
             // to reading Claude Code's Keychain item or usage arrives via the Claude CLI fallback.
-            return ("Allow reading Claude Code's credentials in Settings…", .settings)
+            return ("Allow reading Claude Code's credentials in Settings…", .providerSettings(.claude))
         }
         if self.shouldOpenSettingsForCloudflareChallenge(context: context) {
-            return ("Open Claude Settings…", .settings)
+            return ("Open Claude Settings…", .providerSettings(.claude))
         }
         if self.shouldOpenBrowserForWebSessionError(context: context) {
             return ("Re-login at claude.ai", .loginToProvider(url: "https://claude.ai/"))

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -569,6 +569,16 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         self.openSettings(pane: nil)
     }
 
+    @objc func showProviderSettings(_ sender: NSMenuItem) {
+        guard let rawProvider = sender.representedObject as? String,
+              let provider = UsageProvider(rawValue: rawProvider)
+        else {
+            self.menuLogger.error("Provider settings action is missing a valid provider")
+            return
+        }
+        self.openSettings(pane: .provider(provider.instanceID))
+    }
+
     @objc func showSettingsAbout() {
         self.openSettings(pane: .about)
     }

--- a/Sources/CodexBar/StatusItemController+MenuActionMapping.swift
+++ b/Sources/CodexBar/StatusItemController+MenuActionMapping.swift
@@ -19,6 +19,7 @@ extension StatusItemController {
         case .openCodexWorkspaces:
             (#selector(self.openCodexWorkspaces(_:)), CodexWorkspacesWindowIdentity.menuItem)
         case .settings: (#selector(self.showSettingsGeneral), nil)
+        case let .providerSettings(provider): (#selector(self.showProviderSettings(_:)), provider.rawValue)
         case .about: (#selector(self.showSettingsAbout), nil)
         case .quit: (#selector(self.quit), nil)
         case let .copyError(message): (#selector(self.copyError(_:)), message)

--- a/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
@@ -156,6 +156,8 @@ extension StatusItemController {
             CodexWorkspacesWindowIdentity.menuItem
         case .settings:
             "settings"
+        case let .providerSettings(provider):
+            "providerSettings:\(provider.rawValue)"
         case .about:
             "about"
         case .quit:

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -1582,7 +1582,13 @@ extension UsageStore {
         if case ClaudeWebAPIFetcher.FetchError.unauthorized = error {
             return true
         }
-        return error.localizedDescription == ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription
+        if case ClaudeWebAPIFetcher.FetchError.cloudflareChallenge = error {
+            return true
+        }
+        return [
+            ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription,
+            ClaudeWebAPIFetcher.FetchError.cloudflareChallenge.localizedDescription,
+        ].contains(error.localizedDescription)
     }
 
     nonisolated static func isPermissionPromptWaiting(_ error: Error) -> Bool {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -175,6 +175,7 @@ public enum ClaudeWebAPIFetcher {
         case networkError(Error)
         case invalidResponse
         case unauthorized
+        case cloudflareChallenge
         case serverError(statusCode: Int)
         case noOrganization
         case organizationNotFound(String)
@@ -193,6 +194,10 @@ public enum ClaudeWebAPIFetcher {
                 "Invalid response from Claude API."
             case .unauthorized:
                 "Sign in to claude.ai (or refresh Claude cookies) to load usage data."
+            case .cloudflareChallenge:
+                "claude.ai is behind a Cloudflare challenge, often caused by VPN or datacenter networks. " +
+                    "Re-authenticating will not help. Switch Claude Usage source to OAuth in Settings " +
+                    "(Usage credits balance will be unavailable), or try a different network."
             case let .serverError(code):
                 "Claude API error: HTTP \(code)"
             case .noOrganization:
@@ -620,14 +625,10 @@ extension ClaudeWebAPIFetcher {
 
         logger?("Organizations API status: \(httpResponse.statusCode)")
 
-        switch httpResponse.statusCode {
-        case 200:
+        if httpResponse.statusCode == 200 {
             return try self.parseOrganizationResponse(data, targetOrganizationID: targetOrganizationID)
-        case 401, 403:
-            throw FetchError.unauthorized
-        default:
-            throw FetchError.serverError(statusCode: httpResponse.statusCode)
         }
+        throw self.fetchError(response: httpResponse, data: data)
     }
 
     private static func fetchUsageData(
@@ -652,14 +653,35 @@ extension ClaudeWebAPIFetcher {
 
         logger?("Usage API status: \(httpResponse.statusCode)")
 
-        switch httpResponse.statusCode {
-        case 200:
+        if httpResponse.statusCode == 200 {
             return try self.parseUsageResponse(data, logger: logger)
-        case 401, 403:
-            throw FetchError.unauthorized
-        default:
-            throw FetchError.serverError(statusCode: httpResponse.statusCode)
         }
+        throw self.fetchError(response: httpResponse, data: data)
+    }
+
+    private static func fetchError(response: HTTPURLResponse, data: Data) -> FetchError {
+        switch response.statusCode {
+        case 401:
+            .unauthorized
+        case 403 where self.isCloudflareChallenge(response: response, data: data):
+            .cloudflareChallenge
+        case 403:
+            .unauthorized
+        default:
+            .serverError(statusCode: response.statusCode)
+        }
+    }
+
+    private static func isCloudflareChallenge(response: HTTPURLResponse, data: Data) -> Bool {
+        if response.value(forHTTPHeaderField: "cf-mitigated")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .caseInsensitiveCompare("challenge") == .orderedSame
+        {
+            return true
+        }
+
+        guard let bodyPrefix = String(bytes: data.prefix(64 * 1024), encoding: .utf8) else { return false }
+        return bodyPrefix.localizedCaseInsensitiveContains("Just a moment")
     }
 
     private static func parseUsageResponse(_ data: Data, logger: ((String) -> Void)? = nil) throws -> WebUsageData {

--- a/Tests/CodexBarTests/ClaudeWebBackgroundRecoveryTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebBackgroundRecoveryTests.swift
@@ -9,6 +9,53 @@ import Testing
 /// found" — when that recovery attempt comes back empty.
 @Suite(.serialized)
 struct ClaudeWebBackgroundRecoveryTests {
+    private static let challengeMessage =
+        "claude.ai is behind a Cloudflare challenge, often caused by VPN or datacenter networks. " +
+        "Re-authenticating will not help. Switch Claude Usage source to OAuth in Settings " +
+        "(Usage credits balance will be unavailable), or try a different network."
+
+    @Test
+    func `Cloudflare challenge preserves cached cookie without browser recovery`() async {
+        await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-current-token",
+                sourceLabel: "Chrome")
+            defer { CookieHeaderCache.clear(provider: .claude) }
+            let replacement = ClaudeWebAPIFetcher.SessionKeyInfo(
+                key: "sk-ant-should-not-import",
+                sourceLabel: "Safari",
+                cookieCount: 1)
+
+            do {
+                _ = try await ClaudeWebSessionKeyImport.$overrideForTesting.withValue(replacement) {
+                    try await self.withClaudeWebStub { request in
+                        let url = try #require(request.url)
+                        if url.path == "/api/organizations" {
+                            let response = try #require(HTTPURLResponse(
+                                url: url,
+                                statusCode: 403,
+                                httpVersion: "HTTP/1.1",
+                                headerFields: ["cf-mitigated": "challenge"]))
+                            return (response, Data("challenge".utf8))
+                        }
+                        return try Self.response(for: request, setCookie: nil)
+                    } operation: {
+                        try await ClaudeWebAPIFetcher.fetchUsage(
+                            browserDetection: BrowserDetection(cacheTTL: 0))
+                    }
+                }
+                Issue.record("Expected Cloudflare challenge")
+            } catch {
+                #expect(error.localizedDescription == Self.challengeMessage)
+            }
+
+            let cached = try? #require(CookieHeaderCache.load(provider: .claude))
+            #expect(cached?.cookieHeader == "sessionKey=sk-ant-current-token")
+            #expect(cached?.sourceLabel == "Chrome")
+        }
+    }
+
     @Test
     func `background refresh surfaces original auth error when browser recovery finds nothing`() async {
         await self.withIsolatedCookieCache {

--- a/Tests/CodexBarTests/ClaudeWebCloudflareChallengeTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCloudflareChallengeTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ClaudeWebCloudflareChallengeTests {
+    private static let expectedChallengeMessage =
+        "claude.ai is behind a Cloudflare challenge, often caused by VPN or datacenter networks. " +
+        "Re-authenticating will not help. Switch Claude Usage source to OAuth in Settings " +
+        "(Usage credits balance will be unavailable), or try a different network."
+
+    @Test
+    func `Cloudflare mitigation header has challenge recovery guidance`() async {
+        let error = await Self.fetchError(
+            statusCode: 403,
+            headers: ["cf-mitigated": "challenge"],
+            body: "challenge")
+
+        #expect(error.localizedDescription == Self.expectedChallengeMessage)
+    }
+
+    @Test
+    func `Cloudflare interstitial body has challenge recovery guidance`() async {
+        let error = await Self.fetchError(
+            statusCode: 403,
+            headers: [:],
+            body: "<html><title>Just a moment...</title></html>",
+            challengedPath: "/api/organizations/org-123/usage")
+
+        #expect(error.localizedDescription == Self.expectedChallengeMessage)
+    }
+
+    @Test
+    func `ordinary forbidden response retains web sign in guidance`() async {
+        let error = await Self.fetchError(statusCode: 403, headers: [:], body: "forbidden")
+
+        #expect(error.localizedDescription == ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription)
+    }
+
+    @Test
+    func `unauthorized response cannot become a Cloudflare challenge`() async {
+        let error = await Self.fetchError(
+            statusCode: 401,
+            headers: ["cf-mitigated": "challenge"],
+            body: "<title>Just a moment...</title>")
+
+        #expect(error.localizedDescription == ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription)
+    }
+
+    private static func fetchError(
+        statusCode: Int,
+        headers: [String: String],
+        body: String,
+        challengedPath: String = "/api/organizations") async -> ClaudeWebAPIFetcher.FetchError
+    {
+        let transport = ProviderHTTPTransportHandler { request in
+            let url = try #require(request.url)
+            if url.path != challengedPath {
+                let response = try #require(HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]))
+                let data = Data(
+                    #"[{"uuid":"org-123","name":"Test Org","capabilities":["chat"]}]"#.utf8)
+                return (data, response)
+            }
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: headers))
+            return (Data(body.utf8), response)
+        }
+
+        do {
+            _ = try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+                try await ClaudeWebAPIFetcher.fetchUsage(cookieHeader: "sessionKey=sk-ant-test")
+            }
+            Issue.record("Expected Claude web fetch to fail")
+            return .invalidResponse
+        } catch let error as ClaudeWebAPIFetcher.FetchError {
+            return error
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+            return .invalidResponse
+        }
+    }
+}

--- a/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
@@ -6,6 +6,11 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct ClaudeWebRecoveryMenuTests {
+    private static let cloudflareChallengeMessage =
+        "claude.ai is behind a Cloudflare challenge, often caused by VPN or datacenter networks. " +
+        "Re-authenticating will not help. Switch Claude Usage source to OAuth in Settings " +
+        "(Usage credits balance will be unavailable), or try a different network."
+
     @Test
     func `unauthorized error explains how to restore web usage`() {
         #expect(
@@ -168,6 +173,22 @@ struct ClaudeWebRecoveryMenuTests {
                     $0.1 == .loginToProvider(url: "https://claude.ai/")
             })
         }
+    }
+
+    @Test
+    func `Cloudflare challenge opens Claude settings instead of relogin`() {
+        let actions = self.actions(error: Self.cloudflareChallengeMessage, source: .web)
+
+        #expect(actions.contains { $0.0 == "Open Claude Settings…" && $0.1 == .settings })
+        #expect(!actions.contains { $0.0 == "Re-login at claude.ai" })
+    }
+
+    @Test
+    func `auto source Cloudflare challenge opens Claude settings`() {
+        let actions = self.actions(error: Self.cloudflareChallengeMessage, source: .auto)
+
+        #expect(actions.contains { $0.0 == "Open Claude Settings…" && $0.1 == .settings })
+        #expect(!actions.contains { $0.0 == "Re-login at claude.ai" })
     }
 
     @Test

--- a/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
@@ -179,15 +179,31 @@ struct ClaudeWebRecoveryMenuTests {
     func `Cloudflare challenge opens Claude settings instead of relogin`() {
         let actions = self.actions(error: Self.cloudflareChallengeMessage, source: .web)
 
-        #expect(actions.contains { $0.0 == "Open Claude Settings…" && $0.1 == .settings })
+        #expect(actions.contains {
+            $0.0 == "Open Claude Settings…" && $0.1 == .providerSettings(.claude)
+        })
         #expect(!actions.contains { $0.0 == "Re-login at claude.ai" })
+    }
+
+    @Test
+    func `unreadable OAuth credentials open Claude settings`() {
+        let actions = self.actions(
+            error: ClaudeOAuthUnreadableCredentialsError.descriptionPrefix,
+            source: .oauth)
+
+        #expect(actions.contains {
+            $0.0 == "Allow reading Claude Code's credentials in Settings…" &&
+                $0.1 == .providerSettings(.claude)
+        })
     }
 
     @Test
     func `auto source Cloudflare challenge opens Claude settings`() {
         let actions = self.actions(error: Self.cloudflareChallengeMessage, source: .auto)
 
-        #expect(actions.contains { $0.0 == "Open Claude Settings…" && $0.1 == .settings })
+        #expect(actions.contains {
+            $0.0 == "Open Claude Settings…" && $0.1 == .providerSettings(.claude)
+        })
         #expect(!actions.contains { $0.0 == "Re-login at claude.ai" })
     }
 

--- a/Tests/CodexBarTests/ClaudeWebRefreshResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRefreshResilienceTests.swift
@@ -5,6 +5,44 @@ import Testing
 
 struct ClaudeWebRefreshResilienceTests {
     @Test
+    func `web challenge respects failure gate while keeping prior Claude snapshot`() async throws {
+        try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("missing-credentials.json")
+
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                let prior = Self.makePriorSnapshot()
+                let store = try await MainActor.run {
+                    try Self.makeStore(
+                        suite: "ClaudeWebRefreshResilienceTests-web-challenge",
+                        prior: prior,
+                        strategy: ClaudeCloudflareChallengeFetchStrategy())
+                }
+
+                await store.refreshProvider(.claude)
+                let firstResult = await MainActor.run {
+                    (
+                        updatedAt: store.snapshot(for: .claude)?.updatedAt,
+                        hasError: store.error(for: .claude) != nil)
+                }
+                #expect(firstResult.updatedAt == prior.updatedAt)
+                #expect(!firstResult.hasError)
+
+                await store.refreshProvider(.claude)
+                let secondResult = await MainActor.run {
+                    (
+                        updatedAt: store.snapshot(for: .claude)?.updatedAt,
+                        error: store.error(for: .claude))
+                }
+                #expect(secondResult.updatedAt == prior.updatedAt)
+                #expect(secondResult.error == ClaudeCloudflareChallengeStubError().localizedDescription)
+            }
+        }
+    }
+
+    @Test
     func `web unauthorized respects failure gate while keeping prior Claude snapshot`() async throws {
         try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
             let tempDir = FileManager.default.temporaryDirectory
@@ -232,5 +270,30 @@ private struct ClaudeWebParseFailureFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
         false
+    }
+}
+
+private struct ClaudeCloudflareChallengeFetchStrategy: ProviderFetchStrategy {
+    let id = "test.claude-web-cloudflare-challenge"
+    let kind: ProviderFetchKind = .web
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        throw ClaudeCloudflareChallengeStubError()
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}
+
+private struct ClaudeCloudflareChallengeStubError: LocalizedError {
+    var errorDescription: String? {
+        "claude.ai is behind a Cloudflare challenge, often caused by VPN or datacenter networks. " +
+            "Re-authenticating will not help. Switch Claude Usage source to OAuth in Settings " +
+            "(Usage credits balance will be unavailable), or try a different network."
     }
 }

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2100,7 +2100,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 203,
+            line: 204,
             anchor: "case .codex: \"⌘\"",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 2,
@@ -2108,7 +2108,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 457,
+            line: 458,
             anchor: "if provider == .kiro {",
             expectedProviderIDs: ["kiro"],
             expectedReferenceCount: 1,
@@ -2116,7 +2116,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 471,
+            line: 472,
             anchor: "} else if provider == .kilo {",
             expectedProviderIDs: ["kilo", "mimo", "openrouter", "poe"],
             expectedReferenceCount: 4,
@@ -2124,7 +2124,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 666,
+            line: 667,
             anchor: "let target = provider ?? store.enabledFirstPartyProviders().first ?? .codex",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 4,
@@ -2132,7 +2132,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 694,
+            line: 695,
             anchor: "if provider == .factory, snapshot.tertiary != nil {",
             expectedProviderIDs: ["alibabatokenplan", "amp", "codex", "crof", "doubao", "factory", "grok", "sub2api"],
             expectedReferenceCount: 11,
@@ -2152,7 +2152,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 769,
+            line: 770,
             anchor: "let cleaned = if provider == .codex {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2481,7 +2481,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 610,
+            line: 620,
             anchor: "self.lazyStatusItem(for: provider ?? .codex)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2489,7 +2489,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 707,
+            line: 717,
             anchor: "return .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
@@ -136,6 +136,27 @@ struct StatusItemControllerShutdownTests {
     }
 
     @Test
+    func `provider settings action opens the requested provider pane`() {
+        let controller = self.makeController()
+        defer {
+            StatusItemController.menuCardRenderingEnabled = !SettingsStore.isRunningTests
+            StatusItemController.resetMenuRefreshEnabledForTesting()
+        }
+        var requestedPane: SettingsPane?
+        controller.setSettingsOpenHandler { requestedPane = $0 }
+
+        let (selector, representedObject) = controller.selector(for: .providerSettings(.claude))
+        #expect(selector == #selector(StatusItemController.showProviderSettings(_:)))
+        #expect(representedObject as? String == UsageProvider.claude.rawValue)
+
+        let item = NSMenuItem(title: "Open Claude Settings…", action: selector, keyEquivalent: "")
+        item.representedObject = representedObject
+        controller.showProviderSettings(item)
+
+        #expect(requestedPane == .provider(UsageProvider.claude.instanceID))
+    }
+
+    @Test
     func `app shutdown cancels forced enrichment`() async {
         let controller = self.makeController()
         defer {

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -131,6 +131,10 @@ Admin API key setup:
   - Extra usage spend/limit (if enabled).
   - Remaining Usage credits balance (if enabled).
   - Account email + inferred plan.
+- A Cloudflare challenge on `claude.ai` is a network-path restriction, not a stale-cookie signal. CodexBar keeps the
+  cached cookie and prior quota snapshot, identifies the challenge, and links to Settings. Select OAuth for live
+  quota windows on that network (the web-only Usage credits balance is unavailable), or try a different network.
+  Explicit Web mode remains terminal and never reads OAuth credentials as a fallback.
 
 ## claude-swap accounts (opt-in)
 


### PR DESCRIPTION
## Summary

Classify challenged `claude.ai` responses separately from invalid web sessions. Claude Web now detects HTTP 403 responses carrying `cf-mitigated: challenge` or a bounded `Just a moment` interstitial prefix and explains that re-authentication cannot solve the network-path challenge.

The challenge keeps the valid cached cookie and prior quota snapshot, suppresses the ineffective “Re-login at claude.ai” action, and opens the Claude provider pane directly so the user can explicitly select OAuth or try another network. The same provider-specific route fixes the existing Claude Keychain-consent recovery action without changing its consent policy. Explicit Web remains terminal: this change never reads OAuth credentials, changes Keychain consent, or silently switches the configured source. The message notes the only lost web-only figure when choosing OAuth: Usage credits balance.

Ordinary HTTP 401/403 responses retain the existing sign-in guidance. Response inspection is limited to the Cloudflare header and the first 64 KiB of a 403 body; response HTML is never logged or surfaced.

Refs #3367. Thanks @TPuHo4u for the precise header/body trace and for confirming the narrow explicit-source policy on the affected machine.

## Verification

- Baseline: the 26-test Claude web slice failed in seven intended places—challenge classification at organizations/usage, cached-cookie retention, stale-snapshot retention, and the Settings recovery action.
- Fixed focused slice: 26 tests across four suites pass.
- Broader Claude web selection: 85 tests across eight suites pass, including ordinary unauthorized controls, cookie renewal/recovery, source fallback policy, and deadlines.
- Provider-settings follow-up: 22 focused menu/controller tests pass, including selector payload and final `SettingsPane.provider(.claude)` routing; all 39 provider-architecture gatekeeper tests pass after refreshing their source anchors.
- Codex autoreview is scoped-clean through P2 for the provider-settings implementation and the final gate-anchor adjustment; independent feasibility and overlap audits agree with the narrow repair.
- `make check` passes: all 95 process-cleanup tests pass (one expected Linux-only skip), documentation links pass, and SwiftFormat/SwiftLint report zero violations across 2,085 Swift files.
- Final-head `make test` passes all 992 selections across 83 groups on the first pass, with no failures, timeouts, or retries.
- [Exact-head CI run 33585050628](https://github.com/steipete/CodexBar/actions/runs/33585050628) is green: both macOS shards passed, Linux x64/ARM64 and musl passed, and lint, security, aggregate, and plugin-engine gates passed.

All tests use TaskLocal HTTP transports, fake session keys, isolated test stores, and in-memory cookie/Keychain caches. No real credentials, browser-cookie import, Keychain read, VPN, provider endpoint, or WebView was used.

## Release-note context

Claude Web: identify Cloudflare challenges accurately, retain cached usage, and guide users directly to Claude Settings for OAuth or another network instead of asking them to re-authenticate. Credit @TPuHo4u. No changelog edit before release.
