### PR TITLE
fix(claude): correct restored-history detail note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Antigravity: match local token-history timestamps by per-turn IDs when auxiliary or reordered steps would otherwise assign usage to the wrong day, while withholding conflicting evidence and preserving legacy timestamp recovery (#3403). Thanks @WeGoToMars!
 - Codex: retain completed empty session fragments during cost-history scans instead of repeatedly dropping and rediscovering them, without suppressing usage-bearing duplicates or later appended usage (partial fix for #3316; #3402). Thanks @mauriciopolvora!
 - Agent sessions: explicitly force Tailscale CLI mode during remote-host discovery, preventing repeated app-binary crashes on newer Tailscale installations while preserving existing terminal settings (#3397). Thanks @tzioup!
+- Claude: stop labeling restored quota history as CLI usage, while retaining the limited-detail warning, original percentages, and stale-data guidance.
 
 ## 0.56.4 — 2026-09-03
 

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -325,8 +325,8 @@ extension UsageMenuCardView.Model {
         }
 
         if input.provider == .claude, input.snapshot?.dataConfidence == .percentOnly {
-            // CLI-scraped usage carries rendered percentages only; label the reduced fidelity honestly.
-            return [L("Usage via Claude CLI (limited detail)")] + subscriptionNotes
+            // Both CLI scraping and restored history carry percentages without full usage detail.
+            return [L("claude_limited_usage_detail")] + subscriptionNotes
         }
 
         // Provider-specific by design: OpenCode Go local quota windows need an explicit authority warning.

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1489,6 +1489,7 @@
 "Total usage" = "إجمالي الاستخدام";
 "claude_oauth_keychain_access_revoked" = "تم إلغاء وصول CodexBar إلى سلسلة مفاتيح Claude بسبب تدوير الرمز المميز في Claude Code. انقر على «تحديث» لمنح الوصول مجددًا، أو بدّل مصدر استخدام Claude إلى CLI/Web.";
 "claude_showing_last_known_usage" = "يتم عرض آخر بيانات استخدام معروفة، تم التقاطها %@.";
+"claude_limited_usage_detail" = "تفاصيل الاستخدام محدودة";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1488,6 +1488,7 @@
 "Total usage" = "Ús total";
 "claude_oauth_keychain_access_revoked" = "L'accés al clauer de Claude s'ha revocat per la rotació del token de Claude Code. Feu clic a Actualitza per tornar a concedir l'accés, o canvieu l'origen d'ús de Claude a CLI/Web.";
 "claude_showing_last_known_usage" = "Es mostra l'últim ús conegut capturat %@.";
+"claude_limited_usage_detail" = "Detalls d’ús limitats";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Entrada";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1486,6 +1486,7 @@
 "Total usage" = "Gesamtnutzung";
 "claude_oauth_keychain_access_revoked" = "Der Zugriff auf den Claude-Schlüsselbund wurde durch die Token-Rotation von Claude Code widerrufen. Klicken Sie auf „Aktualisieren“, um den Zugriff erneut zu gewähren, oder stellen Sie die Claude-Nutzungsquelle auf CLI/Web um.";
 "claude_showing_last_known_usage" = "Letzte bekannte Nutzung wird angezeigt (erfasst: %@).";
+"claude_limited_usage_detail" = "Eingeschränkte Nutzungsdetails";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "ollama_browser_cookie_decryption_disabled" = "%@ cookie decryption is disabled in CodexBar; enable Keychain access and refresh.";
 "claude_oauth_keychain_access_revoked" = "Claude Keychain access was revoked by Claude Code's token rotation. Click Refresh to re-grant access, or switch Claude Usage source to CLI/Web.";
 "claude_showing_last_known_usage" = "Showing last-known usage captured %@.";
+"claude_limited_usage_detail" = "Limited usage detail";
 
 " providers" = " providers";
 "(System)" = "(System)";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1484,6 +1484,7 @@
 "Total usage" = "Uso total";
 "claude_oauth_keychain_access_revoked" = "El acceso al llavero de Claude fue revocado por la rotación del token de Claude Code. Haz clic en Actualizar para volver a conceder acceso o cambia el origen del uso de Claude a CLI/Web.";
 "claude_showing_last_known_usage" = "Mostrando el último uso conocido, capturado %@.";
+"claude_limited_usage_detail" = "Detalles de uso limitados";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1489,6 +1489,7 @@
 "Total usage" = "مصرف کل";
 "claude_oauth_keychain_access_revoked" = "دسترسی به Keychain کلود با چرخش توکن Claude Code لغو شد. برای اعطای مجدد دسترسی روی «تازه‌سازی» کلیک کنید، یا منبع استفاده Claude را به CLI/Web تغییر دهید.";
 "claude_showing_last_known_usage" = "آخرین میزان استفاده شناخته‌شده که در %@ ثبت شده نمایش داده می‌شود.";
+"claude_limited_usage_detail" = "جزئیات استفاده محدود است";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1485,6 +1485,7 @@
 "Total usage" = "Utilisation totale";
 "claude_oauth_keychain_access_revoked" = "L’accès au trousseau Claude a été révoqué par la rotation du jeton de Claude Code. Cliquez sur Actualiser pour accorder à nouveau l’accès, ou définissez la source d’utilisation de Claude sur CLI/Web.";
 "claude_showing_last_known_usage" = "Affichage de la dernière utilisation connue, capturée %@.";
+"claude_limited_usage_detail" = "Détails d’utilisation limités";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1485,6 +1485,7 @@
 "Total usage" = "Uso total";
 "claude_oauth_keychain_access_revoked" = "O acceso ao chaveiro de Claude foi revogado pola rotación do token de Claude Code. Preme Actualizar para volver conceder o acceso ou cambia a orixe de uso de Claude a CLI/Web.";
 "claude_showing_last_known_usage" = "Mostrando o último uso coñecido, capturado %@.";
+"claude_limited_usage_detail" = "Detalles de uso limitados";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1489,6 +1489,7 @@
 "Total usage" = "Total penggunaan";
 "claude_oauth_keychain_access_revoked" = "Akses Rantai Kunci Claude dicabut akibat rotasi token Claude Code. Klik Segarkan untuk memberikan akses lagi, atau ubah sumber penggunaan Claude ke CLI/Web.";
 "claude_showing_last_known_usage" = "Menampilkan penggunaan terakhir yang diketahui, diambil %@.";
+"claude_limited_usage_detail" = "Rincian penggunaan terbatas";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1489,6 +1489,7 @@
 "Total usage" = "Utilizzo totale";
 "claude_oauth_keychain_access_revoked" = "L'accesso al portachiavi di Claude è stato revocato dalla rotazione del token di Claude Code. Fai clic su Aggiorna per concedere nuovamente l'accesso oppure imposta la fonte di utilizzo di Claude su CLI/Web.";
 "claude_showing_last_known_usage" = "Visualizzazione dell'ultimo utilizzo noto, acquisito %@.";
+"claude_limited_usage_detail" = "Dettagli di utilizzo limitati";
 /* Spend dashboard cost analysis */
 "90d" = "90 g";
 "Input" = "Ingresso";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1486,6 +1486,7 @@
 "Total usage" = "合計使用量";
 "claude_oauth_keychain_access_revoked" = "Claude Code のトークン更新により、Claude キーチェーンへのアクセスが取り消されました。「更新」をクリックしてアクセスを再許可するか、Claude の使用量の取得元を CLI/Web に切り替えてください。";
 "claude_showing_last_known_usage" = "最後に取得した既知の使用量を表示しています（取得: %@）。";
+"claude_limited_usage_detail" = "使用量の詳細情報は限られています";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1455,6 +1455,7 @@
 "Total usage" = "총 사용량";
 "claude_oauth_keychain_access_revoked" = "Claude Code의 토큰 교체로 Claude 키체인 접근 권한이 취소되었습니다. 새로 고침을 클릭해 접근 권한을 다시 부여하거나 Claude 사용량 소스를 CLI/Web으로 전환하세요.";
 "claude_showing_last_known_usage" = "마지막으로 확인된 사용량을 표시 중입니다(캡처: %@).";
+"claude_limited_usage_detail" = "사용량 세부 정보가 제한적입니다";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1485,6 +1485,7 @@
 "Total usage" = "Totaal gebruik";
 "claude_oauth_keychain_access_revoked" = "De toegang tot de Claude-sleutelhanger is ingetrokken door de tokenrotatie van Claude Code. Klik op Vernieuwen om opnieuw toegang te verlenen of zet de Claude-gebruiksbron op CLI/Web.";
 "claude_showing_last_known_usage" = "De laatst bekende gebruiksgegevens worden weergegeven (vastgelegd: %@).";
+"claude_limited_usage_detail" = "Beperkte gebruiksdetails";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1489,6 +1489,7 @@
 "Total usage" = "Łączne użycie";
 "claude_oauth_keychain_access_revoked" = "Dostęp do pęku kluczy Claude został cofnięty wskutek rotacji tokenu przez Claude Code. Kliknij Odśwież, aby ponownie przyznać dostęp, albo przełącz źródło użycia Claude na CLI/Web.";
 "claude_showing_last_known_usage" = "Wyświetlane jest ostatnie znane użycie zarejestrowane %@.";
+"claude_limited_usage_detail" = "Mniej szczegółowe dane o zużyciu";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1486,6 +1486,7 @@
 "Total usage" = "Uso total";
 "claude_oauth_keychain_access_revoked" = "O acesso às Chaves do Claude foi revogado pela rotação do token do Claude Code. Clique em Atualizar para conceder o acesso novamente ou altere a fonte de uso do Claude para CLI/Web.";
 "claude_showing_last_known_usage" = "Exibindo o último uso conhecido, capturado %@.";
+"claude_limited_usage_detail" = "Detalhes de uso limitados";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1487,6 +1487,7 @@
 "Total usage" = "Общее использование";
 "claude_oauth_keychain_access_revoked" = "Доступ к Связке ключей Claude был отозван из-за ротации токена в Claude Code. Нажмите «Обновить», чтобы повторно предоставить доступ, или переключите источник использования Claude на CLI/Web.";
 "claude_showing_last_known_usage" = "Показаны последние известные данные об использовании (получены %@).";
+"claude_limited_usage_detail" = "Ограниченная детализация использования";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1484,6 +1484,7 @@
 "Total usage" = "Total användning";
 "claude_oauth_keychain_access_revoked" = "Åtkomsten till Claudes nyckelring återkallades när Claude Code roterade token. Klicka på Uppdatera för att ge åtkomst igen, eller byt Claudes användningskälla till CLI/Web.";
 "claude_showing_last_known_usage" = "Visar senast kända användning, registrerad %@.";
+"claude_limited_usage_detail" = "Begränsade användningsdetaljer";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1489,6 +1489,7 @@
 "Total usage" = "การใช้งานทั้งหมด";
 "claude_oauth_keychain_access_revoked" = "สิทธิ์เข้าถึงพวงกุญแจ Claude ถูกเพิกถอนจากการหมุนเวียนโทเค็นของ Claude Code คลิกรีเฟรชเพื่อให้สิทธิ์อีกครั้ง หรือเปลี่ยนแหล่งที่มาการใช้งาน Claude เป็น CLI/Web";
 "claude_showing_last_known_usage" = "กำลังแสดงการใช้งานล่าสุดที่ทราบ ซึ่งบันทึกเมื่อ %@";
+"claude_limited_usage_detail" = "รายละเอียดการใช้งานมีจำกัด";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1487,6 +1487,7 @@
 "Total usage" = "Toplam kullanım";
 "claude_oauth_keychain_access_revoked" = "Claude Anahtar Zinciri erişimi, Claude Code'un token yenilemesi nedeniyle iptal edildi. Erişimi yeniden vermek için Yenile'ye tıklayın veya Claude kullanım kaynağını CLI/Web olarak değiştirin.";
 "claude_showing_last_known_usage" = "Bilinen son kullanım gösteriliyor (yakalanma zamanı: %@).";
+"claude_limited_usage_detail" = "Kullanım ayrıntıları sınırlı";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Girdi";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1485,6 +1485,7 @@
 "Total usage" = "Загальне використання";
 "claude_oauth_keychain_access_revoked" = "Доступ до В’язки ключів Claude було відкликано через ротацію токена в Claude Code. Натисніть «Оновити», щоб повторно надати доступ, або перемкніть джерело використання Claude на CLI/Web.";
 "claude_showing_last_known_usage" = "Показано останні відомі дані про використання (отримано %@).";
+"claude_limited_usage_detail" = "Обмежена деталізація використання";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1486,6 +1486,7 @@
 "Total usage" = "Tổng mức sử dụng";
 "claude_oauth_keychain_access_revoked" = "Quyền truy cập Chuỗi khóa Claude đã bị thu hồi do Claude Code xoay vòng mã thông báo. Nhấp vào Làm mới để cấp lại quyền truy cập hoặc chuyển nguồn sử dụng Claude sang CLI/Web.";
 "claude_showing_last_known_usage" = "Đang hiển thị mức sử dụng đã biết gần nhất, được ghi nhận %@.";
+"claude_limited_usage_detail" = "Thông tin sử dụng ít chi tiết";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1486,6 +1486,7 @@
 "Total usage" = "总用量";
 "claude_oauth_keychain_access_revoked" = "Claude Code 轮换令牌后撤销了对 Claude 钥匙串的访问权限。点击“刷新”以重新授权，或将 Claude 用量来源切换为 CLI/Web。";
 "claude_showing_last_known_usage" = "正在显示 %@ 采集的最后已知用量。";
+"claude_limited_usage_detail" = "用量详情有限";
 
 "menu_bar_layout_token_conditional" = "条件";
 "menu_bar_layout_group_conditionals" = "条件";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1516,6 +1516,7 @@
 "Total usage" = "總用量";
 "claude_oauth_keychain_access_revoked" = "Claude Code 輪替權杖後撤銷了 Claude 鑰匙圈的存取權。按一下「重新整理」以重新授權，或將 Claude 使用量來源切換為 CLI/Web。";
 "claude_showing_last_known_usage" = "正在顯示於 %@ 擷取的最後已知使用量。";
+"claude_limited_usage_detail" = "使用量詳細資訊有限";
 /* Spend dashboard cost analysis */
 "90d" = "90d";
 "Input" = "Input";

--- a/Tests/CodexBarTests/ClaudeOAuthDirectKeychainReadConsentTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDirectKeychainReadConsentTests.swift
@@ -164,28 +164,11 @@ struct ClaudeOAuthDirectKeychainReadConsentTests {
             rawText: nil)
         let degraded = ClaudeOAuthFetchStrategy._snapshotForTesting(from: usage, dataConfidence: .percentOnly)
         #expect(degraded.dataConfidence == .percentOnly)
-        let card = UsageMenuCardView.Model.make(UsageMenuCardView.Model.Input(
-            provider: .claude,
-            metadata: ProviderDescriptorRegistry.descriptor(for: .claude).metadata,
-            snapshot: degraded,
-            credits: nil,
-            creditsError: nil,
-            dashboard: nil,
-            dashboardError: nil,
-            tokenSnapshot: nil,
-            tokenError: nil,
-            account: AccountInfo(email: nil, plan: nil),
-            isRefreshing: false,
-            lastError: nil,
-            usageBarsShowUsed: true,
-            resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
-            showOptionalCreditsAndExtraUsage: true,
-            hidePersonalInfo: false,
-            now: Date()))
-        #expect(card.usageNotes == [L("Usage via Claude CLI (limited detail)")])
+        let card = ClaudeUsageDetailTestSupport.model(snapshot: degraded)
+        #expect(card.usageNotes == [L("claude_limited_usage_detail")])
         let oauth = ClaudeOAuthFetchStrategy._snapshotForTesting(from: usage)
         #expect(oauth.dataConfidence == .unknown)
+        #expect(ClaudeUsageDetailTestSupport.model(snapshot: oauth).usageNotes.isEmpty)
     }
 
     // MARK: - Consent revocation invalidates cached credentials

--- a/Tests/CodexBarTests/ClaudeResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeResilienceTests.swift
@@ -1264,10 +1264,21 @@ extension ClaudeResilienceTests {
 
                 await store.refreshProvider(.claude)
                 let result = await MainActor.run {
-                    (
+                    let snapshot = store.presentationSnapshot(for: .claude)
+                    let card = CodexBarLocalizationOverride.$appLanguage.withValue("en") {
+                        ClaudeUsageDetailTestSupport.model(
+                            snapshot: snapshot,
+                            lastError: store.userFacingError(for: .claude),
+                            sourceLabel: store.sourceLabel(for: .claude))
+                    }
+                    return (
                         primary: store.snapshot(for: .claude)?.primary?.usedPercent,
                         secondary: store.snapshot(for: .claude)?.secondary?.usedPercent,
                         updatedAt: store.snapshot(for: .claude)?.updatedAt,
+                        identity: snapshot?.identity,
+                        confidence: snapshot?.dataConfidence,
+                        sourceMode: store.settings.claudeUsageDataSource,
+                        notes: card.usageNotes,
                         rawError: store.error(for: .claude),
                         userFacingError: store.userFacingError(for: .claude))
                 }
@@ -1275,6 +1286,10 @@ extension ClaudeResilienceTests {
                 #expect(result.primary == 21)
                 #expect(result.secondary == 42)
                 #expect(result.updatedAt == weeklyCapturedAt)
+                #expect(result.identity == nil)
+                #expect(result.confidence == .percentOnly)
+                #expect(result.sourceMode == .auto)
+                #expect(result.notes == ["Limited usage detail"])
                 #expect(result.rawError == ClaudeOAuthCredentialsError.keychainAccessRevoked.localizedDescription)
                 #expect(result.userFacingError?.contains("Showing last-known usage captured") == true)
             }

--- a/Tests/CodexBarTests/ClaudeUsageDetailNoteTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageDetailNoteTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct ClaudeUsageDetailNoteTests {
+    @Test
+    func `limited detail describes fidelity without inventing a source`() {
+        let notes = CodexBarLocalizationOverride.$appLanguage.withValue("en") {
+            ClaudeUsageDetailTestSupport.model(snapshot: ClaudeUsageDetailTestSupport.snapshot()).usageNotes
+        }
+        #expect(notes == ["Limited usage detail"])
+    }
+
+    @Test(arguments: [UsageDataConfidence.exact, .estimated, .unknown])
+    func `other confidence levels do not gain a limited detail note`(_ confidence: UsageDataConfidence) {
+        let snapshot = ClaudeUsageDetailTestSupport.snapshot(confidence: confidence)
+        #expect(ClaudeUsageDetailTestSupport.model(snapshot: snapshot).usageNotes.isEmpty)
+    }
+
+    @Test
+    func `limited detail has a translation in every app catalog`() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let resources = root.appendingPathComponent("Sources/CodexBar/Resources")
+        let catalogs = try FileManager.default.contentsOfDirectory(at: resources, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "lproj" }
+        let languages = Set(AppLanguage.allCases.filter { $0 != .system }.map(\.rawValue))
+        #expect(Set(catalogs.map { $0.deletingPathExtension().lastPathComponent }) == languages)
+        for directory in catalogs {
+            let url = directory.appendingPathComponent("Localizable.strings")
+            let catalog = try #require(NSDictionary(contentsOf: url) as? [String: String])
+            #expect(catalog["claude_limited_usage_detail"]?.isEmpty == false, "\(directory.lastPathComponent)")
+        }
+    }
+}
+
+enum ClaudeUsageDetailTestSupport {
+    static let now = Date(timeIntervalSince1970: 1_787_875_500)
+
+    static func snapshot(confidence: UsageDataConfidence = .percentOnly) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(usedPercent: 21, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 42, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: self.now.addingTimeInterval(-300),
+            dataConfidence: confidence)
+    }
+
+    static func model(
+        snapshot: UsageSnapshot?,
+        lastError: String? = nil,
+        sourceLabel: String? = nil) -> UsageMenuCardView.Model
+    {
+        UsageMenuCardView.Model.make(.init(
+            provider: .claude,
+            metadata: ProviderDescriptorRegistry.descriptor(for: .claude).metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: lastError,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            sourceLabel: sourceLabel,
+            hidePersonalInfo: true,
+            usesLiveSubtitle: false,
+            now: self.now))
+    }
+}

--- a/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
+++ b/Tests/CodexBarTests/MenuLayoutScreenshotRenderTests.swift
@@ -856,6 +856,45 @@ final class MenuLayoutScreenshotRenderTests: XCTestCase {
 }
 
 extension MenuLayoutScreenshotRenderTests {
+    func test_renderClaudeUsageDetailProof() throws {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_CLAUDE_DETAIL_SCREENSHOT_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_CLAUDE_DETAIL_SCREENSHOT_DIR to render the Claude detail proof.")
+        }
+        let expected = ProcessInfo.processInfo.environment["CODEXBAR_CLAUDE_DETAIL_EXPECTED_NOTE"]
+            ?? "Limited usage detail"
+        let directory = URL(fileURLWithPath: dir, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try CodexBarLocalizationOverride.$appLanguage.withValue("en") {
+            let snapshot = ClaudeUsageDetailTestSupport.snapshot()
+            XCTAssertNil(snapshot.identity)
+            let model = ClaudeUsageDetailTestSupport.model(
+                snapshot: snapshot,
+                lastError: "Could not refresh. Showing last-known usage captured 5 minutes ago.",
+                sourceLabel: "auto")
+            XCTAssertEqual(model.usageNotes, [expected])
+            for dark in [false, true] {
+                let view = AnyView(UsageMenuCardView(model: model, width: Self.width)
+                    .environment(\.locale, Locale(identifier: "en_US_POSIX"))
+                    .environment(\.colorScheme, dark ? .dark : .light)
+                    .environment(\.displayScale, 2)
+                    .environment(\.accessibilityEnabled, true)
+                    .background(Color(nsColor: .windowBackgroundColor)))
+                let hosting = NSHostingView(rootView: view)
+                hosting.appearance = NSAppearance(named: dark ? .darkAqua : .aqua)
+                let name = "claude-detail-\(dark ? "dark" : "light")"
+                let png = try XCTUnwrap(Self.pngData(hosting: hosting))
+                try png.write(to: directory.appendingPathComponent("\(name).png"))
+                let accessibility = Self.accessibilityText(hosting)
+                XCTAssertTrue(accessibility.contains(expected), accessibility)
+                XCTAssertTrue(accessibility.contains("last-known usage"), accessibility)
+                try accessibility.write(
+                    to: directory.appendingPathComponent("\(name)-accessibility.txt"),
+                    atomically: true,
+                    encoding: .utf8)
+            }
+        }
+    }
+
     func test_renderOllamaMonthlyCompatibilityProof() throws {
         guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_OLLAMA_MONTHLY_SCREENSHOT_DIR"] else {
             throw XCTSkip("Set CODEXBAR_OLLAMA_MONTHLY_SCREENSHOT_DIR to render the Ollama compatibility proof.")

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -97,6 +97,8 @@ Admin API key setup:
   Keychain access; selecting CLI or Web avoids the foreign-Keychain dependency.
 - When every live Auto source fails, CodexBar keeps the last captured session/weekly percentages from
   `history/claude.json` visible as stale data and shows their capture age instead of blanking the quota bars.
+  Restored history and CLI-scraped percentages both show “Limited usage detail”: the warning describes reduced
+  fidelity, not the source of a historical capture. It does not change sign-in or refresh recovery actions.
 - Plan inference: `subscriptionType` is preferred when present; `rate_limit_tier` falls back to
   Max/Pro/Team/Enterprise. When a Max `rate_limit_tier` carries a usage multiplier
   (`default_claude_max_5x` / `default_claude_max_20x`), it is surfaced in the label as "Max 5x" / "Max 20x".


### PR DESCRIPTION
## Summary

Restored Claude quota history was incorrectly labeled “Usage via Claude CLI (limited detail).” The menu treated the shared `percentOnly` confidence flag as proof of a CLI source, even though history restoration also uses that flag.

Use the neutral “Limited usage detail” note, localized across the existing app languages. Keep the same confidence condition and subscription notes. There are no changes to fetching, account identity, stored history, source selection, credentials, sign-in actions, refresh recovery, percentages, or capture timestamps.

Found while investigating #3395. This fixes the misleading presentation only; the broader authentication/recovery report remains open.

## Proof

The regression drives the real history-restoration path after simulated source failures. Before the fix it reproduced the incorrect CLI label. After the fix it preserves the 21%/42% bars, original capture time, empty identity, Auto mode, raw error, and stale-history warning while showing the neutral note. The real CLI snapshot mapper still gets the limited-detail warning; other confidence levels do not gain one.

The before/after screenshots use the same synthetic snapshot and the production card renderer. Light and dark captures were inspected; their accessibility text differs only in the note. No app launch, real account, credential access, provider request, or desktop capture was used.

| Before | After |
| --- | --- |
| ![Restored history incorrectly attributed to CLI](https://github.com/user-attachments/assets/ca512207-c98a-4822-aed8-c220f652c2d5) | ![Neutral limited-detail note with unchanged percentages and stale warning](https://github.com/user-attachments/assets/37ddf8dc-5d7c-4b6e-ab36-a30529650836) |

## Validation

- 47 focused tests across four suites passed, including actual history restoration, the CLI mapper, confidence controls, and recovery-menu tests.
- The opt-in production-card screenshot test passed separately in light and dark appearance.
- `make check`: passed, zero violations in 2,099 files.
- Required Codex autoreview: no accepted/actionable findings at the configured priority.
- Full `make test`: all 1,003 selections across 84 groups passed first try in 852.0 seconds, with zero failures, timeouts, or retries.
- [Exact-head CI 33794844723](https://github.com/steipete/CodexBar/actions/runs/33794844723): all checks passed, including both macOS shards, Linux x64/ARM64/musl, lint, the aggregate check, and GitGuardian. The rebase onto current main preserves the tested file tree.

The isolated worktree initially needed the repository's existing Sparkle test-runtime repair. The new screenshot method lives in the file's existing extension to stay within the type-size lint rule; neither adjustment changes product behavior.
