### PR TITLE
fix(claude): avoid own-domain defaults suites

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -90,7 +90,7 @@ public enum ClaudeOAuthCredentialsStore {
     private static let directKeychainReadConsentRevocationMarkerKey =
         "ClaudeOAuthDirectKeychainReadConsentRevocationMarkerV1"
     private static var sharedDefaults: UserDefaults {
-        UserDefaults(suiteName: "com.steipete.codexbar") ?? .standard
+        ClaudeOAuthApplicationDefaults.resolve(domain: "com.steipete.codexbar")
     }
 
     private static let pendingCodexBarOAuthKeychainCacheClearStore: ClaudeOAuthPendingCacheClearStore =

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainPromptMode.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainPromptMode.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+enum ClaudeOAuthApplicationDefaults {
+    static func resolve(
+        domain: String,
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        suiteFactory: (String) -> UserDefaults? = { UserDefaults(suiteName: $0) }) -> UserDefaults
+    {
+        // The app already owns its standard domain; child processes still need the shared suite.
+        if domain == currentBundleIdentifier {
+            return .standard
+        }
+        return suiteFactory(domain) ?? .standard
+    }
+}
+
 public enum ClaudeOAuthKeychainPromptMode: String, Sendable, Codable, CaseIterable {
     case never
     case onlyOnUserAction
@@ -97,7 +111,7 @@ public enum ClaudeOAuthKeychainPromptPreference {
             return taskImplicitApplicationUserDefaultsOverride.value
         }
         #endif
-        return UserDefaults(suiteName: self.applicationDefaultsDomain) ?? .standard
+        return ClaudeOAuthApplicationDefaults.resolve(domain: self.applicationDefaultsDomain)
     }
 
     static func resolveApplicationDefaultsDomain(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthPendingCacheClearStore.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthPendingCacheClearStore.swift
@@ -35,6 +35,7 @@ final class ClaudeOAuthPendingCacheClearUserDefaultsStore: ClaudeOAuthPendingCac
     private let domain: String
     private let key: String
     private let lockURL: URL
+    private let userDefaults: UserDefaults
 
     init(
         domain: String,
@@ -46,6 +47,7 @@ final class ClaudeOAuthPendingCacheClearUserDefaultsStore: ClaudeOAuthPendingCac
         self.domain = domain
         self.key = key
         self.lockURL = lockURL
+        self.userDefaults = ClaudeOAuthApplicationDefaults.resolve(domain: domain)
     }
 
     var isPending: Bool {
@@ -275,7 +277,7 @@ final class ClaudeOAuthPendingCacheClearUserDefaultsStore: ClaudeOAuthPendingCac
     }
 
     private func currentGeneration() -> String? {
-        let userDefaults = UserDefaults(suiteName: self.domain) ?? .standard
+        let userDefaults = self.userDefaults
         userDefaults.synchronize()
         if let generation = userDefaults.string(forKey: self.key), !generation.isEmpty {
             return generation
@@ -294,7 +296,7 @@ final class ClaudeOAuthPendingCacheClearUserDefaultsStore: ClaudeOAuthPendingCac
     }
 
     private func currentState() -> State {
-        let userDefaults = UserDefaults(suiteName: self.domain) ?? .standard
+        let userDefaults = self.userDefaults
         userDefaults.synchronize()
         if let generations = userDefaults.dictionary(forKey: self.key) as? [String: String], !generations.isEmpty {
             return .profiles(generations)
@@ -351,7 +353,7 @@ final class ClaudeOAuthPendingCacheClearUserDefaultsStore: ClaudeOAuthPendingCac
     }
 
     private var hasAnyUnlockedProfileFallback: Bool {
-        let userDefaults = UserDefaults(suiteName: self.domain) ?? .standard
+        let userDefaults = self.userDefaults
         userDefaults.synchronize()
         let prefix = self.key + Self.unlockedProfileFallbackKeyPrefix
         return userDefaults.persistentDomain(forName: self.domain)?.keys.contains {
@@ -364,7 +366,7 @@ final class ClaudeOAuthPendingCacheClearUserDefaultsStore: ClaudeOAuthPendingCac
     }
 
     private func unlockedProfileFallbackGeneration(profileIdentifier: String) -> String? {
-        let userDefaults = UserDefaults(suiteName: self.domain) ?? .standard
+        let userDefaults = self.userDefaults
         userDefaults.synchronize()
         let fallbackKey = self.unlockedProfileFallbackKey(profileIdentifier: profileIdentifier)
         guard let generation = userDefaults.string(forKey: fallbackKey), !generation.isEmpty else { return nil }
@@ -385,7 +387,7 @@ final class ClaudeOAuthPendingCacheClearUserDefaultsStore: ClaudeOAuthPendingCac
         _ generation: String?,
         profileIdentifier: String)
     {
-        let userDefaults = UserDefaults(suiteName: self.domain) ?? .standard
+        let userDefaults = self.userDefaults
         let fallbackKey = self.unlockedProfileFallbackKey(profileIdentifier: profileIdentifier)
         if let generation {
             userDefaults.set(generation, forKey: fallbackKey)
@@ -396,7 +398,7 @@ final class ClaudeOAuthPendingCacheClearUserDefaultsStore: ClaudeOAuthPendingCac
     }
 
     private func writeGeneration(_ generation: String?) {
-        let userDefaults = UserDefaults(suiteName: self.domain) ?? .standard
+        let userDefaults = self.userDefaults
         if let generation {
             userDefaults.set(generation, forKey: self.key)
         } else {
@@ -406,7 +408,7 @@ final class ClaudeOAuthPendingCacheClearUserDefaultsStore: ClaudeOAuthPendingCac
     }
 
     private func writeProfileGenerations(_ generations: [String: String]) {
-        let userDefaults = UserDefaults(suiteName: self.domain) ?? .standard
+        let userDefaults = self.userDefaults
         if generations.isEmpty {
             userDefaults.removeObject(forKey: self.key)
         } else {

--- a/Tests/CodexBarTests/ClaudeOAuthApplicationDefaultsTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthApplicationDefaultsTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeOAuthApplicationDefaultsTests {
+    @Test
+    func `application domain uses standard defaults without constructing a suite`() {
+        var requestedDomains: [String] = []
+
+        let defaults = ClaudeOAuthApplicationDefaults.resolve(
+            domain: "com.steipete.codexbar",
+            currentBundleIdentifier: "com.steipete.codexbar",
+            suiteFactory: { domain in
+                requestedDomains.append(domain)
+                return nil
+            })
+
+        #expect(defaults === UserDefaults.standard)
+        #expect(requestedDomains.isEmpty)
+    }
+
+    @Test
+    func `child process keeps using the application suite`() throws {
+        let suiteDomain = "ClaudeOAuthApplicationDefaultsTests.\(UUID().uuidString)"
+        let suite = try #require(UserDefaults(suiteName: suiteDomain))
+        var requestedDomains: [String] = []
+
+        let defaults = ClaudeOAuthApplicationDefaults.resolve(
+            domain: "com.steipete.codexbar",
+            currentBundleIdentifier: "com.steipete.codexbar.widget",
+            suiteFactory: { domain in
+                requestedDomains.append(domain)
+                return suite
+            })
+
+        #expect(defaults === suite)
+        #expect(requestedDomains == ["com.steipete.codexbar"])
+    }
+
+    @Test
+    func `suite creation failure retains the standard fallback`() {
+        var requestedDomains: [String] = []
+
+        let defaults = ClaudeOAuthApplicationDefaults.resolve(
+            domain: "com.steipete.codexbar",
+            currentBundleIdentifier: nil,
+            suiteFactory: { domain in
+                requestedDomains.append(domain)
+                return nil
+            })
+
+        #expect(defaults === UserDefaults.standard)
+        #expect(requestedDomains == ["com.steipete.codexbar"])
+    }
+}


### PR DESCRIPTION
## Summary

Avoid constructing an `NSUserDefaults` suite whose name exactly matches the running app's own bundle identifier. Foundation rejects that combination and logs a misleading warning on every signed CodexBar launch, even though the fallback lands in the correct preferences domain.

Centralize Claude OAuth application-defaults resolution: the owning app now uses `.standard`, while the CLI, widget, debug/release cross-host paths, and processes without a bundle identifier keep using the shared application suite. Cache the resolved defaults object in the pending-clear store so its repeated synchronized reads and writes use one consistent domain object.

The comparison is exact rather than prefix-based, preserving child-process sharing and the existing release-domain tombstone behavior. Suite-construction failure still falls back to `.standard`.

Fixes #3381.

## Verification

- 46 focused tests across four Claude OAuth defaults, credentials, and pending-cache suites passed.
- Full isolated local suite: 995 selections across 83 groups, all first-pass green with retries disabled, zero failed groups, and zero timeouts.
- `make check` passed with zero format or lint violations across 2,090 Swift files.
- Independent review and final scoped review found no actionable P0-P2 defects.

Tests used synthetic preferences and the repository's Keychain/file isolation flags. No real provider probes, browser imports, installed-app launches, or changelog edits were used.
