### PR TITLE
docs: backfill unreleased fixes after 0.56.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Menu bar: discard non-finite saved status-item positions before AppKit restores them, preserving valid placements (#3361; investigated alongside #3355). Thanks @foobra!
+- Antigravity: recover Linux port discovery when `lsof` fails with mount-namespace warnings, while preserving authentication errors and the existing startup deadline (#3364). Thanks @srijits!
+- Menu bar: let live forecast and detail labels use the full row width, preventing text from clipping to its previous width until the menu reopens (#3370).
+- Claude: recognize Cloudflare web challenges without discarding valid cached cookies or prior usage, and offer explicit OAuth or network recovery guidance (#3375). Thanks @TPuHo4u!
+- Codex: preserve the selected workspace through stacked account refreshes and menu rows instead of reverting to the auth file's default workspace (#3348). Thanks @krevoit!
+- Claude: remove misleading defaults-suite warnings at launch while preserving shared OAuth preferences for the CLI and widget (#3384). Thanks @andresg747!
+- Codex: keep selected-workspace ownership consistent across refreshes, credits, history, and account reconciliation; refuse ambiguous System Account promotion instead of silently choosing the auth file's default workspace (#3386).
+
 ## 0.56.3 — 2026-09-01
 
 ### Performance


### PR DESCRIPTION
Add an Unreleased section for the user-visible fixes merged after the frozen 0.56.3 release: menu placement and live labels, Linux Antigravity discovery, Claude web challenges and launch warnings, and Codex workspace ownership. Preserve contributor/report credit and leave the published 0.56.3 notes unchanged.

Checked each entry against its merged PR and commit; test-only and release-artifact commits are intentionally omitted. Validation: `git diff --check` and scoped Codex autoreview passed. This changes documentation only.
