### PR TITLE
fix(settings): disable iCloud sub-options when sync is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Settings: disable iCloud sync sub-options when the main sync switch is off, preserving their saved choices for the next time sync is enabled (#3406). Thanks @elijahfriedman!
 - Antigravity: match local token-history timestamps by per-turn IDs when auxiliary or reordered steps would otherwise assign usage to the wrong day, while withholding conflicting evidence and preserving legacy timestamp recovery (#3403). Thanks @WeGoToMars!
 - Codex: retain completed empty session fragments during cost-history scans instead of repeatedly dropping and rediscovering them, without suppressing usage-bearing duplicates or later appended usage (partial fix for #3316; #3402). Thanks @mauriciopolvora!
 - Agent sessions: explicitly force Tailscale CLI mode during remote-host discovery, preventing repeated app-binary crashes on newer Tailscale installations while preserving existing terminal settings (#3397). Thanks @tzioup!

--- a/Sources/CodexBar/PreferencesICloudSyncPane.swift
+++ b/Sources/CodexBar/PreferencesICloudSyncPane.swift
@@ -40,6 +40,7 @@ struct ICloudSyncPane: View {
                 .toggleStyle(.checkbox)
                 .padding(.leading, 20)
                 .disabled(!self.syncCanRun)
+                .disabled(!self.settings.iCloudSyncEnabled)
             } header: {
                 Text(L("iCloud Sync"))
             } footer: {

--- a/Sources/CodexBar/PreferencesICloudSyncPane.swift
+++ b/Sources/CodexBar/PreferencesICloudSyncPane.swift
@@ -39,8 +39,7 @@ struct ICloudSyncPane: View {
                 }
                 .toggleStyle(.checkbox)
                 .padding(.leading, 20)
-                .disabled(!self.syncCanRun)
-                .disabled(!self.settings.iCloudSyncEnabled)
+                .disabled(!self.syncCanRun || !self.settings.iCloudSyncEnabled)
             } header: {
                 Text(L("iCloud Sync"))
             } footer: {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,6 +276,8 @@ See the [generated provider ID list](provider-ids.md), sourced from `UsageProvid
 The order of `providers` controls display/order in the app and CLI. Reorder the array to change ordering.
 
 ## iCloud sync
+The three sync sub-options are disabled while the main sync switch is off, iCloud is unavailable, or a newer app version is required. Their saved choices are retained when sync is turned off and restored when it is enabled again.
+
 Opt-in (Settings → iCloud Sync, off by default; requires a signed release build and an iCloud account). When enabled, CodexBar syncs across the user's Macs via CloudKit (private database, container `iCloud.com.steipete.codexbar`):
 
 - **Provider configuration** — portable fields of each provider entry (enabled intent, extras, region, workspace, quota-warning overrides, ordering-relevant metadata). Secrets (`apiKey`, `secretKey`, `cookieHeader`, `tokenAccounts`) sync only when "Include API keys, cookies, and tokens" is on, and travel exclusively in CloudKit `encryptedValues` (end-to-end encrypted; readable only on the user's devices).


### PR DESCRIPTION
The three iCloud sync sub-options remained editable after the main sync switch was turned off. Combine the master-switch and availability/update requirements into one disabled condition, preserving saved choices across off/on cycles.

Update the configuration guide and Unreleased changelog. Thanks @elijahfriedman for the fix.

Validation: `make check` passes. A freshly built Developer ID-signed fixture exercised the production settings pane with dictionary-backed synthetic settings: all three children disable with sync off, re-enable with sync on, retain edited choices through an off/on cycle, and remain disabled for unavailable iCloud or an update-required state. The fixture starts no CloudKit engine and uses no real account data. The full `make test` run against the combined final changes passed all 84 groups; one unrelated Codex group timed out and recovered when its 12 selections ran separately. Exact-commit CI results are recorded in the landing comment.

Before — main sync off, children still editable:

![Before: iCloud sync off with editable child controls](https://github.com/user-attachments/assets/854a17b4-3407-472d-9b69-ce2c0ddce143)

After — same saved values, children disabled:

![After: iCloud sync off with disabled child controls](https://github.com/user-attachments/assets/78c27143-a559-4036-8509-2e4065fed4d6)
