### PR TITLE
fix(kilo): use the supported authentication recovery command

### DIFF
--- a/.github/pr-proof/kilo-auth-login-command.log
+++ b/.github/pr-proof/kilo-auth-login-command.log
@@ -1,0 +1,54 @@
+Kilo CLI auth command - real CLI evidence
+Captured: 2026-09-04T00:41:38Z
+Commit: 2b12263e430d70c5b033bd4a69aff9654c300238
+Host: macOS 26.6.2, arm64
+Kilo CLI version: 7.5.9
+
+Claim under review
+- PR replaces the outdated recovery instruction "kilo login" with "kilo auth login"
+  in Kilo provider errors and docs. The submitted unit test only compares strings;
+  this log is direct CLI evidence that "kilo auth login" is the current, real
+  command and that a bare "kilo login" is not a recognized subcommand.
+
+1. Installed Kilo CLI version
+$ kilo --version
+7.5.9
+
+2. Top-level command list has no bare "login" command
+$ kilo help | grep -E "^  kilo (login|auth)"
+  kilo auth                manage AI providers and credentials                  [aliases: providers]
+
+-> "login" does not appear as a top-level command. Running "kilo login" is not
+   routed to an auth flow; the CLI's default command is "kilo [project]" (start
+   the TUI in a directory), so a bare "kilo login" would be parsed as "start the
+   TUI in a directory named ./login", not a login action.
+
+3. "kilo auth" subcommand list confirms "login" lives under "auth"
+$ kilo auth --help
+Commands:
+  kilo auth list               list providers and credentials                          [aliases: ls]
+  kilo auth login [url]        log in to a provider
+
+4. "kilo auth login" resolves as a real, documented subcommand
+$ kilo auth login --help
+kilo auth login [url]
+
+log in to a provider
+
+Positionals:
+  url  kilo auth provider                                                                   [string]
+
+Options:
+  -p, --provider    provider id or name to log in to (skips provider selection)             [string]
+  -m, --method      login method label (skips method selection)                             [string]
+  (plus standard --help/--version/--log-level/--pure flags)
+
+Conclusion
+- "kilo auth login" is the command the current Kilo CLI (v7.5.9) exposes for
+  authentication; "kilo login" is not a recognized command. The PR's replacement
+  text matches the CLI this machine has installed via Homebrew (/opt/homebrew/bin/kilo).
+
+Limit
+- This confirms the command exists and is routed correctly; it does not exercise
+  the interactive OAuth/browser login flow itself (that requires a live Kilo
+  account and was not run here to avoid mutating this machine's Kilo credentials).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Antigravity: match local token-history timestamps by per-turn IDs when auxiliary or reordered steps would otherwise assign usage to the wrong day, while withholding conflicting evidence and preserving legacy timestamp recovery (#3403). Thanks @WeGoToMars!
 - Codex: retain completed empty session fragments during cost-history scans instead of repeatedly dropping and rediscovering them, without suppressing usage-bearing duplicates or later appended usage (partial fix for #3316; #3402). Thanks @mauriciopolvora!
 - Agent sessions: explicitly force Tailscale CLI mode during remote-host discovery, preventing repeated app-binary crashes on newer Tailscale installations while preserving existing terminal settings (#3397). Thanks @tzioup!
+- Kilo: point authentication recovery messages and provider documentation to the supported `kilo auth login` command (#3408). Thanks @Chevalicious!
 - Claude: stop labeling restored quota history as CLI usage, while retaining the limited-detail warning, original percentages, and stale-data guidance.
 
 ## 0.56.4 — 2026-09-03

--- a/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
@@ -213,13 +213,13 @@ public enum KiloUsageError: LocalizedError, Sendable, Equatable {
         case .missingCredentials:
             "Kilo API credentials missing. Set KILO_API_KEY."
         case let .cliSessionMissing(path):
-            "Kilo CLI session not found at \(path). Run `kilo login` to create ~/.local/share/kilo/auth.json."
+            "Kilo CLI session not found at \(path). Run `kilo auth login` to create ~/.local/share/kilo/auth.json."
         case let .cliSessionUnreadable(path):
-            "Kilo CLI session file is unreadable at \(path). Fix permissions or run `kilo login` again."
+            "Kilo CLI session file is unreadable at \(path). Fix permissions or run `kilo auth login` again."
         case let .cliSessionInvalid(path):
-            "Kilo CLI session file is invalid at \(path). Run `kilo login` to refresh auth.json."
+            "Kilo CLI session file is invalid at \(path). Run `kilo auth login` to refresh auth.json."
         case .unauthorized:
-            "Kilo authentication failed (401/403). Refresh KILO_API_KEY or run `kilo login`."
+            "Kilo authentication failed (401/403). Refresh KILO_API_KEY or run `kilo auth login`."
         case .endpointNotFound:
             "Kilo API endpoint not found (404). Verify the tRPC batch path and procedure names."
         case let .serviceUnavailable(statusCode):

--- a/Tests/CodexBarTests/KiloUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KiloUsageFetcherTests.swift
@@ -587,6 +587,20 @@ struct KiloUsageFetcherTests {
     }
 
     @Test
+    func `authentication errors recommend the supported login command`() {
+        let path = "/tmp/kilo/auth.json"
+
+        #expect(KiloUsageError.cliSessionMissing(path).errorDescription ==
+            "Kilo CLI session not found at \(path). Run `kilo auth login` to create ~/.local/share/kilo/auth.json.")
+        #expect(KiloUsageError.cliSessionUnreadable(path).errorDescription ==
+            "Kilo CLI session file is unreadable at \(path). Fix permissions or run `kilo auth login` again.")
+        #expect(KiloUsageError.cliSessionInvalid(path).errorDescription ==
+            "Kilo CLI session file is invalid at \(path). Run `kilo auth login` to refresh auth.json.")
+        #expect(KiloUsageError.unauthorized.errorDescription ==
+            "Kilo authentication failed (401/403). Refresh KILO_API_KEY or run `kilo auth login`.")
+    }
+
+    @Test
     func `fetch usage without credentials fails fast`() async {
         await #expect(throws: KiloUsageError.missingCredentials) {
             _ = try await KiloUsageFetcher.fetchUsage(apiKey: "  ", environment: [:])

--- a/docs/kilo.md
+++ b/docs/kilo.md
@@ -16,7 +16,7 @@ Kilo supports API and CLI-backed auth. Source mode can be `auto`, `api`, or `cli
    - Calls `https://app.kilo.ai/api/trpc`.
 2. CLI session (`cli`)
    - Reads `~/.local/share/kilo/auth.json` and uses `kilo.access`.
-   - Requires a valid CLI login (`kilo login`).
+   - Requires a valid CLI login (`kilo auth login`).
 3. Auto (`auto`)
    - Tries API first.
    - Falls back to CLI only when API credentials are missing or unauthorized (401/403).
@@ -33,8 +33,8 @@ Kilo supports API and CLI-backed auth. Source mode can be `auto`, `api`, or `cli
 
 ## Troubleshooting
 - Missing API token: set `KILO_API_KEY` or provider `apiKey`.
-- Missing CLI session file: run `kilo login` to create `~/.local/share/kilo/auth.json`.
-- Unauthorized API token (401/403): refresh `KILO_API_KEY` or rerun `kilo login`.
+- Missing CLI session file: run `kilo auth login` to create `~/.local/share/kilo/auth.json`.
+- Unauthorized API token (401/403): refresh `KILO_API_KEY` or rerun `kilo auth login`.
 
 ## Organizations
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -196,7 +196,7 @@ complete when the available scan window covers fewer days.
 ## Kilo
 - API token from `~/.codexbar/config.json` (`providers[].apiKey`) or `KILO_API_KEY`.
 - Auto mode tries API first and falls back to CLI auth when API credentials are missing or unauthorized.
-- CLI auth source: `~/.local/share/kilo/auth.json` (`kilo.access`), typically created by `kilo login`.
+- CLI auth source: `~/.local/share/kilo/auth.json` (`kilo.access`), typically created by `kilo auth login`.
 - Status: none yet.
 - Details: `docs/kilo.md`.
 


### PR DESCRIPTION
CodexBar's four missing/invalid Kilo-session recovery messages instructed users to run `kilo login`, but the supported command is `kilo auth login`. Update those messages, the provider documentation, and the Unreleased changelog; retain the focused message assertions and contributor CLI proof.

Thanks @Chevalicious for the fix. The command matches [Kilo's authentication guide](https://github.com/Kilo-Org/kilocode/blob/main/packages/kilo-docs/pages/getting-started/setup-authentication.md).

Validation: `make check` passes. Independently downloaded the official Kilo 7.5.9 macOS arm64 release and ran `--version`, `--help`, `auth --help`, and `auth login --help` with network and user-file access denied. The real CLI exposes `auth login`. Running the freshly packaged CodexBarCLI missing-session path before and after produces the expected exit code 1 and changes the recovery instruction from `kilo login` to `kilo auth login`. These checks use synthetic configuration; no OAuth login is initiated. The full `make test` run against the combined final changes passed all 84 groups; one unrelated Codex group timed out and recovered when its 12 selections ran separately. A focused `swift test --skip-build --no-parallel --filter 'Kilo|SpendActivityHeatmapTests'` run passed all 87 tests. Exact-commit CI results are recorded in the landing comment.
