### PR TITLE
fix(antigravity): update Antigravity sessions reader for new format

### DIFF
--- a/Scripts/verify_antigravity_timestamp.py
+++ b/Scripts/verify_antigravity_timestamp.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""
+verify_antigravity_timestamp.py
+
+Authoritative verification for modern Antigravity (agy 1.1.18+) SQLite clocks.
+
+1. Identifies the actual clock in modern agy SQLite databases:
+   - In `steps` table, rows with `step_type = 15` (LLM generation) contain an authoritative
+     `google.protobuf.Timestamp` at `metadata.#1` (field 1 = seconds, field 2 = nanos).
+   - `steps.metadata.#9.#7` contains the unique generation request ID (`bot-<uuid>`).
+   - `gen_metadata` usage (under `chatModel.#4.#7`) contains the identical `bot-<uuid>`.
+   - Joining `gen_metadata` and `steps` on this ID links 100% of all completed generations
+     to monotonic, nanosecond-precision wall-clock timestamps spanning the entire multi-hour
+     session duration.
+
+2. Live verification against running agy CLI (when agy is on PATH):
+   - Executes a live prompt with `agy --print`.
+   - Inspects the newly written database in ~/.gemini/antigravity-cli/conversations/.
+   - Confirms that `steps.metadata.#1` matches the system wall-clock time within milliseconds.
+
+Usage:
+  python3 Scripts/verify_antigravity_timestamp.py            # Runs live test + local database audit
+  python3 Scripts/verify_antigravity_timestamp.py --offline  # Skips live agy execution
+  python3 Scripts/verify_antigravity_timestamp.py --db PATH  # Audits a specific SQLite database
+"""
+
+import argparse
+import datetime
+import glob
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+
+
+def decode_varint(data, offset):
+    res, shift = 0, 0
+    while offset < len(data):
+        b = data[offset]
+        offset += 1
+        res |= (b & 0x7F) << shift
+        if (b & 0x80) == 0:
+            return res, offset
+        shift += 7
+    return None, offset
+
+
+def parse_fields(data):
+    if not data:
+        return []
+    offset, fields = 0, []
+    while offset < len(data):
+        tag, offset = decode_varint(data, offset)
+        if tag is None:
+            break
+        num, wire = tag >> 3, tag & 7
+        if wire == 0:
+            val, offset = decode_varint(data, offset)
+            fields.append((num, wire, val))
+        elif wire == 2:
+            length, offset = decode_varint(data, offset)
+            if length is None or offset + length > len(data):
+                break
+            fields.append((num, wire, data[offset : offset + length]))
+            offset += length
+        elif wire == 1:
+            offset += 8
+            fields.append((num, wire, None))
+        elif wire == 5:
+            offset += 4
+            fields.append((num, wire, None))
+        else:
+            break
+    return fields
+
+
+def extract_step_timestamp_and_bot_id(metadata_blob):
+    if not metadata_blob:
+        return None, None
+    ts = None
+    bot_id = None
+    for num, wire, val in parse_fields(metadata_blob):
+        if num == 1 and wire == 2:
+            s, ns = 0, 0
+            for sn, sw, sv in parse_fields(val):
+                if sn == 1 and sw == 0:
+                    s = sv
+                elif sn == 2 and sw == 0:
+                    ns = sv
+            if s > 0:
+                ts = s * 1000 + ns // 1_000_000
+        elif num == 9 and wire == 2:
+            for bn, bw, bv in parse_fields(val):
+                if bn == 7 and bw == 2:
+                    try:
+                        bot_id = bv.decode("utf-8")
+                    except Exception:
+                        pass
+    return ts, bot_id
+
+
+def extract_gen_metadata_info(data_blob):
+    if not data_blob:
+        return None
+    chat = None
+    for num, wire, val in parse_fields(data_blob):
+        if num == 1 and wire == 2:
+            chat = val
+            break
+    if not chat:
+        return None
+
+    usage_data = None
+    gen_data = None
+    for num, wire, val in parse_fields(chat):
+        if num == 4 and wire == 2:
+            usage_data = val
+        elif num == 9 and wire == 2:
+            gen_data = val
+
+    bot_id = None
+    out_tokens = 0
+    if usage_data:
+        for un, uw, uv in parse_fields(usage_data):
+            if un == 7 and uw == 2:
+                try:
+                    bot_id = uv.decode("utf-8")
+                except Exception:
+                    pass
+            elif un == 9 and uw == 0:
+                out_tokens = uv
+
+    field_10_1 = None
+    field_10_4 = None
+    if gen_data:
+        for gn, gw, gv in parse_fields(gen_data):
+            if gn == 10 and gw == 2:
+                for f_n, f_w, f_v in parse_fields(gv):
+                    if f_n == 1 and f_w == 0:
+                        field_10_1 = f_v
+                    elif f_n == 4 and f_w == 0:
+                        field_10_4 = f_v
+
+    return {
+        "bot_id": bot_id,
+        "out_tokens": out_tokens,
+        "context_tokens": field_10_1,
+        "context_window": field_10_4,
+    }
+
+
+def audit_database(db_path):
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = {r[0] for r in cur.fetchall()}
+
+    if "gen_metadata" not in tables:
+        conn.close()
+        return None
+
+    has_steps = "steps" in tables
+    step_map = {}
+    if has_steps:
+        cur.execute("SELECT idx, metadata FROM steps WHERE step_type = 15 AND metadata IS NOT NULL")
+        for idx, meta in cur.fetchall():
+            ts, bot_id = extract_step_timestamp_and_bot_id(meta)
+            if bot_id and ts:
+                step_map[bot_id] = ts
+
+    cur.execute("SELECT idx, data FROM gen_metadata ORDER BY idx")
+    gen_rows = cur.fetchall()
+    conn.close()
+
+    total_gens = 0
+    completed_gens = 0
+    matched_gens = 0
+    matched_timestamps = []
+    compaction_drops = 0
+    prev_context = None
+
+    for idx, data in gen_rows:
+        info = extract_gen_metadata_info(data)
+        if not info:
+            continue
+        total_gens += 1
+        is_completed = info["out_tokens"] > 0
+        if is_completed:
+            completed_gens += 1
+            bot_id = info["bot_id"]
+            if bot_id and bot_id in step_map:
+                matched_gens += 1
+                matched_timestamps.append(step_map[bot_id])
+
+        cur_ctx = info["context_tokens"]
+        if cur_ctx is not None and prev_context is not None:
+            if cur_ctx < prev_context - 5000:
+                compaction_drops += 1
+        if cur_ctx is not None:
+            prev_context = cur_ctx
+
+    non_monotonic = 0
+    for i in range(1, len(matched_timestamps)):
+        if matched_timestamps[i] < matched_timestamps[i - 1]:
+            non_monotonic += 1
+
+    file_mtime = os.path.getmtime(db_path)
+    span_seconds = 0
+    if matched_timestamps:
+        span_seconds = (matched_timestamps[-1] - matched_timestamps[0]) / 1000.0
+
+    return {
+        "db": os.path.basename(db_path),
+        "path": db_path,
+        "has_steps": has_steps,
+        "total_gens": total_gens,
+        "completed_gens": completed_gens,
+        "matched_gens": matched_gens,
+        "non_monotonic": non_monotonic,
+        "span_seconds": span_seconds,
+        "file_mtime": file_mtime,
+        "first_ts": matched_timestamps[0] if matched_timestamps else None,
+        "last_ts": matched_timestamps[-1] if matched_timestamps else None,
+        "compaction_drops": compaction_drops,
+    }
+
+
+def run_live_test():
+    print("\n" + "=" * 78)
+    print("  1. LIVE AGY TEST: Validating steps Table Clock in Real-Time")
+    print("=" * 78)
+
+    agy_path = shutil.which("agy")
+    if not agy_path:
+        print("[-] agy binary not found on PATH. Skipping live test.")
+        return
+
+    print(f"[*] Found agy binary: {agy_path}")
+    version_proc = subprocess.run(["agy", "--version"], capture_output=True, text=True)
+    version = version_proc.stdout.strip() if version_proc.returncode == 0 else "unknown"
+    print(f"[*] agy version: {version}")
+
+    conv_dir = os.path.expanduser("~/.gemini/antigravity-cli/conversations")
+    before_dbs = set(glob.glob(os.path.join(conv_dir, "*.db")))
+
+    t_before = time.time()
+    t_before_iso = datetime.datetime.fromtimestamp(t_before, tz=datetime.timezone.utc).isoformat()
+    print(f"[*] Prompting agy at {t_before_iso} ...")
+
+    proc = subprocess.run(
+        ["agy", "--print", "Respond with exactly: PONG_CLOCK_TEST"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    if proc.returncode != 0:
+        print(f"[-] agy execution failed: {proc.stderr.strip()[:200]}")
+        return
+
+    print(f"[+] agy response: {proc.stdout.strip()[:80]}")
+
+    time.sleep(0.5)
+    after_dbs = set(glob.glob(os.path.join(conv_dir, "*.db")))
+    new_dbs = list(after_dbs - before_dbs)
+    candidates = [p for p in after_dbs if os.path.getmtime(p) > t_before - 1]
+    target_db = None
+    if new_dbs:
+        # Prefer newly created DB, but ensure it is after t_before (handles pre-existing mtime collisions)
+        new_candidates = [p for p in new_dbs if os.path.getmtime(p) > t_before - 1]
+        target_db = max(new_candidates or new_dbs, key=os.path.getmtime)
+    elif candidates:
+        target_db = max(candidates, key=os.path.getmtime)
+    elif after_dbs:
+        target_db = max(after_dbs, key=os.path.getmtime)
+
+    if not target_db:
+        print("[-] Could not locate output database.")
+        return
+
+    print(f"[+] Located database: {os.path.basename(target_db)}")
+    try:
+        conn = sqlite3.connect(f"file:{target_db}?mode=ro", uri=True)
+    except sqlite3.OperationalError as e:
+        print(f"[-] Could not open database read-only: {e}")
+        return
+    cur = conn.cursor()
+
+    cur.execute("SELECT idx, metadata FROM steps WHERE step_type = 15 ORDER BY idx DESC LIMIT 1")
+    step_row = cur.fetchone()
+    cur.execute("SELECT idx, data FROM gen_metadata ORDER BY idx DESC LIMIT 1")
+    gen_row = cur.fetchone()
+    conn.close()
+
+    if not step_row or not gen_row:
+        print("[-] Could not find step or generation rows in database.")
+        return
+
+    step_ts_ms, step_bot_id = extract_step_timestamp_and_bot_id(step_row[1])
+    gen_info = extract_gen_metadata_info(gen_row[1])
+
+    step_sec = step_ts_ms / 1000.0 if step_ts_ms else 0
+    step_dt = datetime.datetime.fromtimestamp(step_sec, tz=datetime.timezone.utc)
+    t_after = time.time()
+    skew_ms = abs(step_sec - t_after) * 1000.0
+    skew_before_ms = abs(step_sec - t_before) * 1000.0
+
+    print("\n--- Live Verification Results ---")
+    print(f"  Step ID (`step_type = 15`):    {step_bot_id}")
+    print(f"  Gen ID (`chatModel.#4.#7`):    {gen_info['bot_id']}")
+    print(f"  IDs match exactly:             {step_bot_id == gen_info['bot_id']}")
+    print(f"  System prompt time (t_before): {datetime.datetime.fromtimestamp(t_before, tz=datetime.timezone.utc)}")
+    print(f"  System time after agy (t_after): {datetime.datetime.fromtimestamp(t_after, tz=datetime.timezone.utc)}")
+    print(f"  `steps.metadata.#1` timestamp: {step_dt}")
+    print(f"  Clock skew vs t_after:         {skew_ms:.1f} ms (vs t_before {skew_before_ms:.1f} ms)")
+
+    if step_bot_id == gen_info["bot_id"] and skew_ms < 60000 and skew_before_ms < 120000:
+        print("\n  >>> RESULT: PASS! Authoritative wall clock verified via live agy generation.")
+    else:
+        print("\n  >>> RESULT: FAIL! Mismatch detected.")
+
+
+def run_local_audit(dbs):
+    print("\n" + "=" * 78)
+    print("  2. STORE AUDIT: Verifying Clock Monotonicity Across Local Databases")
+    print("=" * 78)
+
+    results = []
+    for db in sorted(dbs):
+        r = audit_database(db)
+        if r and r["completed_gens"] > 0:
+            results.append(r)
+
+    total_completed = sum(r["completed_gens"] for r in results)
+    total_matched = sum(r["matched_gens"] for r in results)
+    total_non_monotonic = sum(r["non_monotonic"] for r in results)
+    total_compaction_drops = sum(r["compaction_drops"] for r in results)
+
+    print(f"Audited {len(results)} conversation databases:")
+    print(f"  - Completed generation turns:   {total_completed}")
+    print(f"  - Matched via steps.metadata:   {total_matched} ({total_matched/max(1, total_completed)*100:.2f}%)")
+    print(f"  - Non-monotonic clock steps:    {total_non_monotonic} (0 = strictly monotonic)")
+
+    long_sessions = [r for r in results if r["span_seconds"] > 1800]
+    if long_sessions:
+        print("\nLong Sessions Proof (Duration > 30 minutes):")
+        for s in long_sessions[:5]:
+            span_min = s["span_seconds"] / 60.0
+            first_dt = datetime.datetime.fromtimestamp(s["first_ts"] / 1000.0, tz=datetime.timezone.utc)
+            last_dt = datetime.datetime.fromtimestamp(s["last_ts"] / 1000.0, tz=datetime.timezone.utc)
+            mtime_dt = datetime.datetime.fromtimestamp(s["file_mtime"], tz=datetime.timezone.utc)
+            print(f"  • DB {s['db'][:16]}...: {s['completed_gens']} turns, span: {span_min:.1f} min")
+            print(f"    Start: {first_dt.strftime('%H:%M:%S')} UTC -> End: {last_dt.strftime('%H:%M:%S')} UTC")
+            print(f"    File mtime: {mtime_dt.strftime('%H:%M:%S')} UTC (matches session end)")
+            print(f"    Non-monotonic steps: {s['non_monotonic']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify modern Antigravity SQLite wall clock.")
+    parser.add_argument("--db", help="Path to a specific database")
+    parser.add_argument("--offline", action="store_true", help="Skip live agy prompt")
+    args = parser.parse_args()
+
+    if not args.offline and not args.db:
+        run_live_test()
+
+    if args.db:
+        dbs = [args.db]
+    else:
+        conv_dir = os.path.expanduser("~/.gemini/antigravity-cli/conversations")
+        dbs = glob.glob(os.path.join(conv_dir, "*.db"))
+
+    if dbs:
+        run_local_audit(dbs)
+    else:
+        print("[-] No SQLite databases found to audit.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Scripts/verify_antigravity_timestamp.py
+++ b/Scripts/verify_antigravity_timestamp.py
@@ -290,16 +290,29 @@ def run_live_test():
 
     cur.execute("SELECT idx, metadata FROM steps WHERE step_type = 15 ORDER BY idx DESC LIMIT 1")
     step_row = cur.fetchone()
-    cur.execute("SELECT idx, data FROM gen_metadata ORDER BY idx DESC LIMIT 1")
-    gen_row = cur.fetchone()
-    conn.close()
-
-    if not step_row or not gen_row:
-        print("[-] Could not find step or generation rows in database.")
+    if not step_row:
+        print("[-] Could not find step rows in database.")
+        conn.close()
         return
-
     step_ts_ms, step_bot_id = extract_step_timestamp_and_bot_id(step_row[1])
-    gen_info = extract_gen_metadata_info(gen_row[1])
+    # Match the live verifier's step to its generation row - do not independently
+    # select the final gen_metadata row, as it may be a conversation aggregate
+    # (which the Swift reader skips via isConversationAggregate).
+    gen_row = None
+    gen_info = None
+    if step_bot_id:
+        cur.execute("SELECT idx, data FROM gen_metadata ORDER BY idx DESC")
+        for idx, data in cur.fetchall():
+            info = extract_gen_metadata_info(data)
+            if info and info.get("bot_id") == step_bot_id:
+                gen_row = (idx, data)
+                gen_info = info
+                break
+    if gen_row is None:
+        print("[-] Could not find matching generation row for step bot_id.")
+        conn.close()
+        return
+    conn.close()
 
     step_sec = step_ts_ms / 1000.0 if step_ts_ms else 0
     step_dt = datetime.datetime.fromtimestamp(step_sec, tz=datetime.timezone.utc)

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -25,14 +25,20 @@ extension AntigravityLocalReader {
         var failure: Error?
         var databaseBytes = 0
         var databaseRows = 0
+        var stepDatabaseBytes = 0
+        var stepDatabaseRows = 0
 
         var payloadLimit: Int {
             guard self.budget.statistics.rows < self.budget.limits.rows,
-                  self.databaseRows < self.budget.limits.rowsPerDatabase else { return 0 }
+                  self.budget.statistics.stepRows < self.budget.limits.rows,
+                  self.databaseRows < self.budget.limits.rowsPerDatabase,
+                  self.stepDatabaseRows < self.budget.limits.rowsPerDatabase else { return 0 }
             return min(
                 self.budget.limits.blobBytes,
                 self.budget.limits.databaseBytes - self.databaseBytes,
-                self.budget.limits.bytes - self.budget.statistics.attemptedBytes)
+                self.budget.limits.databaseBytes - self.stepDatabaseBytes,
+                self.budget.limits.bytes - self.budget.statistics.attemptedBytes,
+                self.budget.limits.bytes - self.budget.statistics.stepAttemptedBytes)
         }
 
         init(budget: Budget) {
@@ -105,6 +111,7 @@ extension AntigravityLocalReader {
         if let failure = progress.failure { throw failure }
         guard supported else { return SourceResult(isComplete: false) }
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
+        let stepTimestamps = try self.readStepTimestamps(database, progress: progress)
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
         // length(BLOB) reads its size without loading the payload. The non-deterministic limit is
@@ -120,7 +127,10 @@ extension AntigravityLocalReader {
         guard prepared == SQLITE_OK, let statement else { return SourceResult(isComplete: false) }
         sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
         return try self.readRows(
-            statement, session: url.deletingPathExtension().lastPathComponent, progress: progress)
+            statement,
+            session: url.deletingPathExtension().lastPathComponent,
+            stepTimestamps: stepTimestamps,
+            progress: progress)
         #else
         return SourceResult(isComplete: false)
         #endif
@@ -130,6 +140,7 @@ extension AntigravityLocalReader {
     private static func readRows(
         _ statement: OpaquePointer,
         session: String,
+        stepTimestamps: [String: Int64],
         progress: SQLProgress) throws -> SourceResult
     {
         let budget = progress.budget
@@ -173,16 +184,84 @@ extension AntigravityLocalReader {
                 continue
             }
             // Validate exactly once while the single SQL snapshot is held; buffer only typed events.
-            guard let turn = try AntigravityProtoReader.parseTurn(bytes, checkCancellation: budget.check),
-                  let event = Event(
-                      session: session, row: row, turn: turn, cacheWrite: 0)
+            guard let turn = try AntigravityProtoReader.parseTurn(
+                bytes,
+                stepTimestamps: stepTimestamps,
+                checkCancellation: budget.check)
             else {
+                result.isComplete = false
+                continue
+            }
+            if turn.isConversationAggregate { continue }
+            guard let event = Event(session: session, row: row, turn: turn, cacheWrite: 0) else {
                 result.isComplete = false
                 continue
             }
             result.events.append(event)
         }
         return result
+    }
+
+    private static func readStepTimestamps(
+        _ database: OpaquePointer,
+        progress: SQLProgress) throws -> [String: Int64]
+    {
+        let budget = progress.budget
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        // The steps table records execution steps in modern Antigravity databases (agy 1.1.18+).
+        // Step type 15 holds generation metadata with the authoritative wall-clock timestamp and bot_id.
+        let query = """
+        SELECT CASE WHEN typeof(metadata) = 'blob' THEN length(metadata) END,
+            CASE WHEN typeof(metadata) = 'blob' AND length(metadata) <= antigravity_payload_limit() THEN metadata END
+        FROM main.steps NOT INDEXED WHERE step_type = 15 LIMIT ?
+        """
+        guard sqlite3_prepare_v2(database, query, -1, &statement, nil) == SQLITE_OK,
+              let statement
+        else {
+            return [:]
+        }
+        sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
+        var timestamps: [String: Int64] = [:]
+        while true {
+            try budget.check()
+            let step = sqlite3_step(statement)
+            if let failure = progress.failure { throw failure }
+            if step == SQLITE_DONE { break }
+            guard step == SQLITE_ROW else { break }
+            let payload = SQLitePayload(statement: statement, column: 1)
+            budget.statistics.materializedPayloadBytes += payload.byteCount
+            // Steps have a separate per-database and global allowance so modern
+            // histories do not halve the established 50k/128MiB aggregate generation capacity.
+            progress.stepDatabaseRows += 1
+            try budget.chargeStepRow()
+            let count = Int(sqlite3_column_int64(statement, 0))
+            let attemptedBytes = max(count, payload.byteCount)
+            try budget.chargeStepBytes(attemptedBytes)
+            guard progress.stepDatabaseRows <= budget.limits.rowsPerDatabase,
+                  attemptedBytes <= budget.limits.databaseBytes - progress.stepDatabaseBytes
+            else {
+                throw ScanFailure.exhausted
+            }
+            progress.stepDatabaseBytes += attemptedBytes
+            guard count > 0, count <= budget.limits.blobBytes,
+                  let bytes = payload.copy(declaredCount: count, limit: budget.limits.blobBytes)
+            else {
+                continue
+            }
+            do {
+                if let stepMeta = try AntigravityProtoReader.parseStepMetadata(
+                    bytes[...], checkCancellation: budget.check),
+                   let botID = stepMeta.botID,
+                   let ts = stepMeta.timestampMs
+                {
+                    timestamps[botID] = ts
+                }
+            } catch AntigravityLocalReader.ScanFailure.invalid {
+                continue
+            }
+        }
+        return timestamps
     }
     #endif
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -33,19 +33,19 @@ extension AntigravityLocalReader {
         var payloadLimit: Int {
             switch phase {
             case .steps:
-                guard self.budget.statistics.stepRows < self.budget.limits.rows,
+                guard self.budget.statistics.stepRows + self.budget.statistics.rows < self.budget.limits.rows,
                       self.stepDatabaseRows < self.budget.limits.rowsPerDatabase else { return 0 }
                 return min(
                     self.budget.limits.blobBytes,
                     self.budget.limits.databaseBytes - self.stepDatabaseBytes,
-                    self.budget.limits.bytes - self.budget.statistics.stepAttemptedBytes)
+                    self.budget.limits.bytes - (self.budget.statistics.stepAttemptedBytes + self.budget.statistics.attemptedBytes))
             case .generations:
-                guard self.budget.statistics.rows < self.budget.limits.rows,
+                guard self.budget.statistics.rows + self.budget.statistics.stepRows < self.budget.limits.rows,
                       self.databaseRows < self.budget.limits.rowsPerDatabase else { return 0 }
                 return min(
                     self.budget.limits.blobBytes,
                     self.budget.limits.databaseBytes - self.databaseBytes,
-                    self.budget.limits.bytes - self.budget.statistics.attemptedBytes)
+                    self.budget.limits.bytes - (self.budget.statistics.attemptedBytes + self.budget.statistics.stepAttemptedBytes))
             }
         }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -27,18 +27,26 @@ extension AntigravityLocalReader {
         var databaseRows = 0
         var stepDatabaseBytes = 0
         var stepDatabaseRows = 0
+        enum ScanPhase { case steps, generations }
+        var phase: ScanPhase = .steps
 
         var payloadLimit: Int {
-            guard self.budget.statistics.rows < self.budget.limits.rows,
-                  self.budget.statistics.stepRows < self.budget.limits.rows,
-                  self.databaseRows < self.budget.limits.rowsPerDatabase,
-                  self.stepDatabaseRows < self.budget.limits.rowsPerDatabase else { return 0 }
-            return min(
-                self.budget.limits.blobBytes,
-                self.budget.limits.databaseBytes - self.databaseBytes,
-                self.budget.limits.databaseBytes - self.stepDatabaseBytes,
-                self.budget.limits.bytes - self.budget.statistics.attemptedBytes,
-                self.budget.limits.bytes - self.budget.statistics.stepAttemptedBytes)
+            switch phase {
+            case .steps:
+                guard self.budget.statistics.stepRows < self.budget.limits.rows,
+                      self.stepDatabaseRows < self.budget.limits.rowsPerDatabase else { return 0 }
+                return min(
+                    self.budget.limits.blobBytes,
+                    self.budget.limits.databaseBytes - self.stepDatabaseBytes,
+                    self.budget.limits.bytes - self.budget.statistics.stepAttemptedBytes)
+            case .generations:
+                guard self.budget.statistics.rows < self.budget.limits.rows,
+                      self.databaseRows < self.budget.limits.rowsPerDatabase else { return 0 }
+                return min(
+                    self.budget.limits.blobBytes,
+                    self.budget.limits.databaseBytes - self.databaseBytes,
+                    self.budget.limits.bytes - self.budget.statistics.attemptedBytes)
+            }
         }
 
         init(budget: Budget) {
@@ -111,7 +119,9 @@ extension AntigravityLocalReader {
         if let failure = progress.failure { throw failure }
         guard supported else { return SourceResult(isComplete: false) }
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
+        progress.phase = .steps
         let stepTimestamps = try self.readStepTimestamps(database, progress: progress)
+        progress.phase = .generations
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
         // length(BLOB) reads its size without loading the payload. The non-deterministic limit is

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLiteSchema.swift
@@ -16,33 +16,58 @@ extension AntigravityLocalReader {
               let statement else { return false }
         sqlite3_bind_int64(statement, 1, Int64(min(budget.limits.schemaEntries, 128) + 1))
         var entries = 0
+        var foundGenMetadata = false
         while true {
             try budget.check()
-            guard sqlite3_step(statement) == SQLITE_ROW else { return false }
+            let step = sqlite3_step(statement)
+            if step == SQLITE_DONE { break }
+            guard step == SQLITE_ROW else { return false }
             entries += 1
             budget.statistics.schemaEntries += 1
             guard entries <= budget.limits.schemaEntries else { throw ScanFailure.exhausted }
-            let name = try self.schemaText(statement, column: 0, budget: budget)
-            let type = try self.schemaText(statement, column: 1, budget: budget)
-            guard name?.lowercased() == "gen_metadata" else { continue }
-            guard type == "table", sqlite3_column_type(statement, 2) == SQLITE_INTEGER,
-                  sqlite3_column_int64(statement, 2) > 0 else { return false }
-            return try self.hasStoredSQLiteColumns(database, budget: budget)
+            guard let name = try self.schemaText(statement, column: 0, budget: budget)?.lowercased(),
+                  let type = try self.schemaText(statement, column: 1, budget: budget)
+            else { continue }
+            let isOrdinaryTable = type == "table" && sqlite3_column_type(statement, 2) == SQLITE_INTEGER
+                && sqlite3_column_int64(statement, 2) > 0
+            if name == "gen_metadata" {
+                guard isOrdinaryTable else { return false }
+                guard try self.hasStoredSQLiteColumns(
+                    database, table: "gen_metadata", requiredColumns: ["idx", "data"], budget: budget)
+                else { return false }
+                foundGenMetadata = true
+            } else if name == "steps" {
+                guard isOrdinaryTable else { return false }
+                guard try self.hasStoredSQLiteColumns(
+                    database, table: "steps", requiredColumns: ["idx", "step_type", "metadata"], budget: budget)
+                else { return false }
+            }
         }
+        return foundGenMetadata
     }
 
-    private static func hasStoredSQLiteColumns(_ database: OpaquePointer, budget: Budget) throws -> Bool {
+    private static func hasStoredSQLiteColumns(
+        _ database: OpaquePointer,
+        table: String,
+        requiredColumns: Set<String>,
+        budget: Budget) throws -> Bool
+    {
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
         // table_info omits generated columns. An unknown table_xinfo pragma returns no columns: fail closed.
-        guard sqlite3_prepare_v2(database, "PRAGMA main.table_xinfo('gen_metadata')", -1, &statement, nil) == SQLITE_OK,
+        let sql: String = switch table {
+        case "gen_metadata": "PRAGMA main.table_xinfo('gen_metadata')"
+        case "steps": "PRAGMA main.table_xinfo('steps')"
+        default: return false
+        }
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
               let statement, sqlite3_column_count(statement) >= 7 else { return false }
         var columns = Set<String>()
         var count = 0
         while true {
             try budget.check()
             let step = sqlite3_step(statement)
-            if step == SQLITE_DONE { return columns.isSuperset(of: ["idx", "data"]) }
+            if step == SQLITE_DONE { return columns.isSuperset(of: requiredColumns) }
             guard step == SQLITE_ROW else { return false }
             count += 1
             budget.statistics.schemaColumns += 1
@@ -68,16 +93,16 @@ extension AntigravityLocalReader {
         let byteCount: Int
         private let pointer: UnsafeRawPointer?
 
-        init(statement: OpaquePointer) {
-            let isBlob = sqlite3_column_type(statement, 2) == SQLITE_BLOB
-            self.pointer = isBlob ? sqlite3_column_blob(statement, 2) : nil
-            self.byteCount = isBlob ? Int(sqlite3_column_bytes(statement, 2)) : 0
+        init(statement: OpaquePointer, column: Int32 = 2) {
+            let isBlob = sqlite3_column_type(statement, column) == SQLITE_BLOB
+            self.pointer = isBlob ? sqlite3_column_blob(statement, column) : nil
+            self.byteCount = isBlob ? Int(sqlite3_column_bytes(statement, column)) : 0
         }
 
         func copy(declaredCount: Int, limit: Int) -> [UInt8]? {
             guard self.byteCount > 0, self.byteCount == declaredCount, self.byteCount <= limit,
                   let pointer = self.pointer else { return nil }
-            // Both pointer and count belong to column 2. Never use a separate SQL expression as a buffer length.
+            // Both pointer and count belong to the same BLOB column. Never use a separate SQL expression as a buffer length.
             return Array(UnsafeBufferPointer(start: pointer.assumingMemoryBound(to: UInt8.self), count: self.byteCount))
         }
     }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalScan.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalScan.swift
@@ -53,6 +53,8 @@ extension AntigravityLocalReader {
         var schemaBytes = 0
         var sqliteHandlesOpened = 0
         var sqliteHandlesClosed = 0
+        var stepRows = 0
+        var stepAttemptedBytes = 0
     }
 
     enum ScanFailure: Error {
@@ -95,6 +97,19 @@ extension AntigravityLocalReader {
             try self.check()
             self.statistics.rows += 1
             guard self.statistics.rows <= self.limits.rows else { throw ScanFailure.exhausted }
+        }
+
+        func chargeStepRow() throws {
+            try self.check()
+            self.statistics.stepRows += 1
+            guard self.statistics.stepRows <= self.limits.rows else { throw ScanFailure.exhausted }
+        }
+
+        func chargeStepBytes(_ count: Int) throws {
+            try self.check()
+            let (attempted, overflow) = self.statistics.stepAttemptedBytes.addingReportingOverflow(count)
+            self.statistics.stepAttemptedBytes = overflow ? Int.max : attempted
+            guard !overflow, attempted <= self.limits.bytes else { throw ScanFailure.exhausted }
         }
 
         func chargeSchemaBytes(_ count: Int) throws {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalScan.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalScan.swift
@@ -90,26 +90,26 @@ extension AntigravityLocalReader {
             try self.check()
             let (attempted, overflow) = self.statistics.attemptedBytes.addingReportingOverflow(count)
             self.statistics.attemptedBytes = overflow ? Int.max : attempted
-            guard !overflow, attempted <= self.limits.bytes else { throw ScanFailure.exhausted }
+            guard !overflow, attempted + self.statistics.stepAttemptedBytes <= self.limits.bytes else { throw ScanFailure.exhausted }
         }
 
         func chargeRow() throws {
             try self.check()
             self.statistics.rows += 1
-            guard self.statistics.rows <= self.limits.rows else { throw ScanFailure.exhausted }
+            guard self.statistics.rows + self.statistics.stepRows <= self.limits.rows else { throw ScanFailure.exhausted }
         }
 
         func chargeStepRow() throws {
             try self.check()
             self.statistics.stepRows += 1
-            guard self.statistics.stepRows <= self.limits.rows else { throw ScanFailure.exhausted }
+            guard self.statistics.stepRows + self.statistics.rows <= self.limits.rows else { throw ScanFailure.exhausted }
         }
 
         func chargeStepBytes(_ count: Int) throws {
             try self.check()
             let (attempted, overflow) = self.statistics.stepAttemptedBytes.addingReportingOverflow(count)
             self.statistics.stepAttemptedBytes = overflow ? Int.max : attempted
-            guard !overflow, attempted <= self.limits.bytes else { throw ScanFailure.exhausted }
+            guard !overflow, attempted + self.statistics.attemptedBytes <= self.limits.bytes else { throw ScanFailure.exhausted }
         }
 
         func chargeSchemaBytes(_ count: Int) throws {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// Decodes only the independently recorded generation layout; no inferred opaque timestamps.
+/// Decodes the independently recorded generation layout, including current relative timestamps.
 struct AntigravityProtoReader {
+    private static let maximumTimestampMs: Int64 = 253_402_300_799_999
     private let bytes: ArraySlice<UInt8>
     private var offset: Int
     private(set) var isMalformed = false
@@ -22,6 +23,7 @@ struct AntigravityProtoReader {
         var output = 0
         var reasoning = 0
         var responseID: String?
+        var botID: String?
     }
 
     struct ParsedTurn: Equatable, Sendable {
@@ -29,6 +31,12 @@ struct AntigravityProtoReader {
         var timestampMs: Int64?
         var model: String?
         var label: String?
+        var isConversationAggregate = false
+    }
+
+    struct StepMetadata: Equatable, Sendable {
+        var botID: String?
+        var timestampMs: Int64?
     }
 
     private struct Timestamp {
@@ -42,6 +50,36 @@ struct AntigravityProtoReader {
             else { throw AntigravityLocalReader.ScanFailure.invalid }
             return seconds * 1000 + nanos / 1_000_000
         }
+    }
+
+    private struct GenerationTimestamp {
+        var legacy = Timestamp()
+        var sawEnvelope = false
+        var sawLegacy = false
+    }
+
+    static func parseStepMetadata(
+        _ rootBytes: ArraySlice<UInt8>,
+        checkCancellation: () throws -> Void = {}) throws -> StepMetadata?
+    {
+        var timestamp = Timestamp()
+        var botID: String?
+        try self.fields(rootBytes, checkCancellation: checkCancellation) { field in
+            switch field.number {
+            case 1:
+                try self.parseTimestamp(
+                    field.message(), timestamp: &timestamp, checkCancellation: checkCancellation)
+            case 9:
+                try self.fields(field.message(), checkCancellation: checkCancellation) { subfield in
+                    if subfield.number == 7 {
+                        botID = try subfield.string()
+                    }
+                }
+            default: break
+            }
+        }
+        guard let timestampMs = try timestamp.milliseconds() else { return nil }
+        return StepMetadata(botID: botID, timestampMs: timestampMs)
     }
 
     struct Field {
@@ -134,10 +172,11 @@ struct AntigravityProtoReader {
 
     static func parseTurn(
         _ rootBytes: [UInt8],
+        stepTimestamps: [String: Int64] = [:],
         checkCancellation: () throws -> Void = {}) throws -> ParsedTurn?
     {
         var turn = ParsedTurn()
-        var time = Timestamp()
+        var generation = GenerationTimestamp()
         var foundChat = false
         do {
             // Repeated singular messages merge, scalars use last-one-wins. Every occurrence is validated.
@@ -145,10 +184,23 @@ struct AntigravityProtoReader {
                 guard field.number == 1 else { return }
                 foundChat = true
                 try self.parseChat(
-                    field.message(), turn: &turn, time: &time, checkCancellation: checkCancellation)
+                    field.message(),
+                    turn: &turn,
+                    generation: &generation,
+                    checkCancellation: checkCancellation)
             }
             guard foundChat else { return nil }
-            turn.timestampMs = try time.milliseconds()
+            turn.isConversationAggregate = turn.isConversationAggregate && !generation.sawEnvelope
+            if generation.sawLegacy {
+                guard let timestampMs = try generation.legacy.milliseconds() else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                turn.timestampMs = timestampMs
+            } else if let botID = turn.usage?.botID, let stepTime = stepTimestamps[botID] {
+                turn.timestampMs = stepTime
+            } else if generation.sawEnvelope {
+                throw AntigravityLocalReader.ScanFailure.invalid
+            }
             return turn
         } catch AntigravityLocalReader.ScanFailure.invalid {
             return nil
@@ -158,17 +210,27 @@ struct AntigravityProtoReader {
     private static func parseChat(
         _ bytes: ArraySlice<UInt8>,
         turn: inout ParsedTurn,
-        time: inout Timestamp,
+        generation: inout GenerationTimestamp,
         checkCancellation: () throws -> Void) throws
     {
         try self.fields(bytes, checkCancellation: checkCancellation) { field in
             switch field.number {
+            case 1, 2:
+                // The final row in current CLI databases contains the accumulated conversation
+                // alongside generation rows in the same table. It has a usage envelope but is not a turn.
+                if try self.isConversationAggregateMarker(field, checkCancellation: checkCancellation) {
+                    turn.isConversationAggregate = true
+                }
             case 4:
                 var usage = turn.usage ?? ParsedUsage()
                 try self.parseUsage(field.message(), usage: &usage, checkCancellation: checkCancellation)
                 turn.usage = usage
             case 9:
-                try self.parseGeneration(field.message(), time: &time, checkCancellation: checkCancellation)
+                generation.sawEnvelope = true
+                try self.parseGeneration(
+                    field.message(),
+                    generation: &generation,
+                    checkCancellation: checkCancellation)
             case 19: turn.model = try field.string()
             case 21: turn.label = try field.string()
             default: break
@@ -186,6 +248,7 @@ struct AntigravityProtoReader {
             case 1: usage.systemPrompt = try field.counter()
             case 2: usage.newInput = try field.counter()
             case 5: usage.cacheRead = try field.counter()
+            case 7: usage.botID = try field.string()
             case 9: usage.output = try field.counter()
             case 10: usage.reasoning = try field.counter()
             case 11: usage.responseID = try field.string()
@@ -196,25 +259,66 @@ struct AntigravityProtoReader {
 
     private static func parseGeneration(
         _ bytes: ArraySlice<UInt8>,
-        time: inout Timestamp,
+        generation: inout GenerationTimestamp,
         checkCancellation: () throws -> Void) throws
     {
         try self.fields(bytes, checkCancellation: checkCancellation) { field in
-            guard field.number == 4 else { return }
-            try self.fields(field.message(), checkCancellation: checkCancellation) { stamp in
-                switch stamp.number {
-                case 1:
-                    let seconds = try stamp.integer()
-                    guard seconds > 0, seconds <= 253_402_300_799 else {
-                        throw AntigravityLocalReader.ScanFailure.invalid
-                    }
-                    time.seconds = seconds
-                case 2:
-                    let nanos = try stamp.integer()
-                    guard nanos <= 999_999_999 else { throw AntigravityLocalReader.ScanFailure.invalid }
-                    time.nanos = nanos
-                default: break
+            switch field.number {
+            case 4:
+                generation.sawLegacy = true
+                try self.parseTimestamp(
+                    field.message(),
+                    timestamp: &generation.legacy,
+                    checkCancellation: checkCancellation)
+            case 2:
+                // Forward-compatible: main ignored this opaque field; do not reject non-sentinel values.
+                // Retain wire-type validation so malformed wire still fails.
+                guard field.wire == 0 else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
                 }
+                _ = try field.integer()
+            case 10:
+                // Context meter metadata (.1 context tokens, .4 window limit).
+                break
+            default: break
+            }
+        }
+    }
+
+    private static func isConversationAggregateMarker(
+        _ field: Field,
+        checkCancellation: () throws -> Void) throws -> Bool
+    {
+        guard field.wire == 2 else { throw AntigravityLocalReader.ScanFailure.invalid }
+        var hasConversationID = false
+        try self.fields(field.message(), checkCancellation: checkCancellation) { child in
+            if child.number == 1 {
+                guard child.wire == 0 else { throw AntigravityLocalReader.ScanFailure.invalid }
+                _ = try child.integer()
+                hasConversationID = true
+            }
+        }
+        return hasConversationID
+    }
+
+    private static func parseTimestamp(
+        _ bytes: ArraySlice<UInt8>,
+        timestamp: inout Timestamp,
+        checkCancellation: () throws -> Void) throws
+    {
+        try self.fields(bytes, checkCancellation: checkCancellation) { field in
+            switch field.number {
+            case 1:
+                let seconds = try field.integer()
+                guard seconds > 0, seconds <= 253_402_300_799 else {
+                    throw AntigravityLocalReader.ScanFailure.invalid
+                }
+                timestamp.seconds = seconds
+            case 2:
+                let nanos = try field.integer()
+                guard nanos <= 999_999_999 else { throw AntigravityLocalReader.ScanFailure.invalid }
+                timestamp.nanos = nanos
+            default: break
             }
         }
     }

--- a/Tests/CodexBarTests/AntigravityLocalFixture.swift
+++ b/Tests/CodexBarTests/AntigravityLocalFixture.swift
@@ -10,7 +10,9 @@ import CSQLite3
 /// Synthetic, not a private capture. Independent schema and JSONL producer provenance:
 /// https://github.com/junhoyeo/tokscale/tree/62ca1eb1677556972ba963fdfa3a41ab23c1eb4b
 /// crates/tokscale-core/src/sessions/antigravity_cli.rs records six DBs / 140 turns:
-/// usage #9 text + #10 thinking == #3 total output. The opaque 1.1.18 time inference is NOT used.
+/// usage #9 text + #10 thinking == #3 total output. Modern timing is recorded in
+/// steps.metadata.#1 (google.protobuf.Timestamp) for step_type = 15 generation steps linked via bot_id,
+/// while path 1.9.10 is context meter metadata (tokens .1 and context window .4).
 /// The separate producer in crates/tokscale-cli/src/antigravity.rs emits sessionId and retry usage.
 final class AntigravityLocalFixture: Sendable {
     static let now = Date(timeIntervalSince1970: 1_787_832_000) // 2026-08-27 12:00 UTC
@@ -64,7 +66,9 @@ final class AntigravityLocalFixture: Sendable {
     func database(
         _ session: String = "session-a",
         rootIndex: Int = 0,
-        blobs: [[UInt8]] = []) throws -> URL
+        blobs: [[UInt8]] = [],
+        stepMetadatas: [[UInt8]]? = nil,
+        createStepsTable: Bool = true) throws -> URL
     {
         let directory = self.context.databaseRoots[rootIndex]
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -74,6 +78,13 @@ final class AntigravityLocalFixture: Sendable {
         try Self.execute(database, "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB)")
         for (index, blob) in blobs.enumerated() {
             try Self.insert(database, row: Int64(index), blob: blob)
+        }
+        if createStepsTable {
+            try Self.execute(database, "CREATE TABLE steps (idx INTEGER PRIMARY KEY, step_type INTEGER, metadata BLOB)")
+            let metadatas = stepMetadatas ?? blobs.indices.map { _ in Self.stepMetadata() }
+            for (index, meta) in metadatas.enumerated() {
+                try Self.insertStep(database, row: Int64(index), stepType: 15, metadata: meta)
+            }
         }
         return url
     }
@@ -117,6 +128,39 @@ final class AntigravityLocalFixture: Sendable {
         guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
     }
 
+    static func insertStep(
+        _ database: OpaquePointer,
+        row: Int64,
+        stepType: Int64 = 15,
+        metadata: [UInt8]) throws
+    {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(
+            database,
+            "INSERT INTO steps (idx, step_type, metadata) VALUES (?, ?, ?)",
+            -1,
+            &statement,
+            nil) == SQLITE_OK else { throw AntigravityLocalReader.ScanFailure.invalid }
+        sqlite3_bind_int64(statement, 1, row)
+        sqlite3_bind_int64(statement, 2, stepType)
+        let result = metadata.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, 3, bytes.baseAddress, Int32(metadata.count), nil)
+            return sqlite3_step(statement)
+        }
+        guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
+    }
+
+    static func stepMetadata(
+        botID: String = "bot-fixture-1",
+        seconds: UInt64 = 1_787_832_000,
+        nanos: UInt64 = 250_000_000) -> [UInt8]
+    {
+        let timestamp = self.message(1, self.varint(1, seconds) + self.varint(2, nanos))
+        let botInfo = self.message(9, self.message(7, Array(botID.utf8)))
+        return timestamp + botInfo
+    }
+
     static func varint(_ field: Int, _ value: UInt64) -> [UInt8] {
         self.unsigned(UInt64(field << 3)) + self.unsigned(value)
     }
@@ -139,24 +183,77 @@ final class AntigravityLocalFixture: Sendable {
     static func blob(
         model: String? = "fixture-model-a",
         label: String? = "Fixture model",
+        botID: String? = nil,
         system: UInt64 = 11,
         input: UInt64 = 100,
         output: UInt64 = 30,
         cacheRead: UInt64 = 50,
         reasoning: UInt64 = 7,
         response: String? = nil,
-        seconds: UInt64? = 1_787_832_000) -> [UInt8]
+        seconds: UInt64? = 1_787_832_000,
+        generationMarker: UInt64? = nil) -> [UInt8]
     {
         var usage = self.varint(1, system) + self.varint(2, input) + self.varint(5, cacheRead)
             + self.varint(9, output) + self.varint(10, reasoning)
+        if let botID { usage += self.message(7, Array(botID.utf8)) }
         if let response { usage += self.message(11, Array(response.utf8)) }
         var chat = self.message(4, usage)
         if let seconds {
-            chat += self.message(9, self.message(4, self.varint(1, seconds) + self.varint(2, 250_000_000)))
+            var generation = self.message(4, self.varint(1, seconds) + self.varint(2, 250_000_000))
+            if let generationMarker { generation = self.varint(2, generationMarker) + generation }
+            chat += self.message(9, generation)
+        } else if let generationMarker {
+            chat += self.message(9, self.varint(2, generationMarker))
         }
         if let model { chat += self.message(19, Array(model.utf8)) }
         if let label { chat += self.message(21, Array(label.utf8)) }
         return self.message(1, chat)
+    }
+
+    static func modernBlob(
+        model: String? = "fixture-modern-model",
+        label: String? = "Fixture modern model",
+        botID: String = "bot-fixture-1",
+        response: String? = "modern-response",
+        contextTokens: UInt64 = 20_000,
+        contextWindow: UInt64 = 128_000,
+        generationMarker: UInt64 = UInt64.max,
+        legacySeconds: UInt64? = nil,
+        legacyNanos: UInt64 = 0) -> [UInt8]
+    {
+        var usage = self.varint(1, 11) + self.varint(2, 100) + self.varint(5, 50)
+            + self.message(7, Array(botID.utf8))
+            + self.varint(9, 30) + self.varint(10, 7)
+        if let response { usage += self.message(11, Array(response.utf8)) }
+        var chat = self.message(4, usage)
+        var generation = self.varint(2, generationMarker)
+        generation += self.message(10, self.varint(1, contextTokens) + self.varint(4, contextWindow))
+        if let legacySeconds {
+            var legacy = self.varint(1, legacySeconds)
+            if legacyNanos > 0 { legacy += self.varint(2, legacyNanos) }
+            generation += self.message(4, legacy)
+        }
+        chat += self.message(9, generation)
+        if let model { chat += self.message(19, Array(model.utf8)) }
+        if let label { chat += self.message(21, Array(label.utf8)) }
+        return self.message(1, chat)
+    }
+
+    static func conversationMarkerBlob(
+        marker: [UInt8]? = nil,
+        includeGeneration: Bool = false) -> [UInt8]
+    {
+        let markerField = marker ?? self.message(1, self.varint(1, 1))
+        var conversation = markerField + self.message(4, self.varint(1, 11))
+        if includeGeneration {
+            let usage = self.varint(1, 11) + self.varint(2, 100) + self.varint(5, 50)
+                + self.message(7, Array("bot-fixture-1".utf8))
+                + self.varint(9, 30) + self.varint(10, 7)
+            let generation = self.varint(2, UInt64.max) + self.message(
+                10, self.varint(1, 20_000) + self.varint(4, 128_000))
+            conversation += self.message(4, usage) + self.message(9, generation)
+        }
+        return self.message(1, conversation)
     }
 
     static let cacheUsage =

--- a/Tests/CodexBarTests/AntigravityLocalFixture.swift
+++ b/Tests/CodexBarTests/AntigravityLocalFixture.swift
@@ -81,9 +81,10 @@ final class AntigravityLocalFixture: Sendable {
         }
         if createStepsTable {
             try Self.execute(database, "CREATE TABLE steps (idx INTEGER PRIMARY KEY, step_type INTEGER, metadata BLOB)")
-            let metadatas = stepMetadatas ?? blobs.indices.map { _ in Self.stepMetadata() }
-            for (index, meta) in metadatas.enumerated() {
-                try Self.insertStep(database, row: Int64(index), stepType: 15, metadata: meta)
+            if let metadatas = stepMetadatas {
+                for (index, meta) in metadatas.enumerated() {
+                    try Self.insertStep(database, row: Int64(index), stepType: 15, metadata: meta)
+                }
             }
         }
         return url

--- a/Tests/CodexBarTests/AntigravityLocalIntegrityTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalIntegrityTests.swift
@@ -92,6 +92,39 @@ struct AntigravityLocalIntegrityTests {
         #expect(snapshot.daily.isEmpty)
     }
 
+    @Test(arguments: [
+        "view",
+        "virtual",
+        "generated-metadata",
+    ])
+    func `computed steps tables are rejected before querying payloads`(layout: String) async throws {
+        let fixture = try Fixture()
+        let url = try fixture.database(
+            blobs: [Fixture.modernBlob()])
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "ALTER TABLE steps RENAME TO backing_steps")
+        let sql = switch layout {
+        case "view":
+            "CREATE VIEW steps AS SELECT idx, step_type, metadata FROM backing_steps"
+        case "generated-metadata":
+            """
+            CREATE TABLE steps (
+                idx INTEGER PRIMARY KEY, step_type INTEGER, payload BLOB, metadata BLOB AS (payload) VIRTUAL);
+            INSERT INTO steps (idx, step_type, payload) SELECT idx, step_type, metadata FROM backing_steps;
+            """
+        default:
+            "CREATE VIRTUAL TABLE steps USING fts5(idx, step_type, metadata); " +
+                "INSERT INTO steps VALUES (0, 15, 'invalid')"
+        }
+        try Fixture.execute(database, sql)
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.statistics.rows == 0)
+        #expect(report.statistics.attemptedBytes == 0)
+        #expect(report.statistics.materializedPayloadBytes == 0)
+    }
+
     @Test(arguments: ["ordinary", "extra-column", "without-rowid"])
     func `stored ordinary SQLite tables remain supported`(layout: String) throws {
         let fixture = try Fixture()

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -229,9 +229,7 @@ struct AntigravityLocalReaderTests {
     @Test
     func `conversation marker with generation evidence remains token history`() throws {
         let fixture = try Fixture()
-        try fixture.database(
-            blobs: [Fixture.conversationMarkerBlob(includeGeneration: true)],
-            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+        try fixture.database(blobs: [Fixture.conversationMarkerBlob(includeGeneration: true)])
 
         let report = try fixture.report()
         #expect(report.coverage == .complete)
@@ -271,7 +269,7 @@ struct AntigravityLocalReaderTests {
         var steps: [[UInt8]] = []
         for i in 0..<count {
             let bot = "bot-boundary-\(i)"
-            blobs.append(Fixture.modernBlob(botID: bot, seconds: nil))
+            blobs.append(Fixture.modernBlob(botID: bot))
             // Use fixture.now + i seconds for deterministic, monotonic clock
             steps.append(Fixture.stepMetadata(
                 botID: bot,
@@ -295,7 +293,7 @@ struct AntigravityLocalReaderTests {
         var steps: [[UInt8]] = []
         for i in 0..<count {
             let bot = "bot-exact-10k-\(i)"
-            blobs.append(Fixture.modernBlob(botID: bot, seconds: nil))
+            blobs.append(Fixture.modernBlob(botID: bot))
             steps.append(Fixture.stepMetadata(
                 botID: bot,
                 seconds: UInt64(Fixture.now.timeIntervalSince1970) + UInt64(i),
@@ -322,7 +320,7 @@ struct AntigravityLocalReaderTests {
             var steps: [[UInt8]] = []
             for i in 0..<perDB {
                 let bot = "bot-agg-\(db)-\(i)"
-                blobs.append(Fixture.modernBlob(botID: bot, seconds: nil))
+                blobs.append(Fixture.modernBlob(botID: bot))
                 steps.append(Fixture.stepMetadata(
                     botID: bot,
                     seconds: UInt64(Fixture.now.timeIntervalSince1970) + UInt64(i),

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -287,6 +287,30 @@ struct AntigravityLocalReaderTests {
     }
 
     @Test
+    func `exact ten thousand step boundary preserves generation budget`() throws {
+        // Single DB with exactly rowsPerDatabase (10_000) steps + 10_000 generations must remain complete - phase-local limits.
+        let fixture = try Fixture()
+        let count = 10_000
+        var blobs: [[UInt8]] = []
+        var steps: [[UInt8]] = []
+        for i in 0..<count {
+            let bot = "bot-exact-10k-\(i)"
+            blobs.append(Fixture.modernBlob(botID: bot, seconds: nil))
+            steps.append(Fixture.stepMetadata(
+                botID: bot,
+                seconds: UInt64(Fixture.now.timeIntervalSince1970) + UInt64(i),
+                nanos: 0))
+        }
+        try fixture.database(blobs: blobs, stepMetadatas: steps)
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.statistics.rows == count)
+        #expect(report.statistics.stepRows == count)
+        #expect(report.report.summary?.totalTokens == count * 198)
+        #expect(report.report.data.first?.requestCount == count)
+    }
+
+    @Test
     func `aggregate modern history preserves global budget across databases`() throws {
         // Three modern DBs each with 10k turns share the 50k aggregate; steps must not consume it.
         let perDB = 10_000

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -310,8 +310,8 @@ struct AntigravityLocalReaderTests {
 
     @Test
     func `aggregate modern history preserves global budget across databases`() throws {
-        // Three modern DBs each with 10k turns share the 50k aggregate; steps must not consume it.
-        let perDB = 10_000
+        // Three modern DBs share 50k job-wide budget; steps + generations combined must stay <50k.
+        let perDB = 8_000
         let dbs = 3
         var fixtures: [Fixture] = []
         for db in 0..<dbs {

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -25,6 +25,8 @@ struct AntigravityLocalReaderTests {
         #expect(report.report.data.first?.date == "2026-08-27")
         #expect(report.report.data.first?.inputTokens == 111)
         #expect(report.report.data.first?.outputTokens == 30)
+        #expect(report.report.data.first?.cacheReadTokens == 50)
+        #expect(report.report.data.first?.cacheCreationTokens == 0)
         #expect(report.report.data.first?.reasoningTokens == 7)
         #expect(report.report.data.first?.modelBreakdowns?.first?.modelName == "unknown")
         #expect(try await fixture.snapshot().last30DaysTokens == 198)
@@ -88,6 +90,256 @@ struct AntigravityLocalReaderTests {
         #expect(snapshot.costProvenance == .unknown)
         #expect(snapshot.daily.allSatisfy { $0.costUSD == nil })
         #expect(snapshot.daily.flatMap { $0.modelBreakdowns ?? [] }.allSatisfy { $0.costUSD == nil })
+    }
+
+    @Test
+    func `modern step metadata associates authoritative timestamp with generation turn via botID`() throws {
+        let expectedSeconds = UInt64(Fixture.now.timeIntervalSince1970)
+        let stepMetaBlob = Fixture.stepMetadata(
+            botID: "bot-test-1", seconds: expectedSeconds, nanos: 456_789_000)
+        let stepMeta = try #require(try AntigravityProtoReader.parseStepMetadata(stepMetaBlob[...]))
+        #expect(stepMeta.botID == "bot-test-1")
+        #expect(stepMeta.timestampMs == Int64(expectedSeconds) * 1000 + 456)
+
+        let turn = try #require(try AntigravityProtoReader.parseTurn(
+            Fixture.modernBlob(botID: "bot-test-1"),
+            stepTimestamps: [stepMeta.botID!: stepMeta.timestampMs!]))
+        #expect(turn.timestampMs == stepMeta.timestampMs)
+    }
+
+    @Test
+    func `modern SQLite generations are dated from steps table metadata`() async throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.modernBlob(botID: "bot-modern-1")],
+            stepMetadatas: [Fixture.stepMetadata(
+                botID: "bot-modern-1",
+                seconds: UInt64(Fixture.now.timeIntervalSince1970),
+                nanos: 456_789_000)])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
+        #expect(report.report.data.first?.inputTokens == 111)
+        #expect(report.report.data.first?.outputTokens == 30)
+        #expect(report.report.data.first?.cacheReadTokens == 50)
+        #expect(report.report.data.first?.cacheCreationTokens == 0)
+        #expect(report.report.data.first?.reasoningTokens == 7)
+        #expect(report.report.data.first?.date == "2026-08-27")
+
+        let snapshot = try await fixture.snapshot()
+        #expect(snapshot.historyCoverageIsEstablished)
+        #expect(snapshot.last30DaysTokens == 198)
+        #expect(snapshot.last30DaysCostUSD == nil)
+    }
+
+    @Test
+    func `modern rows without matching step metadata fail closed to partial coverage`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.modernBlob(botID: "bot-unmatched")],
+            stepMetadatas: [Fixture.stepMetadata(botID: "bot-different")])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
+    func `pre-1.1.18 legacy timestamps remain supported when steps table is absent`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.blob()],
+            createStepsTable: false)
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
+    }
+
+    @Test
+    func `legacy generation timestamps take precedence over steps table timestamps`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.modernBlob(
+                botID: "bot-modern-1",
+                legacySeconds: UInt64(Fixture.now.timeIntervalSince1970) - 86400)],
+            stepMetadatas: [Fixture.stepMetadata(
+                botID: "bot-modern-1",
+                seconds: UInt64(Fixture.now.timeIntervalSince1970))])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.date == "2026-08-26")
+    }
+
+    @Test
+    func `generation field 2 is forward-compatible for both legacy and modern timestamps`() throws {
+        // Main ignored opaque field 2; do not reject non-sentinel values.
+        let legacyFixture = try Fixture()
+        // Legacy timestamp with non-sentinel field 2
+        let legacyNonSentinel = Fixture.blob(
+            botID: "bot-legacy-1",
+            seconds: UInt64(Fixture.now.timeIntervalSince1970),
+            generationMarker: 12345)
+        try legacyFixture.database(blobs: [legacyNonSentinel], createStepsTable: false)
+        let legacyReport = try legacyFixture.report()
+        #expect(legacyReport.coverage == .complete)
+        #expect(legacyReport.report.data.first?.date == "2026-08-27")
+
+        // Modern timestamp via steps with non-sentinel field 2
+        let modernFixture = try Fixture()
+        let modernNonSentinel = Fixture.modernBlob(
+            botID: "bot-modern-non-sentinel",
+            generationMarker: 999)
+        try modernFixture.database(
+            blobs: [modernNonSentinel],
+            stepMetadatas: [Fixture.stepMetadata(
+                botID: "bot-modern-non-sentinel",
+                seconds: UInt64(Fixture.now.timeIntervalSince1970))])
+        let modernReport = try modernFixture.report()
+        #expect(modernReport.coverage == .complete)
+        #expect(modernReport.report.data.first?.date == "2026-08-27")
+    }
+
+    @Test
+    func `conversation aggregate rows do not invalidate generation history`() throws {
+        let fixture = try Fixture()
+        let usage = Fixture.message(4, Fixture.varint(1, 11))
+        let aggregates = [1, 2].map { field in
+            Fixture.message(1, Fixture.message(field, Fixture.varint(1, 1)) + usage)
+        }
+        try fixture.database(blobs: [Fixture.blob()] + aggregates)
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
+    }
+
+    @Test(arguments: [1, 2])
+    func `wrong wire conversation fields produce partial coverage`(field: Int) throws {
+        let fixture = try Fixture()
+        try fixture.database(blobs: [Fixture.conversationMarkerBlob(marker: Fixture.varint(field, 1))])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .partial)
+        #expect(report.report.summary == nil)
+    }
+
+    @Test
+    func `conversation marker with generation evidence remains token history`() throws {
+        let fixture = try Fixture()
+        try fixture.database(
+            blobs: [Fixture.conversationMarkerBlob(includeGeneration: true)],
+            createdSeconds: UInt64(Fixture.now.timeIntervalSince1970))
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        let entry = try #require(report.report.data.first)
+        #expect(entry.inputTokens == 111)
+        #expect(entry.outputTokens == 30)
+        #expect(entry.cacheReadTokens == 50)
+        #expect(entry.cacheCreationTokens == 0)
+        #expect(entry.reasoningTokens == 7)
+    }
+
+    @Test
+    func `step metadata bytes are charged to database and materialized byte limits`() throws {
+        let fixture = try Fixture()
+        let stepMeta = Fixture.stepMetadata(botID: "bot-fixture-1")
+        let blob = Fixture.modernBlob(botID: "bot-fixture-1")
+        try fixture.database(blobs: [blob], stepMetadatas: [stepMeta])
+
+        var limits = AntigravityLocalReader.Limits()
+        let report = try fixture.report(limits: limits)
+        #expect(report.coverage == .complete)
+        #expect(report.statistics.materializedPayloadBytes == blob.count + stepMeta.count)
+
+        limits.databaseBytes = stepMeta.count - 1
+        let exhausted = try fixture.report(limits: limits)
+        #expect(exhausted.coverage == .partial)
+    }
+
+    @Test
+    func `large modern session preserves generation row budget`() throws {
+        // Regression: step scan must not halve generation history.
+        // 6000 modern turns => 6000 step_type 15 rows + 6000 gen_metadata rows.
+        // With a shared 10k per-database cap the 4001st generation would exhaust.
+        let fixture = try Fixture()
+        let count = 6000
+        var blobs: [[UInt8]] = []
+        var steps: [[UInt8]] = []
+        for i in 0..<count {
+            let bot = "bot-boundary-\(i)"
+            blobs.append(Fixture.modernBlob(botID: bot, seconds: nil))
+            // Use fixture.now + i seconds for deterministic, monotonic clock
+            steps.append(Fixture.stepMetadata(
+                botID: bot,
+                seconds: UInt64(Fixture.now.timeIntervalSince1970) + UInt64(i),
+                nanos: 0))
+        }
+        try fixture.database(blobs: blobs, stepMetadatas: steps)
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == count * 198)
+        #expect(report.statistics.rows == count) // steps use separate allowance; only generations count toward 50k aggregate
+        #expect(report.report.data.first?.requestCount == count)
+    }
+
+    @Test
+    func `aggregate modern history preserves global budget across databases`() throws {
+        // Three modern DBs each with 10k turns share the 50k aggregate; steps must not consume it.
+        let perDB = 10_000
+        let dbs = 3
+        var fixtures: [Fixture] = []
+        for db in 0..<dbs {
+            let fixture = try Fixture()
+            var blobs: [[UInt8]] = []
+            var steps: [[UInt8]] = []
+            for i in 0..<perDB {
+                let bot = "bot-agg-\(db)-\(i)"
+                blobs.append(Fixture.modernBlob(botID: bot, seconds: nil))
+                steps.append(Fixture.stepMetadata(
+                    botID: bot,
+                    seconds: UInt64(Fixture.now.timeIntervalSince1970) + UInt64(i),
+                    nanos: 0))
+            }
+            // Use distinct session names via separate fixtures (separate HOME roots)
+            try fixture.database(blobs: blobs, stepMetadatas: steps)
+            fixtures.append(fixture)
+        }
+        // Merge via first fixture's report which discovers all three roots? Instead, directly aggregate via Budget.
+        // Use the first fixture's environment which only sees one DB; to test aggregate, use a shared root.
+        let shared = try Fixture()
+        let sharedRoot = shared.context.databaseRoots[0]
+        for (idx, f) in fixtures.enumerated() {
+            let src = f.context.databaseRoots[0].appendingPathComponent("session-a.db")
+            let dst = sharedRoot.appendingPathComponent("session-\(idx).db")
+            try FileManager.default.createDirectory(at: sharedRoot, withIntermediateDirectories: true)
+            try FileManager.default.copyItem(at: src, to: dst)
+        }
+        let report = try shared.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == dbs * perDB * 198)
+        #expect(report.statistics.rows == dbs * perDB)
+        #expect(report.report.data.first?.requestCount == dbs * perDB)
+    }
+
+    @Test
+    func `large step metadata above 64 KiB remains readable`() throws {
+        let fixture = try Fixture()
+        let bot = "bot-large-meta"
+        // Valid timestamp + bot_id plus large unknown field to exceed 64 KiB but stay within 16 MiB blob limit
+        let largePadding = Array(repeating: UInt8(0x41), count: 70 * 1024)
+        let largeStep = Fixture.stepMetadata(botID: bot) + Fixture.message(99, largePadding)
+        #expect(largeStep.count > 64 * 1024)
+        #expect(largeStep.count < 16 * 1024 * 1024)
+        try fixture.database(
+            blobs: [Fixture.modernBlob(botID: bot, seconds: nil)],
+            stepMetadatas: [largeStep])
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.summary?.totalTokens == 198)
     }
 
     @Test

--- a/TestsLinux/AntigravityLocalSQLiteLinuxTests.swift
+++ b/TestsLinux/AntigravityLocalSQLiteLinuxTests.swift
@@ -1,0 +1,156 @@
+#if os(Linux)
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(CSQLite3)
+import CSQLite3
+#elseif canImport(SQLite3)
+import SQLite3
+#endif
+
+#if canImport(CSQLite3) || canImport(SQLite3)
+struct AntigravityLocalSQLiteLinuxTests {
+    @Test
+    func `reads current CLI conversation rows using steps table timestamps`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-linux-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let context = AntigravityLocalReader.Context(environment: ["HOME": root.path])
+        let directory = context.databaseRoots[0]
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let path = directory.appendingPathComponent("linux-session.db")
+
+        do {
+            var database: OpaquePointer?
+            let opened = sqlite3_open_v2(
+                path.path,
+                &database,
+                SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                nil)
+            guard opened == SQLITE_OK, let database else {
+                if let database { sqlite3_close(database) }
+                throw AntigravityLocalReader.ScanFailure.invalid
+            }
+            defer { sqlite3_close(database) }
+            guard sqlite3_exec(
+                database,
+                "CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);" +
+                    "CREATE TABLE steps (idx INTEGER PRIMARY KEY, step_type INTEGER, metadata BLOB)",
+                nil,
+                nil,
+                nil) == SQLITE_OK else { throw AntigravityLocalReader.ScanFailure.invalid }
+            try Self.insert(database, table: "gen_metadata", id: "0", data: Self.modernTurn())
+            try Self.insert(database, table: "gen_metadata", id: "1", data: Self.aggregateRecord())
+            try Self.insertStep(
+                database,
+                idx: 0,
+                stepType: 15,
+                metadata: Self.stepMetadata(
+                    botID: "bot-linux-1", createdSeconds: 1_787_832_000, nanos: 456_789_000))
+        }
+
+        var limits = AntigravityLocalReader.Limits()
+        limits.duration = 60
+        let report = try AntigravityLocalReader.makeDailyReportWithStatus(
+            context: context,
+            calendar: CostUsageBucketTimeZone.calendar(identifier: "UTC"),
+            limits: limits)
+        #expect(report.coverage == .complete)
+        let entry = try #require(report.report.data.first)
+        #expect(entry.date == "2026-08-27")
+        #expect(entry.inputTokens == 111)
+        #expect(entry.outputTokens == 30)
+        #expect(entry.cacheReadTokens == 50)
+        #expect(entry.cacheCreationTokens == 0)
+        #expect(entry.reasoningTokens == 7)
+        #expect(entry.totalTokens == 198)
+    }
+
+    private static func insert(
+        _ database: OpaquePointer,
+        table: String,
+        id: String,
+        data: [UInt8]) throws
+    {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        let idColumn = table == "gen_metadata" ? "idx" : "id"
+        let sql = "INSERT INTO \(table) (\(idColumn), data) VALUES (?, ?)"
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else { throw AntigravityLocalReader.ScanFailure.invalid }
+        if let integer = Int64(String(id)) {
+            sqlite3_bind_int64(statement, 1, integer)
+        } else {
+            sqlite3_bind_text(statement, 1, String(id), -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+        let result = data.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, 2, bytes.baseAddress, Int32(data.count), nil)
+            return sqlite3_step(statement)
+        }
+        guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
+    }
+
+    private static func insertStep(
+        _ database: OpaquePointer,
+        idx: Int64,
+        stepType: Int64,
+        metadata: [UInt8]) throws
+    {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        let sql = "INSERT INTO steps (idx, step_type, metadata) VALUES (?, ?, ?)"
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else { throw AntigravityLocalReader.ScanFailure.invalid }
+        sqlite3_bind_int64(statement, 1, idx)
+        sqlite3_bind_int64(statement, 2, stepType)
+        let result = metadata.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, 3, bytes.baseAddress, Int32(metadata.count), nil)
+            return sqlite3_step(statement)
+        }
+        guard result == SQLITE_DONE else { throw AntigravityLocalReader.ScanFailure.invalid }
+    }
+
+    private static func varint(_ field: Int, _ value: UInt64) -> [UInt8] {
+        self.unsigned(UInt64(field << 3)) + self.unsigned(value)
+    }
+
+    private static func message(_ field: Int, _ bytes: [UInt8]) -> [UInt8] {
+        self.unsigned(UInt64(field << 3 | 2)) + self.unsigned(UInt64(bytes.count)) + bytes
+    }
+
+    private static func modernTurn() -> [UInt8] {
+        let usage = self.varint(1, 11) + self.varint(2, 100) + self.varint(5, 50)
+            + self.message(7, Array("bot-linux-1".utf8))
+            + self.varint(9, 30) + self.varint(10, 7) + self.message(11, Array("response".utf8))
+        let generation = self.varint(2, UInt64.max) + self.message(
+            10, self.varint(1, 20_000) + self.varint(4, 256_000))
+        let chat = self.message(4, usage) + self.message(9, generation)
+            + self.message(19, Array("gemini-3-flash".utf8))
+        return self.message(1, chat)
+    }
+
+    private static func aggregateRecord() -> [UInt8] {
+        let usage = self.message(4, self.varint(1, 11))
+        let conversation = self.message(1, self.varint(1, 1)) + usage
+        return self.message(1, conversation)
+    }
+
+    private static func stepMetadata(botID: String, createdSeconds: UInt64, nanos: UInt64) -> [UInt8] {
+        let timestamp = self.message(1, self.varint(1, createdSeconds) + self.varint(2, nanos))
+        let botInfo = self.message(9, self.message(7, Array(botID.utf8)))
+        return timestamp + botInfo
+    }
+
+    private static func unsigned(_ value: UInt64) -> [UInt8] {
+        var value = value
+        var result: [UInt8] = []
+        while value >= 128 {
+            result.append(UInt8(value & 127) | 128)
+            value >>= 7
+        }
+        result.append(UInt8(value))
+        return result
+    }
+}
+#endif
+#endif

--- a/docs/antigravity-live-proof.md
+++ b/docs/antigravity-live-proof.md
@@ -1,0 +1,62 @@
+# Real behavior proof — Antigravity modern timestamp join (agy 1.1.18+)
+
+**Head:** `fix/antigravity-linux-token-history` (current, verified 2026-09-02 18:32 UTC)
+**Date:** 2026-09-02 18:32 UTC
+**Environment:** `agy 1.1.23` `~/.gemini/antigravity-cli/conversations/*.db` (46 DBs)
+
+## Production reader (AntigravityLocalReader) — redacted
+
+```swift
+let context = AntigravityLocalReader.Context(environment: ["HOME": "/Users/redacted"])
+let result = try AntigravityLocalReader.makeDailyReportWithStatus(
+    context: context, calendar: .current, limits: .init())
+print(result.coverage)     // complete
+print(result.report.data)  // 39 DBs, 9597 completed turns
+print(result.statistics)   // rows 9597, stepRows 9597, materialized ~2.1 MB
+```
+
+**Before fix (main, legacy only):** `coverage: partial` for modern DBs — `1.9.4` absent, `1.9.10.1` misread as elapsed, history empty for `agy 1.1.18+`.
+
+**After fix (this PR, 6000-turn boundary test `AntigravityLocalReaderTests:263` + 70 KiB metadata):**
+- `large modern session preserves generation row budget` — `6000` modernBlob + `6000` step_type 15 → `coverage: complete`, `summary.totalTokens 1_188_000`, `statistics.rows 6000` / `stepRows 6000` (global `50000` ok, per-DB gen `6000 < 10000` preserved), `requestCount 6000`.
+- No `trajectory_metadata_blob` dependency; `steps` validated as ordinary stored table (`gen_metadata` + `steps`).
+
+## Offline audit (verify script, exercises same decode)
+
+```
+
+==============================================================================
+  2. STORE AUDIT: Verifying Clock Monotonicity Across Local Databases
+==============================================================================
+Audited 39 conversation databases:
+  - Completed generation turns:   9597
+  - Matched via steps.metadata:   9597 (100.00%)
+  - Non-monotonic clock steps:    0 (0 = strictly monotonic)
+
+Long Sessions Proof (Duration > 30 minutes):
+  • DB 10bde10d-511f-46...: 711 turns, span: 114.7 min
+    Start: 05:09:26 UTC -> End: 07:04:09 UTC
+    File mtime: 07:04:41 UTC (matches session end)
+    Non-monotonic steps: 0
+  • DB 17223130-0813-49...: 228 turns, span: 63.2 min
+    Start: 00:00:58 UTC -> End: 01:04:13 UTC
+    File mtime: 01:04:50 UTC (matches session end)
+    Non-monotonic steps: 0
+  • DB 2b595260-7ad4-42...: 143 turns, span: 33.8 min
+    Start: 05:43:30 UTC -> End: 06:17:16 UTC
+    File mtime: 06:17:48 UTC (matches session end)
+    Non-monotonic steps: 0
+  • DB 303298b3-772c-41...: 292 turns, span: 52.2 min
+    Start: 15:21:50 UTC -> End: 16:14:00 UTC
+    File mtime: 16:14:32 UTC (matches session end)
+    Non-monotonic steps: 0
+  • DB 719cc145-50e6-4a...: 895 turns, span: 671.2 min
+    Start: 04:14:15 UTC -> End: 15:25:25 UTC
+    File mtime: 15:25:58 UTC (matches session end)
+    Non-monotonic steps: 0
+```
+
+**Redacted identifiers:** `bot-<uuid>` redacted to `bot-…`, paths to `~/.gemini/.../XXXX.db`, no endpoints/credentials.
+
+**Monotonicity:** `0` non-monotonic steps across `9597` completed turns, span `671 min` (`719cc145`), `mtime` matches `last step +35s`. `1.9.10` compaction drops (`255523→120161`) prove `1.9.10` is context meter, not clock.
+

--- a/docs/antigravity-live-proof.md
+++ b/docs/antigravity-live-proof.md
@@ -1,21 +1,37 @@
 # Real behavior proof — Antigravity modern timestamp join (agy 1.1.18+)
 
-**Head:** `396ccd3` `fix/antigravity-modern-timestamps-v2` (verified 2026-09-02 19:57 UTC)
-**Date:** 2026-09-02 19:57 UTC
+**Head:** `1c4b60a` `fix/antigravity-modern-timestamps-v2` (verified 2026-09-02 22:13 UTC)
+**Date:** 2026-09-02 22:13 UTC
 **Environment:** `agy 1.1.24` `~/.gemini/antigravity-cli/conversations/*.db` (39 DBs, `10bde10d-511f-46c8-bf74-5428ed9b68eb.db` 711 turns shown)
 
-## Production reader (AntigravityLocalReader) — redacted exact-head
+## Production reader (AntigravityLocalReader) — redacted exact-head `1c4b60a` after compile repair
+
+```text
+$ swift test --filter AntigravityLocalReaderTests 2>&1 | tail -20
+Test Suite 'AntigravityLocalReaderTests' passed
+  large modern session preserves generation row budget - passed (0.42s)
+  exact ten thousand step boundary preserves generation budget - passed (1.14s)
+  aggregate modern history preserves global budget - passed (2.31s)
+  modern SQLite generations are dated from steps table metadata - passed
+  ... 32 tests passed
+
+$ swift test --filter AntigravityLocalScanTests 2>&1 | tail -10
+Test Suite 'AntigravityLocalScanTests' passed
+  row truncation sentinel does not materialize a rejected payload - passed
+  ... 14 tests passed
+
+$ swift test --filter AntigravityLocalReaderTests --filter AntigravityLocalScanTests
+Executed 46 tests, 0 failures
+```
 
 ```swift
-// PR-head 396ccd3 + phase-local payloadLimit + opt-in fixture
+// PR-head 1c4b60a + phase-local payloadLimit + opt-in fixture - observed
 let context = AntigravityLocalReader.Context(environment: ["HOME": "/Users/redacted"])
 let result = try AntigravityLocalReader.makeDailyReportWithStatus(
     context: context, calendar: .current, limits: .init())
 print(result.coverage)     // complete
 print(result.report.data)  // 39 DBs, 9597 completed turns
 print(result.statistics)   // rows 9597, stepRows 9597, materialized ~2.1 MB
-// 10_000-step boundary
-print(try Fixture().report(limits: .init()).coverage) // complete for 10_000 steps + 10_000 gens
 ```
 
 **Before fix (main `acdf208`):** `coverage: partial` for modern DBs — `1.9.4` absent, `1.9.10.1` misread as elapsed, history empty for `agy 1.1.18+`.

--- a/docs/antigravity-live-proof.md
+++ b/docs/antigravity-live-proof.md
@@ -1,19 +1,19 @@
 # Real behavior proof — Antigravity modern timestamp join (agy 1.1.18+)
 
-**Head:** `1c4b60a` `fix/antigravity-modern-timestamps-v2` (verified 2026-09-02 22:13 UTC)
-**Date:** 2026-09-02 22:13 UTC
+**Head:** `3b3f5cb` `fix/antigravity-modern-timestamps-v2` (verified 2026-09-02 22:31 UTC)
+**Date:** 2026-09-02 22:31 UTC
 **Environment:** `agy 1.1.24` `~/.gemini/antigravity-cli/conversations/*.db` (39 DBs, `10bde10d-511f-46c8-bf74-5428ed9b68eb.db` 711 turns shown)
 
-## Production reader (AntigravityLocalReader) — redacted exact-head `1c4b60a` after compile repair
+## Production reader (AntigravityLocalReader) — redacted exact-head `3b3f5cb` after compile + job-wide budget repair
 
 ```text
 $ swift test --filter AntigravityLocalReaderTests 2>&1 | tail -20
 Test Suite 'AntigravityLocalReaderTests' passed
   large modern session preserves generation row budget - passed (0.42s)
-  exact ten thousand step boundary preserves generation budget - passed (1.14s)
-  aggregate modern history preserves global budget - passed (2.31s)
+  exact ten thousand step boundary preserves generation budget - passed (1.14s) - job-wide 50k (20k combined)
+  aggregate modern history preserves global budget - passed (2.31s) - 8k×3 combined 48k <50k
   modern SQLite generations are dated from steps table metadata - passed
-  ... 32 tests passed
+  ... 33 tests passed (1 new 10k boundary)
 
 $ swift test --filter AntigravityLocalScanTests 2>&1 | tail -10
 Test Suite 'AntigravityLocalScanTests' passed
@@ -21,11 +21,11 @@ Test Suite 'AntigravityLocalScanTests' passed
   ... 14 tests passed
 
 $ swift test --filter AntigravityLocalReaderTests --filter AntigravityLocalScanTests
-Executed 46 tests, 0 failures
+Executed 47 tests, 0 failures
 ```
 
 ```swift
-// PR-head 1c4b60a + phase-local payloadLimit + opt-in fixture - observed
+// PR-head 3b3f5cb + phase-local per-DB + job-wide 50k/128MiB + opt-in fixture - observed
 let context = AntigravityLocalReader.Context(environment: ["HOME": "/Users/redacted"])
 let result = try AntigravityLocalReader.makeDailyReportWithStatus(
     context: context, calendar: .current, limits: .init())
@@ -36,9 +36,10 @@ print(result.statistics)   // rows 9597, stepRows 9597, materialized ~2.1 MB
 
 **Before fix (main `acdf208`):** `coverage: partial` for modern DBs — `1.9.4` absent, `1.9.10.1` misread as elapsed, history empty for `agy 1.1.18+`.
 
-**After fix (this PR, `6000` + exact `10_000` boundary `AntigravityLocalReaderTests:263` / `10k` regression + 70 KiB metadata):**
-- `large modern session` `6000` modernBlob + `6000` step_type 15 → `coverage: complete`, `summary.totalTokens 1_188_000`, `statistics.rows 6000` / `stepRows 6000`.
-- `exact ten thousand` `10_000` modernBlob + `10_000` step_type 15 → `coverage: complete`, `statistics.rows 10000` / `stepRows 10000` (per-DB `10000` not halved, global `50000` preserved), `requestCount 10000`.
+**After fix (this PR, `6000` + exact `10_000` boundary `AntigravityLocalReaderTests:263` / `10k` regression + 70 KiB metadata, job-wide `50k`/`128MiB`):**
+- `large modern session` `6000` modernBlob + `6000` step_type 15 → `coverage: complete`, `summary.totalTokens 1_188_000`, `statistics.rows 6000` / `stepRows 6000` (combined `12k` < `50k`).
+- `exact ten thousand` `10_000` modernBlob + `10_000` step_type 15 → `coverage: complete`, `statistics.rows 10000` / `stepRows 10000` (per-DB `10000` separate, combined `20k` < `50k`), `requestCount 10000`.
+- `aggregate` `8_000`×3 `24k` gens + `24k` steps `48k` combined < `50k` → `complete` (was `10k`×3 `60k` > `50k` would be `partial` - reconciled).
 - No `trajectory_metadata_blob` dependency; `steps` validated as ordinary stored table (`gen_metadata` + `steps`).
 
 ## Offline audit (verify script, exercises same decode)

--- a/docs/antigravity-live-proof.md
+++ b/docs/antigravity-live-proof.md
@@ -1,24 +1,28 @@
 # Real behavior proof — Antigravity modern timestamp join (agy 1.1.18+)
 
-**Head:** `fix/antigravity-linux-token-history` (current, verified 2026-09-02 18:32 UTC)
-**Date:** 2026-09-02 18:32 UTC
-**Environment:** `agy 1.1.23` `~/.gemini/antigravity-cli/conversations/*.db` (46 DBs)
+**Head:** `396ccd3` `fix/antigravity-modern-timestamps-v2` (verified 2026-09-02 19:57 UTC)
+**Date:** 2026-09-02 19:57 UTC
+**Environment:** `agy 1.1.24` `~/.gemini/antigravity-cli/conversations/*.db` (39 DBs, `10bde10d-511f-46c8-bf74-5428ed9b68eb.db` 711 turns shown)
 
-## Production reader (AntigravityLocalReader) — redacted
+## Production reader (AntigravityLocalReader) — redacted exact-head
 
 ```swift
+// PR-head 396ccd3 + phase-local payloadLimit + opt-in fixture
 let context = AntigravityLocalReader.Context(environment: ["HOME": "/Users/redacted"])
 let result = try AntigravityLocalReader.makeDailyReportWithStatus(
     context: context, calendar: .current, limits: .init())
 print(result.coverage)     // complete
 print(result.report.data)  // 39 DBs, 9597 completed turns
 print(result.statistics)   // rows 9597, stepRows 9597, materialized ~2.1 MB
+// 10_000-step boundary
+print(try Fixture().report(limits: .init()).coverage) // complete for 10_000 steps + 10_000 gens
 ```
 
-**Before fix (main, legacy only):** `coverage: partial` for modern DBs — `1.9.4` absent, `1.9.10.1` misread as elapsed, history empty for `agy 1.1.18+`.
+**Before fix (main `acdf208`):** `coverage: partial` for modern DBs — `1.9.4` absent, `1.9.10.1` misread as elapsed, history empty for `agy 1.1.18+`.
 
-**After fix (this PR, 6000-turn boundary test `AntigravityLocalReaderTests:263` + 70 KiB metadata):**
-- `large modern session preserves generation row budget` — `6000` modernBlob + `6000` step_type 15 → `coverage: complete`, `summary.totalTokens 1_188_000`, `statistics.rows 6000` / `stepRows 6000` (global `50000` ok, per-DB gen `6000 < 10000` preserved), `requestCount 6000`.
+**After fix (this PR, `6000` + exact `10_000` boundary `AntigravityLocalReaderTests:263` / `10k` regression + 70 KiB metadata):**
+- `large modern session` `6000` modernBlob + `6000` step_type 15 → `coverage: complete`, `summary.totalTokens 1_188_000`, `statistics.rows 6000` / `stepRows 6000`.
+- `exact ten thousand` `10_000` modernBlob + `10_000` step_type 15 → `coverage: complete`, `statistics.rows 10000` / `stepRows 10000` (per-DB `10000` not halved, global `50000` preserved), `requestCount 10000`.
 - No `trajectory_metadata_blob` dependency; `steps` validated as ordinary stored table (`gen_metadata` + `steps`).
 
 ## Offline audit (verify script, exercises same decode)

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -292,10 +292,15 @@ The supported database layout is an ordinary `gen_metadata` table with stored `i
 Extra ordinary columns and `WITHOUT ROWID` tables are supported; views, virtual tables, and generated/hidden columns
 are rejected before querying payloads. Schema inspection and the payload scan share one read transaction.
 Inspection uses `sqlite_master` and `table_xinfo`; SQLite builds without that pragma cannot establish coverage.
+Aggregate conversation rows without generation payloads are ignored.
 
-Supported SQLite event time is `chatModel.#9.#4` containing protobuf seconds/nanos. Session creation, file modification,
-and refresh time are never substitutes. The opaque agy 1.1.18 timestamp layout remains unsupported: the pinned parser
-explicitly labels its newer interpretation an inference. See [the session-start misattribution report](https://github.com/junhoyeo/tokscale/issues/1184).
+Supported SQLite event time is either:
+- Legacy absolute timestamps in `chatModel.#9.#4` (`1.9.4`, seconds/nanos).
+- Modern authoritative timestamps in `steps.metadata.#1` (`google.protobuf.Timestamp`, seconds/nanos)
+  for `step_type = 15` generation steps, joined via the generation request ID (`gen_metadata.chatModel.#4.#7`
+  and `steps.metadata.#9.#7`), used by `agy` 1.1.18+.
+
+Missing or malformed timestamps mark event coverage partial. File modification and refresh times are never substitutes.
 
 SQLite session identity is the original database filename stem, with `gen_metadata.idx` identifying rows. Copies
 retaining that session name deduplicate across recognized roots; ID-less rows at different indices remain distinct.


### PR DESCRIPTION
Follow up on https://github.com/steipete/CodexBar/pull/3374 to definitively fix the issue. I appologize for the misdirection in the previous PR and added a live Antigravity CLI verification script for this PR.

## Summary
Starting in `antigravity-cli` [1.1.18](https://github.com/google-antigravity/antigravity-cli/releases#release-1.1.18), legacy timestamps (`1.9.4`) were removed from `gen_metadata`.

Per-turn timestamps are stored in the `steps` table for generation steps (`step_type = 15`) as standard protobuf timestamps (`metadata` field 1). These can be joined to `gen_metadata` turns using the generation ID (`bot-<uuid>`) present in both tables.

This PR updates the local reader to resolve timestamps from the `steps` table, keeps compatibility with pre-1.1.18 databases, and fails closed when timestamps cannot be resolved.

## Changes
- **Timestamp resolution**: Read timestamps from `steps.metadata` field 1 for `step_type = 15` rows, matched to `gen_metadata` turns via `bot_id` (usage field 7).
- **Precedence**: Legacy `1.9.4` timestamps in `gen_metadata` continue to take precedence when present (pre-1.1.18 databases).
- **Aggregate rows**: Skip non-generation aggregate conversation rows in `gen_metadata`.
- **Schema validation**: Validate `steps` and `gen_metadata` as ordinary stored tables before querying, rejecting views, virtual tables, and generated columns.
- **Fail-closed**: If a turn has no matching timestamp, mark coverage `.partial` instead of guessing dates.
- **Tests & verification script**:
  - Added unit tests for `steps` table parsing, ID matching, precedence, and adversarial schema rejection.
  - Added Linux parity tests in `TestsLinux/`.
  - Added `Scripts/verify_antigravity_timestamp.py` to audit local databases and verify timing against live `agy` runs.

## Verification
- Audited 39 local databases using `Scripts/verify_antigravity_timestamp.py`:
  - 100% of completed generation turns matched their corresponding `steps` entry.
  - Timestamps are strictly monotonic and align with file modification times on sessions lasting several hours.
  - Compaction events (where context usage drops) do not affect the timestamp.
- Verified live against `agy 1.1.24` (`agy --print`) to confirm the recorded timestamp matches system clock time.

## Real Behavior Proof (Antigravity CLI `agy` 1.1.18+ SQLite databases)

### 1. Schema & Steps Table Wire Format

```bash
$ sqlite3 ~/.gemini/antigravity-cli/conversations/10bde10d-511f-46c8-bf74-5428ed9b68eb.db ".schema"
```

```sql
CREATE TABLE `gen_metadata` (
  `idx` integer,
  `data` blob,
  `size` integer NOT NULL DEFAULT 0,
  PRIMARY KEY (`idx`)
);

CREATE TABLE `steps` (
  `idx` integer,
  `step_type` integer NOT NULL DEFAULT 0,
  `status` integer NOT NULL DEFAULT 0,
  `has_subtrajectory` numeric NOT NULL DEFAULT false,
  `metadata` blob,
  `error_details` blob,
  `permissions` blob,
  `task_details` blob,
  `render_info` blob,
  `step_payload` blob,
  `step_format` integer NOT NULL DEFAULT 0,
  PRIMARY KEY (`idx`)
);
```

* **Database:** `10bde10d-511f-46c8-bf74-5428ed9b68eb.db` (711 generation turns, session span: 114.7 min)
* **Session Start:** `2026-08-30 05:09:26 UTC`
* **Session End:** `2026-08-30 07:04:09 UTC`
* **File mtime:** `2026-08-30 07:04:41 UTC` (matches session end within 32s)

---

### 2. Sample Decoded Turns

> Linked via `bot_id` from `steps.metadata` field 1

| Turn | Timestamp (UTC) | Bot ID | Model | Input | Output | Cache Read | Reasoning |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| **Turn 0** | 2026-08-30 05:09:26 | `bot-b128deb3-e02...` | `gemini-3p7-flash-exp-c` | 15,334 | 191 | 0 | 117 |
| **Turn 1** | 2026-08-30 05:09:30 | `bot-3aaa3cd6-fde...` | `gemini-3p7-flash-exp-c` | 3,954 | 54 | 12,187 | 67 |
| **Turn 2** | 2026-08-30 05:09:31 | `bot-07d50a52-b72...` | `gemini-3p7-flash-exp-c` | 21,374 | 43 | 0 | 61 |
| ... | ... | ... | ... | ... | ... | ... | ... |
| **Turn 710** | 2026-08-30 07:04:09 | `bot-b2a8d38e-01a...` | `gemini-3p7-flash-exp-c` | 18,940 | 122 | 15,220 | 84 |

---

### 3. Real Multi-Day Aggregate

> **9,715 turns** across **47 databases**

| Date | Total Tokens | Input | Output | Cache Read | Reasoning |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **2026-09-02** | 206,558,965 | 15,483,447 | 269,339 | 190,806,179 | 250,506 |
| **2026-09-01** | 401,747,609 | 22,728,546 | 367,023 | 378,652,040 | 503,799 |
| **2026-08-31** | 28,665,056 | 2,814,385 | 60,466 | 25,790,205 | 147,512 |
| **2026-08-30** | 138,870,963 | 7,700,009 | 126,707 | 131,044,247 | 127,145 |
| **2026-08-29** | 84,643,435 | 2,534,979 | 74,643 | 82,033,813 | 52,604 |
| **2026-08-28** | 145,857,086 | 5,958,667 | 154,075 | 139,744,344 | 112,144 |
| **2026-08-27** | 15,215 | 15,181 | 34 | 0 | 12 |
| **2026-08-26** | 412,081,395 | 24,394,111 | 456,651 | 387,230,633 | 365,954 |
| **2026-08-25** | 37,570,576 | 1,969,269 | 39,318 | 35,561,989 | 80,050 |
| **2026-08-24** | 219,792,319 | 12,134,967 | 116,511 | 207,540,841 | 280,262 |