### PR TITLE
fix(antigravity): recover step timestamps via exact bot ID join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Antigravity: match local token-history timestamps by per-turn IDs when auxiliary or reordered steps would otherwise assign usage to the wrong day, while withholding conflicting evidence and preserving legacy timestamp recovery (#3403). Thanks @WeGoToMars!
 - Codex: retain completed empty session fragments during cost-history scans instead of repeatedly dropping and rediscovering them, without suppressing usage-bearing duplicates or later appended usage (partial fix for #3316; #3402). Thanks @mauriciopolvora!
 - Agent sessions: explicitly force Tailscale CLI mode during remote-host discovery, preventing repeated app-binary crashes on newer Tailscale installations while preserving existing terminal settings (#3397). Thanks @tzioup!
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -153,16 +153,16 @@ extension AntigravityLocalReader {
                     database,
                     neededStepOccurrences: neededStepOccurrences,
                     progress: progress)
-                guard stepScan.isComplete else {
+                guard stepScan.isComplete,
+                      self.embeddedTimestampsAgree(neededStepOccurrences, with: stepScan, botIDUses: rows.botIDUses)
+                else {
                     rows.source.isComplete = false
                     return rows.source
                 }
                 let recoveredCount = self.appendRecoveredEvents(
-                    to: &rows.source,
+                    to: &rows,
                     session: session,
-                    pendingRows: rows.pendingTimestampRows,
-                    stepTimestamps: stepScan.timestamps,
-                    stepOccurrences: rows.stepOccurrences)
+                    stepScan: stepScan)
                 if recoveredCount < rows.pendingTimestampRows.count {
                     rows.source.isComplete = false
                 }
@@ -187,20 +187,30 @@ extension AntigravityLocalReader {
         var source: SourceResult
         var pendingTimestampRows: [PendingTimestampRow]
         var stepOccurrences: [String: [StepOccurrence]]
+        var botIDUses: [String: Int]
     }
 
     private struct StepOccurrence {
         let row: Int64
         let timestampMs: Int64?
+        let botID: String?
     }
 
     private struct StepTimestamp {
         let row: Int64
         let timestampMs: Int64?
+        let botID: String?
+    }
+
+    private struct ExactStepTimestamp {
+        let stepUUID: String
+        let timestampMs: Int64
     }
 
     private struct StepTimestampScan {
         let timestamps: [String: [Int64]]
+        let byBotID: [String: ExactStepTimestamp]
+        let ambiguousBotIDs: Set<String>
         let isComplete: Bool
     }
 
@@ -229,7 +239,9 @@ extension AntigravityLocalReader {
         neededStepOccurrences: [String: [StepOccurrence]],
         progress: SQLProgress) throws -> StepTimestampScan
     {
-        guard !neededStepOccurrences.isEmpty else { return StepTimestampScan(timestamps: [:], isComplete: true) }
+        guard !neededStepOccurrences.isEmpty else {
+            return StepTimestampScan(timestamps: [:], byBotID: [:], ambiguousBotIDs: [], isComplete: true)
+        }
         let neededStepUUIDCounts = neededStepOccurrences.mapValues(\.count)
         let stepProgress = StepScanProgress(progress: progress)
         let registered = sqlite3_create_function_v2(
@@ -246,7 +258,9 @@ extension AntigravityLocalReader {
             nil,
             nil,
             nil)
-        guard registered == SQLITE_OK else { return StepTimestampScan(timestamps: [:], isComplete: false) }
+        guard registered == SQLITE_OK else {
+            return StepTimestampScan(timestamps: [:], byBotID: [:], ambiguousBotIDs: [], isComplete: false)
+        }
         var statement: OpaquePointer?
         defer {
             withExtendedLifetime(stepProgress) {
@@ -274,9 +288,11 @@ extension AntigravityLocalReader {
             throw failure
         }
         guard prepared == SQLITE_OK, let statement else {
-            return StepTimestampScan(timestamps: [:], isComplete: false)
+            return StepTimestampScan(timestamps: [:], byBotID: [:], ambiguousBotIDs: [], isComplete: false)
         }
         var stepTimestamps: [String: [StepTimestamp]] = [:]
+        var exactByBotID: [String: ExactStepTimestamp] = [:]
+        var ambiguousBotIDs = Set<String>()
         var isComplete = false
         var rowsAreValid = true
         while true {
@@ -319,16 +335,80 @@ extension AntigravityLocalReader {
                 rowsAreValid = false
                 continue
             }
+            if let botID = parsed.botID {
+                self.recordExactBotID(
+                    botID,
+                    stepUUID: stepUUID,
+                    timestampMs: parsed.timestampMs,
+                    exact: &exactByBotID,
+                    ambiguous: &ambiguousBotIDs)
+            }
             if neededStepUUIDCounts[stepUUID] != nil {
                 stepTimestamps[stepUUID, default: []].append(StepTimestamp(
                     row: sqlite3_column_int64(statement, 0),
-                    timestampMs: parsed.timestampMs))
+                    timestampMs: parsed.timestampMs,
+                    botID: parsed.botID))
             }
         }
+        // Preserve ambiguous rows' positions; removing them would shift later timestamps into their slots.
+        let positionalEntries = Dictionary(uniqueKeysWithValues: stepTimestamps.map { entry in
+            (entry.key, entry.value.map { step in
+                StepTimestamp(
+                    row: step.row,
+                    timestampMs: step.botID.map { ambiguousBotIDs.contains($0) } == true ? nil : step.timestampMs,
+                    botID: step.botID)
+            })
+        })
         let resolved = self.resolveStepTimestamps(
-            stepTimestamps,
+            positionalEntries,
             neededStepOccurrences: neededStepOccurrences)
-        return StepTimestampScan(timestamps: resolved, isComplete: isComplete && rowsAreValid)
+        return StepTimestampScan(
+            timestamps: resolved,
+            byBotID: exactByBotID,
+            ambiguousBotIDs: ambiguousBotIDs,
+            isComplete: isComplete && rowsAreValid)
+    }
+
+    private static func recordExactBotID(
+        _ botID: String,
+        stepUUID: String,
+        timestampMs: Int64?,
+        exact: inout [String: ExactStepTimestamp],
+        ambiguous: inout Set<String>)
+    {
+        guard !ambiguous.contains(botID) else { return }
+        guard let timestampMs else {
+            exact.removeValue(forKey: botID)
+            ambiguous.insert(botID)
+            return
+        }
+        if let existing = exact[botID] {
+            if existing.timestampMs != timestampMs || existing.stepUUID != stepUUID {
+                exact.removeValue(forKey: botID)
+                ambiguous.insert(botID)
+            }
+        } else {
+            exact[botID] = ExactStepTimestamp(stepUUID: stepUUID, timestampMs: timestampMs)
+        }
+    }
+
+    private static func embeddedTimestampsAgree(
+        _ occurrences: [String: [StepOccurrence]],
+        with stepScan: StepTimestampScan,
+        botIDUses: [String: Int]) -> Bool
+    {
+        for (stepUUID, rows) in occurrences {
+            for row in rows {
+                guard let timestampMs = row.timestampMs, let botID = row.botID else { continue }
+                guard !stepScan.ambiguousBotIDs.contains(botID) else { return false }
+                if let exact = stepScan.byBotID[botID],
+                   exact.stepUUID != stepUUID || (botIDUses[botID] == 1 && exact.timestampMs != timestampMs)
+                {
+                    return false
+                }
+            }
+        }
+        return true
     }
 
     private static func resolveStepTimestamps(
@@ -374,6 +454,7 @@ extension AntigravityLocalReader {
         var result = SourceResult()
         var pendingTimestampRows: [PendingTimestampRow] = []
         var stepOccurrences: [String: [StepOccurrence]] = [:]
+        var botIDUses: [String: Int] = [:]
         while true {
             try budget.check()
             let step = sqlite3_step(statement)
@@ -421,13 +502,18 @@ extension AntigravityLocalReader {
                 result.isComplete = false
                 continue
             }
+            if let botID = turn.usage?.botID {
+                botIDUses[botID, default: 0] += 1
+            }
             if let stepUUID = turn.stepUUID {
                 stepOccurrences[stepUUID, default: []].append(StepOccurrence(
                     row: row,
-                    timestampMs: turn.timestampMs))
+                    timestampMs: turn.timestampMs,
+                    botID: turn.usage?.botID))
             }
             if turn.timestampMs == nil, let stepUUID = turn.stepUUID {
-                pendingTimestampRows.append(PendingTimestampRow(row: row, stepUUID: stepUUID, turn: turn))
+                pendingTimestampRows.append(PendingTimestampRow(
+                    row: row, stepUUID: stepUUID, turn: turn))
                 continue
             }
             guard let event = Event(session: session, row: row, turn: turn, cacheWrite: 0) else {
@@ -439,26 +525,44 @@ extension AntigravityLocalReader {
         return ParsedRows(
             source: result,
             pendingTimestampRows: pendingTimestampRows,
-            stepOccurrences: stepOccurrences)
+            stepOccurrences: stepOccurrences,
+            botIDUses: botIDUses)
     }
 
     private static func appendRecoveredEvents(
-        to source: inout SourceResult,
+        to rows: inout ParsedRows,
         session: String,
-        pendingRows: [PendingTimestampRow],
-        stepTimestamps: [String: [Int64]],
-        stepOccurrences: [String: [StepOccurrence]]) -> Int
+        stepScan: StepTimestampScan) -> Int
     {
         var occurrenceOffsets: [String: [Int64: Int]] = [:]
-        for (stepUUID, occurrences) in stepOccurrences {
+        for (stepUUID, occurrences) in rows.stepOccurrences {
             let sorted = occurrences.map(\.row).sorted()
             guard Set(sorted).count == sorted.count else { continue }
             occurrenceOffsets[stepUUID] = Dictionary(
                 uniqueKeysWithValues: sorted.enumerated().map { ($0.element, $0.offset) })
         }
         var recoveredCount = 0
-        for pending in pendingRows.sorted(by: { $0.row < $1.row }) {
-            guard let timestamps = stepTimestamps[pending.stepUUID],
+        for pending in rows.pendingTimestampRows.sorted(by: { $0.row < $1.row }) {
+            if let botID = pending.turn.usage?.botID {
+                if stepScan.ambiguousBotIDs.contains(botID) {
+                    // Conflicting step timestamps for one bot ID: withhold rather than guess.
+                    continue
+                }
+                if let exact = stepScan.byBotID[botID] {
+                    guard exact.stepUUID == pending.stepUUID else { continue }
+                }
+                // All generations participate, including rows with an embedded timestamp.
+                if rows.botIDUses[botID] == 1, let exact = stepScan.byBotID[botID] {
+                    var turn = pending.turn
+                    turn.timestampMs = exact.timestampMs
+                    if let event = Event(session: session, row: pending.row, turn: turn, cacheWrite: 0) {
+                        rows.source.events.append(event)
+                        recoveredCount += 1
+                    }
+                    continue
+                }
+            }
+            guard let timestamps = stepScan.timestamps[pending.stepUUID],
                   let offset = occurrenceOffsets[pending.stepUUID]?[pending.row]
             else {
                 continue
@@ -467,11 +571,11 @@ extension AntigravityLocalReader {
             var turn = pending.turn
             turn.timestampMs = timestamps[offset]
             if let event = Event(session: session, row: pending.row, turn: turn, cacheWrite: 0) {
-                source.events.append(event)
+                rows.source.events.append(event)
                 recoveredCount += 1
             }
         }
-        source.events.sort { $0.row < $1.row }
+        rows.source.events.sort { $0.row < $1.row }
         return recoveredCount
     }
     #endif

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProtoReader.swift
@@ -22,6 +22,11 @@ struct AntigravityProtoReader {
         var output = 0
         var reasoning = 0
         var responseID: String?
+        fileprivate var botIdentifier = AuxiliaryIdentifier()
+
+        var botID: String? {
+            self.botIdentifier.value
+        }
     }
 
     struct ParsedTurn: Equatable, Sendable {
@@ -77,15 +82,45 @@ struct AntigravityProtoReader {
         }
     }
 
+    fileprivate struct AuxiliaryIdentifier: Equatable, Sendable {
+        private(set) var value: String?
+        private var isValid = true
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            // Parser invalidity is not part of finalized event identity or copied-row deduplication.
+            lhs.value == rhs.value
+        }
+
+        mutating func read(_ field: Field) throws {
+            do {
+                let value = try field.string()
+                if self.isValid {
+                    self.value = value
+                }
+            } catch AntigravityLocalReader.ScanFailure.invalid {
+                self.invalidate()
+            }
+        }
+
+        mutating func invalidate() {
+            self.value = nil
+            self.isValid = false
+        }
+    }
+
     mutating func readVarint() -> UInt64? {
         var result: UInt64 = 0
         for index in 0..<10 {
             guard self.offset < self.bytes.endIndex else { break }
             let byte = self.bytes[self.offset]
             self.offset += 1
-            if index == 9, byte > 1 { break }
+            if index == 9, byte > 1 {
+                break
+            }
             result |= UInt64(byte & 0x7F) << (index * 7)
-            if byte & 0x80 == 0 { return result }
+            if byte & 0x80 == 0 {
+                return result
+            }
         }
         self.isMalformed = true
         return nil
@@ -162,11 +197,18 @@ struct AntigravityProtoReader {
         }
     }
 
+    struct StepMetadata: Equatable, Sendable {
+        var stepUUID: String?
+        var botID: String?
+        var timestampMs: Int64?
+    }
+
     static func parseStepMetadata(
         _ bytes: [UInt8],
-        checkCancellation: () throws -> Void = {}) throws -> (stepUUID: String?, timestampMs: Int64?)?
+        checkCancellation: () throws -> Void = {}) throws -> StepMetadata?
     {
         var stepUUID: String?
+        var botIdentifier = AuxiliaryIdentifier()
         var time = Timestamp()
         var timestampIsValid = true
         do {
@@ -179,6 +221,17 @@ struct AntigravityProtoReader {
                     } catch AntigravityLocalReader.ScanFailure.invalid {
                         timestampIsValid = false
                     }
+                case 9:
+                    // Malformed auxiliary IDs disable exact matching, even if a later envelope is valid.
+                    do {
+                        try self.fields(field.message(), checkCancellation: checkCancellation) { subfield in
+                            if subfield.number == 7 {
+                                try botIdentifier.read(subfield)
+                            }
+                        }
+                    } catch AntigravityLocalReader.ScanFailure.invalid {
+                        botIdentifier.invalidate()
+                    }
                 case 12:
                     stepUUID = try field.string()
                 default:
@@ -186,7 +239,7 @@ struct AntigravityProtoReader {
                 }
             }
             let ms = timestampIsValid ? try time.milliseconds() : nil
-            return (stepUUID, ms)
+            return StepMetadata(stepUUID: stepUUID, botID: botIdentifier.value, timestampMs: ms)
         } catch AntigravityLocalReader.ScanFailure.invalid {
             return nil
         }
@@ -223,6 +276,7 @@ struct AntigravityProtoReader {
             case 1: usage.systemPrompt = try field.counter()
             case 2: usage.newInput = try field.counter()
             case 5: usage.cacheRead = try field.counter()
+            case 7: try usage.botIdentifier.read(field)
             case 9: usage.output = try field.counter()
             case 10: usage.reasoning = try field.counter()
             case 11: usage.responseID = try field.string()

--- a/Tests/CodexBarTests/AntigravityBotIDValidationTests.swift
+++ b/Tests/CodexBarTests/AntigravityBotIDValidationTests.swift
@@ -1,0 +1,268 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct AntigravityBotIDValidationTests {
+    private typealias Fixture = AntigravityLocalFixture
+    private static let early: UInt64 = 1_787_875_140
+    private static let late: UInt64 = 1_787_875_260
+
+    @Test
+    func `embedded generations also participate in bot ID uniqueness`() throws {
+        let fixture = try Fixture()
+        let url = try fixture.database(blobs: [
+            Fixture.blobWithRootEnvelope(botID: "shared", seconds: Self.early),
+            Fixture.blobWithRootEnvelope(botID: "shared", seconds: nil),
+        ], stepBlobs: [Fixture.stepMetadataBlob(botID: "shared", seconds: Self.late)])
+
+        let source = try Self.read(url)
+
+        #expect(!source.isComplete)
+        #expect(source.events.map(\.row) == [0])
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_250])
+    }
+
+    @Test(arguments: [false, true])
+    func `repeated generation IDs retain consistent positional evidence`(unrelatedUUID: Bool) throws {
+        let fixture = try Fixture()
+        let url = try fixture.database(blobs: [
+            Fixture.blobWithRootEnvelope(
+                stepUUID: unrelatedUUID ? nil : "step-uuid-1", botID: "shared", seconds: Self.early),
+            Fixture.blobWithRootEnvelope(botID: "shared", seconds: nil),
+        ], stepBlobs: [
+            Fixture.stepMetadataBlob(seconds: Self.early),
+            Fixture.stepMetadataBlob(botID: "shared", seconds: Self.late),
+        ])
+
+        let source = try Self.read(url)
+
+        #expect(source.isComplete)
+        #expect(source.events.map(\.turn.timestampMs) == [
+            1_787_875_140_250, unrelatedUUID ? 1_787_875_140_250 : 1_787_875_260_250,
+        ])
+    }
+
+    @Test(arguments: [false, true])
+    func `exact step evidence must agree with embedded timestamps without requiring positional order`(
+        conflicting: Bool) throws
+    {
+        let fixture = try Fixture()
+        let url = try fixture.database(blobs: [
+            Fixture.blobWithRootEnvelope(botID: "embedded", seconds: Self.early),
+            Fixture.blobWithRootEnvelope(botID: "pending", seconds: nil),
+        ], stepBlobs: [
+            Fixture.stepMetadataBlob(botID: "pending", seconds: Self.late),
+            Fixture.stepMetadataBlob(botID: "embedded", seconds: conflicting ? Self.late : Self.early),
+        ])
+
+        let source = try Self.read(url)
+
+        #expect(source.isComplete == !conflicting)
+        #expect(source.events.first?.turn.timestampMs == 1_787_875_140_250)
+        if conflicting {
+            #expect(source.events.map(\.row) == [0])
+        } else {
+            #expect(source.events.map(\.row) == [0, 1])
+            #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_250, 1_787_875_260_250])
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `embedded timestamps without exact identity evidence do not block reordered exact recovery`(
+        hasUnmatchedID: Bool) throws
+    {
+        let fixture = try Fixture()
+        let url = try fixture.database(blobs: [
+            Fixture.blobWithRootEnvelope(botID: hasUnmatchedID ? "absent" : nil, seconds: Self.early),
+            Fixture.blobWithRootEnvelope(botID: "pending", seconds: nil),
+        ], stepBlobs: [
+            Fixture.stepMetadataBlob(botID: "pending", seconds: Self.late),
+            Fixture.stepMetadataBlob(seconds: Self.early),
+        ])
+
+        let source = try Self.read(url)
+
+        #expect(source.isComplete)
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_250, 1_787_875_260_250])
+    }
+
+    @Test
+    func `an unrelated UUID retains embedded timestamp precedence during exact recovery`() throws {
+        let fixture = try Fixture()
+        let url = try fixture.database(blobs: [
+            Fixture.blobWithRootEnvelope(stepUUID: "complete", botID: "embedded", seconds: Self.early),
+            Fixture.blobWithRootEnvelope(stepUUID: "recover", botID: "pending", seconds: nil),
+        ], stepBlobs: [
+            Fixture.stepMetadataBlob(stepUUID: "complete", botID: "embedded", seconds: Self.late),
+            Fixture.stepMetadataBlob(stepUUID: "recover", botID: "pending", seconds: Self.late),
+        ])
+
+        let source = try Self.read(url)
+
+        #expect(source.isComplete)
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_250, 1_787_875_260_250])
+    }
+
+    @Test(arguments: [false, true])
+    func `ambiguous steps cannot compress positions or activate single timestamp sharing`(embedded: Bool) throws {
+        let fixture = try Fixture()
+        var steps = [
+            Fixture.stepMetadataBlob(botID: "conflict", seconds: Self.early - 20),
+            Fixture.stepMetadataBlob(botID: "conflict", seconds: Self.early - 10),
+        ]
+        if embedded {
+            steps.append(Fixture.stepMetadataBlob(seconds: Self.early))
+        }
+        steps.append(Fixture.stepMetadataBlob(seconds: Self.late))
+        let url = try fixture.database(blobs: [
+            Fixture.blobWithRootEnvelope(seconds: embedded ? Self.early : nil),
+            Fixture.blobWithRootEnvelope(seconds: nil),
+        ], stepBlobs: steps)
+
+        let source = try Self.read(url)
+
+        #expect(!source.isComplete)
+        #expect(source.events.map(\.row) == (embedded ? [0] : []))
+    }
+
+    @Test
+    func `an exact ID owned by another UUID cannot fall back to positional evidence`() throws {
+        let fixture = try Fixture()
+        let url = try fixture.database(blobs: [
+            Fixture.blobWithRootEnvelope(stepUUID: "local", botID: "owned-elsewhere", seconds: nil),
+        ], stepBlobs: [
+            Fixture.stepMetadataBlob(stepUUID: "local", seconds: Self.early),
+            Fixture.stepMetadataBlob(stepUUID: "other", botID: "owned-elsewhere", seconds: Self.late),
+        ])
+
+        let source = try Self.read(url)
+
+        #expect(!source.isComplete)
+        #expect(source.events.isEmpty)
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func `timestamp less duplicate step IDs invalidate exact evidence in either order`(
+        crossUUID: Bool,
+        missingFirst: Bool) throws
+    {
+        let fixture = try Fixture()
+        let valid = Fixture.stepMetadataBlob(stepUUID: "local", botID: "duplicate", seconds: Self.early)
+        let missing = Fixture.message(9, Fixture.message(7, Array("duplicate".utf8)))
+            + Fixture.message(12, Array((crossUUID ? "other" : "local").utf8))
+        let url = try fixture.database(blobs: [
+            Fixture.blobWithRootEnvelope(stepUUID: "local", botID: "duplicate", seconds: nil),
+        ], stepBlobs: missingFirst ? [missing, valid] : [valid, missing])
+
+        let source = try Self.read(url)
+
+        #expect(!source.isComplete)
+        #expect(source.events.isEmpty)
+    }
+
+    enum InvalidID: CaseIterable {
+        case utf8
+        case wire
+
+        var field: [UInt8] {
+            switch self {
+            case .utf8: Fixture.message(7, [0xFF])
+            case .wire: Fixture.varint(7, 1)
+            }
+        }
+    }
+
+    @Test(arguments: InvalidID.allCases, [false, true])
+    func `invalid repeated step IDs stay invalid across envelopes`(_ invalid: InvalidID, invalidFirst: Bool) throws {
+        let valid = Fixture.message(9, Fixture.message(7, Array("later-key".utf8)))
+        let malformed = Fixture.message(9, invalid.field)
+        let bytes = Fixture.stepMetadataBlob(seconds: Self.early)
+            + (invalidFirst ? malformed + valid : valid + malformed)
+
+        let parsed = try #require(try AntigravityProtoReader.parseStepMetadata(bytes))
+
+        #expect(parsed.botID == nil)
+        #expect(parsed.timestampMs == 1_787_875_140_250)
+    }
+
+    @Test(arguments: [false, true])
+    func `a malformed step envelope cannot be repaired by a later valid ID`(invalidFirst: Bool) throws {
+        let valid = Fixture.message(9, Fixture.message(7, Array("later-key".utf8)))
+        let malformed = Fixture.message(9, [0x3A, 0x02, 0x61])
+        let bytes = Fixture.stepMetadataBlob(seconds: Self.early)
+            + (invalidFirst ? malformed + valid : valid + malformed)
+
+        let parsed = try #require(try AntigravityProtoReader.parseStepMetadata(bytes))
+
+        #expect(parsed.botID == nil)
+        #expect(parsed.timestampMs == 1_787_875_140_250)
+    }
+
+    @Test(arguments: ["", " \n"])
+    func `empty step ID scalars clear earlier values`(_ empty: String) throws {
+        let bytes = Fixture.stepMetadataBlob(botID: "earlier", seconds: Self.early)
+            + Fixture.message(9, Fixture.message(7, Array(empty.utf8)))
+
+        #expect(try AntigravityProtoReader.parseStepMetadata(bytes)?.botID == nil)
+    }
+
+    @Test(arguments: ["", " \n"])
+    func `empty generation ID scalars clear earlier values`(_ empty: String) throws {
+        let bytes = Fixture.blobWithRootEnvelope(botID: "earlier", seconds: Self.early)
+            + Fixture.message(1, Fixture.message(4, Fixture.message(7, Array(empty.utf8))))
+
+        let turn = try #require(try AntigravityProtoReader.parseTurn(bytes))
+        #expect(turn.usage?.botID == nil)
+        #expect(turn.timestampMs == 1_787_875_140_250)
+    }
+
+    @Test(arguments: InvalidID.allCases, [false, true])
+    func `malformed generation IDs preserve valid usage and remain invalid across envelopes`(
+        _ invalid: InvalidID,
+        invalidFirst: Bool) throws
+    {
+        let valid = Fixture.message(1, Fixture.message(4, Fixture.message(7, Array("later-key".utf8))))
+        let malformed = Fixture.message(1, Fixture.message(4, invalid.field))
+        let blob = Fixture.blobWithRootEnvelope(seconds: Self.early)
+            + (invalidFirst ? malformed + valid : valid + malformed)
+        let fixture = try Fixture()
+        let url = try fixture.database(blobs: [blob])
+
+        let source = try Self.read(url)
+        let turn = try #require(source.events.first?.turn)
+
+        #expect(source.isComplete)
+        #expect(turn.timestampMs == 1_787_875_140_250)
+        #expect(turn.usage?.botID == nil)
+        #expect(turn.usage?.newInput == 100)
+    }
+
+    @Test
+    func `optional ID tolerance does not relax counters or protobuf framing`() throws {
+        let base = Fixture.blobWithRootEnvelope(seconds: Self.early)
+        let invalidCounter = Fixture.message(1, Fixture.message(4, Fixture.message(2, [1])))
+        let truncatedUsage = Fixture.message(1, Fixture.message(4, [0x3A, 0x02, 0x61]))
+
+        #expect(try AntigravityProtoReader.parseTurn(base + invalidCounter) == nil)
+        #expect(try AntigravityProtoReader.parseTurn(base + truncatedUsage) == nil)
+    }
+
+    @Test(arguments: [false, true])
+    func `malformed optional IDs do not turn equivalent copies into conflicts`(malformedFirst: Bool) throws {
+        let fixture = try Fixture()
+        let absent = Fixture.blobWithRootEnvelope(seconds: Self.early)
+        let malformed = absent + Fixture.message(1, Fixture.message(4, InvalidID.utf8.field))
+        try fixture.database(rootIndex: 0, blobs: [malformedFirst ? malformed : absent])
+        try fixture.database(rootIndex: 1, blobs: [malformedFirst ? absent : malformed])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.count == 1)
+        #expect(report.report.data.first?.totalTokens == 198)
+    }
+
+    private static func read(_ url: URL) throws -> AntigravityLocalReader.SourceResult {
+        try AntigravityLocalReader.readDatabases([url], budget: .init(limits: .init(), cancellation: {}))
+    }
+}

--- a/Tests/CodexBarTests/AntigravityLocalBotIDJoinTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalBotIDJoinTests.swift
@@ -1,0 +1,256 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(SQLite3)
+import SQLite3
+#elseif canImport(CSQLite3)
+import CSQLite3
+#endif
+
+struct AntigravityLocalBotIDJoinTests {
+    private typealias Fixture = AntigravityLocalFixture
+
+    @Test
+    func `bot ID exact join recovers turns when step counts mismatch`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "shared-session-uuid"
+        let first = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-aaa", seconds: nil)
+        let second = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-bbb", seconds: nil)
+        // An auxiliary step must not take the later generation's timestamp slot.
+        let firstStep = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-aaa", seconds: 1_787_875_140)
+        let extraStep = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-inflight", seconds: 1_787_875_200)
+        let secondStep = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-bbb", seconds: 1_787_875_260)
+        let url = try fixture.database(blobs: [first, second], stepBlobs: [firstStep, extraStep, secondStep])
+
+        let source = try AntigravityLocalReader.readDatabases(
+            [url], budget: .init(limits: .init(), cancellation: {}))
+        let report = try fixture.report()
+
+        #expect(source.events.map(\.row) == [0, 1])
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_250, 1_787_875_260_250])
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27", "2026-08-28"])
+    }
+
+    @Test
+    func `bot ID exact join ignores step idx order`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "shared-session-uuid"
+        let first = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-aaa", seconds: nil)
+        let second = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-bbb", seconds: nil)
+        // Steps stored in reverse idx order: positional prefix would misattribute dates.
+        let url = try fixture.database(blobs: [first, second])
+        let database = try Fixture.open(url)
+        defer { sqlite3_close(database) }
+        try Fixture.execute(database, "CREATE TABLE steps (idx INTEGER, metadata BLOB)")
+        try Fixture.insertStep(
+            database,
+            row: 20,
+            blob: Fixture.stepMetadataBlob(stepUUID: stepUUID, botID: "bot-aaa", seconds: 1_787_875_140))
+        try Fixture.insertStep(
+            database,
+            row: 10,
+            blob: Fixture.stepMetadataBlob(stepUUID: stepUUID, botID: "bot-bbb", seconds: 1_787_875_260))
+
+        let source = try AntigravityLocalReader.readDatabases(
+            [url], budget: .init(limits: .init(), cancellation: {}))
+        let report = try fixture.report()
+
+        #expect(source.events.map(\.row) == [0, 1])
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_250, 1_787_875_260_250])
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27", "2026-08-28"])
+    }
+
+    @Test
+    func `conflicting duplicate bot IDs fail closed`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "shared-session-uuid"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-dup", seconds: nil)
+        let first = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-dup", seconds: 1_787_875_140)
+        let second = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-dup", seconds: 1_787_875_260)
+        try fixture.database(blobs: [turn], stepBlobs: [first, second])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+
+    @Test
+    func `duplicate bot IDs with identical timestamps still recover`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "shared-session-uuid"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-retry", seconds: nil)
+        // Retried step writes agree on the timestamp: idempotent, not ambiguous.
+        let first = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-retry", seconds: 1_787_875_140)
+        let second = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-retry", seconds: 1_787_875_140)
+        try fixture.database(blobs: [turn], stepBlobs: [first, second])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27"])
+    }
+
+    @Test
+    func `embedded timestamp takes precedence over bot ID join`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "legacy-step-uuid"
+        let turn = Fixture.blobWithRootEnvelope(
+            stepUUID: stepUUID, botID: "bot-legacy", seconds: 1_787_875_140)
+        let step = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-legacy", seconds: 1_787_875_260)
+        try fixture.database(blobs: [turn], stepBlobs: [step])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27"])
+    }
+
+    @Test
+    func `bot ID without matching step falls back to positional recovery`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "mixed-write-step-uuid"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-new", seconds: nil)
+        // Step rows predate bot ID writes: no exact key, positional still applies.
+        let step = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
+        try fixture.database(blobs: [turn], stepBlobs: [step])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27"])
+    }
+
+    @Test
+    func `malformed step bot ID falls back without failing the scan`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "mixed-bot-step-uuid"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-aaa", seconds: nil)
+        // Non-UTF8 bot ID bytes: the step stays positionally usable, exact join uses the valid row.
+        let malformed = Fixture.message(1, Fixture.varint(1, 1_787_875_140) + Fixture.varint(2, 0))
+            + Fixture.message(9, Fixture.message(7, [0xFF, 0xFE]))
+            + Fixture.message(12, Array(stepUUID.utf8))
+        let step = Fixture.stepMetadataBlob(stepUUID: stepUUID, botID: "bot-aaa", seconds: 1_787_875_260)
+        try fixture.database(blobs: [turn], stepBlobs: [malformed, step])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-28"])
+    }
+
+    @Test
+    func `missing bot ID falls back to positional recovery`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "fallback-step-uuid"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let step = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140)
+        try fixture.database(blobs: [turn], stepBlobs: [step])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27"])
+    }
+
+    @Test
+    func `interactive session shape with content envelopes recovers via bot ID`() throws {
+        // Mirrors a live agy interactive session row: the root carries extra envelopes
+        // (fields 3/8) and the chat carries large content envelopes (fields 1/2/8) with
+        // usage but no embedded timestamp; the generation envelope holds only the
+        // context-meter sentinel and meter. A non-generation step shares the table.
+        let fixture = try Fixture()
+        let stepUUID = "live-session-uuid"
+        let botID = "bot-live-1"
+        let usage = Fixture.varint(1, 1318) + Fixture.varint(2, 15669) + Fixture.varint(9, 123)
+            + Fixture.varint(10, 27) + Fixture.message(7, Array(botID.utf8))
+        var chat = Fixture.message(1, [UInt8](repeating: 0x61, count: 24775))
+        chat += Fixture.message(2, [UInt8](repeating: 0x62, count: 433))
+        chat += Fixture.message(4, usage)
+        chat += Fixture.message(
+            9, Fixture.varint(2, UInt64.max) + Fixture.message(10, Fixture.varint(1, 255_523)))
+        chat += Fixture.message(8, [UInt8](repeating: 0x63, count: 2362))
+        var root = Fixture.message(2, [0x01])
+        root += Fixture.message(3, [UInt8](repeating: 0x64, count: 3020))
+        root += Fixture.message(4, Array(stepUUID.utf8))
+        root += Fixture.message(8, [UInt8](repeating: 0x65, count: 424))
+        root += Fixture.message(1, chat)
+        let otherStep = Fixture.message(1, Fixture.varint(1, 1_787_875_140) + Fixture.varint(2, 0))
+            + Fixture.varint(3, 4) + Fixture.message(12, Array(stepUUID.utf8))
+        let step = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: botID, seconds: 1_787_875_260)
+        try fixture.database(blobs: [root], stepBlobs: [otherStep, step])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-28"])
+    }
+
+    @Test
+    func `structurally malformed step bot ID keeps row positionally usable`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "mixed-shape-step-uuid"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-aaa", seconds: nil)
+        // Field 9 with the wrong wire type: no exact key, but the row still counts positionally.
+        let malformed = Fixture.message(1, Fixture.varint(1, 1_787_875_140) + Fixture.varint(2, 0))
+            + Fixture.varint(9, 1)
+            + Fixture.message(12, Array(stepUUID.utf8))
+        let step = Fixture.stepMetadataBlob(stepUUID: stepUUID, botID: "bot-aaa", seconds: 1_787_875_260)
+        try fixture.database(blobs: [turn], stepBlobs: [malformed, step])
+
+        let report = try fixture.report()
+
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-28"])
+    }
+
+    @Test
+    func `repeated generation bot ID skips exact matching but keeps positional guard`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "reused-bot-step-uuid"
+        let first = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-dup", seconds: nil)
+        let second = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-dup", seconds: nil)
+        let firstStep = Fixture.stepMetadataBlob(stepUUID: stepUUID, botID: "bot-dup", seconds: 1_787_875_140)
+        let secondStep = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        try fixture.database(blobs: [first, second], stepBlobs: [firstStep, secondStep])
+
+        let report = try fixture.report()
+
+        // Exact matching is withheld for the reused identity; the guarded positional path
+        // still dates each turn instead of stamping both with the first timestamp.
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27", "2026-08-28"])
+    }
+
+    @Test
+    func `conflicted bot ID rows stay out of positional matching`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "leak-step-uuid"
+        let conflicted = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: "bot-dup", seconds: nil)
+        let plain = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil)
+        let first = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-dup", seconds: 1_787_875_140)
+        let second = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: "bot-dup", seconds: 1_787_875_180)
+        let third = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260)
+        let fourth = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_320)
+        try fixture.database(blobs: [conflicted, plain], stepBlobs: [first, second, third, fourth])
+
+        let report = try fixture.report()
+
+        // Ambiguous steps must retain their slots; removing them can shift unrelated turns.
+        #expect(report.coverage == .partial)
+        #expect(report.report.data.isEmpty)
+    }
+}

--- a/Tests/CodexBarTests/AntigravityLocalFixture.swift
+++ b/Tests/CodexBarTests/AntigravityLocalFixture.swift
@@ -98,7 +98,9 @@ final class AntigravityLocalFixture: Sendable {
         var database: OpaquePointer?
         let result = sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil)
         guard result == SQLITE_OK, let database else {
-            if let database { sqlite3_close(database) }
+            if let database {
+                sqlite3_close(database)
+            }
             throw AntigravityLocalReader.ScanFailure.invalid
         }
         return database
@@ -170,18 +172,25 @@ final class AntigravityLocalFixture: Sendable {
     {
         var usage = self.varint(1, system) + self.varint(2, input) + self.varint(5, cacheRead)
             + self.varint(9, output) + self.varint(10, reasoning)
-        if let response { usage += self.message(11, Array(response.utf8)) }
+        if let response {
+            usage += self.message(11, Array(response.utf8))
+        }
         var chat = self.message(4, usage)
         if let seconds {
             chat += self.message(9, self.message(4, self.varint(1, seconds) + self.varint(2, 250_000_000)))
         }
-        if let model { chat += self.message(19, Array(model.utf8)) }
-        if let label { chat += self.message(21, Array(label.utf8)) }
+        if let model {
+            chat += self.message(19, Array(model.utf8))
+        }
+        if let label {
+            chat += self.message(21, Array(label.utf8))
+        }
         return self.message(1, chat)
     }
 
     static func blobWithRootEnvelope(
         stepUUID: String? = "step-uuid-1",
+        botID: String? = nil,
         model: String? = "fixture-model-a",
         label: String? = "Fixture model",
         system: UInt64 = 11,
@@ -193,27 +202,45 @@ final class AntigravityLocalFixture: Sendable {
         seconds: UInt64? = nil) -> [UInt8]
     {
         var root = self.message(2, [0x01, 0x02])
-        if let stepUUID { root += self.message(4, Array(stepUUID.utf8)) }
+        if let stepUUID {
+            root += self.message(4, Array(stepUUID.utf8))
+        }
         var usage = self.varint(1, system) + self.varint(2, input) + self.varint(5, cacheRead)
             + self.varint(9, output) + self.varint(10, reasoning)
-        if let response { usage += self.message(11, Array(response.utf8)) }
+        if let botID {
+            usage += self.message(7, Array(botID.utf8))
+        }
+        if let response {
+            usage += self.message(11, Array(response.utf8))
+        }
         var chat = self.message(4, usage)
         if let seconds {
             chat += self.message(9, self.message(4, self.varint(1, seconds) + self.varint(2, 250_000_000)))
         }
-        if let model { chat += self.message(19, Array(model.utf8)) }
-        if let label { chat += self.message(21, Array(label.utf8)) }
+        if let model {
+            chat += self.message(19, Array(model.utf8))
+        }
+        if let label {
+            chat += self.message(21, Array(label.utf8))
+        }
         root += self.message(1, chat)
         return root
     }
 
     static func stepMetadataBlob(
         stepUUID: String? = "step-uuid-1",
+        botID: String? = nil,
         seconds: UInt64 = 1_787_832_000,
         nanos: UInt64 = 250_000_000) -> [UInt8]
     {
         var meta = self.message(1, self.varint(1, seconds) + self.varint(2, nanos))
-        if let stepUUID { meta += self.message(12, Array(stepUUID.utf8)) }
+        if let botID {
+            let usage = self.message(7, Array(botID.utf8))
+            meta += self.message(9, usage)
+        }
+        if let stepUUID {
+            meta += self.message(12, Array(stepUUID.utf8))
+        }
         return meta
     }
 

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -293,8 +293,17 @@ Extra ordinary columns and `WITHOUT ROWID` tables are supported; views, virtual 
 are rejected before querying payloads. Schema inspection and the payload scan share one read transaction.
 Inspection uses `sqlite_master` and `table_xinfo`; SQLite builds without that pragma cannot establish coverage.
 
-Supported SQLite event time is `chatModel.#9.#4` containing protobuf seconds/nanos. Session creation, file modification,
-and refresh time are never substitutes. The opaque agy 1.1.18 timestamp layout remains unsupported: the pinned parser
+Supported SQLite event time is `chatModel.#9.#4` containing protobuf seconds/nanos. When it is absent, the reader can
+recover the standard seconds/nanos timestamp from `steps.metadata.#1`, joining the generation's root step UUID (`#4`)
+to `steps.metadata.#12`. A unique generation usage `bot_id` (`chatModel.#4.#7`) first selects the matching
+`steps.metadata.#9.#7` within that UUID, so auxiliary or reordered steps do not shift a turn's date. Conflicting,
+cross-UUID, or timestamp-less duplicate step IDs cannot supply exact or positional evidence. Embedded timestamps
+in a UUID needing recovery must agree with available generation-unique exact matches; unrelated UUIDs retain their
+embedded timestamps. Missing or malformed auxiliary IDs retain the guarded legacy positional fallback, as do repeated
+generation IDs: ordered step timestamps must agree with embedded generation timestamps, and ambiguous positions are
+never removed or compressed. Malformed auxiliary IDs do not discard otherwise valid embedded usage or relax token-counter
+and protobuf framing validation. Session creation, file modification, and refresh time are never substitutes.
+The opaque agy 1.1.18 timestamp layout remains unsupported: the pinned parser
 explicitly labels its newer interpretation an inference. See [the session-start misattribution report](https://github.com/junhoyeo/tokscale/issues/1184).
 
 SQLite session identity is the original database filename stem, with `gen_metadata.idx` identifying rows. Copies


### PR DESCRIPTION
## Summary

Fix Antigravity local token history being assigned to the wrong timestamp when auxiliary or reordered step rows share a generation's step UUID. The previous reader accepts an ordered step prefix; a count mismatch alone does not necessarily make it withhold history.

Use the generation usage `bot_id` and the matching step metadata `bot_id` to recover the standard seconds/nanos timestamp within the same UUID. This does not interpret opaque context-meter fields, use session creation time, or change token counts, pricing, credentials, discovery roots, or stored data.

The maintainer revision retains the contributor's exact-ID approach and strengthens its safety boundaries:

- Count identities across every parsed generation, including embedded timestamps and rows without UUIDs. Repeated generation IDs retain the guarded legacy fallback.
- Withhold contradictory, cross-UUID, or timestamp-less duplicate step evidence. Keep ambiguous positional slots in place instead of shifting later rows forward.
- Check generation-unique exact matches against embedded timestamps in UUIDs needing recovery, without invalidating unrelated embedded-only UUIDs or requiring positional alignment for a clean exact join.
- Treat malformed auxiliary IDs as unavailable, persist that invalidity across repeated envelopes, and preserve otherwise valid usage. Keep counter/framing validation strict and parser-state validity out of copied-row equality.
- Update the local-history documentation and Unreleased changelog. Thanks @WeGoToMars!

## Proof

Ran the shipped 0.56.4 CLI and the rebuilt CLI against three synthetic SQLite histories, with a temporary home, account-file/Keychain test isolation, network denied, and real home-directory reads denied. No real accounts or history were used.

| Synthetic history | 0.56.4 | Repaired CLI |
| --- | --- | --- |
| Auxiliary step before the exact turn | 198 tokens assigned to August 26 | Same 198 tokens correctly assigned to August 28 |
| Duplicate ID with conflicting timestamps | Incorrectly establishes complete history | Withholds rows; coverage unavailable, not confirmed zero |
| Legacy history without per-turn IDs | 198 tokens on August 28 | Unchanged |

The final CLI run left all three input database hashes unchanged. Assertions cover input, cache-read, output, and reasoning buckets as well as dates and coverage.

Focused regression tests first failed on the contributor proposal, including embedded-ID uniqueness, malformed repeated IDs, positional compression, cross-UUID fallback, and missing-time duplicates. Additional tests caught and repaired over-withholding of repeated generation IDs and false copied-row conflicts.

- `swift test --filter Antigravity`: 401 tests across 34 suites passed (383 macOS tests and 18 portable tests).
- `make check`: passed, zero violations in 2,098 files. A local Homebrew Bash here-document stall was isolated to a temporary system-Bash command path; no repository toolchain change.
- Required Codex autoreview: no accepted/actionable findings at the configured priority.
- Full `make test`: all 1,002 selections across 84 groups passed first try in 861.9 seconds, with zero failures, timeouts, or retries.
- Exact-head CI [33790377020](https://github.com/steipete/CodexBar/actions/runs/33790377020): all checks passed, including both macOS shards, Linux x64/ARM64/musl, lint, the aggregate check, and GitGuardian.

The original author's live-data observations are useful schema evidence but were not independently replayed against private history. This revision's executable proof is synthetic and uses the actual CLI entry point.
