### PR TITLE
fix(spend): keep heatmap tooltips within the grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Codex: retain completed empty session fragments during cost-history scans instead of repeatedly dropping and rediscovering them, without suppressing usage-bearing duplicates or later appended usage (partial fix for #3316; #3402). Thanks @mauriciopolvora!
 - Agent sessions: explicitly force Tailscale CLI mode during remote-host discovery, preventing repeated app-binary crashes on newer Tailscale installations while preserving existing terminal settings (#3397). Thanks @tzioup!
 - Claude: stop labeling restored quota history as CLI usage, while retaining the limited-detail warning, original percentages, and stale-data guidance.
+- Usage & Spend: prefer heatmap tooltips above hovered cells and keep them within narrow grids; retain daily keyboard selection without the extra system focus rectangle (#3407). Thanks @elijahfriedman!
 
 ## 0.56.4 — 2026-09-03
 

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -304,13 +304,17 @@ struct SpendActivityGridGeometry {
         return min(max(anchorX, lower), upper)
     }
 
+    /// Caps the tooltip to the grid's own height so a very short grid (e.g. a narrow window with the
+    /// sidebar expanded) compacts the tooltip instead of letting it overflow past the grid's edges.
+    static func effectiveTooltipHeight(gridHeight: CGFloat) -> CGFloat {
+        min(self.tooltipHeight, gridHeight)
+    }
+
     static func tooltipOriginY(anchorY: CGFloat, tooltipHeight: CGFloat, gridHeight: CGFloat) -> CGFloat {
+        let maxOrigin = max(gridHeight - tooltipHeight, 0)
         let above = anchorY - tooltipHeight - self.tooltipGap
-        if above >= self.tooltipInset {
-            return above
-        }
-        let below = anchorY + self.tooltipGap
-        return min(below, max(gridHeight - tooltipHeight - self.tooltipInset, self.tooltipInset))
+        let candidate = above >= self.tooltipInset ? above : anchorY + self.tooltipGap
+        return min(max(candidate, 0), maxOrigin)
     }
 }
 
@@ -670,22 +674,24 @@ private struct SpendActivityDailyGrid: View {
             let anchorX = CGFloat(col) * pitch + pitch / 2
             let anchorY = CGFloat(row) * pitch + pitch / 2
             let width = min(SpendActivityGridGeometry.tooltipWidth, max(size.width - 8, 1))
+            let height = SpendActivityGridGeometry.effectiveTooltipHeight(gridHeight: size.height)
             let originY = SpendActivityGridGeometry.tooltipOriginY(
                 anchorY: anchorY,
-                tooltipHeight: SpendActivityGridGeometry.tooltipHeight,
+                tooltipHeight: height,
                 gridHeight: size.height)
             SpendActivityTooltip(
                 title: self.series.isCovered[index]
                     ? UsageFormatter.tokenCountString(self.series.daily[index])
                     : L("Unavailable"),
                 subtitle: SpendActivityDateFormatting.mediumDateString(date, calendar: self.series.calendar),
-                width: width)
+                width: width,
+                height: height)
                 .position(
                     x: SpendActivityGridGeometry.tooltipCenterX(
                         anchorX: anchorX,
                         tooltipWidth: width,
                         gridWidth: size.width),
-                    y: originY + SpendActivityGridGeometry.tooltipHeight / 2)
+                    y: originY + height / 2)
                 .allowsHitTesting(false)
         }
     }
@@ -893,22 +899,24 @@ private struct SpendActivityWeekGrid: View {
            let weekStart = self.series.weekStartDate(at: col)
         {
             let width = min(SpendActivityGridGeometry.tooltipWidth, max(size.width - 8, 1))
+            let height = SpendActivityGridGeometry.effectiveTooltipHeight(gridHeight: size.height)
             let originY = SpendActivityGridGeometry.tooltipOriginY(
                 anchorY: location.y,
-                tooltipHeight: SpendActivityGridGeometry.tooltipHeight,
+                tooltipHeight: height,
                 gridHeight: size.height)
             SpendActivityTooltip(
                 title: self.activity.isCovered[col]
                     ? UsageFormatter.tokenCountString(self.activity.values[col])
                     : L("Unavailable"),
                 subtitle: SpendActivityDateFormatting.mediumDateString(weekStart, calendar: self.series.calendar),
-                width: width)
+                width: width,
+                height: height)
                 .position(
                     x: SpendActivityGridGeometry.tooltipCenterX(
                         anchorX: CGFloat(col) * pitch + pitch / 2,
                         tooltipWidth: width,
                         gridWidth: size.width),
-                    y: originY + SpendActivityGridGeometry.tooltipHeight / 2)
+                    y: originY + height / 2)
                 .allowsHitTesting(false)
         }
     }
@@ -964,6 +972,7 @@ private struct SpendActivityTooltip: View {
     let title: String
     let subtitle: String
     let width: CGFloat
+    let height: CGFloat
 
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
@@ -979,7 +988,7 @@ private struct SpendActivityTooltip: View {
         .padding(.horizontal, 8)
         .frame(
             width: self.width,
-            height: SpendActivityGridGeometry.tooltipHeight,
+            height: self.height,
             alignment: .leading)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
         .overlay {

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -304,8 +304,13 @@ struct SpendActivityGridGeometry {
         return min(max(anchorX, lower), upper)
     }
 
-    static func tooltipOriginY(anchorY: CGFloat, tooltipHeight: CGFloat, gridHeight _: CGFloat) -> CGFloat {
-        anchorY - tooltipHeight - self.tooltipGap
+    static func tooltipOriginY(anchorY: CGFloat, tooltipHeight: CGFloat, gridHeight: CGFloat) -> CGFloat {
+        let above = anchorY - tooltipHeight - self.tooltipGap
+        if above >= self.tooltipInset {
+            return above
+        }
+        let below = anchorY + self.tooltipGap
+        return min(below, max(gridHeight - tooltipHeight - self.tooltipInset, self.tooltipInset))
     }
 }
 

--- a/Sources/CodexBar/SpendActivityHeatmap.swift
+++ b/Sources/CodexBar/SpendActivityHeatmap.swift
@@ -281,8 +281,8 @@ enum SpendActivityLevels {
 struct SpendActivityGridGeometry {
     static let weekdayGutterWidth: CGFloat = 40
     static let gridSpacing: CGFloat = 8
-    static let tooltipInset: CGFloat = 4
-    static let tooltipGap: CGFloat = 7
+    static let tooltipInset: CGFloat = 8
+    static let tooltipGap: CGFloat = 5
     static let tooltipWidth: CGFloat = 148
     static let tooltipHeight: CGFloat = 50
 
@@ -304,12 +304,8 @@ struct SpendActivityGridGeometry {
         return min(max(anchorX, lower), upper)
     }
 
-    static func tooltipOriginY(anchorY: CGFloat, tooltipHeight: CGFloat, gridHeight: CGFloat) -> CGFloat {
-        let below = anchorY + self.tooltipGap
-        if below + tooltipHeight <= gridHeight {
-            return below
-        }
-        return max(anchorY - tooltipHeight - self.tooltipGap, 0)
+    static func tooltipOriginY(anchorY: CGFloat, tooltipHeight: CGFloat, gridHeight _: CGFloat) -> CGFloat {
+        anchorY - tooltipHeight - self.tooltipGap
     }
 }
 
@@ -587,6 +583,7 @@ private struct SpendActivityDailyGrid: View {
             .aspectRatio(CGFloat(self.columns + 2) / CGFloat(self.rows), contentMode: .fit)
         }
         .focusable()
+        .focusEffectDisabled()
         .focused(self.$isKeyboardFocused)
         .onMoveCommand(perform: self.moveKeyboardSelection)
         .onChange(of: self.isKeyboardFocused) { _, isFocused in

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -511,6 +511,24 @@ struct SpendActivityHeatmapTests {
     }
 
     @Test
+    func `tooltip compacts instead of overflowing a grid shorter than its full height`() {
+        // Roughly matches the grid produced at the supported 800pt minimum window width
+        // with the sidebar expanded to 380pt, where the heatmap has very little height to work with.
+        let gridHeight: CGFloat = 38
+        let height = SpendActivityGridGeometry.effectiveTooltipHeight(gridHeight: gridHeight)
+        #expect(height <= gridHeight)
+
+        for anchorY: CGFloat in [0, 10, 19, 30, gridHeight] {
+            let originY = SpendActivityGridGeometry.tooltipOriginY(
+                anchorY: anchorY,
+                tooltipHeight: height,
+                gridHeight: gridHeight)
+            #expect(originY >= 0)
+            #expect(originY + height <= gridHeight)
+        }
+    }
+
+    @Test
     func `weekday and date formatting follow the selected resource locale`() throws {
         let date = try #require(Self.calendar.date(
             from: DateComponents(year: 2026, month: 8, day: 1, hour: 12)))

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -488,13 +488,25 @@ struct SpendActivityHeatmapTests {
     }
 
     @Test
-    func `tooltip always sits a fixed gap above the hovered cell`() {
-        for anchorY: CGFloat in [0, 10, 65, 120] {
+    func `tooltip prefers sitting above the hovered cell when there is room`() {
+        let originY = SpendActivityGridGeometry.tooltipOriginY(
+            anchorY: 120,
+            tooltipHeight: 50,
+            gridHeight: 130)
+        #expect(originY == 120 - 50 - SpendActivityGridGeometry.tooltipGap)
+    }
+
+    @Test
+    func `tooltip never renders outside the grid when there is no room above`() {
+        let gridHeight: CGFloat = 130
+        let tooltipHeight: CGFloat = 50
+        for anchorY: CGFloat in [0, 10, 30] {
             let originY = SpendActivityGridGeometry.tooltipOriginY(
                 anchorY: anchorY,
-                tooltipHeight: 50,
-                gridHeight: 130)
-            #expect(originY == anchorY - 50 - SpendActivityGridGeometry.tooltipGap)
+                tooltipHeight: tooltipHeight,
+                gridHeight: gridHeight)
+            #expect(originY >= 0)
+            #expect(originY + tooltipHeight <= gridHeight)
         }
     }
 

--- a/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
+++ b/Tests/CodexBarTests/SpendActivityHeatmapTests.swift
@@ -485,14 +485,17 @@ struct SpendActivityHeatmapTests {
         #expect(centered == 500)
         #expect(trailing > 900)
         #expect(trailing <= gridWidth - width / 2)
-        #expect(SpendActivityGridGeometry.tooltipOriginY(
-            anchorY: 10,
-            tooltipHeight: 50,
-            gridHeight: 130) > 10)
-        #expect(SpendActivityGridGeometry.tooltipOriginY(
-            anchorY: 120,
-            tooltipHeight: 50,
-            gridHeight: 130) < 70)
+    }
+
+    @Test
+    func `tooltip always sits a fixed gap above the hovered cell`() {
+        for anchorY: CGFloat in [0, 10, 65, 120] {
+            let originY = SpendActivityGridGeometry.tooltipOriginY(
+                anchorY: anchorY,
+                tooltipHeight: 50,
+                gridHeight: 130)
+            #expect(originY == anchorY - 50 - SpendActivityGridGeometry.tooltipGap)
+        }
     }
 
     @Test

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -8,6 +8,7 @@ read_when:
 # UI & icon
 
 ## Settings
+- Usage & Spend heatmap tooltips prefer the space above the hovered cell and stay within the grid, falling below when needed. On narrow grids they compact vertically and may overlap cells; keyboard selection remains available in the daily grid.
 - Both the application menu and status menu open About in the Settings window. An existing Settings window is reused
   and switches to the About pane.
 


### PR DESCRIPTION
Keep Token activity tooltips inside the grid while preferring space above the hovered cell. Fall below when needed and compact the tooltip height in short grids; at the minimum window width the two text rows remain readable even when the tooltip overlaps cells. Remove the extra system focus rectangle while retaining daily keyboard and accessibility selection.

Retain focused layout regression tests and document the behavior in the UI guide and Unreleased changelog. Thanks @elijahfriedman for the fix.

Validation: `make check` passes. A freshly built Developer ID-signed fixture exercised the production heatmap with 365 synthetic days at normal width and the 339-point minimum-width panel. Live checks covered left/right edges, above/below placement, unavailable days, compact daily/weekly/cumulative tooltips, a grid near the enclosing scroll viewport's top, arrow-key navigation, and accessibility increment. The fixture uses dictionary-backed preferences; remounting the view applies persisted mode changes without involving user defaults. The full `make test` run against the combined final changes passed all 84 groups; one unrelated Codex group timed out and recovered when its 12 selections ran separately. A focused `swift test --skip-build --no-parallel --filter 'Kilo|SpendActivityHeatmapTests'` run passed all 87 tests. Exact-commit CI results are recorded in the landing comment.

Before — narrow grid with the extra focus rectangle and an overflowing tooltip:

![Before: narrow token activity tooltip](https://github.com/user-attachments/assets/eb5caf24-c846-4945-8a51-a968469daab4)

After — the same synthetic day, compact tooltip contained in the grid:

![After: narrow token activity tooltip stays within the grid](https://github.com/user-attachments/assets/4f008d74-335d-4ea7-8bfb-d6c663e8abab)
