### PR TITLE
Fix repeated Tailscale discovery crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Agent sessions: explicitly force Tailscale CLI mode during remote-host discovery, preventing repeated app-binary crashes on newer Tailscale installations while preserving existing terminal settings (#3397). Thanks @tzioup!
+
 ## 0.56.4 — 2026-09-03
 
 ### Fixed

--- a/Sources/CodexBarCore/RemoteSessionFetcher.swift
+++ b/Sources/CodexBarCore/RemoteSessionFetcher.swift
@@ -244,20 +244,15 @@ public struct RemoteSessionFetcher: Sendable {
 
     /// Environment that keeps the dual-mode Tailscale app binary in CLI mode.
     ///
-    /// With no shell/terminal marker present the binary boots the full menu-bar GUI
-    /// (SkyLight/WindowServer, status icon) instead of running the CLI: it never emits
-    /// JSON, the probe times out, and the Tailscale icon flickers on every refresh. A
-    /// set `TERM` or `SHLVL` forces CLI mode (argv[0] casing and `XPC_SERVICE_NAME` do
-    /// not). `SHLVL` is what the app's own `/bin/sh` CLI wrapper injects, so we mirror it here.
-    ///
-    /// Applied to every probe, not just the app-binary fallback: it is redundant but harmless for the
-    /// CLI wrapper (itself a `/bin/sh` script that already exports `SHLVL`), and injecting it
-    /// unconditionally keeps CLI mode guaranteed regardless of which binary `tailscaleBinary` resolves.
-    /// An existing `TERM`/`SHLVL` (real terminal context) is left untouched.
+    /// Shell markers alone can still select the GUI path and crash newer app binaries. Force the
+    /// documented CLI override for every candidate, including symlinks to the app. Retain the shell
+    /// marker for older installations without changing an existing terminal context.
     package static func tailscaleCLIEnvironment(from environment: [String: String]) -> [String: String] {
-        guard environment["TERM"] == nil, environment["SHLVL"] == nil else { return environment }
         var environment = environment
-        environment["SHLVL"] = "1"
+        environment["TAILSCALE_BE_CLI"] = "1"
+        if environment["TERM"] == nil, environment["SHLVL"] == nil {
+            environment["SHLVL"] = "1"
+        }
         return environment
     }
 

--- a/Tests/CodexBarTests/TailscaleSessionTests.swift
+++ b/Tests/CodexBarTests/TailscaleSessionTests.swift
@@ -44,13 +44,35 @@ struct TailscaleSessionTests {
 
     @Test
     func `cli environment preserves an existing terminal context`() {
-        // Already CLI-safe: leave TERM alone and don't fabricate a SHLVL…
+        // Leave TERM alone and don't fabricate a SHLVL…
         let withTerm = RemoteSessionFetcher.tailscaleCLIEnvironment(from: ["TERM": "xterm-256color"])
         #expect(withTerm["SHLVL"] == nil)
 
         // …and never clobber a caller-provided SHLVL.
         let withShlvl = RemoteSessionFetcher.tailscaleCLIEnvironment(from: ["SHLVL": "3"])
         #expect(withShlvl["SHLVL"] == "3")
+    }
+
+    @Test(arguments: [
+        [String: String](),
+        ["TERM": "xterm-256color"],
+        ["SHLVL": "3"],
+        ["TERM": "xterm-256color", "SHLVL": "1"],
+        ["TAILSCALE_BE_CLI": "0"],
+        ["TERM": "", "TAILSCALE_BE_CLI": ""],
+        ["SHLVL": "3", "TAILSCALE_BE_CLI": "1"],
+    ])
+    func `cli environment forces CLI mode and preserves unrelated values`(_ context: [String: String]) {
+        var original = context
+        original["PATH"] = "/usr/bin:/bin"
+        original["LANG"] = "en_US.UTF-8"
+        var expected = original
+        expected["TAILSCALE_BE_CLI"] = "1"
+        if original["TERM"] == nil, original["SHLVL"] == nil {
+            expected["SHLVL"] = "1"
+        }
+
+        #expect(RemoteSessionFetcher.tailscaleCLIEnvironment(from: original) == expected)
     }
 
     @Test

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -39,3 +39,5 @@ codexbar sessions focus <session-id>
 Remote fetching tries `sessions --json-v2` before the legacy `sessions --json`, first through `codexbar` on `PATH` and then through the bundled app CLI. This lets current hosts return Pi-family rows while both host-first and client-first mixed-version upgrades remain decodable.
 
 Remote hosts need key-based, non-interactive SSH and either `codexbar` on `PATH` or CodexBar installed in `/Applications`.
+
+Tailscale discovery forces the [documented CLI mode](https://tailscale.com/docs/reference/tailscale-cli?tab=macos) with `TAILSCALE_BE_CLI=1` for every local probe, including launchers or symlinks to the macOS app binary. This keeps discovery headless even when inherited terminal variables do not prevent the app binary from launching its GUI or crashing.


### PR DESCRIPTION
## Summary

Fixes #3397. Thanks @tzioup for the controlled reproduction.

Force `TAILSCALE_BE_CLI=1` at the shared Tailscale discovery environment boundary, including PATH candidates and symlinks to the macOS app executable. Preserve inherited terminal settings, unrelated environment values, and the existing shell marker for older installations. No candidate-order, discovery-frequency, SSH, or persistence changes.

The previous shell-marker safeguard is no longer sufficient for the reported Tailscale 1.102.3 installation: the app executable can trap before discovery falls through to a working standalone CLI. The explicit override follows [Tailscale's documented scripted invocation contract](https://tailscale.com/docs/reference/tailscale-cli?tab=macos). A larger discovery refactor is unnecessary for this bug.

## Verification

- Regression first: six of seven synthetic environment cases fail against the old helper, including existing TERM/SHLVL and inherited disabled/empty override values.
- Fixed helper: all 12 TailscaleSessionTests pass, including all seven environment cases and unchanged candidate fallback/parser/SSH-sanitization coverage.
- `make check`: passes; SwiftLint reports zero violations in 2,095 files.
- Independent Codex autoreview: no accepted/actionable findings at the configured blocking threshold.
- Full `make test`: all 999 selections across 84 groups pass on the first attempt; zero retries or timeouts.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33775418000): all checks pass on `4f331bd539b87b588eb2806663e489ec34b03f7a`, including both macOS shards, Linux x64/ARM64/musl builds, lint, and the aggregate CI gate.

Tests use synthetic data with Keychain and session-file isolation. No live Tailscale or account probe was run, and no GUI behavior changed. Updated session documentation and the Unreleased changelog entry.
