### PR TITLE
docs(bedrock): disclose monitoring API charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Claude: remove misleading defaults-suite warnings at launch while preserving shared OAuth preferences for the CLI and widget (#3384). Thanks @andresg747!
 - Codex: keep selected-workspace ownership consistent across refreshes, credits, history, and account reconciliation; refuse ambiguous System Account promotion instead of silently choosing the auth file's default workspace (#3386).
 
+### Documentation
+- AWS Bedrock: explain monitoring API charges, the shared refresh controls, and why Manual mode and the displayed budget do not impose a billing cap (partial follow-up to #3387). Thanks @kyen99!
+
 ## 0.56.3 — 2026-09-01
 
 ### Performance

--- a/docs/bedrock.md
+++ b/docs/bedrock.md
@@ -11,6 +11,22 @@ read_when:
 CodexBar reads AWS Cost Explorer for Bedrock spend and can compare the current month against an optional budget. When
 permitted, it also reads CloudWatch for rolling 14-day Claude token and request totals in the configured region.
 
+## Monitoring charges and refresh frequency
+
+**Monitoring Bedrock spend can add charges to your AWS bill.** AWS currently charges **$0.01 per Cost Explorer API
+request** against the primary billing view, separately from Bedrock inference charges. See the
+[AWS Cost Explorer pricing page](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/pricing/) for current rates.
+For example, 5,000 billed requests cost $50 at that rate. A CodexBar refresh is not a fixed-price unit: monthly spend,
+daily cost history, and paginated responses can make separate requests. Optional CloudWatch activity uses another API
+and is subject to [CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/).
+
+To reduce automatic requests, open **Settings → General → Refreshing** and choose a longer refresh interval or
+**Manual**. This setting applies to all providers. Manual stops the recurring timer; startup, explicit refreshes,
+and **Refresh when the menu opens** can still fetch data. Turn off that option as well to reduce menu-triggered requests.
+Disable AWS Bedrock in Providers to stop its app refreshes; separate CLI invocations can still make billed requests.
+
+The optional monthly budget only changes the displayed progress. It does not cap AWS charges or stop polling.
+
 ## Authentication
 
 CodexBar supports two authentication modes, selected in Preferences → Providers → AWS Bedrock → Authentication.


### PR DESCRIPTION
AWS Bedrock monitoring uses paid AWS APIs, but the provider guide did not disclose those charges. Add the current Cost Explorer request price with its official source, explain that history and pagination can issue additional requests, and link CloudWatch pricing for optional activity data.

Document the existing shared refresh interval, Manual mode, menu-open refresh control, provider disablement, and the distinction between a displayed budget and a billing cap. This is the documentation part of #3387; the issue remains open for an in-app disclosure and any decision on per-provider scheduling.

Validation: checked AWS's current pricing pages and the existing fetch, pagination, budget and scheduling paths; `git diff --check` and scoped Codex autoreview passed. Documentation only; no paid AWS requests were made. Thanks @kyen99 for the report.
