### PR TITLE
fix(test): prevent widget timeline reloads during tests

### DIFF
--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -50,18 +50,36 @@ extension UsageStore {
                 return
             }
 
-            let widgetSnapshotURL = self.widgetSnapshotURL
-            await Task.detached(priority: .utility) {
-                if let widgetSnapshotURL {
-                    WidgetSnapshotStore.save(snapshot, to: widgetSnapshotURL)
-                } else {
-                    WidgetSnapshotStore.save(snapshot)
-                }
-            }.value
-            #if canImport(WidgetKit)
-            WidgetCenter.shared.reloadAllTimelines()
-            #endif
+            await Self.saveWidgetSnapshot(
+                snapshot,
+                to: self.widgetSnapshotURL,
+                isRunningTests: SettingsStore.isRunningTests,
+                reloadTimelines: self.widgetTimelineReloader)
         }
+    }
+
+    static func saveWidgetSnapshot(
+        _ snapshot: WidgetSnapshot,
+        to url: URL?,
+        isRunningTests: Bool,
+        reloadTimelines: @MainActor () -> Void) async
+    {
+        await Task.detached(priority: .utility) {
+            if let url {
+                WidgetSnapshotStore.save(snapshot, to: url)
+            } else {
+                WidgetSnapshotStore.save(snapshot)
+            }
+        }.value
+        // Opting into file persistence in tests never opts into WidgetKit side effects.
+        guard !isRunningTests else { return }
+        reloadTimelines()
+    }
+
+    static func reloadWidgetTimelines() {
+        #if canImport(WidgetKit)
+        WidgetCenter.shared.reloadAllTimelines()
+        #endif
     }
 
     /// Builds outbound snapshots only from this Mac's UsageStore; remote fleet snapshots live in CloudSyncState.

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -319,6 +319,7 @@ final class UsageStore {
     @ObservationIgnored var widgetSnapshotPersistTask: Task<Void, Never>?
     @ObservationIgnored var lastQueuedWidgetSnapshot: WidgetSnapshot?
     @ObservationIgnored let widgetSnapshotURL: URL?
+    @ObservationIgnored let widgetTimelineReloader: @MainActor () -> Void
     @ObservationIgnored var widgetUsagePreservationBlockedProviders: Set<ProviderInstanceID> = []
 
     @ObservationIgnored let codexFetcher: UsageFetcher
@@ -490,6 +491,7 @@ final class UsageStore {
         startupBehavior: StartupBehavior = .automatic,
         environmentBase: [String: String] = ProcessInfo.processInfo.environment,
         widgetSnapshotURL: URL? = nil,
+        widgetTimelineReloader: @escaping @MainActor () -> Void = UsageStore.reloadWidgetTimelines,
         planUtilizationHistoryLoadGateForTesting: PlanUtilizationHistoryLoadGate? = nil)
     {
         self.codexFetcher = fetcher
@@ -500,6 +502,7 @@ final class UsageStore {
         self.registry = registry
         self.environmentBase = environmentBase
         self.widgetSnapshotURL = widgetSnapshotURL
+        self.widgetTimelineReloader = widgetTimelineReloader
         self.historicalUsageHistoryStore = historicalUsageHistoryStore
         self.startupBehavior = startupBehavior.resolved(isRunningTests: Self.isRunningTestsProcess())
         let planHistoryStore = Self.resolvedPlanHistoryStore(planUtilizationHistoryStore, startup: self.startupBehavior)

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1332,31 +1332,31 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 286,
+            line: 304,
             anchor: "return self.tokenAccountSnapshotCacheKey(provider: .claude, account: account)",
             expectedProviderIDs: ["claude"],
             reason: "Claude widget quota ownership uses the selected Claude account's isolated snapshot key."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 290,
+            line: 308,
             anchor: "provider: .claude,",
             expectedProviderIDs: ["claude"],
             reason: "Claude widget quota ownership uses the selected Claude account's isolated snapshot key."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1070,
+            line: 1073,
             anchor: "provider: .deepseek,",
             expectedProviderIDs: ["deepseek"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1172,
+            line: 1175,
             anchor: "let sourceMode = self.sourceMode(for: .claude)",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1176,
+            line: 1179,
             anchor: "provider: .claude,",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -3288,7 +3288,7 @@ struct ProviderArchitectureGatekeeperTests {
                 "including Vertex AI's shared transcript scanner would change its error-surfacing behavior."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 193,
+            line: 211,
             anchor: "let claudeQuotaOwnerKey: String? = if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 2,
@@ -3296,7 +3296,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 215,
+            line: 233,
             anchor: "(provider == .claude && (storedTokenSnapshot != nil || preservedClaudeUsage != nil))",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3304,7 +3304,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 235,
+            line: 253,
             anchor: "if provider == .codex, let snapshot {",
             expectedProviderIDs: ["claude", "codex", "devin"],
             expectedReferenceCount: 3,
@@ -3312,7 +3312,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 285,
+            line: 303,
             anchor: "if let account = self.settings.effectiveSelectedTokenAccount(for: .claude) {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3320,7 +3320,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 301,
+            line: 319,
             anchor: "guard let entry, entry.provider == .claude else { return nil }",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3328,7 +3328,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 355,
+            line: 373,
             anchor: "let sessionLabel = if provider == .bedrock || provider == .mistral {",
             expectedProviderIDs: ["bedrock", "codex", "mistral"],
             expectedReferenceCount: 4,
@@ -3336,7 +3336,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 425,
+            line: 443,
             anchor: "if provider == .codex {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3344,7 +3344,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 444,
+            line: 462,
             anchor: "if provider == .claude,",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3352,7 +3352,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 385,
+            line: 403,
             anchor: "if provider == .cursor, snapshot.detailRow(label: \"Request quota\") != nil {",
             expectedProviderIDs: ["alibabatokenplan", "amp", "crof", "cursor", "doubao", "grok", "ollama"],
             expectedReferenceCount: 7,
@@ -3368,7 +3368,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 457,
+            line: 475,
             anchor: "if provider == .antigravity,",
             expectedProviderIDs: ["alibabatokenplan", "amp", "antigravity"],
             expectedReferenceCount: 4,
@@ -3376,7 +3376,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 499,
+            line: 517,
             anchor: "if provider == .cursor {",
             expectedProviderIDs: ["cursor"],
             expectedReferenceCount: 1,
@@ -3384,7 +3384,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Cursor Grok Bot weekly included usage is a named extraRateWindow on the shared widget projection."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 512,
+            line: 530,
             anchor: "if provider == .claude, self.settings.claudeModelScopedWeeklyUsageVisible {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3392,7 +3392,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Claude's opt-in widget projection adds provider-owned model-scoped weekly quota rows."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+WidgetSnapshot.swift",
-            line: 526,
+            line: 544,
             anchor: "if provider == .kimi {",
             expectedProviderIDs: ["kimi"],
             expectedReferenceCount: 1,
@@ -3400,7 +3400,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 611,
+            line: 614,
             anchor: "self.metadata(for: .codex).browserCookieOrder ?? Browser.defaultImportOrder",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3408,7 +3408,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 663,
+            line: 666,
             anchor: "self.providerSpecs[provider]?.style ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3416,7 +3416,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 696,
+            line: 699,
             anchor: "guard provider != .codex else { return true }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3424,7 +3424,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1044,
+            line: 1047,
             anchor: "let claudeDebugConfiguration: ClaudeDebugLogConfiguration? = if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3432,7 +3432,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1067,
+            line: 1070,
             anchor: "let deepSeekHasTokenAccount = self.settings.selectedTokenAccount(for: .deepseek) != nil",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3440,7 +3440,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1124,
+            line: 1127,
             anchor: "case .amp:",
             expectedProviderIDs: ["amp", "deepseek", "notion", "ollama", "warp"],
             expectedReferenceCount: 7,
@@ -3456,7 +3456,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1179,
+            line: 1182,
             anchor: "let claudeSettings = snapshot.claude ?? ProviderSettingsSnapshot.ClaudeProviderSettings(",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/WidgetSnapshotTestIsolationTests.swift
+++ b/Tests/CodexBarTests/WidgetSnapshotTestIsolationTests.swift
@@ -8,7 +8,7 @@ import Testing
 /// test that reaches `persistWidgetSnapshot` without stubbing the save path hangs
 /// the whole suite. These tests pin the gate that keeps container I/O out of tests:
 /// persistence runs only for tests that opt in via the in-memory save override or
-/// an injected snapshot URL.
+/// an injected snapshot URL. Neither opt-in permits WidgetKit reloads.
 @MainActor
 struct WidgetSnapshotTestIsolationTests {
     @Test
@@ -25,17 +25,25 @@ struct WidgetSnapshotTestIsolationTests {
 
     @Test
     func `persist without any opt-in queues no widget snapshot work`() {
-        let store = Self.makeStore(suite: "no-opt-in")
+        var reloadCount = 0
+        let store = Self.makeStore(suite: "no-opt-in", reloadTimelines: { reloadCount += 1 })
 
         store.persistWidgetSnapshot(reason: "test-no-opt-in")
 
         #expect(store.widgetSnapshotPersistTask == nil)
         #expect(store.lastQueuedWidgetSnapshot == nil)
+        #expect(reloadCount == 0)
     }
 
-    @Test
-    func `persist with a save override routes the snapshot through the override`() async {
-        let store = Self.makeStore(suite: "override")
+    @Test(arguments: [false, true])
+    func `persist with a save override stays in memory without reloading`(injectURL: Bool) async {
+        let snapshotURL = Self.temporarySnapshotURL()
+        defer { try? FileManager.default.removeItem(at: snapshotURL) }
+        var reloadCount = 0
+        let store = Self.makeStore(
+            suite: "override",
+            widgetSnapshotURL: injectURL ? snapshotURL : nil,
+            reloadTimelines: { reloadCount += 1 })
         var saved: [WidgetSnapshot] = []
         store._test_widgetSnapshotSaveOverride = { saved.append($0) }
         defer { store._test_widgetSnapshotSaveOverride = nil }
@@ -44,22 +52,70 @@ struct WidgetSnapshotTestIsolationTests {
         await store.widgetSnapshotPersistTask?.value
 
         #expect(saved.count == 1)
+        #expect(!FileManager.default.fileExists(atPath: snapshotURL.path))
+        #expect(reloadCount == 0)
     }
 
     @Test
-    func `persist with an injected snapshot URL writes to that file`() async {
-        let snapshotURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("WidgetSnapshotTestIsolationTests-\(UUID().uuidString).json")
+    func `persist with an injected snapshot URL writes to that file without reloading`() async {
+        let snapshotURL = Self.temporarySnapshotURL()
         defer { try? FileManager.default.removeItem(at: snapshotURL) }
-        let store = Self.makeStore(suite: "injected-url", widgetSnapshotURL: snapshotURL)
+        var reloadCount = 0
+        let store = Self.makeStore(
+            suite: "injected-url",
+            widgetSnapshotURL: snapshotURL,
+            reloadTimelines: { reloadCount += 1 })
 
         store.persistWidgetSnapshot(reason: "test-injected-url")
         await store.widgetSnapshotPersistTask?.value
 
         #expect(WidgetSnapshotStore.load(from: snapshotURL) != nil)
+        #expect(reloadCount == 0)
     }
 
-    private static func makeStore(suite: String, widgetSnapshotURL: URL? = nil) -> UsageStore {
+    @Test(arguments: [true, false])
+    func `file save reload boundary respects test mode and finishes saving before reload`(
+        isRunningTests: Bool) async throws
+    {
+        // Only the helper's decision is varied; process-wide test isolation stays enabled.
+        try #require(SettingsStore.isRunningTests)
+        let snapshotURL = Self.temporarySnapshotURL()
+        defer { try? FileManager.default.removeItem(at: snapshotURL) }
+        let snapshot = WidgetSnapshot(
+            entries: [],
+            enabledProviders: [.codex],
+            usageBarsShowUsed: true,
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        var reloadCount = 0
+        #expect(!FileManager.default.fileExists(atPath: snapshotURL.path))
+
+        await UsageStore.saveWidgetSnapshot(
+            snapshot,
+            to: snapshotURL,
+            isRunningTests: isRunningTests,
+            reloadTimelines: {
+                reloadCount += 1
+                #expect(WidgetSnapshotStore.load(from: snapshotURL)?.generatedAt == snapshot.generatedAt)
+            })
+
+        let saved = try #require(WidgetSnapshotStore.load(from: snapshotURL))
+        #expect(saved.generatedAt == snapshot.generatedAt)
+        #expect(saved.enabledProviders == snapshot.enabledProviders)
+        #expect(saved.usageBarsShowUsed == snapshot.usageBarsShowUsed)
+        #expect(reloadCount == (isRunningTests ? 0 : 1))
+        #expect(SettingsStore.isRunningTests)
+    }
+
+    private static func temporarySnapshotURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("WidgetSnapshotTestIsolationTests-\(UUID().uuidString).json")
+    }
+
+    private static func makeStore(
+        suite: String,
+        widgetSnapshotURL: URL? = nil,
+        reloadTimelines: @escaping @MainActor () -> Void) -> UsageStore
+    {
         let settings = testSettingsStore(suiteName: "WidgetSnapshotTestIsolationTests-\(suite)")
         settings.providerDetectionCompleted = true
         return UsageStore(
@@ -68,6 +124,7 @@ struct WidgetSnapshotTestIsolationTests {
             settings: settings,
             startupBehavior: .testing,
             environmentBase: [:],
-            widgetSnapshotURL: widgetSnapshotURL)
+            widgetSnapshotURL: widgetSnapshotURL,
+            widgetTimelineReloader: reloadTimelines)
     }
 }

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -26,6 +26,12 @@ read_when:
   Claude quota data is available.
 - If no snapshot is available, widgets fall back to preview/empty data.
 
+Tests must opt into snapshot persistence with an in-memory save override or a test-owned snapshot URL.
+Neither opt-in reloads WidgetKit timelines. Production still awaits the file save before requesting a reload;
+the save/reload helper accepts an explicit test-mode decision and reload callback so tests can verify that ordering
+with temporary files and a fake callback, without changing process-wide test isolation. The per-store reload callback
+also lets persistence integration tests count reload attempts without calling WidgetKit.
+
 ## Extension
 - `Sources/CodexBarWidget` contains timeline + views.
 - `WidgetExtension/CodexBarWidgetExtension.xcodeproj` builds those sources as the packaged macOS WidgetKit app extension.


### PR DESCRIPTION
## Summary

Tests that inject a temporary widget snapshot URL currently save to that file and then request a real WidgetKit timeline reload. The in-memory save override already returned before reload, so file injection was the missing side-effect boundary.

This change separates snapshot persistence from reload permission:

- test processes may opt into an in-memory save or a test-owned file, but never reload real WidgetKit timelines
- production still awaits the file save before requesting exactly one reload
- the reload callback is immutable, per-store, and `@MainActor`, avoiding process-global test overrides
- the helper takes an explicit test-mode decision so save/reload ordering can be proven with a temporary file and fake callback
- widget documentation records the isolation contract

The architecture audit catalog also refreshes source-line anchors shifted by the added code. Anchor text, provider fingerprints, reasons, and audit rules are unchanged.

There is no intended user-visible production behavior change.

## Verification

- rebased onto `main` after #3365 and #3330, retaining the broader shared test-process detector and app-group defaults isolation
- focused nonparallel run: 58 tests across `WidgetSnapshotTestIsolationTests`, `WidgetSnapshotBoundedIOTests`, `TestProcessSafetyTests`, `SettingsStoreKeychainPreferenceTests`, and `ProviderArchitectureGatekeeperTests` passed
- `make check`
- final Codex autoreview: no actionable P0-P2 findings
- `make test` with isolated file, session, defaults, and Keychain settings and non-timeout retries disabled: 994 selections, 83/83 groups passed on the first attempt, 0 retries, 0 timeouts
- hosted CI: https://github.com/steipete/CodexBar/actions/runs/33616860899

The first local full-suite attempt exposed only a task-owned native-build resource lookup problem: the executable-adjacent `CodexBarCore` bundle link was absent. After linking `.build/debug` to the actual scratch products, the clean no-retry run above passed in full.

Receipts:

- base: `33fd05ba73edf08ff92a7dd9d1205594d5ee62ab`
- final candidate: `7b1ffa9b6ce7941982a0efb4d8684fdf67d726a1`
- final tree: `d6b51d595bb822b45219217f0ecd7f67221dde54`
