### PR TITLE
fix(codex): preserve selected workspace ownership

### DIFF
--- a/Sources/CodexBar/CodexAccountPromotionCoordinator.swift
+++ b/Sources/CodexBar/CodexAccountPromotionCoordinator.swift
@@ -88,6 +88,10 @@ final class CodexAccountPromotionCoordinator {
                 L("CodexBar could not find saved auth for that account. Re-authenticate it and try again.")
             case .targetManagedAccountAuthUnreadable:
                 L("CodexBar could not read saved auth for that account. Re-authenticate it and try again.")
+            case .targetManagedAccountWorkspaceDiffersFromAuthDefault:
+                L(
+                    "That managed account uses a workspace that differs from its saved Codex auth default. " +
+                        "Keep it as a managed account; CodexBar will not rewrite Codex-owned auth to promote it.")
             case .liveAccountUnreadable:
                 L("CodexBar could not read the current system account on this Mac.")
             case .liveAccountMissingIdentityForPreservation:

--- a/Sources/CodexBar/CodexAccountPromotionExecution.swift
+++ b/Sources/CodexBar/CodexAccountPromotionExecution.swift
@@ -14,15 +14,18 @@ struct CodexDisplacedLivePreservationExecutionResult: Equatable {
 struct CodexDisplacedLivePreservationExecutor {
     private let store: any ManagedCodexAccountStoring
     private let homeFactory: any ManagedCodexHomeProducing
+    private let authMaterialReader: any CodexAuthMaterialReading
     private let fileManager: FileManager
 
     init(
         store: any ManagedCodexAccountStoring,
         homeFactory: any ManagedCodexHomeProducing,
+        authMaterialReader: any CodexAuthMaterialReading = DefaultCodexAuthMaterialReader(),
         fileManager: FileManager = .default)
     {
         self.store = store
         self.homeFactory = homeFactory
+        self.authMaterialReader = authMaterialReader
         self.fileManager = fileManager
     }
 
@@ -46,7 +49,9 @@ struct CodexDisplacedLivePreservationExecutor {
 
         case .importNew:
             let importedAccount = try self.importDisplacedLiveAccount(from: context)
-            return try self.commitImportedAccount(importedAccount)
+            return try self.commitImportedAccount(
+                importedAccount,
+                excludingTargetID: context.target.persisted.id)
 
         case let .refreshExisting(destination, _),
              let .repairExisting(destination, _):
@@ -121,7 +126,9 @@ struct CodexDisplacedLivePreservationExecutor {
         }
     }
 
-    private func commitImportedAccount(_ importedAccount: CodexPreparedImportedAccount) throws
+    private func commitImportedAccount(
+        _ importedAccount: CodexPreparedImportedAccount,
+        excludingTargetID: UUID) throws
         -> CodexDisplacedLivePreservationExecutionResult
     {
         do {
@@ -129,7 +136,9 @@ struct CodexDisplacedLivePreservationExecutor {
             try self.store.storeAccounts(ManagedCodexAccountSet(
                 version: latestManagedAccounts.version,
                 accounts: latestManagedAccounts.accounts + [importedAccount.account]))
-            return try self.resolveImportedAccountAfterCommit(importedAccount)
+            return try self.resolveImportedAccountAfterCommit(
+                importedAccount,
+                excludingTargetID: excludingTargetID)
         } catch let error as CodexAccountPromotionError {
             try? self.removeManagedHomeIfSafe(importedAccount.homeURL)
             throw error
@@ -139,7 +148,9 @@ struct CodexDisplacedLivePreservationExecutor {
         }
     }
 
-    private func resolveImportedAccountAfterCommit(_ importedAccount: CodexPreparedImportedAccount) throws
+    private func resolveImportedAccountAfterCommit(
+        _ importedAccount: CodexPreparedImportedAccount,
+        excludingTargetID: UUID) throws
         -> CodexDisplacedLivePreservationExecutionResult
     {
         let persistedManagedAccounts = try self.store.loadAccounts()
@@ -150,10 +161,12 @@ struct CodexDisplacedLivePreservationExecutor {
 
         guard let existingManagedAccount = self.repairDestination(
             in: persistedManagedAccounts,
-            for: importedAccount.account)
+            for: importedAccount.account,
+            excludingTargetID: excludingTargetID)
         else {
             throw CodexAccountPromotionError.managedStoreCommitFailed
         }
+        try self.validateRepairDestination(existingManagedAccount, for: importedAccount.account)
 
         let repairedManagedAccount = ManagedCodexAccount(
             id: existingManagedAccount.id,
@@ -181,12 +194,41 @@ struct CodexDisplacedLivePreservationExecutor {
             displacedLiveDisposition: .alreadyManaged(managedAccountID: existingManagedAccount.id))
     }
 
+    private func validateRepairDestination(
+        _ existingManagedAccount: ManagedCodexAccount,
+        for importedAccount: ManagedCodexAccount) throws
+    {
+        guard let providerAccountID = importedAccount.providerAccountID else { return }
+        let homeURL = URL(fileURLWithPath: existingManagedAccount.managedHomePath, isDirectory: true)
+        guard let authData = try? self.authMaterialReader.readAuthData(homeURL: homeURL),
+              (try? CodexOAuthCredentialsStore.parse(data: authData)) != nil,
+              let authIdentity = try? PreparedPromotionContextBuilder.runtimeAccount(from: authData)
+        else {
+            // Missing or unreadable auth is the repair case already accepted by the planner.
+            return
+        }
+
+        let importedIdentity = CodexIdentity.providerAccount(id: providerAccountID)
+        guard CodexIdentityMatcher.matches(
+            authIdentity.identity,
+            lhsEmail: authIdentity.email,
+            importedIdentity,
+            rhsEmail: importedAccount.email)
+        else {
+            throw CodexAccountPromotionError.displacedLiveManagedAccountConflict
+        }
+    }
+
     private func repairDestination(
         in persistedManagedAccounts: ManagedCodexAccountSet,
-        for importedAccount: ManagedCodexAccount) -> ManagedCodexAccount?
+        for importedAccount: ManagedCodexAccount,
+        excludingTargetID: UUID) -> ManagedCodexAccount?
     {
+        let candidates = ManagedCodexAccountSet(
+            version: persistedManagedAccounts.version,
+            accounts: persistedManagedAccounts.accounts.filter { $0.id != excludingTargetID })
         if let workspaceAccountID = importedAccount.effectiveWorkspaceAccountID {
-            return persistedManagedAccounts.account(
+            return candidates.account(
                 email: importedAccount.email,
                 providerAccountID: workspaceAccountID)
         }
@@ -194,7 +236,7 @@ struct CodexDisplacedLivePreservationExecutor {
         let normalizedEmail = importedAccount.email
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        return persistedManagedAccounts.accounts.first {
+        return candidates.accounts.first {
             $0.email == normalizedEmail && $0.effectiveWorkspaceAccountID == nil
         }
     }

--- a/Sources/CodexBar/CodexAccountPromotionExecution.swift
+++ b/Sources/CodexBar/CodexAccountPromotionExecution.swift
@@ -185,17 +185,17 @@ struct CodexDisplacedLivePreservationExecutor {
         in persistedManagedAccounts: ManagedCodexAccountSet,
         for importedAccount: ManagedCodexAccount) -> ManagedCodexAccount?
     {
-        if let providerAccountID = importedAccount.providerAccountID {
+        if let workspaceAccountID = importedAccount.effectiveWorkspaceAccountID {
             return persistedManagedAccounts.account(
                 email: importedAccount.email,
-                providerAccountID: providerAccountID)
+                providerAccountID: workspaceAccountID)
         }
 
         let normalizedEmail = importedAccount.email
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         return persistedManagedAccounts.accounts.first {
-            $0.email == normalizedEmail && $0.providerAccountID == nil
+            $0.email == normalizedEmail && $0.effectiveWorkspaceAccountID == nil
         }
     }
 

--- a/Sources/CodexBar/CodexAccountPromotionPlanning.swift
+++ b/Sources/CodexBar/CodexAccountPromotionPlanning.swift
@@ -57,12 +57,12 @@ struct CodexDisplacedLivePreservationPlanner {
             return .reject(reason: .liveIdentityMissingForPreservation)
         }
 
-        if let targetAuthIdentity = context.target.authIdentity,
-           CodexIdentityMatcher.matches(
-               targetAuthIdentity.identity,
-               lhsEmail: targetAuthIdentity.email,
-               liveAuthIdentity.identity,
-               rhsEmail: liveAuthIdentity.email)
+        let targetIdentity = context.target.remoteIdentity
+        if CodexIdentityMatcher.matches(
+            targetIdentity.identity,
+            lhsEmail: targetIdentity.email,
+            liveAuthIdentity.identity,
+            rhsEmail: liveAuthIdentity.email)
         {
             return .none(reason: .targetMatchesLiveAuthIdentity)
         }
@@ -100,11 +100,17 @@ struct CodexDisplacedLivePreservationPlanner {
     {
         candidates.first { candidate in
             guard let candidateAuthIdentity = candidate.authIdentity else { return false }
+            let candidateRemoteIdentity = candidate.remoteIdentity
             return CodexIdentityMatcher.matches(
-                candidateAuthIdentity.identity,
-                lhsEmail: candidateAuthIdentity.email,
+                candidateRemoteIdentity.identity,
+                lhsEmail: candidateRemoteIdentity.email,
                 liveAuthIdentity.identity,
-                rhsEmail: liveAuthIdentity.email)
+                rhsEmail: liveAuthIdentity.email) &&
+                CodexIdentityMatcher.matches(
+                    candidateAuthIdentity.identity,
+                    lhsEmail: candidateAuthIdentity.email,
+                    liveAuthIdentity.identity,
+                    rhsEmail: liveAuthIdentity.email)
         }
     }
 
@@ -115,9 +121,9 @@ struct CodexDisplacedLivePreservationPlanner {
     {
         switch liveAuthIdentity.identity {
         case let .providerAccount(id):
-            let providerAccountID = ManagedCodexAccount.normalizeProviderAccountID(id)
+            let providerAccountID = ManagedCodexAccount.normalizeWorkspaceAccountID(id)
             if let destination = candidates.first(where: {
-                guard $0.persisted.providerAccountID == providerAccountID else { return false }
+                guard $0.persisted.effectiveWorkspaceAccountID == providerAccountID else { return false }
                 guard let liveEmail = liveAuthIdentity.email else { return true }
                 return $0.persisted.email == liveEmail
             }),
@@ -128,7 +134,7 @@ struct CodexDisplacedLivePreservationPlanner {
 
             if let liveEmail = liveAuthIdentity.email,
                let destination = candidates.first(where: {
-                   $0.persisted.providerAccountID == nil && $0.persisted.email == liveEmail
+                   $0.persisted.effectiveWorkspaceAccountID == nil && $0.persisted.email == liveEmail
                })
             {
                 return (destination, .persistedLegacyEmailMatch)
@@ -138,7 +144,7 @@ struct CodexDisplacedLivePreservationPlanner {
 
         case let .emailOnly(normalizedEmail):
             guard let destination = candidates.first(where: {
-                $0.persisted.providerAccountID == nil && $0.persisted.email == normalizedEmail
+                $0.persisted.effectiveWorkspaceAccountID == nil && $0.persisted.email == normalizedEmail
             }) else {
                 return nil
             }
@@ -158,17 +164,17 @@ struct CodexDisplacedLivePreservationPlanner {
             return false
         }
 
-        let providerAccountID = ManagedCodexAccount.normalizeProviderAccountID(id)
+        let providerAccountID = ManagedCodexAccount.normalizeWorkspaceAccountID(id)
         return candidates.contains { candidate in
-            guard candidate.persisted.providerAccountID == providerAccountID else { return false }
+            guard candidate.persisted.effectiveWorkspaceAccountID == providerAccountID else { return false }
             if let liveEmail = liveAuthIdentity.email, candidate.persisted.email != liveEmail {
                 return false
             }
             guard case .readable = candidate.homeState else { return false }
-            guard let candidateAuthIdentity = candidate.authIdentity else { return false }
+            guard let candidateIdentity = candidate.authIdentity else { return false }
             return !CodexIdentityMatcher.matches(
-                candidateAuthIdentity.identity,
-                lhsEmail: candidateAuthIdentity.email,
+                candidateIdentity.identity,
+                lhsEmail: candidateIdentity.email,
                 liveAuthIdentity.identity,
                 rhsEmail: liveAuthIdentity.email)
         }

--- a/Sources/CodexBar/CodexAccountPromotionPreparation.swift
+++ b/Sources/CodexBar/CodexAccountPromotionPreparation.swift
@@ -268,7 +268,7 @@ struct PreparedPromotionContextBuilder {
         }
     }
 
-    private static func runtimeAccount(from rawData: Data) throws -> CodexAuthBackedAccount {
+    static func runtimeAccount(from rawData: Data) throws -> CodexAuthBackedAccount {
         guard let json = try JSONSerialization.jsonObject(with: rawData) as? [String: Any] else {
             throw CodexOAuthCredentialsError.decodeFailed("Invalid JSON")
         }

--- a/Sources/CodexBar/CodexAccountPromotionPreparation.swift
+++ b/Sources/CodexBar/CodexAccountPromotionPreparation.swift
@@ -36,6 +36,28 @@ struct PreparedStoredManagedAccount {
             nil
         }
     }
+
+    var remoteIdentity: PreparedIdentity {
+        guard let workspaceAccountID = self.persisted.effectiveWorkspaceAccountID else {
+            return self.authIdentity ?? self.persistedIdentity
+        }
+        return PreparedIdentity(
+            email: self.authIdentity?.email ?? self.persistedIdentity.email,
+            identity: .providerAccount(id: workspaceAccountID),
+            providerAccountID: workspaceAccountID,
+            workspaceLabel: self.persistedIdentity.workspaceLabel ?? self.authIdentity?.workspaceLabel,
+            workspaceAccountID: workspaceAccountID)
+    }
+
+    var selectedWorkspaceDiffersFromAuthDefault: Bool {
+        guard let selectedWorkspaceAccountID = self.persisted.effectiveWorkspaceAccountID,
+              let authIdentity = self.authIdentity
+        else {
+            return false
+        }
+        return selectedWorkspaceAccountID != ManagedCodexAccount.normalizeWorkspaceAccountID(
+            authIdentity.providerAccountID)
+    }
 }
 
 enum PreparedLiveHomeState {
@@ -195,7 +217,7 @@ struct PreparedPromotionContextBuilder {
         let normalizedIdentity = Self.normalizedIdentity(runtimeAccount.identity, email: normalizedEmail)
         let providerAccountID: String? = switch normalizedIdentity {
         case let .providerAccount(id):
-            ManagedCodexAccount.normalizeProviderAccountID(id)
+            ManagedCodexAccount.normalizeWorkspaceAccountID(id)
         case .emailOnly, .unresolved:
             nil
         }
@@ -217,7 +239,7 @@ struct PreparedPromotionContextBuilder {
 
     private static func persistedIdentity(from account: ManagedCodexAccount) -> PreparedIdentity {
         let normalizedEmail = Self.normalizeEmail(account.email)
-        let providerAccountID = ManagedCodexAccount.normalizeProviderAccountID(account.providerAccountID)
+        let providerAccountID = account.effectiveWorkspaceAccountID
         let identity = Self.normalizedIdentity(
             CodexIdentityResolver.resolve(accountId: providerAccountID, email: normalizedEmail),
             email: normalizedEmail)
@@ -227,7 +249,7 @@ struct PreparedPromotionContextBuilder {
             identity: identity,
             providerAccountID: providerAccountID,
             workspaceLabel: account.workspaceLabel,
-            workspaceAccountID: account.workspaceAccountID)
+            workspaceAccountID: providerAccountID)
     }
 
     private func liveHomeURL() -> URL {
@@ -263,7 +285,7 @@ struct PreparedPromotionContextBuilder {
             (payload?["email"] as? String) ?? (profileDict?["email"] as? String))
         let plan = Self.normalizedField(
             (authDict?["chatgpt_plan_type"] as? String) ?? (payload?["chatgpt_plan_type"] as? String))
-        let accountID = ManagedCodexAccount.normalizeProviderAccountID(
+        let accountID = ManagedCodexAccount.normalizeWorkspaceAccountID(
             tokens.flatMap {
                 Self.nonEmptyString(in: $0, snakeCaseKey: "account_id", camelCaseKey: "accountId")
             }

--- a/Sources/CodexBar/CodexAccountPromotionService.swift
+++ b/Sources/CodexBar/CodexAccountPromotionService.swift
@@ -241,6 +241,7 @@ final class CodexAccountPromotionService {
         let executionResult = try CodexDisplacedLivePreservationExecutor(
             store: self.store,
             homeFactory: self.homeFactory,
+            authMaterialReader: self.authMaterialReader,
             fileManager: self.fileManager)
             .execute(plan: preservationPlan, context: context)
 

--- a/Sources/CodexBar/CodexAccountPromotionService.swift
+++ b/Sources/CodexBar/CodexAccountPromotionService.swift
@@ -52,7 +52,9 @@ struct DefaultCodexLiveAuthSwapper: CodexLiveAuthSwapping {
     func swapLiveAuthData(_ data: Data, liveHomeURL: URL) throws {
         let liveAuthURL = CodexAccountPromotionService.authFileURL(for: liveHomeURL)
         guard CodexCredentialFileAccess.permits(liveAuthURL) else { throw CodexOAuthCredentialsError.notFound }
-        if try CodexCredentialFileAccess.substituteWriteForTesting(at: liveAuthURL) { return }
+        if try CodexCredentialFileAccess.substituteWriteForTesting(at: liveAuthURL) {
+            return
+        }
         try CodexCredentialFileAccess.createDirectory(forCredentialAt: liveAuthURL)
 
         let stagedAuthURL = liveHomeURL.appendingPathComponent(
@@ -139,6 +141,7 @@ enum CodexAccountPromotionError: Error, Equatable {
     case targetManagedAccountNotFound
     case targetManagedAccountAuthMissing
     case targetManagedAccountAuthUnreadable
+    case targetManagedAccountWorkspaceDiffersFromAuthDefault
     case liveAccountUnreadable
     case liveAccountMissingIdentityForPreservation
     case liveAccountAPIKeyOnlyUnsupported
@@ -229,6 +232,10 @@ final class CodexAccountPromotionService {
                 resultingActiveSource: resultingActiveSource)
         }
 
+        guard !context.target.selectedWorkspaceDiffersFromAuthDefault else {
+            throw CodexAccountPromotionError.targetManagedAccountWorkspaceDiffersFromAuthDefault
+        }
+
         let targetAuthMaterial = try self.requiredTargetAuthMaterial(from: context.target)
         let preservationPlan = CodexDisplacedLivePreservationPlanner().makePlan(context: context)
         let executionResult = try CodexDisplacedLivePreservationExecutor(
@@ -260,7 +267,7 @@ final class CodexAccountPromotionService {
 
     private func convergedActiveSource(for context: PreparedPromotionContext) -> CodexActiveSource? {
         if let liveAuthIdentity = context.live.authIdentity {
-            let targetIdentity = context.target.authIdentity ?? context.target.persistedIdentity
+            let targetIdentity = context.target.remoteIdentity
             guard CodexIdentityMatcher.matches(
                 targetIdentity.identity,
                 lhsEmail: targetIdentity.email,
@@ -286,7 +293,7 @@ final class CodexAccountPromotionService {
         }
 
         guard CodexIdentityMatcher.matches(
-            context.snapshot.runtimeIdentity(for: context.target.persisted),
+            context.snapshot.managedRemoteIdentity(for: context.target.persisted),
             lhsEmail: context.snapshot.runtimeEmail(for: context.target.persisted),
             context.snapshot.runtimeIdentity(for: liveSystemAccount),
             rhsEmail: liveSystemAccount.email)

--- a/Sources/CodexBar/CodexHistoryOwnership.swift
+++ b/Sources/CodexBar/CodexHistoryOwnership.swift
@@ -16,7 +16,7 @@ enum CodexHistoryOwnership {
     static func canonicalKey(for identity: CodexIdentity) -> String? {
         switch identity {
         case let .providerAccount(id):
-            guard let normalized = Self.normalizeScopedValue(id) else { return nil }
+            guard let normalized = ManagedCodexAccount.normalizeWorkspaceAccountID(id) else { return nil }
             return "\(Self.providerAccountPrefix)\(normalized)"
         case let .emailOnly(normalizedEmail):
             guard let normalized = CodexIdentityResolver.normalizeEmail(normalizedEmail) else { return nil }
@@ -42,8 +42,8 @@ enum CodexHistoryOwnership {
         guard let normalizedKey = normalizeScopedValue(rawKey) else {
             return .legacyUnscoped
         }
-        if self.isCanonicalKey(normalizedKey) {
-            return .canonical(normalizedKey)
+        if let normalizedCanonicalKey = self.normalizedCanonicalKey(normalizedKey) {
+            return .canonical(normalizedCanonicalKey)
         }
         if let legacyEmailHash, normalizedKey == legacyEmailHash {
             return .legacyEmailHash(normalizedKey)
@@ -113,8 +113,15 @@ enum CodexHistoryOwnership {
         return true
     }
 
-    private static func isCanonicalKey(_ rawKey: String) -> Bool {
-        self.isCanonicalProviderAccountKey(rawKey) || self.isCanonicalEmailHashKey(rawKey)
+    private static func normalizedCanonicalKey(_ rawKey: String) -> String? {
+        if self.isCanonicalProviderAccountKey(rawKey) {
+            let rawAccountID = String(rawKey.dropFirst(self.providerAccountPrefix.count))
+            guard let accountID = ManagedCodexAccount.normalizeWorkspaceAccountID(rawAccountID) else {
+                return nil
+            }
+            return "\(self.providerAccountPrefix)\(accountID)"
+        }
+        return self.isCanonicalEmailHashKey(rawKey) ? rawKey : nil
     }
 
     static func isCanonicalProviderAccountKey(_ rawKey: String) -> Bool {

--- a/Sources/CodexBar/CodexOwnershipContext.swift
+++ b/Sources/CodexBar/CodexOwnershipContext.swift
@@ -109,10 +109,10 @@ extension UsageStore {
         let snapshot = self.settings.codexAccountReconciliationSnapshot
         var distinctAccounts: Set<String> = []
 
-        if let activeManagedAccount = self.settings.activeManagedCodexAccount {
-            distinctAccounts.insert(CodexIdentityMatcher.selectionKey(
-                for: snapshot.runtimeIdentity(for: activeManagedAccount),
-                fallbackEmail: snapshot.runtimeEmail(for: activeManagedAccount)))
+        if let activeOwner = snapshot.activeStoredAccount ?? snapshot.matchingStoredAccountForLiveSystemAccount {
+            distinctAccounts.formUnion(self.codexManagedOwnerKeys(
+                account: activeOwner,
+                snapshot: snapshot))
         }
 
         if let liveSystemAccount = snapshot.liveSystemAccount {
@@ -128,12 +128,12 @@ extension UsageStore {
         let snapshot = self.settings.codexAccountReconciliationSnapshot
         var distinctAccounts: Set<String> = []
 
-        if let activeManagedAccount = self.settings.activeManagedCodexAccount,
-           CodexIdentityResolver.normalizeEmail(snapshot.runtimeEmail(for: activeManagedAccount)) == normalizedEmail
+        if let activeOwner = snapshot.activeStoredAccount ?? snapshot.matchingStoredAccountForLiveSystemAccount,
+           CodexIdentityResolver.normalizeEmail(snapshot.runtimeEmail(for: activeOwner)) == normalizedEmail
         {
-            distinctAccounts.insert(CodexIdentityMatcher.selectionKey(
-                for: snapshot.runtimeIdentity(for: activeManagedAccount),
-                fallbackEmail: snapshot.runtimeEmail(for: activeManagedAccount)))
+            distinctAccounts.formUnion(self.codexManagedOwnerKeys(
+                account: activeOwner,
+                snapshot: snapshot))
         }
 
         if let liveSystemAccount = snapshot.liveSystemAccount,
@@ -145,6 +145,26 @@ extension UsageStore {
         }
 
         return distinctAccounts.count > 1
+    }
+
+    private func codexManagedOwnerKeys(
+        account: ManagedCodexAccount,
+        snapshot: CodexAccountReconciliationSnapshot) -> Set<String>
+    {
+        let email = snapshot.runtimeEmail(for: account)
+        let remoteIdentity = snapshot.managedRemoteIdentity(for: account)
+        var keys = [CodexIdentityMatcher.selectionKey(
+            for: remoteIdentity,
+            fallbackEmail: email)]
+        let runtimeIdentity = snapshot.runtimeIdentity(for: account)
+        if runtimeIdentity != .unresolved,
+           !CodexIdentityMatcher.matches(runtimeIdentity, remoteIdentity)
+        {
+            keys.append(CodexIdentityMatcher.selectionKey(
+                for: runtimeIdentity,
+                fallbackEmail: email))
+        }
+        return Set(keys)
     }
 
     private func codexVisibleAccountsHaveAdjacentMultiAccountVeto() -> Bool {
@@ -163,6 +183,7 @@ extension UsageStore {
     }
 
     private func codexVisibleAccountsHaveAdjacentEmailScopeAmbiguity(normalizedEmail: String) -> Bool {
+        let snapshot = self.settings.codexAccountReconciliationSnapshot
         let accounts = self.settings.codexVisibleAccountProjection.visibleAccounts
         var distinctAccounts: Set<String> = []
         for account in accounts where CodexIdentityResolver.normalizeEmail(account.email) == normalizedEmail {
@@ -172,6 +193,14 @@ extension UsageStore {
                 distinctAccounts.insert("provider:\(workspaceAccountID)")
             } else {
                 distinctAccounts.insert("email:\(normalizedEmail)")
+            }
+            if let storedAccountID = account.storedAccountID,
+               let storedAccount = snapshot.storedAccounts.first(where: { $0.id == storedAccountID }),
+               CodexIdentityResolver.normalizeEmail(snapshot.runtimeEmail(for: storedAccount)) == normalizedEmail
+            {
+                distinctAccounts.formUnion(self.codexManagedOwnerKeys(
+                    account: storedAccount,
+                    snapshot: snapshot))
             }
         }
         return distinctAccounts.count > 1

--- a/Sources/CodexBar/ManagedCodexAccountService.swift
+++ b/Sources/CodexBar/ManagedCodexAccountService.swift
@@ -257,7 +257,7 @@ final class ManagedCodexAccountService {
             }
             let authenticatedProviderAccountID: String? = switch identity.identity {
             case let .providerAccount(id):
-                ManagedCodexAccount.normalizeProviderAccountID(id)
+                ManagedCodexAccount.normalizeWorkspaceAccountID(id)
             case .emailOnly, .unresolved:
                 nil
             }
@@ -394,7 +394,7 @@ final class ManagedCodexAccountService {
         if let existingAccountID,
            let existingByID = snapshot.account(id: existingAccountID),
            existingByID.email == Self.normalizeEmail(authenticatedEmail),
-           providerAccountID == nil || existingByID.providerAccountID == nil
+           providerAccountID == nil || existingByID.effectiveWorkspaceAccountID == nil
         {
             return existingByID
         }
@@ -423,7 +423,7 @@ final class ManagedCodexAccountService {
             let legacySameEmailIDs = snapshot.accounts
                 .filter {
                     $0.id != matchedAccountID &&
-                        $0.providerAccountID == nil &&
+                        $0.effectiveWorkspaceAccountID == nil &&
                         $0.email == normalizedEmail
                 }
                 .map(\.id)
@@ -437,7 +437,7 @@ final class ManagedCodexAccountService {
             return ids
         }
 
-        if existingByID.providerAccountID == nil,
+        if existingByID.effectiveWorkspaceAccountID == nil,
            existingByID.email == normalizedEmail,
            providerAccountID != nil
         {
@@ -459,7 +459,8 @@ final class ManagedCodexAccountService {
         workspaceAccountID: String?)
     {
         if let authenticatedProviderAccountID {
-            let isExistingProviderMatch = existingAccount?.providerAccountID == authenticatedProviderAccountID
+            let isExistingProviderMatch =
+                existingAccount?.effectiveWorkspaceAccountID == authenticatedProviderAccountID
             return (
                 providerAccountID: authenticatedProviderAccountID,
                 workspaceLabel: resolvedWorkspaceIdentity?.workspaceLabel
@@ -469,13 +470,13 @@ final class ManagedCodexAccountService {
                     authenticatedProviderAccountID)
         }
 
-        guard let existingAccount, existingAccount.providerAccountID != nil else {
+        guard let existingAccount, existingAccount.effectiveWorkspaceAccountID != nil else {
             return (providerAccountID: nil, workspaceLabel: nil, workspaceAccountID: nil)
         }
 
         return (
             providerAccountID: existingAccount.providerAccountID,
             workspaceLabel: existingAccount.workspaceLabel,
-            workspaceAccountID: existingAccount.workspaceAccountID ?? existingAccount.providerAccountID)
+            workspaceAccountID: existingAccount.effectiveWorkspaceAccountID)
     }
 }

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -100,6 +100,7 @@ extension UsageStore {
         self.lastCreditsError = nil
         self.lastCreditsSnapshot = nil
         self.lastCreditsSnapshotAccountKey = nil
+        self.lastCreditsSnapshotOwnerGuard = nil
         self.lastCreditsSource = .none
         self.creditsFailureStreak = 0
 
@@ -661,7 +662,7 @@ extension UsageStore {
             guard let activeStoredAccount = self.settings.codexAccountReconciliationSnapshot.activeStoredAccount else {
                 return .unresolved
             }
-            return self.settings.codexAccountReconciliationSnapshot.runtimeIdentity(for: activeStoredAccount)
+            return self.settings.codexAccountReconciliationSnapshot.managedRemoteIdentity(for: activeStoredAccount)
         case let .profileHome(path):
             guard let profileAccount = self.settings.codexAccountReconciliationSnapshot.profileHomeAccount(path: path)
             else {
@@ -685,7 +686,7 @@ extension UsageStore {
             guard let activeStoredAccount = self.settings.codexAccountReconciliationSnapshot.activeStoredAccount else {
                 return .unresolved
             }
-            return self.settings.codexAccountReconciliationSnapshot.runtimeIdentity(for: activeStoredAccount)
+            return self.settings.codexAccountReconciliationSnapshot.managedRemoteIdentity(for: activeStoredAccount)
         case let .profileHome(path):
             guard let profileAccount = self.settings.codexAccountReconciliationSnapshot.profileHomeAccount(path: path)
             else {

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
@@ -93,7 +93,7 @@ extension UsageStore {
             return
         }
         do {
-            let credits = try await self.loadLatestCodexCredits(accountKey: expectedGuard.accountKey)
+            let credits = try await self.loadLatestCodexCredits(expectedGuard: expectedGuard)
             guard !Task.isCancelled else { return }
             guard let applyGuard = self.codexScopedNonUsageSuccessApplyGuard(
                 expectedGuard: expectedGuard) else { return }
@@ -103,6 +103,7 @@ extension UsageStore {
                 self.lastCreditsError = nil
                 self.lastCreditsSnapshot = credits
                 self.lastCreditsSnapshotAccountKey = applyGuard.accountKey
+                self.lastCreditsSnapshotOwnerGuard = applyGuard
                 self.lastCreditsSource = credits == nil ? .none : .api
                 self.creditsFailureStreak = 0
                 self.lastCodexAccountScopedRefreshGuard = applyGuard
@@ -133,7 +134,8 @@ extension UsageStore {
                 self.reconcileCodexPublishedUsageOwner(with: expectedGuard)
                 await MainActor.run {
                     if let cached = self.lastCreditsSnapshot,
-                       self.lastCreditsSnapshotAccountKey == expectedGuard.accountKey
+                       let cachedOwnerGuard = self.lastCreditsSnapshotOwnerGuard,
+                       Self.codexScopedRefreshGuardsMatchAccount(cachedOwnerGuard, expectedGuard)
                     {
                         self.credits = cached
                         self.lastCreditsError = nil
@@ -152,7 +154,8 @@ extension UsageStore {
             await MainActor.run {
                 self.creditsFailureStreak += 1
                 if let cached = self.lastCreditsSnapshot,
-                   self.lastCreditsSnapshotAccountKey == expectedGuard.accountKey
+                   let cachedOwnerGuard = self.lastCreditsSnapshotOwnerGuard,
+                   Self.codexScopedRefreshGuardsMatchAccount(cachedOwnerGuard, expectedGuard)
                 {
                     self.credits = cached
                     let stamp = cached.updatedAt.formatted(date: .abbreviated, time: .shortened)
@@ -168,7 +171,9 @@ extension UsageStore {
         }
     }
 
-    private func loadLatestCodexCredits(accountKey: String?) async throws -> CreditsSnapshot? {
+    private func loadLatestCodexCredits(
+        expectedGuard: CodexAccountScopedRefreshGuard) async throws -> CreditsSnapshot?
+    {
         if let override = self._test_codexCreditsLoaderOverride {
             return try await override()
         }
@@ -177,7 +182,11 @@ extension UsageStore {
         let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(context)
         var lastAvailableError: Error?
         let prior = await MainActor.run { () -> CreditsSnapshot? in
-            guard self.lastCreditsSnapshotAccountKey == accountKey else { return nil }
+            guard let cachedOwnerGuard = self.lastCreditsSnapshotOwnerGuard,
+                  Self.codexScopedRefreshGuardsMatchAccount(cachedOwnerGuard, expectedGuard)
+            else {
+                return nil
+            }
             return self.lastCreditsSnapshot
         }
 
@@ -278,7 +287,10 @@ extension UsageStore {
         self.codexPlanHistoryBackfillTask = nil
     }
 
-    func publishHydratedCodexCreditsIfNeeded(from persistedCredits: CreditsSnapshot?, accountKey: String?) {
+    func publishHydratedCodexCreditsIfNeeded(
+        from persistedCredits: CreditsSnapshot?,
+        ownerGuard: CodexAccountScopedRefreshGuard)
+    {
         guard let credits = CodexMonthlyCreditPreservation.hydrationCredits(
             existingCredits: self.credits,
             persistedCredits: persistedCredits)
@@ -286,25 +298,36 @@ extension UsageStore {
         self.credits = credits
         self.lastCreditsError = nil
         self.lastCreditsSnapshot = credits
-        self.lastCreditsSnapshotAccountKey = accountKey
+        self.lastCreditsSnapshotAccountKey = ownerGuard.accountKey
+        self.lastCreditsSnapshotOwnerGuard = ownerGuard
         self.lastCreditsSource = .api
     }
 
     func shouldPublishSelectedCodexCredits(
         _ result: ProviderFetchResult,
-        publishedCredits: CreditsSnapshot?) -> Bool
+        publishedCredits: CreditsSnapshot?,
+        publicationGuard: CodexAccountScopedRefreshGuard) -> Bool
     {
-        CodexMonthlyCreditPreservation.shouldPublishSelectedCredits(
+        let ownerMatches = self.lastCreditsSnapshotOwnerGuard.map {
+            Self.codexScopedRefreshGuardsMatchAccount($0, publicationGuard)
+        } ?? false
+        let cachedCredits = ownerMatches
+            ? self.lastCreditsSnapshot
+            : nil
+        let currentCredits = ownerMatches
+            ? self.credits
+            : nil
+        return CodexMonthlyCreditPreservation.shouldPublishSelectedCredits(
             enrichmentFailed: result.codexMonthlyLimitEnrichmentFailed,
             publishedCredits: publishedCredits,
-            currentCredits: self.credits,
-            cachedCredits: self.lastCreditsSnapshot)
+            currentCredits: currentCredits,
+            cachedCredits: cachedCredits)
     }
 
     func persistPublishedCodexCreditsIntoAccountSnapshotsIfNeeded() {
-        let refreshGuard = self.lastCodexAccountScopedRefreshGuard
-        let accountKey = self.lastCreditsSnapshotAccountKey ?? refreshGuard?.accountKey
-        guard let accountKey else { return }
+        guard let refreshGuard = self.lastCreditsSnapshotOwnerGuard,
+              let accountKey = refreshGuard.accountKey
+        else { return }
         var matches = self.codexAccountSnapshots.indices.filter { index in
             Self.codexAccountSnapshot(
                 self.codexAccountSnapshots[index],

--- a/Sources/CodexBar/UsageStore+HistoricalPace.swift
+++ b/Sources/CodexBar/UsageStore+HistoricalPace.swift
@@ -166,8 +166,12 @@ extension UsageStore {
                 accountKey: ownership.canonicalKey)
             let dataset = await historyStore.loadCodexDataset(
                 canonicalAccountKey: ownership.canonicalKey,
-                canonicalEmailHashKey: ownership.canonicalEmailHashKey,
-                legacyEmailHash: ownership.historicalLegacyEmailHash,
+                canonicalEmailHashKey: ownership.hasAdjacentEmailScopeAmbiguity
+                    ? nil
+                    : ownership.canonicalEmailHashKey,
+                legacyEmailHash: ownership.hasAdjacentEmailScopeAmbiguity
+                    ? nil
+                    : ownership.historicalLegacyEmailHash,
                 hasAdjacentMultiAccountVeto: ownership.hasAdjacentMultiAccountVeto)
             await MainActor.run { [weak self] in
                 self?.setCodexHistoricalDataset(dataset, accountKey: ownership.canonicalKey)
@@ -183,8 +187,12 @@ extension UsageStore {
         let ownership = self.codexOwnershipContext()
         let dataset = await self.historicalUsageHistoryStore.loadCodexDataset(
             canonicalAccountKey: ownership.canonicalKey,
-            canonicalEmailHashKey: ownership.canonicalEmailHashKey,
-            legacyEmailHash: ownership.historicalLegacyEmailHash,
+            canonicalEmailHashKey: ownership.hasAdjacentEmailScopeAmbiguity
+                ? nil
+                : ownership.canonicalEmailHashKey,
+            legacyEmailHash: ownership.hasAdjacentEmailScopeAmbiguity
+                ? nil
+                : ownership.historicalLegacyEmailHash,
             hasAdjacentMultiAccountVeto: ownership.hasAdjacentMultiAccountVeto)
         self.setCodexHistoricalDataset(dataset, accountKey: ownership.canonicalKey)
         if let dashboard = self.openAIDashboard {
@@ -246,8 +254,12 @@ extension UsageStore {
                 accountKey: ownership.canonicalKey)
             let dataset = await historyStore.loadCodexDataset(
                 canonicalAccountKey: ownership.canonicalKey,
-                canonicalEmailHashKey: ownership.canonicalEmailHashKey,
-                legacyEmailHash: ownership.historicalLegacyEmailHash,
+                canonicalEmailHashKey: ownership.hasAdjacentEmailScopeAmbiguity
+                    ? nil
+                    : ownership.canonicalEmailHashKey,
+                legacyEmailHash: ownership.hasAdjacentEmailScopeAmbiguity
+                    ? nil
+                    : ownership.historicalLegacyEmailHash,
                 hasAdjacentMultiAccountVeto: ownership.hasAdjacentMultiAccountVeto)
             await MainActor.run { [weak self] in
                 self?.setCodexHistoricalDataset(dataset, accountKey: ownership.canonicalKey)

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -278,20 +278,22 @@ extension UsageStore {
                     allowLastKnownLiveFallback: false)
             }
 
+            if decision.allowedEffects.contains(.refreshGuardSeed) {
+                self.seedCodexAccountScopedRefreshGuard(accountEmail: attachedAccountEmail)
+            }
+
             if decision.allowedEffects.contains(.creditsAttachment),
                self.credits == nil,
                let credits = dashboard.toCreditsSnapshot()
             {
+                let ownerGuard = self.lastCodexAccountScopedRefreshGuard
                 self.credits = credits
                 self.lastCreditsSnapshot = credits
-                self.lastCreditsSnapshotAccountKey = Self.normalizeCodexAccountScopedKey(attachedAccountEmail)
+                self.lastCreditsSnapshotAccountKey = ownerGuard?.accountKey
+                self.lastCreditsSnapshotOwnerGuard = ownerGuard
                 self.lastCreditsSource = .dashboardWeb
                 self.lastCreditsError = nil
                 self.creditsFailureStreak = 0
-            }
-
-            if decision.allowedEffects.contains(.refreshGuardSeed) {
-                self.seedCodexAccountScopedRefreshGuard(accountEmail: attachedAccountEmail)
             }
 
             if let attachedAccountEmail, !attachedAccountEmail.isEmpty {
@@ -360,6 +362,7 @@ extension UsageStore {
         self.lastCreditsError = nil
         self.lastCreditsSnapshot = nil
         self.lastCreditsSnapshotAccountKey = nil
+        self.lastCreditsSnapshotOwnerGuard = nil
         self.lastCreditsSource = .none
         self.creditsFailureStreak = 0
     }

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -309,7 +309,7 @@ extension UsageStore {
             self.lastKnownResetSnapshots[.codex] = hydratedSnapshot
             self.errors[.codex] = hydratedPrior.error
             self.lastSourceLabels[.codex] = hydratedPrior.sourceLabel
-            self.publishHydratedCodexCreditsIfNeeded(from: hydratedPrior.credits, accountKey: expectedGuard.accountKey)
+            self.publishHydratedCodexCreditsIfNeeded(from: hydratedPrior.credits, ownerGuard: expectedGuard)
             self.lastCodexUsagePublicationGuard = expectedGuard
             self.lastCodexAccountScopedRefreshGuard = expectedGuard
         }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -428,7 +428,7 @@ extension UsageStore {
                         authFingerprint: authFingerprint ?? (requiresLiveAuth ? nil : account.authFingerprint),
                         workspaceAccountID: authFingerprint == nil && requiresLiveAuth
                             ? nil
-                            : (account.workspaceAccountID ?? account.providerAccountID ?? authWorkspaceAccountID)))
+                            : (account.effectiveWorkspaceAccountID ?? authWorkspaceAccountID)))
             })
         let visibleAccounts = projection.visibleAccounts.map { account in
             guard case let .managedAccount(id) = account.selectionSource else { return account }
@@ -1428,11 +1428,16 @@ extension UsageStore {
             self.lastFetchAttempts[.codex] = outcome.attempts
             let publishedCredits = self.codexAccountSnapshots.first(where: { $0.id == account.id })?.credits
                 ?? result.credits
-            if self.shouldPublishSelectedCodexCredits(result, publishedCredits: publishedCredits) {
+            if self.shouldPublishSelectedCodexCredits(
+                result,
+                publishedCredits: publishedCredits,
+                publicationGuard: publicationGuard)
+            {
                 self.credits = publishedCredits
                 self.lastCreditsError = nil
                 self.lastCreditsSnapshot = publishedCredits
                 self.lastCreditsSnapshotAccountKey = publicationGuard.accountKey
+                self.lastCreditsSnapshotOwnerGuard = publicationGuard
                 self.lastCreditsSource = publishedCredits == nil ? .none : .api
             }
             self.handleCodexResetCreditNotifications(snapshot: snapshot)

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -226,6 +226,7 @@ final class UsageStore {
     var providerStorageFootprints: [ProviderInstanceID: ProviderStorageFootprint] = [:]
     @ObservationIgnored var lastCreditsSnapshot: CreditsSnapshot?
     @ObservationIgnored var lastCreditsSnapshotAccountKey: String?
+    @ObservationIgnored var lastCreditsSnapshotOwnerGuard: CodexAccountScopedRefreshGuard?
     @ObservationIgnored var lastCreditsSource: CodexCreditsSource = .none
     @ObservationIgnored var creditsFailureStreak: Int = 0
     @ObservationIgnored var openAIDashboardAttachmentAuthorized: Bool = false {

--- a/Sources/CodexBarCore/CodexManagedAccounts.swift
+++ b/Sources/CodexBarCore/CodexManagedAccounts.swift
@@ -42,7 +42,7 @@ public struct ManagedCodexAccount: Codable, Identifiable, Sendable {
     }
 
     public static func normalizeProviderAccountID(_ providerAccountID: String?) -> String? {
-        CodexIdentityResolver.normalizeAccountID(providerAccountID)
+        self.normalizeWorkspaceAccountID(providerAccountID)
     }
 
     public static func normalizeWorkspaceLabel(_ workspaceLabel: String?) -> String? {
@@ -57,6 +57,15 @@ public struct ManagedCodexAccount: Codable, Identifiable, Sendable {
             return nil
         }
         return trimmed.lowercased()
+    }
+
+    /// The remote workspace CodexBar selected for this managed account.
+    ///
+    /// New records store the explicit workspace separately. Older provider-backed records used
+    /// `providerAccountID` for the same purpose. The managed auth file can name a different default
+    /// workspace, so callers deciding remote ownership must prefer this app-owned selection.
+    public var effectiveWorkspaceAccountID: String? {
+        Self.normalizeWorkspaceAccountID(self.workspaceAccountID ?? self.providerAccountID)
     }
 
     public init(from decoder: any Decoder) throws {
@@ -126,17 +135,16 @@ public struct ManagedCodexAccountSet: Codable, Sendable {
 
     public func account(email: String, providerAccountID: String? = nil) -> ManagedCodexAccount? {
         let normalizedEmail = ManagedCodexAccount.normalizeEmail(email)
-        if let normalizedProviderAccountID = ManagedCodexAccount.normalizeProviderAccountID(providerAccountID),
+        if let normalizedWorkspaceAccountID = ManagedCodexAccount.normalizeWorkspaceAccountID(providerAccountID),
            let exactMatch = self.accounts.first(where: {
-               $0.email == normalizedEmail && $0.providerAccountID == normalizedProviderAccountID
+               $0.email == normalizedEmail && $0.effectiveWorkspaceAccountID == normalizedWorkspaceAccountID
            })
         {
             return exactMatch
         }
-        if providerAccountID != nil {
-            return self.accounts.first { $0.email == normalizedEmail && $0.providerAccountID == nil }
+        return self.accounts.first {
+            $0.email == normalizedEmail && $0.effectiveWorkspaceAccountID == nil
         }
-        return self.accounts.first { $0.email == normalizedEmail }
     }
 
     public init(from decoder: any Decoder) throws {
@@ -147,15 +155,15 @@ public struct ManagedCodexAccountSet: Codable, Sendable {
 
     private static func sanitizedAccounts(_ accounts: [ManagedCodexAccount]) -> [ManagedCodexAccount] {
         var seenIDs: Set<UUID> = []
-        var seenProviderAccountKeys: Set<String> = []
+        var seenWorkspaceAccountKeys: Set<String> = []
         var seenLegacyEmails: Set<String> = []
         var sanitized: [ManagedCodexAccount] = []
         sanitized.reserveCapacity(accounts.count)
 
         for account in accounts {
             guard seenIDs.insert(account.id).inserted else { continue }
-            if let providerAccountID = account.providerAccountID {
-                guard seenProviderAccountKeys.insert("\(account.email)\u{0}\(providerAccountID)").inserted else {
+            if let workspaceAccountID = account.effectiveWorkspaceAccountID {
+                guard seenWorkspaceAccountKeys.insert("\(account.email)\u{0}\(workspaceAccountID)").inserted else {
                     continue
                 }
             } else {

--- a/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
@@ -74,6 +74,14 @@ public enum CodexActiveSourceResolver {
         liveSystemAccount: ObservedSystemCodexAccount?) -> Bool
     {
         guard let liveSystemAccount else { return false }
+        let liveIdentity = snapshot.runtimeIdentity(for: liveSystemAccount)
+        if storedAccount.effectiveWorkspaceAccountID != nil {
+            return CodexIdentityMatcher.matches(
+                snapshot.managedRemoteIdentity(for: storedAccount),
+                lhsEmail: snapshot.runtimeEmail(for: storedAccount),
+                liveIdentity,
+                rhsEmail: liveSystemAccount.email)
+        }
         if let storedFingerprint = storedAccount.authFingerprint,
            let liveFingerprint = liveSystemAccount.authFingerprint,
            storedFingerprint == liveFingerprint
@@ -83,7 +91,7 @@ public enum CodexActiveSourceResolver {
         return CodexIdentityMatcher.matches(
             snapshot.runtimeIdentity(for: storedAccount),
             lhsEmail: snapshot.runtimeEmail(for: storedAccount),
-            snapshot.runtimeIdentity(for: liveSystemAccount),
+            liveIdentity,
             rhsEmail: liveSystemAccount.email)
     }
 }
@@ -144,15 +152,20 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
             ?? CodexIdentityResolver.resolve(accountId: nil, email: storedAccount.email)
     }
 
+    public func managedRemoteIdentity(for storedAccount: ManagedCodexAccount) -> CodexIdentity {
+        if let workspaceAccountID = storedAccount.effectiveWorkspaceAccountID {
+            return .providerAccount(id: workspaceAccountID)
+        }
+        return self.runtimeIdentity(for: storedAccount)
+    }
+
     public func runtimeEmail(for storedAccount: ManagedCodexAccount) -> String {
         self.storedAccountRuntimeEmails[storedAccount.id]
             ?? Self.normalizeEmail(storedAccount.email)
     }
 
     public func runtimeIdentity(for liveSystemAccount: ObservedSystemCodexAccount) -> CodexIdentity {
-        CodexIdentityMatcher.normalized(
-            liveSystemAccount.identity,
-            fallbackEmail: liveSystemAccount.email)
+        CodexIdentityMatcher.normalized(liveSystemAccount)
     }
 
     public func profileHomeAccount(path: String) -> ObservedSystemCodexAccount? {
@@ -247,20 +260,33 @@ public struct DefaultCodexAccountReconciler: Sendable {
                 nil
             }
             let matchingStoredAccountForLiveSystemAccount = liveSystemAccount.flatMap { liveAccount in
-                if let liveFingerprint = liveAccount.authFingerprint,
-                   let exactFingerprintMatch = accounts.accounts.first(where: {
-                       $0.authFingerprint == liveFingerprint
-                   })
-                {
-                    return exactFingerprintMatch
+                if let liveFingerprint = liveAccount.authFingerprint {
+                    let fingerprintMatches = accounts.accounts.filter { $0.authFingerprint == liveFingerprint }
+                    if let selectedWorkspaceMatch = fingerprintMatches.first(where: {
+                        guard $0.effectiveWorkspaceAccountID != nil,
+                              let runtimeAccount = runtimeAccounts[$0.id]
+                        else {
+                            return false
+                        }
+                        return self.managedAccount(
+                            $0,
+                            runtimeAccount: runtimeAccount,
+                            matchesLiveAccount: liveAccount)
+                    }) {
+                        return selectedWorkspaceMatch
+                    }
+                    if let legacyMatch = fingerprintMatches.first(where: {
+                        $0.effectiveWorkspaceAccountID == nil
+                    }) {
+                        return legacyMatch
+                    }
                 }
                 return accounts.accounts.first { account in
                     guard let runtimeAccount = runtimeAccounts[account.id] else { return false }
-                    return CodexIdentityMatcher.matches(
-                        runtimeAccount.identity,
-                        lhsEmail: runtimeAccount.email,
-                        self.runtimeIdentity(for: liveAccount),
-                        rhsEmail: liveAccount.email)
+                    return self.managedAccount(
+                        account,
+                        runtimeAccount: runtimeAccount,
+                        matchesLiveAccount: liveAccount)
                 }
             }
 
@@ -363,6 +389,23 @@ public struct DefaultCodexAccountReconciler: Sendable {
             identity: identity)
     }
 
+    private func managedAccount(
+        _ account: ManagedCodexAccount,
+        runtimeAccount: RuntimeManagedCodexAccount,
+        matchesLiveAccount liveAccount: ObservedSystemCodexAccount) -> Bool
+    {
+        let managedIdentity: CodexIdentity = if let workspaceAccountID = account.effectiveWorkspaceAccountID {
+            .providerAccount(id: workspaceAccountID)
+        } else {
+            runtimeAccount.identity
+        }
+        return CodexIdentityMatcher.matches(
+            managedIdentity,
+            lhsEmail: runtimeAccount.email,
+            self.runtimeIdentity(for: liveAccount),
+            rhsEmail: liveAccount.email)
+    }
+
     private func profileHomeAccounts(
         _ profileHomeAccounts: [ObservedSystemCodexAccount],
         excludingManagedAccounts managedAccounts: [ManagedCodexAccount]) -> [ObservedSystemCodexAccount]
@@ -375,9 +418,7 @@ public struct DefaultCodexAccountReconciler: Sendable {
     }
 
     private func runtimeIdentity(for liveSystemAccount: ObservedSystemCodexAccount) -> CodexIdentity {
-        CodexIdentityMatcher.normalized(
-            liveSystemAccount.identity,
-            fallbackEmail: liveSystemAccount.email)
+        CodexIdentityMatcher.normalized(liveSystemAccount)
     }
 
     private static func uniqueNormalizedPaths(_ paths: [String]) -> [String] {
@@ -392,14 +433,34 @@ public struct DefaultCodexAccountReconciler: Sendable {
 }
 
 public enum CodexIdentityMatcher {
+    public static func normalized(_ liveSystemAccount: ObservedSystemCodexAccount) -> CodexIdentity {
+        let normalizedIdentity = self.normalized(
+            liveSystemAccount.identity,
+            fallbackEmail: liveSystemAccount.email)
+        if case .providerAccount = normalizedIdentity {
+            return normalizedIdentity
+        }
+        if let workspaceAccountID = ManagedCodexAccount.normalizeWorkspaceAccountID(
+            liveSystemAccount.workspaceAccountID)
+        {
+            return .providerAccount(id: workspaceAccountID)
+        }
+        return normalizedIdentity
+    }
+
     public static func matches(_ lhs: CodexIdentity, _ rhs: CodexIdentity) -> Bool {
         switch (lhs, rhs) {
         case let (.providerAccount(leftID), .providerAccount(rightID)):
-            leftID == rightID
+            guard let normalizedLeftID = ManagedCodexAccount.normalizeWorkspaceAccountID(leftID),
+                  let normalizedRightID = ManagedCodexAccount.normalizeWorkspaceAccountID(rightID)
+            else {
+                return false
+            }
+            return normalizedLeftID == normalizedRightID
         case let (.emailOnly(leftEmail), .emailOnly(rightEmail)):
-            leftEmail == rightEmail
+            return leftEmail == rightEmail
         default:
-            false
+            return false
         }
     }
 
@@ -421,8 +482,9 @@ public enum CodexIdentityMatcher {
 
     public static func normalized(_ identity: CodexIdentity, fallbackEmail: String) -> CodexIdentity {
         switch identity {
-        case .providerAccount:
-            identity
+        case let .providerAccount(id):
+            ManagedCodexAccount.normalizeWorkspaceAccountID(id).map { .providerAccount(id: $0) }
+                ?? .unresolved
         case let .emailOnly(normalizedEmail):
             CodexIdentityResolver.resolve(accountId: nil, email: normalizedEmail)
         case .unresolved:

--- a/Sources/CodexBarCore/Providers/Codex/CodexDashboardAuthority.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexDashboardAuthority.swift
@@ -259,7 +259,7 @@ public enum CodexDashboardAuthority {
     private static func normalizeIdentity(_ identity: CodexIdentity) -> CodexIdentity {
         switch identity {
         case let .providerAccount(id):
-            if let normalizedID = CodexIdentityResolver.normalizeAccountID(id) {
+            if let normalizedID = ManagedCodexAccount.normalizeWorkspaceAccountID(id) {
                 return .providerAccount(id: normalizedID)
             }
             return .unresolved

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderSettingsBuilder.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderSettingsBuilder.swift
@@ -29,10 +29,21 @@ public enum CodexKnownOwnerCatalog {
     public static func candidates(
         from snapshot: CodexAccountReconciliationSnapshot) -> [CodexDashboardKnownOwnerCandidate]
     {
-        var candidates = snapshot.storedAccounts.map { account in
-            CodexDashboardKnownOwnerCandidate(
-                identity: snapshot.runtimeIdentity(for: account),
-                normalizedEmail: CodexIdentityResolver.normalizeEmail(snapshot.runtimeEmail(for: account)))
+        var candidates = snapshot.storedAccounts.flatMap { account in
+            let normalizedEmail = CodexIdentityResolver.normalizeEmail(snapshot.runtimeEmail(for: account))
+            let remoteIdentity = snapshot.managedRemoteIdentity(for: account)
+            let runtimeIdentity = snapshot.runtimeIdentity(for: account)
+            var managedCandidates = [CodexDashboardKnownOwnerCandidate(
+                identity: remoteIdentity,
+                normalizedEmail: normalizedEmail)]
+            if runtimeIdentity != .unresolved,
+               !CodexIdentityMatcher.matches(runtimeIdentity, remoteIdentity)
+            {
+                managedCandidates.append(CodexDashboardKnownOwnerCandidate(
+                    identity: runtimeIdentity,
+                    normalizedEmail: normalizedEmail))
+            }
+            return managedCandidates
         }
 
         if let liveSystemAccount = snapshot.liveSystemAccount {
@@ -84,8 +95,7 @@ public enum CodexProviderSettingsBuilder {
         case .liveSystem, .profileHome:
             nil
         case .managedAccount:
-            input.reconciliationSnapshot.activeStoredAccount?.workspaceAccountID
-                ?? input.reconciliationSnapshot.activeStoredAccount?.providerAccountID
+            input.reconciliationSnapshot.activeStoredAccount?.effectiveWorkspaceAccountID
         }
 
         return ProviderSettingsSnapshot.CodexProviderSettings(

--- a/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
@@ -155,8 +155,8 @@ extension CodexVisibleAccountProjection {
 
         for storedAccount in snapshot.storedAccounts {
             let normalizedEmail = snapshot.runtimeEmail(for: storedAccount)
-            let runtimeIdentity = snapshot.runtimeIdentity(for: storedAccount)
-            let runtimeWorkspaceAccountID: String? = switch runtimeIdentity {
+            let remoteIdentity = snapshot.managedRemoteIdentity(for: storedAccount)
+            let remoteWorkspaceAccountID: String? = switch remoteIdentity {
             case let .providerAccount(id):
                 ManagedCodexAccount.normalizeWorkspaceAccountID(id)
             case .emailOnly, .unresolved:
@@ -165,16 +165,14 @@ extension CodexVisibleAccountProjection {
             drafts.append(VisibleAccountDraft(
                 email: normalizedEmail,
                 workspaceLabel: Self.normalizeWorkspaceLabel(storedAccount.workspaceLabel),
-                workspaceAccountID: storedAccount.workspaceAccountID
-                    ?? storedAccount.providerAccountID
-                    ?? runtimeWorkspaceAccountID,
+                workspaceAccountID: remoteWorkspaceAccountID,
                 authFingerprint: storedAccount.authFingerprint,
                 storedAccountID: storedAccount.id,
                 selectionSource: .managedAccount(id: storedAccount.id),
                 isLive: false,
                 canReauthenticate: true,
                 canRemove: true,
-                identity: runtimeIdentity))
+                identity: remoteIdentity))
         }
 
         if let liveSystemAccount = snapshot.liveSystemAccount {

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -250,6 +250,7 @@ extension CodexAccountScopedRefreshTests {
         #expect(store.credits?.remaining == 42)
         #expect(store.lastCreditsSnapshotAccountKey == "alpha@example.com")
         #expect(store.lastCodexAccountScopedRefreshGuard?.authFingerprint == "new-token-material")
+        #expect(store.lastCreditsSnapshotOwnerGuard?.authFingerprint == "new-token-material")
         #expect(store.lastCreditsError == nil)
     }
 

--- a/Tests/CodexBarTests/CodexAccountCreditsOwnershipTests.swift
+++ b/Tests/CodexBarTests/CodexAccountCreditsOwnershipTests.swift
@@ -1,0 +1,44 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `credits fallback preserves same provider owner across auth fingerprint rotation`() async {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-credits-provider-fingerprint-rotation")
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            workspaceAccountID: "acct-alpha",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+
+        let store = self.makeUsageStore(settings: settings)
+        let cachedCredits = self.credits(remaining: 12)
+        store.lastCreditsSnapshot = cachedCredits
+        store.lastCreditsSnapshotAccountKey = "alpha@example.com"
+        store.lastCreditsSnapshotOwnerGuard = store.freshCodexAccountScopedRefreshGuard()
+        store._test_codexCreditsLoaderOverride = {
+            throw TestRefreshError(message: "Codex credits data not available yet")
+        }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            workspaceAccountID: "acct-alpha",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+
+        await store.refreshCreditsIfNeeded()
+
+        #expect(store.credits == cachedCredits)
+        #expect(store.lastCreditsError == nil)
+    }
+}

--- a/Tests/CodexBarTests/CodexAccountFingerprintReconciliationTests.swift
+++ b/Tests/CodexBarTests/CodexAccountFingerprintReconciliationTests.swift
@@ -38,7 +38,7 @@ struct CodexAccountFingerprintReconciliationTests {
 
     @Test
     @MainActor
-    func `auth fingerprint matches live account before semantic duplicate identity`() throws {
+    func `auth fingerprint does not collapse explicit managed workspace into unresolved live owner`() throws {
         let suite = "CodexAccountFingerprintReconciliationTests-auth-fingerprint"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -87,10 +87,137 @@ struct CodexAccountFingerprintReconciliationTests {
         let snapshot = settings.codexAccountReconciliationSnapshot
         let projection = settings.codexVisibleAccountProjection
 
-        #expect(snapshot.matchingStoredAccountForLiveSystemAccount?.id == secondID)
+        #expect(snapshot.matchingStoredAccountForLiveSystemAccount?.id == firstID)
         #expect(projection.liveVisibleAccountID == "live:email:same@example.com")
-        #expect(projection.visibleAccounts.first { $0.storedAccountID == secondID }?.isLive == true)
-        #expect(projection.visibleAccounts.first { $0.storedAccountID == firstID }?.isLive == false)
+        #expect(projection.visibleAccounts.first { $0.storedAccountID == secondID }?.isLive == false)
+        #expect(projection.visibleAccounts.first { $0.storedAccountID == firstID }?.isLive == true)
+    }
+
+    @Test
+    func `legacy fingerprint merges missing managed home with live provider account`() throws {
+        let accountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-444444444444"))
+        let missingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-managed-codex-home-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.removeItem(at: missingHome)
+        let legacy = ManagedCodexAccount(
+            id: accountID,
+            email: "same@example.com",
+            authFingerprint: "shared-fingerprint",
+            managedHomePath: missingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let live = ObservedSystemCodexAccount(
+            email: "same@example.com",
+            workspaceAccountID: "account-live",
+            authFingerprint: "shared-fingerprint",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date())
+        let reconciler = DefaultCodexAccountReconciler(
+            storeLoader: { ManagedCodexAccountSet(version: 1, accounts: [legacy]) },
+            systemObserver: FingerprintSystemObserver(account: live),
+            activeSource: .managedAccount(id: accountID),
+            baseEnvironment: [:])
+
+        let snapshot = reconciler.loadSnapshot()
+        let resolution = CodexActiveSourceResolver.resolve(from: snapshot)
+        let projection = CodexVisibleAccountProjection.make(from: snapshot)
+
+        #expect(snapshot.storedAccountRuntimeIdentities[accountID] ==
+            .emailOnly(normalizedEmail: "same@example.com"))
+        #expect(snapshot.matchingStoredAccountForLiveSystemAccount?.id == accountID)
+        #expect(resolution.resolvedSource == .liveSystem)
+        #expect(resolution.requiresPersistenceCorrection)
+        #expect(projection.visibleAccounts.count == 1)
+        #expect(projection.visibleAccounts.first?.storedAccountID == accountID)
+        #expect(projection.visibleAccounts.first?.selectionSource == .liveSystem)
+        #expect(projection.visibleAccounts.first?.isLive == true)
+        #expect(projection.activeVisibleAccountID == projection.liveVisibleAccountID)
+    }
+
+    @Test
+    func `selected workspace fingerprint merges missing managed home with matching live owner`() throws {
+        let accountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-555555555555"))
+        let missingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-selected-codex-home-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.removeItem(at: missingHome)
+        let selected = ManagedCodexAccount(
+            id: accountID,
+            email: "same@example.com",
+            workspaceAccountID: "account-live",
+            authFingerprint: "shared-fingerprint",
+            managedHomePath: missingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let live = ObservedSystemCodexAccount(
+            email: "same@example.com",
+            workspaceAccountID: "account-live",
+            authFingerprint: "shared-fingerprint",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date())
+        let reconciler = DefaultCodexAccountReconciler(
+            storeLoader: { ManagedCodexAccountSet(version: 1, accounts: [selected]) },
+            systemObserver: FingerprintSystemObserver(account: live),
+            activeSource: .managedAccount(id: accountID),
+            baseEnvironment: [:])
+
+        let snapshot = reconciler.loadSnapshot()
+        let resolution = CodexActiveSourceResolver.resolve(from: snapshot)
+        let projection = CodexVisibleAccountProjection.make(from: snapshot)
+
+        #expect(snapshot.storedAccountRuntimeIdentities[accountID] ==
+            .emailOnly(normalizedEmail: "same@example.com"))
+        #expect(snapshot.matchingStoredAccountForLiveSystemAccount?.id == accountID)
+        #expect(resolution.resolvedSource == .liveSystem)
+        #expect(resolution.requiresPersistenceCorrection)
+        #expect(projection.visibleAccounts.count == 1)
+        #expect(projection.visibleAccounts.first?.storedAccountID == accountID)
+        #expect(projection.visibleAccounts.first?.selectionSource == .liveSystem)
+        #expect(projection.visibleAccounts.first?.isLive == true)
+        #expect(projection.activeVisibleAccountID == projection.liveVisibleAccountID)
+    }
+
+    @Test
+    func `selected workspace outranks legacy fingerprint match for the same live owner`() throws {
+        let legacyID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-666666666666"))
+        let selectedID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-777777777777"))
+        let legacy = ManagedCodexAccount(
+            id: legacyID,
+            email: "same@example.com",
+            authFingerprint: "shared-fingerprint",
+            managedHomePath: "/tmp/legacy",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let selected = ManagedCodexAccount(
+            id: selectedID,
+            email: "same@example.com",
+            workspaceAccountID: "account-live",
+            authFingerprint: "shared-fingerprint",
+            managedHomePath: "/tmp/selected",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let live = ObservedSystemCodexAccount(
+            email: "same@example.com",
+            workspaceAccountID: "account-live",
+            authFingerprint: "shared-fingerprint",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "account-live"))
+        let reconciler = DefaultCodexAccountReconciler(
+            storeLoader: { ManagedCodexAccountSet(version: 1, accounts: [legacy, selected]) },
+            systemObserver: FingerprintSystemObserver(account: live),
+            activeSource: .managedAccount(id: selectedID),
+            baseEnvironment: [:])
+
+        let snapshot = reconciler.loadSnapshot()
+        let projection = CodexVisibleAccountProjection.make(from: snapshot)
+
+        #expect(snapshot.matchingStoredAccountForLiveSystemAccount?.id == selectedID)
+        #expect(projection.visibleAccounts.first { $0.storedAccountID == selectedID }?.isLive == true)
+        #expect(projection.visibleAccounts.first { $0.storedAccountID == legacyID }?.isLive == false)
     }
 
     private static func writeManagedCodexStore(_ accounts: ManagedCodexAccountSet, to storeURL: URL) throws {
@@ -98,5 +225,13 @@ struct CodexAccountFingerprintReconciliationTests {
         encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(accounts)
         try data.write(to: storeURL, options: [.atomic])
+    }
+}
+
+private struct FingerprintSystemObserver: CodexSystemAccountObserving {
+    let account: ObservedSystemCodexAccount?
+
+    func loadSystemAccount(environment _: [String: String]) throws -> ObservedSystemCodexAccount? {
+        self.account
     }
 }

--- a/Tests/CodexBarTests/CodexAccountPromotionExecutionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionExecutionTests.swift
@@ -121,6 +121,90 @@ struct CodexAccountPromotionExecutionTests {
     }
 
     @Test
+    func `executor import repairs a raced collision with matching readable auth identity`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionExecutionTests-import-matching-readable-collision")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "beta@example.com",
+            authAccountID: "acct-beta")
+        let concurrentManaged = try container.createManagedAccount(
+            persistedEmail: "alpha@example.com",
+            authAccountID: "acct-alpha",
+            workspaceLabel: "Personal",
+            workspaceAccountID: "acct-alpha",
+            plan: "Team")
+        let concurrentAuthData = try container.managedAuthData(for: concurrentManaged)
+        try container.persistAccounts([target])
+        let liveAuthData = try container.writeLiveOAuthAuthFile(
+            email: "alpha@example.com",
+            accountID: "acct-alpha")
+        #expect(concurrentAuthData != liveAuthData)
+        let context = try await self.makeContext(container: container, targetID: target.id)
+        let executor = CodexDisplacedLivePreservationExecutor(
+            store: ConcurrentDuplicateManagedCodexAccountStore(
+                base: container.fileStore,
+                concurrentAccount: concurrentManaged),
+            homeFactory: container.homeFactory,
+            authMaterialReader: DefaultCodexAuthMaterialReader(),
+            fileManager: .default)
+
+        let result = try executor.execute(plan: .importNew(reason: .noExistingManagedDestination), context: context)
+
+        #expect(result.displacedLiveDisposition == .alreadyManaged(managedAccountID: concurrentManaged.id))
+        let accounts = try container.loadAccounts().accounts
+        let repaired = try #require(accounts.first(where: { $0.id == concurrentManaged.id }))
+        #expect(accounts.count == 2)
+        #expect(repaired.managedHomePath != concurrentManaged.managedHomePath)
+        #expect(try container.managedAuthData(for: repaired) == liveAuthData)
+    }
+
+    @Test
+    func `executor import rejects a raced workspace collision with conflicting readable auth`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionExecutionTests-import-conflicting-collision")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "beta@example.com",
+            authAccountID: "acct-beta")
+        let concurrentManaged = try container.createManagedAccount(
+            persistedEmail: "alpha@example.com",
+            authAccountID: "acct-gamma",
+            persistedProviderAccountID: nil,
+            useAuthAccountIDAsPersistedProviderAccountID: false,
+            workspaceLabel: "Personal",
+            workspaceAccountID: "acct-alpha")
+        let concurrentAuthData = try container.managedAuthData(for: concurrentManaged)
+        try container.persistAccounts([target])
+        let liveAuthData = try container.writeLiveOAuthAuthFile(
+            email: "alpha@example.com",
+            accountID: "acct-alpha")
+        let context = try await self.makeContext(container: container, targetID: target.id)
+        let executor = CodexDisplacedLivePreservationExecutor(
+            store: ConcurrentDuplicateManagedCodexAccountStore(
+                base: container.fileStore,
+                concurrentAccount: concurrentManaged),
+            homeFactory: container.homeFactory,
+            authMaterialReader: DefaultCodexAuthMaterialReader(),
+            fileManager: .default)
+
+        #expect(throws: CodexAccountPromotionError.displacedLiveManagedAccountConflict) {
+            try executor.execute(plan: .importNew(reason: .noExistingManagedDestination), context: context)
+        }
+
+        let accounts = try container.loadAccounts().accounts
+        let persistedConflict = try #require(accounts.first(where: { $0.id == concurrentManaged.id }))
+        #expect(accounts.count == 2)
+        #expect(persistedConflict.workspaceAccountID == "acct-alpha")
+        #expect(persistedConflict.managedHomePath == concurrentManaged.managedHomePath)
+        #expect(try container.managedAuthData(for: persistedConflict) == concurrentAuthData)
+        #expect(try container.liveAuthData() == liveAuthData)
+        #expect(try container.managedHomeURLs().count == 2)
+    }
+
+    @Test
     func `executor refresh filesystem failure maps to managed store error`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionExecutionTests-refresh-filesystem-failure")

--- a/Tests/CodexBarTests/CodexAccountPromotionExecutionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionExecutionTests.swift
@@ -77,7 +77,7 @@ struct CodexAccountPromotionExecutionTests {
     }
 
     @Test
-    func `executor import verifies persisted account after concurrent duplicate collision`() async throws {
+    func `executor import repairs an explicit workspace only collision`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionExecutionTests-import-collision-repair")
         defer { container.tearDown() }
@@ -93,7 +93,6 @@ struct CodexAccountPromotionExecutionTests {
         let concurrentManaged = ManagedCodexAccount(
             id: concurrentID,
             email: "alpha@example.com",
-            providerAccountID: "acct-alpha",
             workspaceLabel: "Personal",
             workspaceAccountID: "acct-alpha",
             managedHomePath: concurrentHomeURL.path,
@@ -115,6 +114,8 @@ struct CodexAccountPromotionExecutionTests {
         #expect(result.displacedLiveDisposition == .alreadyManaged(managedAccountID: concurrentManaged.id))
         let accounts = try container.loadAccounts().accounts
         let repaired = try #require(accounts.first(where: { $0.id == concurrentManaged.id }))
+        #expect(repaired.providerAccountID == "acct-alpha")
+        #expect(repaired.workspaceAccountID == "acct-alpha")
         #expect(repaired.managedHomePath != concurrentHomeURL.path)
         #expect(try container.managedAuthData(for: repaired) == liveAuthData)
     }

--- a/Tests/CodexBarTests/CodexAccountPromotionPlanningTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionPlanningTests.swift
@@ -59,7 +59,7 @@ struct CodexAccountPromotionPlanningTests {
     }
 
     @Test
-    func `planner uses repair for persisted provider match before any import fallback`() async throws {
+    func `planner repairs persisted provider match across mixed case identity`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionPlanningTests-repair-before-import")
         defer { container.tearDown() }
@@ -79,7 +79,7 @@ struct CodexAccountPromotionPlanningTests {
             updatedAt: 1,
             lastAuthenticatedAt: 1)
         try container.persistAccounts([target, staleManaged])
-        _ = try container.writeLiveOAuthAuthFile(email: "alpha@example.com", accountID: "acct-alpha")
+        _ = try container.writeLiveOAuthAuthFile(email: "alpha@example.com", accountID: "ACCT-ALPHA")
 
         let context = try await self.makeContext(container: container, targetID: target.id)
         let plan = CodexDisplacedLivePreservationPlanner().makePlan(context: context)
@@ -94,7 +94,7 @@ struct CodexAccountPromotionPlanningTests {
     }
 
     @Test
-    func `planner rejects persisted provider match when readable home belongs to a different account`() async throws {
+    func `planner rejects selected workspace when saved auth is a different same email workspace`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionPlanningTests-conflicting-readable-home")
         defer { container.tearDown() }
@@ -104,10 +104,11 @@ struct CodexAccountPromotionPlanningTests {
             authAccountID: "acct-beta")
         let conflictingManaged = try container.createManagedAccount(
             persistedEmail: "alpha@example.com",
-            authEmail: "gamma@example.com",
+            authEmail: "alpha@example.com",
             authAccountID: "acct-gamma",
             persistedProviderAccountID: "acct-alpha",
-            useAuthAccountIDAsPersistedProviderAccountID: false)
+            useAuthAccountIDAsPersistedProviderAccountID: false,
+            workspaceAccountID: "acct-alpha")
         try container.persistAccounts([target, conflictingManaged])
         _ = try container.writeLiveOAuthAuthFile(email: "alpha@example.com", accountID: "acct-alpha")
 

--- a/Tests/CodexBarTests/CodexAccountPromotionPreparationTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionPreparationTests.swift
@@ -110,9 +110,10 @@ struct CodexAccountPromotionPreparationTests {
         let preparedLegacy = try #require(context.storedManagedAccounts.first(where: { $0.persisted.id == legacy.id }))
 
         #expect(preparedLegacy.persistedIdentity.email == "legacy@example.com")
-        #expect(preparedLegacy.persistedIdentity.identity == .emailOnly(normalizedEmail: "legacy@example.com"))
+        #expect(preparedLegacy.persistedIdentity.identity == .providerAccount(id: "acct-alpha"))
         #expect(preparedLegacy.authIdentity?.email == "alpha@example.com")
         #expect(preparedLegacy.authIdentity?.identity == .providerAccount(id: "acct-alpha"))
         #expect(preparedLegacy.authIdentity?.workspaceLabel == "Personal")
+        #expect(preparedLegacy.remoteIdentity.email == "alpha@example.com")
     }
 }

--- a/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
@@ -243,6 +243,112 @@ struct CodexAccountPromotionServiceTests {
     }
 
     @Test
+    func `promotion rejects a selected workspace that differs from the saved auth default`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionServiceTests-selected-workspace-auth-default")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "member@example.com",
+            authAccountID: "auth-default",
+            persistedProviderAccountID: "selected-workspace",
+            workspaceLabel: "Selected",
+            workspaceAccountID: "selected-workspace")
+        try container.persistAccounts([target])
+        container.settings.codexActiveSource = .managedAccount(id: target.id)
+        let liveAuthData = try container.writeLiveOAuthAuthFile(
+            email: "member@example.com",
+            accountID: "auth-default")
+        let targetAuthData = try container.managedAuthData(for: target)
+        let swapper = RecordingCodexLiveAuthSwapper()
+
+        await #expect(throws: CodexAccountPromotionError.targetManagedAccountWorkspaceDiffersFromAuthDefault) {
+            try await container.makeService(liveAuthSwapper: swapper).promoteManagedAccount(id: target.id)
+        }
+
+        let persisted = try #require(try container.loadAccounts().account(id: target.id))
+        #expect(swapper.swapCallCount == 0)
+        #expect(try container.liveAuthData() == liveAuthData)
+        #expect(try container.managedAuthData(for: persisted) == targetAuthData)
+        #expect(persisted.providerAccountID == "selected-workspace")
+        #expect(persisted.workspaceAccountID == "selected-workspace")
+        #expect(container.settings.codexActiveSource == .managedAccount(id: target.id))
+    }
+
+    @Test
+    func `already live selected workspace converges across mixed case auth identity`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionServiceTests-selected-workspace-already-live")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "member@example.com",
+            authAccountID: "SELECTED-WORKSPACE",
+            persistedProviderAccountID: "selected-workspace",
+            workspaceLabel: "Selected",
+            workspaceAccountID: "selected-workspace")
+        try container.persistAccounts([target])
+        container.settings.codexActiveSource = .managedAccount(id: target.id)
+        let targetAuthData = try container.managedAuthData(for: target)
+        let liveAuthData = try container.writeLiveOAuthAuthFile(
+            email: "member@example.com",
+            accountID: "selected-workspace")
+        let swapper = RecordingCodexLiveAuthSwapper()
+
+        let result = try await container.makeService(liveAuthSwapper: swapper).promoteManagedAccount(id: target.id)
+
+        #expect(result.outcome == .convergedNoOp)
+        #expect(result.didMutateLiveAuth == false)
+        #expect(swapper.swapCallCount == 0)
+        #expect(try container.liveAuthData() == liveAuthData)
+        #expect(try container.managedAuthData(for: target) == targetAuthData)
+        #expect(container.settings.codexActiveSource == .liveSystem)
+    }
+
+    @Test
+    func `displaced auth default does not overwrite an explicit workspace only managed account`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionServiceTests-preserve-selected-workspace")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "target@example.com",
+            authAccountID: "target-workspace")
+        let selected = try container.createManagedAccount(
+            persistedEmail: "member@example.com",
+            authAccountID: "auth-default",
+            useAuthAccountIDAsPersistedProviderAccountID: false,
+            workspaceLabel: "Selected",
+            workspaceAccountID: "selected-workspace")
+        try container.persistAccounts([target, selected])
+        let selectedAuthData = try container.managedAuthData(for: selected)
+        let displacedLiveAuthData = try container.writeLiveOAuthAuthFile(
+            email: "member@example.com",
+            accountID: "auth-default")
+
+        let result = try await container.makeService().promoteManagedAccount(id: target.id)
+        let accounts = try container.loadAccounts().accounts
+        let preservedSelected = try #require(accounts.first { $0.id == selected.id })
+        let importedID: UUID
+        switch result.displacedLiveDisposition {
+        case let .imported(managedAccountID):
+            importedID = managedAccountID
+        case .none, .alreadyManaged:
+            Issue.record("Expected the distinct auth-default workspace to be imported")
+            throw PromotionTestError.unexpectedDisposition
+        }
+        let imported = try #require(accounts.first { $0.id == importedID })
+
+        #expect(preservedSelected.providerAccountID == nil)
+        #expect(preservedSelected.workspaceAccountID == "selected-workspace")
+        #expect(try container.managedAuthData(for: preservedSelected) == selectedAuthData)
+        #expect(imported.providerAccountID == "auth-default")
+        #expect(imported.workspaceAccountID == "auth-default")
+        #expect(try container.managedAuthData(for: imported) == displacedLiveAuthData)
+        #expect(try container.liveAuthData() == container.managedAuthData(for: target))
+    }
+
+    @Test
     func `same email different workspace imports displaced live as a distinct managed account`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionServiceTests-same-email-different-workspace",
@@ -610,7 +716,7 @@ struct CodexAccountPromotionServiceTests {
     }
 
     @Test
-    func `promotion rejects conflicting readable managed home before overwriting auth`() async throws {
+    func `promotion preserves live and managed auth when selected workspace conflicts with saved auth`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionServiceTests-conflicting-readable-home")
         defer { container.tearDown() }
@@ -620,23 +726,29 @@ struct CodexAccountPromotionServiceTests {
             authAccountID: "acct-beta")
         let conflictingManaged = try container.createManagedAccount(
             persistedEmail: "alpha@example.com",
-            authEmail: "gamma@example.com",
+            authEmail: "alpha@example.com",
             authAccountID: "acct-gamma",
             persistedProviderAccountID: "acct-alpha",
-            useAuthAccountIDAsPersistedProviderAccountID: false)
+            useAuthAccountIDAsPersistedProviderAccountID: false,
+            workspaceAccountID: "acct-alpha")
         try container.persistAccounts([target, conflictingManaged])
         let liveAuthData = try container.writeLiveOAuthAuthFile(email: "alpha@example.com", accountID: "acct-alpha")
         let conflictingAuthData = try container.managedAuthData(for: conflictingManaged)
+        let managedHomePaths = try Set(container.managedHomeURLs().map(\.path))
+        let swapper = RecordingCodexLiveAuthSwapper()
 
         await #expect(throws: CodexAccountPromotionError.displacedLiveManagedAccountConflict) {
-            try await container.makeService().promoteManagedAccount(id: target.id)
+            try await container.makeService(liveAuthSwapper: swapper).promoteManagedAccount(id: target.id)
         }
 
         let accounts = try container.loadAccounts().accounts
         let persistedConflict = try #require(accounts.first(where: { $0.id == conflictingManaged.id }))
         #expect(try container.liveAuthData() == liveAuthData)
         #expect(try container.managedAuthData(for: persistedConflict) == conflictingAuthData)
+        #expect(persistedConflict.effectiveWorkspaceAccountID == "acct-alpha")
         #expect(accounts.count == 2)
+        #expect(swapper.swapCallCount == 0)
+        #expect(try Set(container.managedHomeURLs().map(\.path)) == managedHomePaths)
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
@@ -201,6 +201,7 @@ struct CodexAccountScopedRefreshTests {
         store._setSnapshotForTesting(self.codexSnapshot(email: "alpha@example.com", usedPercent: 10), provider: .codex)
         store.lastCreditsSnapshot = cachedCredits
         store.lastCreditsSnapshotAccountKey = "alpha@example.com"
+        store.lastCreditsSnapshotOwnerGuard = store.freshCodexAccountScopedRefreshGuard()
         store._test_codexCreditsLoaderOverride = {
             throw TestRefreshError(message: "Codex credits data not available yet")
         }

--- a/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
@@ -159,13 +159,27 @@ extension CodexAccountScopedRefreshTests {
         settings.multiAccountMenuLayout = .stacked
         let targetID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-121212121212"))
         let siblingID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-343434343434"))
+        let targetHome = CodexCredentialFixtures.root
+            .appendingPathComponent("codex-materialize-target-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = CodexCredentialFixtures.root
+            .appendingPathComponent("codex-materialize-sibling-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "materialize-stack@example.com",
+            plan: "pro",
+            accountId: "acct-materialize-stack")
+        try Self.writeCodexAuthFile(
+            homeURL: siblingHome,
+            email: "other-stack@example.com",
+            plan: "pro",
+            accountId: "acct-materialize-other")
         let targetAccount = ManagedCodexAccount(
             id: targetID,
             email: "materialize-stack@example.com",
             providerAccountID: "acct-materialize-stack",
             workspaceLabel: "Target Team",
             workspaceAccountID: "acct-materialize-stack",
-            managedHomePath: "/tmp/materialize-stack-target",
+            managedHomePath: targetHome.path,
             createdAt: 1,
             updatedAt: 2,
             lastAuthenticatedAt: 2)
@@ -175,7 +189,7 @@ extension CodexAccountScopedRefreshTests {
             providerAccountID: "acct-materialize-other",
             workspaceLabel: "Other Team",
             workspaceAccountID: "acct-materialize-other",
-            managedHomePath: "/tmp/materialize-stack-other",
+            managedHomePath: siblingHome.path,
             createdAt: 1,
             updatedAt: 2,
             lastAuthenticatedAt: 2)
@@ -183,6 +197,8 @@ extension CodexAccountScopedRefreshTests {
         defer {
             settings._test_managedCodexAccountStoreURL = nil
             try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
         }
         settings._test_managedCodexAccountStoreURL = storeURL
         settings.codexActiveSource = .managedAccount(id: targetID)

--- a/Tests/CodexBarTests/CodexHistoryOwnershipTests.swift
+++ b/Tests/CodexBarTests/CodexHistoryOwnershipTests.swift
@@ -15,6 +15,16 @@ struct CodexHistoryOwnershipTests {
     }
 
     @Test
+    func `normalizes canonical provider-account ids case insensitively`() {
+        let key = CodexHistoryOwnership.canonicalKey(for: .providerAccount(id: "WORKSPACE-X"))
+        let persisted = CodexHistoryOwnership.classifyPersistedKey(
+            "codex:v1:provider-account:WORKSPACE-X")
+
+        #expect(key == "codex:v1:provider-account:workspace-x")
+        #expect(persisted == .canonical("codex:v1:provider-account:workspace-x"))
+    }
+
+    @Test
     func `serializes canonical email-hash key`() {
         let key = CodexHistoryOwnership.canonicalKey(for: .emailOnly(normalizedEmail: self.normalizedEmail))
 

--- a/Tests/CodexBarTests/CodexManagedRemoteOwnerReconciliationTests.swift
+++ b/Tests/CodexBarTests/CodexManagedRemoteOwnerReconciliationTests.swift
@@ -1,0 +1,193 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+@Suite(.serialized, CodexCredentialFixtures())
+struct CodexManagedRemoteOwnerReconciliationTests {
+    @Test
+    func `selected managed workspace does not collapse into auth default live account`() throws {
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "member@example.com",
+            accountID: "auth-default")
+        let fingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        let stored = ManagedCodexAccount(
+            id: UUID(),
+            email: "member@example.com",
+            providerAccountID: "selected-workspace",
+            workspaceLabel: "Selected",
+            workspaceAccountID: nil,
+            authFingerprint: fingerprint,
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let live = ObservedSystemCodexAccount(
+            email: "member@example.com",
+            workspaceLabel: "Default",
+            workspaceAccountID: "auth-default",
+            authFingerprint: fingerprint,
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "auth-default"))
+        let reconciler = DefaultCodexAccountReconciler(
+            storeLoader: { ManagedCodexAccountSet(version: 1, accounts: [stored]) },
+            systemObserver: SelectedWorkspaceSystemObserver(account: live),
+            activeSource: .managedAccount(id: stored.id),
+            baseEnvironment: [:])
+
+        let snapshot = reconciler.loadSnapshot()
+        let resolution = CodexActiveSourceResolver.resolve(from: snapshot)
+        let projection = CodexVisibleAccountProjection.make(from: snapshot)
+        let knownOwners = CodexKnownOwnerCatalog.candidates(from: snapshot)
+
+        #expect(snapshot.managedRemoteIdentity(for: stored) == .providerAccount(id: "selected-workspace"))
+        #expect(snapshot.matchingStoredAccountForLiveSystemAccount == nil)
+        #expect(resolution.resolvedSource == .managedAccount(id: stored.id))
+        #expect(projection.visibleAccounts.count == 2)
+        #expect(projection.visibleAccounts.first { $0.selectionSource == .managedAccount(id: stored.id) }?
+            .workspaceAccountID == "selected-workspace")
+        #expect(projection.visibleAccounts.first { $0.selectionSource == .liveSystem }?
+            .workspaceAccountID == "auth-default")
+        #expect(knownOwners.contains { $0.identity == .providerAccount(id: "selected-workspace") })
+        #expect(knownOwners.contains { $0.identity == .providerAccount(id: "auth-default") })
+    }
+
+    @Test
+    func `managed auth default remains a dashboard owner without live or profile evidence`() throws {
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "member@example.com",
+            accountID: "auth-default")
+        let stored = ManagedCodexAccount(
+            id: UUID(),
+            email: "member@example.com",
+            providerAccountID: "selected-workspace",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let reconciler = DefaultCodexAccountReconciler(
+            storeLoader: { ManagedCodexAccountSet(version: 1, accounts: [stored]) },
+            systemObserver: SelectedWorkspaceSystemObserver(account: nil),
+            activeSource: .managedAccount(id: stored.id),
+            baseEnvironment: [:])
+
+        let snapshot = reconciler.loadSnapshot()
+        let knownOwners = CodexKnownOwnerCatalog.candidates(from: snapshot)
+        let decision = CodexDashboardAuthority.evaluate(CodexDashboardAuthorityInput(
+            sourceKind: .liveWeb,
+            proof: CodexDashboardOwnershipProofContext(
+                currentIdentity: snapshot.managedRemoteIdentity(for: stored),
+                expectedScopedEmail: "member@example.com",
+                trustedCurrentUsageEmail: nil,
+                dashboardSignedInEmail: "member@example.com",
+                knownOwners: knownOwners),
+            routing: CodexDashboardRoutingHints(
+                targetEmail: "member@example.com",
+                lastKnownDashboardRoutingEmail: nil)))
+
+        #expect(snapshot.liveSystemAccount == nil)
+        #expect(snapshot.profileHomeAccounts.isEmpty)
+        #expect(knownOwners.contains { $0.identity == .providerAccount(id: "selected-workspace") })
+        #expect(knownOwners.contains { $0.identity == .providerAccount(id: "auth-default") })
+        #expect(decision.disposition == .displayOnly)
+        #expect(decision.reason == .sameEmailAmbiguity(email: "member@example.com"))
+        #expect(decision.allowedEffects.isEmpty)
+    }
+
+    @Test
+    func `managed email only auth remains a dashboard owner without live or profile evidence`() throws {
+        let managedHome = CodexCredentialFixtures.root.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "member@example.com",
+            accountID: nil)
+        let stored = ManagedCodexAccount(
+            id: UUID(),
+            email: "member@example.com",
+            workspaceAccountID: "selected-workspace",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let reconciler = DefaultCodexAccountReconciler(
+            storeLoader: { ManagedCodexAccountSet(version: 1, accounts: [stored]) },
+            systemObserver: SelectedWorkspaceSystemObserver(account: nil),
+            activeSource: .managedAccount(id: stored.id),
+            baseEnvironment: [:])
+
+        let snapshot = reconciler.loadSnapshot()
+        let knownOwners = CodexKnownOwnerCatalog.candidates(from: snapshot)
+        let decision = CodexDashboardAuthority.evaluate(CodexDashboardAuthorityInput(
+            sourceKind: .liveWeb,
+            proof: CodexDashboardOwnershipProofContext(
+                currentIdentity: snapshot.managedRemoteIdentity(for: stored),
+                expectedScopedEmail: "member@example.com",
+                trustedCurrentUsageEmail: nil,
+                dashboardSignedInEmail: "member@example.com",
+                knownOwners: knownOwners),
+            routing: CodexDashboardRoutingHints(
+                targetEmail: "member@example.com",
+                lastKnownDashboardRoutingEmail: nil)))
+
+        #expect(snapshot.liveSystemAccount == nil)
+        #expect(snapshot.profileHomeAccounts.isEmpty)
+        #expect(snapshot.runtimeIdentity(for: stored) == .emailOnly(normalizedEmail: "member@example.com"))
+        #expect(knownOwners.contains { $0.identity == .providerAccount(id: "selected-workspace") })
+        #expect(knownOwners.contains { $0.identity == .emailOnly(normalizedEmail: "member@example.com") })
+        #expect(decision.disposition == .displayOnly)
+        #expect(decision.reason == .sameEmailAmbiguity(email: "member@example.com"))
+        #expect(decision.allowedEffects.isEmpty)
+    }
+
+    private static func writeCodexAuthFile(homeURL: URL, email: String, accountID: String?) throws {
+        try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
+        let header = try JSONSerialization.data(withJSONObject: ["alg": "none"])
+        var authClaims: [String: Any] = ["chatgpt_plan_type": "business"]
+        if let accountID {
+            authClaims["chatgpt_account_id"] = accountID
+        }
+        let payload = try JSONSerialization.data(withJSONObject: [
+            "email": email,
+            "https://api.openai.com/auth": authClaims,
+        ])
+        let idToken = "\(Self.base64URL(header)).\(Self.base64URL(payload))."
+        var tokens: [String: Any] = [
+            "accessToken": "access-token",
+            "refreshToken": "refresh-token",
+            "idToken": idToken,
+        ]
+        if let accountID {
+            tokens["account_id"] = accountID
+        }
+        let data = try JSONSerialization.data(withJSONObject: ["tokens": tokens])
+        try data.write(to: homeURL.appendingPathComponent("auth.json"))
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "=", with: "")
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+    }
+}
+
+private struct SelectedWorkspaceSystemObserver: CodexSystemAccountObserving {
+    let account: ObservedSystemCodexAccount?
+
+    func loadSystemAccount(environment _: [String: String]) throws -> ObservedSystemCodexAccount? {
+        self.account
+    }
+}

--- a/Tests/CodexBarTests/CodexManagedWorkspaceRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexManagedWorkspaceRefreshTests.swift
@@ -5,6 +5,232 @@ import Testing
 
 @MainActor
 extension CodexAccountScopedRefreshTests {
+    @Test
+    func `account scoped refresh keeps selected workspace ownership through credits`() async throws {
+        let suite = "CodexManagedWorkspaceRefreshTests-account-scoped-credits"
+        let root = CodexCredentialFixtures.root
+            .appendingPathComponent("managed-workspace-account-refresh-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let targetHome = root.appendingPathComponent("target", isDirectory: true)
+        let siblingHome = root.appendingPathComponent("sibling", isDirectory: true)
+        let authenticatedTarget = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: UUID(),
+            email: "workspace-member@example.com",
+            workspaceID: "auth-default-workspace",
+            workspaceLabel: "Default",
+            homeURL: targetHome)
+        let target = ManagedCodexAccount(
+            id: authenticatedTarget.id,
+            email: authenticatedTarget.email,
+            providerAccountID: "selected-team-workspace",
+            workspaceLabel: "Selected Team",
+            workspaceAccountID: nil,
+            authFingerprint: authenticatedTarget.authFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let sibling = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: UUID(),
+            email: "sibling@example.com",
+            workspaceID: "sibling-workspace",
+            workspaceLabel: "Sibling",
+            homeURL: siblingHome)
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [target, sibling])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_codexReconciliationEnvironment = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: target.id)
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = self.makeCodexWeeklyPublicationStore(
+            settings: settings,
+            suite: suite,
+            snapshotStore: snapshotStore)
+        let publishedCredits = self.credits(remaining: 42)
+        let targetSnapshot = self.codexSnapshot(email: target.email, usedPercent: 64)
+        let siblingSnapshot = self.codexSnapshot(email: sibling.email, usedPercent: 22)
+        store._test_codexCreditsLoaderOverride = { publishedCredits }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+        self.installContextualCodexProvider(on: store) { context in
+            switch context.env["CODEX_HOME"] {
+            case targetHome.path:
+                #expect(context.codexWorkspaceID == "selected-team-workspace")
+                return targetSnapshot
+            case siblingHome.path:
+                return siblingSnapshot
+            default:
+                throw TestRefreshError(message: "Unexpected Codex home")
+            }
+        }
+
+        await store.refreshCodexAccountScopedState(allowDisabled: true)
+
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 64)
+        #expect(store.lastCodexUsagePublicationGuard?.identity == .providerAccount(id: "selected-team-workspace"))
+        #expect(store.lastCodexAccountScopedRefreshGuard?.identity == .providerAccount(id: "selected-team-workspace"))
+        #expect(store.credits?.remaining == 42)
+        #expect(store.codexAccountSnapshots.first { $0.account.storedAccountID == target.id }?.credits?.remaining == 42)
+        #expect(snapshotStore.storedSnapshots.first { $0.account.storedAccountID == target.id }?.credits?
+            .remaining == 42)
+    }
+
+    @Test
+    func `workspace switch changes credits key and rejects the in flight result`() async throws {
+        let suite = "CodexManagedWorkspaceRefreshTests-credits-workspace-switch"
+        let root = CodexCredentialFixtures.root
+            .appendingPathComponent("managed-workspace-credits-switch-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let targetHome = root.appendingPathComponent("target", isDirectory: true)
+        let authenticatedTarget = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: UUID(),
+            email: "workspace-member@example.com",
+            workspaceID: "auth-default-workspace",
+            workspaceLabel: "Default",
+            homeURL: targetHome)
+        let target = ManagedCodexAccount(
+            id: authenticatedTarget.id,
+            email: authenticatedTarget.email,
+            providerAccountID: "selected-team-workspace",
+            workspaceLabel: "Selected Team",
+            workspaceAccountID: nil,
+            authFingerprint: authenticatedTarget.authFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [target])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_codexReconciliationEnvironment = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: target.id)
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        let blocker = BlockingCreditsLoader()
+        store._test_codexCreditsLoaderOverride = { try await blocker.awaitResult() }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+        let initialGuard = store.freshCodexAccountScopedRefreshGuard()
+        let initialKey = store.codexCreditsRefreshKey(expectedGuard: initialGuard)
+
+        let refresh = Task { await store.refreshCreditsIfNeeded() }
+        await blocker.waitUntilStarted()
+        let replacement = ManagedCodexAccount(
+            id: target.id,
+            email: target.email,
+            providerAccountID: "replacement-team-workspace",
+            workspaceLabel: "Replacement Team",
+            workspaceAccountID: nil,
+            authFingerprint: target.authFingerprint,
+            managedHomePath: target.managedHomePath,
+            createdAt: target.createdAt,
+            updatedAt: 3,
+            lastAuthenticatedAt: target.lastAuthenticatedAt)
+        try FileManagedCodexAccountStore(fileURL: storeURL).storeAccounts(ManagedCodexAccountSet(
+            version: FileManagedCodexAccountStore.currentVersion,
+            accounts: [replacement]))
+        let replacementGuard = store.freshCodexAccountScopedRefreshGuard()
+        let replacementKey = store.codexCreditsRefreshKey(expectedGuard: replacementGuard)
+        await blocker.resumeNext(with: .success(self.credits(remaining: 42)))
+        await refresh.value
+
+        #expect(initialGuard.identity == .providerAccount(id: "selected-team-workspace"))
+        #expect(replacementGuard.identity == .providerAccount(id: "replacement-team-workspace"))
+        #expect(initialKey != replacementKey)
+        #expect(store.credits == nil)
+        #expect(store.lastCreditsSnapshot == nil)
+    }
+
+    @Test(arguments: [false, true])
+    func `failed workspace switch never republishes prior workspace credits`(
+        dataNotAvailableFailure: Bool) async throws
+    {
+        let suite = "CodexManagedWorkspaceRefreshTests-failed-credits-switch-\(dataNotAvailableFailure)"
+        let root = CodexCredentialFixtures.root
+            .appendingPathComponent("managed-workspace-failed-credits-switch-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let targetHome = root.appendingPathComponent("target", isDirectory: true)
+        let authenticatedTarget = try self.makeManagedCodexWeeklyPublicationAccount(
+            id: UUID(),
+            email: "workspace-member@example.com",
+            workspaceID: "auth-default-workspace",
+            workspaceLabel: "Default",
+            homeURL: targetHome)
+        let firstWorkspace = ManagedCodexAccount(
+            id: authenticatedTarget.id,
+            email: authenticatedTarget.email,
+            workspaceLabel: "First Team",
+            workspaceAccountID: "first-team-workspace",
+            authFingerprint: authenticatedTarget.authFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [firstWorkspace])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: firstWorkspace.id)
+        let store = self.makeCodexWeeklyPublicationStore(settings: settings, suite: suite)
+        let cachedCredits = self.credits(remaining: 42)
+        store._test_codexCreditsLoaderOverride = { cachedCredits }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+        let firstGuard = store.freshCodexAccountScopedRefreshGuard()
+
+        await store.refreshCreditsIfNeeded()
+
+        #expect(firstWorkspace.providerAccountID == nil)
+        #expect(firstGuard.identity == .providerAccount(id: "first-team-workspace"))
+        #expect(store.credits == cachedCredits)
+        #expect(store.lastCreditsSnapshotOwnerGuard == firstGuard)
+
+        let secondWorkspace = ManagedCodexAccount(
+            id: firstWorkspace.id,
+            email: firstWorkspace.email,
+            workspaceLabel: "Second Team",
+            workspaceAccountID: "second-team-workspace",
+            authFingerprint: firstWorkspace.authFingerprint,
+            managedHomePath: firstWorkspace.managedHomePath,
+            createdAt: firstWorkspace.createdAt,
+            updatedAt: 3,
+            lastAuthenticatedAt: firstWorkspace.lastAuthenticatedAt)
+        try FileManagedCodexAccountStore(fileURL: storeURL).storeAccounts(ManagedCodexAccountSet(
+            version: FileManagedCodexAccountStore.currentVersion,
+            accounts: [secondWorkspace]))
+        let secondGuard = store.freshCodexAccountScopedRefreshGuard()
+        let failureMessage = dataNotAvailableFailure
+            ? "Codex credits data not available yet"
+            : "Second workspace credits failed"
+        store._test_codexCreditsLoaderOverride = {
+            throw TestRefreshError(message: failureMessage)
+        }
+
+        await store.refreshCreditsIfNeeded()
+
+        #expect(secondWorkspace.providerAccountID == nil)
+        #expect(secondGuard.identity == .providerAccount(id: "second-team-workspace"))
+        #expect(store.codexCreditsRefreshKey(expectedGuard: firstGuard) !=
+            store.codexCreditsRefreshKey(expectedGuard: secondGuard))
+        #expect(store.credits == nil)
+        #expect(store.lastCreditsSnapshot == cachedCredits)
+        #expect(store.lastCreditsSnapshotOwnerGuard == firstGuard)
+        #expect(store.lastCreditsError == (dataNotAvailableFailure
+                ? "Codex credits are still loading; will retry shortly."
+                : failureMessage))
+    }
+
     @Test(arguments: [false, true], [false, true])
     func `stacked refresh keeps selected managed workspace separate from auth default`(
         switchesWorkspaceDuringRefresh: Bool,

--- a/Tests/CodexBarTests/CodexMonthlyCreditPreservationTests.swift
+++ b/Tests/CodexBarTests/CodexMonthlyCreditPreservationTests.swift
@@ -316,15 +316,25 @@ extension CodexAccountScopedRefreshTests {
                 remainingPercent: 97.3,
                 resetsAt: nil,
                 updatedAt: Date()))
+        let ownerGuard = CodexAccountScopedRefreshGuard(
+            source: .liveSystem,
+            identity: .emailOnly(normalizedEmail: "biz@example.com"),
+            accountKey: "biz@example.com")
 
-        store.publishHydratedCodexCreditsIfNeeded(from: persisted, accountKey: "biz@example.com")
+        store.publishHydratedCodexCreditsIfNeeded(from: persisted, ownerGuard: ownerGuard)
         #expect(store.credits?.codexCreditLimit?.limit == 1000)
         #expect(store.lastCreditsSnapshot?.codexCreditLimit?.used == 27)
         #expect(store.lastCreditsSnapshotAccountKey == "biz@example.com")
+        #expect(store.lastCreditsSnapshotOwnerGuard == ownerGuard)
         #expect(store.lastCreditsSource == .api)
 
         let other = CreditsSnapshot(remaining: 4, events: [], updatedAt: Date())
-        store.publishHydratedCodexCreditsIfNeeded(from: other, accountKey: "other@example.com")
+        store.publishHydratedCodexCreditsIfNeeded(
+            from: other,
+            ownerGuard: CodexAccountScopedRefreshGuard(
+                source: .liveSystem,
+                identity: .emailOnly(normalizedEmail: "other@example.com"),
+                accountKey: "other@example.com"))
         #expect(store.credits?.codexCreditLimit?.limit == 1000)
         #expect(store.lastCreditsSnapshotAccountKey == "biz@example.com")
     }
@@ -427,11 +437,13 @@ extension CodexAccountScopedRefreshTests {
                 sourceLabel: "api",
                 credits: nil),
         ]
-        store.lastCodexAccountScopedRefreshGuard = CodexAccountScopedRefreshGuard(
+        let ownerGuard = CodexAccountScopedRefreshGuard(
             source: .liveSystem,
             identity: .providerAccount(id: "acct-biz"),
             accountKey: "biz@example.com")
+        store.lastCodexAccountScopedRefreshGuard = ownerGuard
         store.lastCreditsSnapshotAccountKey = "biz@example.com"
+        store.lastCreditsSnapshotOwnerGuard = ownerGuard
         store.credits = CreditsSnapshot(
             remaining: 0,
             events: [],

--- a/Tests/CodexBarTests/CodexSelectedWorkspaceHistoryOwnershipTests.swift
+++ b/Tests/CodexBarTests/CodexSelectedWorkspaceHistoryOwnershipTests.swift
@@ -1,0 +1,125 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `non active selected workspace does not adopt its auth default email history`() throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountVisibleHistoryBackfillTests-non-active-selected-owner")
+        settings.multiAccountMenuLayout = .stacked
+        let accountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-565656565656"))
+        let managedHome = CodexCredentialFixtures.root
+            .appendingPathComponent("codex-non-active-selected-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "shared@example.com",
+            plan: "pro",
+            accountId: "auth-default")
+        let selectedAccount = ManagedCodexAccount(
+            id: accountID,
+            email: "shared@example.com",
+            providerAccountID: "selected-workspace",
+            workspaceLabel: "Selected Team",
+            workspaceAccountID: "selected-workspace",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [selectedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "active@example.com",
+            identity: .providerAccount(id: "active-workspace"))
+        settings.codexActiveSource = .liveSystem
+        let store = self.makeUsageStore(settings: settings)
+        let visibleAccount = try #require(settings.codexVisibleAccountProjection.visibleAccounts.first {
+            $0.storedAccountID == accountID
+        })
+        let selectedHistoryKey = try #require(CodexHistoryOwnership.canonicalKey(for: .providerAccount(
+            id: "selected-workspace")))
+        let emailHistoryKey = CodexHistoryOwnership.canonicalEmailHashKey(for: "shared@example.com")
+        let session = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_800_000_000), usedPercent: 1),
+        ])
+        store.planUtilizationHistory[.codex] = PlanUtilizationHistoryBuckets(accounts: [
+            emailHistoryKey: [session],
+        ])
+
+        let histories = store.codexPlanUtilizationHistories(forVisibleAccount: visibleAccount)
+
+        #expect(histories.isEmpty)
+        #expect(store.planUtilizationHistory[.codex]?.accounts[selectedHistoryKey] == nil)
+        #expect(store.planUtilizationHistory[.codex]?.accounts[emailHistoryKey] == [session])
+    }
+
+    @Test
+    func `live merged selected workspace does not adopt hidden auth owner history`() throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountVisibleHistoryBackfillTests-live-merged-selected-owner")
+        let accountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-787878787878"))
+        let managedHome = CodexCredentialFixtures.root
+            .appendingPathComponent("codex-live-merged-selected-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "shared@example.com",
+            plan: "pro",
+            accountId: "auth-default")
+        let selectedAccount = ManagedCodexAccount(
+            id: accountID,
+            email: "shared@example.com",
+            providerAccountID: "selected-workspace",
+            workspaceLabel: "Selected Team",
+            workspaceAccountID: "selected-workspace",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [selectedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "shared@example.com",
+            identity: .providerAccount(id: "selected-workspace"))
+        settings.codexActiveSource = .liveSystem
+        let store = self.makeUsageStore(settings: settings)
+        let selectedHistoryKey = try #require(CodexHistoryOwnership.canonicalKey(for: .providerAccount(
+            id: "selected-workspace")))
+        let emailHistoryKey = CodexHistoryOwnership.canonicalEmailHashKey(for: "shared@example.com")
+        let unscoped = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_799_000_000), usedPercent: 1),
+        ])
+        let emailHistory = planSeries(name: .weekly, windowMinutes: 10080, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_800_000_000), usedPercent: 2),
+        ])
+        store.planUtilizationHistory[.codex] = PlanUtilizationHistoryBuckets(
+            unscoped: [unscoped],
+            accounts: [emailHistoryKey: [emailHistory]])
+        store._setSnapshotForTesting(
+            self.codexSnapshot(email: "shared@example.com", usedPercent: 10),
+            provider: .codex)
+
+        let history = store.planUtilizationHistory(for: .codex)
+        let buckets = try #require(store.planUtilizationHistory[.codex])
+
+        #expect(settings.activeManagedCodexAccount == nil)
+        #expect(settings.codexAccountReconciliationSnapshot.matchingStoredAccountForLiveSystemAccount?.id == accountID)
+        #expect(history.isEmpty)
+        #expect(buckets.unscoped == [unscoped])
+        #expect(buckets.accounts[emailHistoryKey] == [emailHistory])
+        #expect(buckets.accounts[selectedHistoryKey] == nil)
+    }
+}

--- a/Tests/CodexBarTests/CodexSystemPromotionUITests.swift
+++ b/Tests/CodexBarTests/CodexSystemPromotionUITests.swift
@@ -75,6 +75,17 @@ struct CodexSystemPromotionUITests {
     }
 
     @Test
+    func `promotion coordinator explains selected workspace auth mismatch`() {
+        let error = CodexAccountPromotionCoordinator.mapUserFacingError(
+            CodexAccountPromotionError.targetManagedAccountWorkspaceDiffersFromAuthDefault)
+
+        #expect(error.title == "Could not switch system account")
+        #expect(error.message.contains("differs from its saved Codex auth default"))
+        #expect(error.message.contains("Keep it as a managed account"))
+        #expect(error.message.contains("will not rewrite Codex-owned auth"))
+    }
+
+    @Test
     func `codex menu descriptor includes system account submenu`() throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexSystemPromotionUITests-menu-descriptor")

--- a/Tests/CodexBarTests/HistoricalUsagePaceOwnershipTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceOwnershipTests.swift
@@ -178,6 +178,61 @@ extension HistoricalUsagePaceTests {
     }
 
     @MainActor
+    @Test(arguments: [false, true])
+    func `selected workspace does not adopt ambiguous runtime owner legacy history without live evidence`(
+        emailOnlyRuntime: Bool) async throws
+    {
+        let historyStore = HistoricalUsageHistoryStore(fileURL: Self.makeTempURL())
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "member@example.com",
+            workspaceAccountID: "selected-workspace",
+            managedHomePath: "/tmp/selected-workspace",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let runtimeIdentity: CodexIdentity = emailOnlyRuntime
+            ? .emailOnly(normalizedEmail: managedAccount.email)
+            : .providerAccount(id: "auth-default")
+        let reconciliationSnapshot = CodexAccountReconciliationSnapshot(
+            storedAccounts: [managedAccount],
+            activeStoredAccount: managedAccount,
+            liveSystemAccount: nil,
+            matchingStoredAccountForLiveSystemAccount: nil,
+            activeSource: .managedAccount(id: managedAccount.id),
+            hasUnreadableAddedAccountStore: false,
+            storedAccountRuntimeIdentities: [
+                managedAccount.id: runtimeIdentity,
+            ],
+            storedAccountRuntimeEmails: [managedAccount.id: managedAccount.email])
+        let resetsAt = Date(timeIntervalSince1970: 1_770_000_000)
+        let legacyEmailHash = CodexHistoryOwnership.legacyEmailHash(normalizedEmail: managedAccount.email)
+        let selectedWorkspaceKey = try #require(
+            CodexHistoryOwnership.canonicalKey(for: .providerAccount(id: "selected-workspace")))
+        await Self.recordCompleteWeek(
+            into: historyStore,
+            resetsAt: resetsAt,
+            accountKey: legacyEmailHash)
+
+        let store = try Self.makeUsageStoreForHistoricalTests(
+            suite: "HistoricalUsagePaceTests-selected-workspace-runtime-owner-\(emailOnlyRuntime)",
+            historicalUsageHistoryStore: historyStore)
+        store.settings._test_codexAccountSnapshotLoader = { _ in reconciliationSnapshot }
+        store.settings._test_activeManagedCodexAccount = managedAccount
+        store.settings.codexActiveSource = .managedAccount(id: managedAccount.id)
+        defer {
+            store.settings._test_codexAccountSnapshotLoader = nil
+            store.settings._test_activeManagedCodexAccount = nil
+            store.settings.codexActiveSource = .liveSystem
+        }
+
+        await store.refreshHistoricalDatasetIfNeeded()
+
+        #expect(store.codexHistoricalDataset == nil)
+        #expect(store.codexHistoricalDatasetAccountKey == selectedWorkspaceKey)
+    }
+
+    @MainActor
     @Test
     func `refresh historical dataset ignores extra saved managed accounts for adjacent veto`() async throws {
         let historyStore = HistoricalUsageHistoryStore(fileURL: Self.makeTempURL())
@@ -249,6 +304,25 @@ extension HistoricalUsagePaceTests {
             canonicalAccountKey: providerAccountKey,
             canonicalEmailHashKey: canonicalEmailHashKey,
             legacyEmailHash: legacyEmailHash,
+            hasAdjacentMultiAccountVeto: false)
+
+        #expect(dataset?.weeks.count == 1)
+    }
+
+    @Test
+    func `history store reads pre-normalization provider account key casing`() async throws {
+        let store = HistoricalUsageHistoryStore(fileURL: Self.makeTempURL())
+        let resetsAt = Date(timeIntervalSince1970: 1_770_000_000)
+        let persistedKey = "codex:v1:provider-account:WORKSPACE-X"
+        let canonicalKey = try #require(CodexHistoryOwnership.canonicalKey(for: .providerAccount(
+            id: "workspace-x")))
+
+        await Self.recordCompleteWeek(into: store, resetsAt: resetsAt, accountKey: persistedKey)
+
+        let dataset = await store.loadCodexDataset(
+            canonicalAccountKey: canonicalKey,
+            canonicalEmailHashKey: nil,
+            legacyEmailHash: nil,
             hasAdjacentMultiAccountVeto: false)
 
         #expect(dataset?.weeks.count == 1)

--- a/Tests/CodexBarTests/ManagedCodexAccountServiceTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountServiceTests.swift
@@ -338,7 +338,8 @@ struct ManagedCodexAccountServiceTests {
         let account = try await service.authenticateManagedAccount(existingAccountID: aliceID)
 
         let storedAlice = try #require(store.snapshot.account(id: aliceID))
-        let storedBob = try #require(store.snapshot.account(email: "bob@example.com"))
+        let storedBob = try #require(
+            store.snapshot.account(email: "bob@example.com", providerAccountID: "account-bob"))
         #expect(account.id != aliceID)
         #expect(account.id == storedBob.id)
         #expect(store.snapshot.accounts.count == 2)
@@ -354,7 +355,7 @@ struct ManagedCodexAccountServiceTests {
     }
 
     @Test
-    func `reauth on same email different workspace does not overwrite selected workspace`() async throws {
+    func `reauth on same email different workspace does not overwrite explicit workspace only account`() async throws {
         let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let personalHome = root.appendingPathComponent("accounts/personal", isDirectory: true)
         try FileManager.default.createDirectory(at: personalHome, withIntermediateDirectories: true)
@@ -364,7 +365,6 @@ struct ManagedCodexAccountServiceTests {
         let personalAccount = ManagedCodexAccount(
             id: personalID,
             email: "alice@example.com",
-            providerAccountID: "workspace-personal",
             workspaceLabel: "Personal",
             workspaceAccountID: "workspace-personal",
             managedHomePath: personalHome.path,
@@ -395,7 +395,8 @@ struct ManagedCodexAccountServiceTests {
         #expect(account.id == storedTeam.id)
         #expect(account.id != personalID)
         #expect(store.snapshot.accounts.count == 2)
-        #expect(storedPersonal.providerAccountID == "workspace-personal")
+        #expect(storedPersonal.providerAccountID == nil)
+        #expect(storedPersonal.workspaceAccountID == "workspace-personal")
         #expect(storedPersonal.workspaceLabel == "Personal")
         #expect(storedPersonal.managedHomePath == personalHome.path)
         #expect(storedTeam.providerAccountID == "workspace-team")
@@ -403,6 +404,53 @@ struct ManagedCodexAccountServiceTests {
         #expect(storedTeam.managedHomePath != personalHome.path)
         #expect(FileManager.default.fileExists(atPath: personalHome.path))
         #expect(FileManager.default.fileExists(atPath: storedTeam.managedHomePath))
+    }
+
+    @Test
+    func `reauth canonicalizes mixed case workspace identity onto the existing account`() async throws {
+        let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let existingHome = root.appendingPathComponent("accounts/personal", isDirectory: true)
+        try FileManager.default.createDirectory(at: existingHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let accountID = try #require(UUID(uuidString: "41414141-5252-6363-7474-858585858585"))
+        let existingAccount = ManagedCodexAccount(
+            id: accountID,
+            email: "alice@example.com",
+            workspaceLabel: "Personal",
+            workspaceAccountID: "workspace-personal",
+            managedHomePath: existingHome.path,
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let store = InMemoryManagedCodexAccountStore(accounts: ManagedCodexAccountSet(
+            version: FileManagedCodexAccountStore.currentVersion,
+            accounts: [existingAccount]))
+        let service = ManagedCodexAccountService(
+            store: store,
+            homeFactory: TestManagedCodexHomeFactory(root: root),
+            loginRunner: StubManagedCodexLoginRunner.success,
+            identityReader: StubManagedCodexIdentityReader.accounts([
+                .init(identity: .providerAccount(id: "WORKSPACE-PERSONAL"), email: "alice@example.com", plan: "Pro"),
+            ]),
+            workspaceResolver: StubManagedCodexWorkspaceResolver(identities: [
+                "workspace-personal": CodexOpenAIWorkspaceIdentity(
+                    workspaceAccountID: "workspace-personal",
+                    workspaceLabel: "Personal"),
+            ]))
+
+        let account = try await service.authenticateManagedAccount(existingAccountID: accountID)
+        let stored = try #require(store.snapshot.account(id: accountID))
+
+        #expect(account.id == accountID)
+        #expect(stored.id == accountID)
+        #expect(store.snapshot.accounts.count == 1)
+        #expect(stored.providerAccountID == "workspace-personal")
+        #expect(stored.workspaceAccountID == "workspace-personal")
+        #expect(stored.managedHomePath == account.managedHomePath)
+        #expect(stored.managedHomePath != existingHome.path)
+        #expect(FileManager.default.fileExists(atPath: existingHome.path) == false)
+        #expect(FileManager.default.fileExists(atPath: stored.managedHomePath))
     }
 
     @Test

--- a/Tests/CodexBarTests/ManagedCodexAccountStoreTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountStoreTests.swift
@@ -237,6 +237,47 @@ func `managed account set keeps same provider account I D when emails differ`() 
     #expect(set.account(email: "mich.aelfmk5542@gmail.com", providerAccountID: "team-4107")?.id == secondID)
 }
 
+@Test
+func `managed account set keeps explicit same email workspaces separate from legacy`() {
+    let personalID = UUID()
+    let teamID = UUID()
+    let duplicatePersonalID = UUID()
+    let personal = ManagedCodexAccount(
+        id: personalID,
+        email: "user@example.com",
+        workspaceAccountID: "WORKSPACE-PERSONAL",
+        managedHomePath: "/tmp/managed-home-personal",
+        createdAt: 10,
+        updatedAt: 20,
+        lastAuthenticatedAt: nil)
+    let team = ManagedCodexAccount(
+        id: teamID,
+        email: "USER@example.com",
+        workspaceAccountID: "workspace-team",
+        managedHomePath: "/tmp/managed-home-team",
+        createdAt: 30,
+        updatedAt: 40,
+        lastAuthenticatedAt: nil)
+    let duplicatePersonal = ManagedCodexAccount(
+        id: duplicatePersonalID,
+        email: "user@example.com",
+        providerAccountID: "workspace-personal",
+        managedHomePath: "/tmp/managed-home-duplicate-personal",
+        createdAt: 50,
+        updatedAt: 60,
+        lastAuthenticatedAt: nil)
+
+    let set = ManagedCodexAccountSet(
+        version: FileManagedCodexAccountStore.currentVersion,
+        accounts: [personal, team, duplicatePersonal])
+
+    #expect(set.accounts.count == 2)
+    #expect(set.account(email: "user@example.com", providerAccountID: "workspace-personal")?.id == personalID)
+    #expect(set.account(email: "user@example.com", providerAccountID: "WORKSPACE-PERSONAL")?.id == personalID)
+    #expect(set.account(email: "user@example.com", providerAccountID: "workspace-team")?.id == teamID)
+    #expect(set.account(email: "user@example.com") == nil)
+}
+
 @Test(CodexCredentialFixtures())
 func `FileManagedCodexAccountStore hydrates provider account I D from id token when account field is absent`() throws {
     let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1121,7 +1121,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+HistoricalPace.swift",
-            line: 219,
+            line: 227,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -1223,43 +1223,43 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1444,
+            line: 1449,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1440,
+            line: 1445,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1447,
+            line: 1452,
             anchor: "self.handlePredictivePaceWarningTransitions(provider: .codex, snapshot: snapshot)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1457,
+            line: 1462,
             anchor: "self.rememberLiveSystemCodexEmailIfNeeded(snapshot.accountEmail(for: .codex))",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1460,
+            line: 1465,
             anchor: "provider: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1480,
+            line: 1485,
             anchor: "self.snapshots.removeValue(forKey: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1516,
+            line: 1521,
             anchor: "from: self.presentationSnapshot(for: .deepseek))",
             expectedProviderIDs: ["deepseek"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -1344,19 +1344,19 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Claude widget quota ownership uses the selected Claude account's isolated snapshot key."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1073,
+            line: 1074,
             anchor: "provider: .deepseek,",
             expectedProviderIDs: ["deepseek"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1175,
+            line: 1176,
             anchor: "let sourceMode = self.sourceMode(for: .claude)",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1179,
+            line: 1180,
             anchor: "provider: .claude,",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -1584,7 +1584,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Gemini login cleanup addresses the CLI's fixed default configuration directory."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+OpenAIWeb.swift",
-            line: 1572,
+            line: 1575,
             anchor: "&& (lower.contains(\"about\") || lower.contains(\"openai\") || lower.contains(\"chatgpt\"))",
             expectedProviderIDs: ["openai"],
             reason: "This logged-out-page classifier matches OpenAI's public landing-page brand token."),
@@ -1750,7 +1750,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/CodexOwnershipContext.swift",
-            line: 181,
+            line: 210,
             anchor: "self.sha256Hex(\"\\(UsageProvider.codex.rawValue):email:\\(normalizedEmail)\")",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2730,7 +2730,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+HistoricalPace.swift",
-            line: 213,
+            line: 221,
             anchor: "let codexSnapshot = self.snapshots[.codex]",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2770,7 +2770,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+OpenAIWeb.swift",
-            line: 353,
+            line: 355,
             anchor: "guard self.lastSourceLabels[.codex] == \"openai-web\" else { return }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2778,7 +2778,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+OpenAIWeb.swift",
-            line: 371,
+            line: 374,
             anchor: "if self.snapshots[.codex] != nil,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2786,7 +2786,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+OpenAIWeb.swift",
-            line: 418,
+            line: 421,
             anchor: "guard self.isEnabled(.codex),",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3147,7 +3147,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1473,
+            line: 1478,
             anchor: "self.lastFetchAttempts[.codex] = outcome.attempts",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 12,
@@ -3168,7 +3168,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1514,
+            line: 1519,
             anchor: "provider == .deepseek",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3176,7 +3176,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1529,
+            line: 1534,
             anchor: "accountDiscriminatorOverride: provider == .claude ? warningAccountDiscriminator : nil)",
             expectedProviderIDs: ["claude", "deepseek"],
             expectedReferenceCount: 2,
@@ -3184,7 +3184,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1550,
+            line: 1555,
             anchor: "if provider == .claude,",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3192,7 +3192,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+TokenAccounts.swift",
-            line: 1576,
+            line: 1581,
             anchor: "if provider == .deepseek {",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3400,7 +3400,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 614,
+            line: 615,
             anchor: "self.metadata(for: .codex).browserCookieOrder ?? Browser.defaultImportOrder",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3408,7 +3408,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 666,
+            line: 667,
             anchor: "self.providerSpecs[provider]?.style ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3416,7 +3416,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 699,
+            line: 700,
             anchor: "guard provider != .codex else { return true }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3424,7 +3424,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1047,
+            line: 1048,
             anchor: "let claudeDebugConfiguration: ClaudeDebugLogConfiguration? = if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3432,7 +3432,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1070,
+            line: 1071,
             anchor: "let deepSeekHasTokenAccount = self.settings.selectedTokenAccount(for: .deepseek) != nil",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3440,7 +3440,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1127,
+            line: 1128,
             anchor: "case .amp:",
             expectedProviderIDs: ["amp", "deepseek", "notion", "ollama", "warp"],
             expectedReferenceCount: 7,
@@ -3456,7 +3456,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1182,
+            line: 1183,
             anchor: "let claudeSettings = snapshot.claude ?? ProviderSettingsSnapshot.ClaudeProviderSettings(",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationCodexOwnershipTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationCodexOwnershipTests.swift
@@ -6,6 +6,38 @@ import Testing
 struct UsageStorePlanUtilizationCodexOwnershipTests {
     @MainActor
     @Test
+    func `codex plan history migrates pre-normalization provider account key casing`() throws {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let persistedKey = "codex:v1:provider-account:WORKSPACE-X"
+        let canonicalKey = try #require(CodexHistoryOwnership.canonicalKey(for: .providerAccount(
+            id: "workspace-x")))
+        let weekly = planSeries(name: .weekly, windowMinutes: 10080, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 20),
+        ])
+        store.planUtilizationHistory[.codex] = PlanUtilizationHistoryBuckets(accounts: [
+            persistedKey: [weekly],
+        ])
+        store.settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "person@example.com",
+            workspaceAccountID: "workspace-x",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "workspace-x"))
+        defer { store.settings._test_liveSystemCodexAccount = nil }
+        store._setSnapshotForTesting(
+            UsageStorePlanUtilizationTests.makeSnapshot(provider: .codex, email: "person@example.com"),
+            provider: .codex)
+
+        let history = store.planUtilizationHistory(for: .codex)
+        let buckets = try #require(store.planUtilizationHistory[.codex])
+
+        #expect(history == [weekly])
+        #expect(buckets.accounts[canonicalKey] == [weekly])
+        #expect(buckets.accounts[persistedKey] == nil)
+    }
+
+    @MainActor
+    @Test
     func `codex plan history aliases pre-upgrade codex email hash bucket into canonical email hash`() throws {
         let store = UsageStorePlanUtilizationTests.makeStore()
         let snapshot = UsageStorePlanUtilizationTests.makeSnapshot(provider: .codex, email: "alice@example.com")
@@ -425,6 +457,75 @@ struct UsageStorePlanUtilizationCodexOwnershipTests {
         #expect(history == [weekly])
         #expect(buckets.unscoped == [bootstrap])
         #expect(buckets.accounts[canonicalKey] == [weekly])
+    }
+
+    @MainActor
+    @Test(arguments: [false, true])
+    func `selected workspace does not adopt ambiguous runtime owner history without live evidence`(
+        emailOnlyRuntime: Bool) throws
+    {
+        let store = UsageStorePlanUtilizationTests.makeStore()
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "member@example.com",
+            workspaceAccountID: "selected-workspace",
+            managedHomePath: "/tmp/selected-workspace",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let runtimeIdentity: CodexIdentity = emailOnlyRuntime
+            ? .emailOnly(normalizedEmail: managedAccount.email)
+            : .providerAccount(id: "auth-default")
+        let reconciliationSnapshot = CodexAccountReconciliationSnapshot(
+            storedAccounts: [managedAccount],
+            activeStoredAccount: managedAccount,
+            liveSystemAccount: nil,
+            matchingStoredAccountForLiveSystemAccount: nil,
+            activeSource: .managedAccount(id: managedAccount.id),
+            hasUnreadableAddedAccountStore: false,
+            storedAccountRuntimeIdentities: [
+                managedAccount.id: runtimeIdentity,
+            ],
+            storedAccountRuntimeEmails: [managedAccount.id: managedAccount.email])
+        let selectedWorkspaceKey = try #require(
+            CodexHistoryOwnership.canonicalKey(for: .providerAccount(id: "selected-workspace")))
+        let canonicalEmailHashKey = CodexHistoryOwnership.canonicalEmailHashKey(for: managedAccount.email)
+        let legacyEmailHash = UsageStore._codexLegacyPlanUtilizationEmailHashKeyForTesting(
+            normalizedEmail: managedAccount.email)
+        let unscoped = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_699_900_000), usedPercent: 10),
+        ])
+        let canonicalEmail = planSeries(name: .session, windowMinutes: 300, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_699_950_000), usedPercent: 15),
+        ])
+        let legacyEmail = planSeries(name: .weekly, windowMinutes: 10080, entries: [
+            planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 20),
+        ])
+
+        store.planUtilizationHistory[.codex] = PlanUtilizationHistoryBuckets(
+            unscoped: [unscoped],
+            accounts: [
+                canonicalEmailHashKey: [canonicalEmail],
+                legacyEmailHash: [legacyEmail],
+            ])
+        store.settings._test_codexAccountSnapshotLoader = { _ in reconciliationSnapshot }
+        store.settings._test_activeManagedCodexAccount = managedAccount
+        store.settings.codexActiveSource = .managedAccount(id: managedAccount.id)
+        defer {
+            store.settings._test_codexAccountSnapshotLoader = nil
+            store.settings._test_activeManagedCodexAccount = nil
+            store.settings.codexActiveSource = .liveSystem
+        }
+
+        let history = store.planUtilizationHistory(for: .codex)
+        let buckets = try #require(store.planUtilizationHistory[.codex])
+
+        #expect(history.isEmpty)
+        #expect(buckets.preferredAccountKey == selectedWorkspaceKey)
+        #expect(buckets.unscoped == [unscoped])
+        #expect(buckets.accounts[canonicalEmailHashKey] == [canonicalEmail])
+        #expect(buckets.accounts[legacyEmailHash] == [legacyEmail])
+        #expect(buckets.accounts[selectedWorkspaceKey] == nil)
     }
 
     @MainActor

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -71,6 +71,8 @@ Usage source picker:
 - Stacked account refreshes retain each managed account's selected workspace through usage publication and menu
   matching, even when its auth file names a different default workspace. Changing the selected workspace while a
   refresh is running discards the old workspace's result.
+- System Account promotion fails closed when a managed selection differs from the auth file's default workspace.
+  CodexBar keeps that selection managed rather than silently promoting the default or rewriting Codex-owned auth.
 - Reusing OpenCode OAuth enables remote account quota, not OpenCode session token/cost ingestion. See
   [OpenCode with Codex or OpenAI](opencode.md#using-opencode-with-codex-or-openai) for the current history boundary.
 


### PR DESCRIPTION
## Summary

- make CodexBar's selected managed workspace the canonical remote owner across reconciliation, refreshes, credits, history, dashboards, and promotion
- fail closed when a managed account's selected workspace differs from the saved auth default instead of silently using or overwriting the wrong workspace
- revalidate a concurrently inserted promotion-collision destination before replacing its auth, while preserving missing/unreadable-home repair
- preserve legacy managed-account compatibility while normalizing workspace IDs and migrating pre-normalization history keys

## Root cause

CodexBar intentionally stores the user-selected workspace as app-owned metadata while leaving the managed `auth.json` default unchanged. Several downstream paths still treated the auth-file default as authoritative. A selected workspace could therefore be fetched under one owner but published, cached, promoted, or reconciled as another owner with the same email.

This centralizes the effective remote owner and carries it through the full account lifecycle. Credits and history reuse stable provider ownership across ordinary token rotation, but workspace or same-workspace member changes still fail closed. Promotion now refuses ambiguous selected/default combinations rather than rewriting account metadata under the wrong identity.

## Testing

- `make check`
- 182 focused tests across reconciliation, refresh guards, credits, history ownership, and plan migration
- 43 promotion-path tests, including missing, matching, and conflicting post-planning collision races
- focused provider architecture gate
- full no-retry suite on final ancestry: 997 selections / 84 groups, all first-pass green, zero retries and timeouts
- independent review and final autoreview: clean

No screenshot: this changes account ownership and error-path behavior without changing visual layout.
