### PR TITLE
fix(claude): recognize successful CLI usage in account actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## Unreleased
 
 ### Fixed
-- Claude: offer Switch Account after a successful CLI quota read without identity fields, while preserving recovery actions for failed refreshes and restored history (partial fix for #3395). Thanks @PoroGramr!
 - Settings: disable iCloud sync sub-options when the main sync switch is off, preserving their saved choices for the next time sync is enabled (#3406). Thanks @elijahfriedman!
 - Antigravity: match local token-history timestamps by per-turn IDs when auxiliary or reordered steps would otherwise assign usage to the wrong day, while withholding conflicting evidence and preserving legacy timestamp recovery (#3403). Thanks @WeGoToMars!
 - Codex: retain completed empty session fragments during cost-history scans instead of repeatedly dropping and rediscovering them, without suppressing usage-bearing duplicates or later appended usage (partial fix for #3316; #3402). Thanks @mauriciopolvora!
 - Agent sessions: explicitly force Tailscale CLI mode during remote-host discovery, preventing repeated app-binary crashes on newer Tailscale installations while preserving existing terminal settings (#3397). Thanks @tzioup!
 - Kilo: point authentication recovery messages and provider documentation to the supported `kilo auth login` command (#3408). Thanks @Chevalicious!
 - Claude: stop labeling restored quota history as CLI usage, while retaining the limited-detail warning, original percentages, and stale-data guidance.
+- Claude: offer Switch Account after a successful CLI quota read without identity fields, while preserving recovery actions for failed refreshes and restored history (partial fix for #3395). Thanks @PoroGramr!
 - Usage & Spend: prefer heatmap tooltips above hovered cells and keep them within narrow grids; retain daily keyboard selection without the extra system focus rectangle (#3407). Thanks @elijahfriedman!
 
 ## 0.56.4 — 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Claude: offer Switch Account after a successful CLI quota read without identity fields, while preserving recovery actions for failed refreshes and restored history (partial fix for #3395). Thanks @PoroGramr!
 - Settings: disable iCloud sync sub-options when the main sync switch is off, preserving their saved choices for the next time sync is enabled (#3406). Thanks @elijahfriedman!
 - Antigravity: match local token-history timestamps by per-turn IDs when auxiliary or reordered steps would otherwise assign usage to the wrong day, while withholding conflicting evidence and preserving legacy timestamp recovery (#3403). Thanks @WeGoToMars!
 - Codex: retain completed empty session fragments during cost-history scans instead of repeatedly dropping and rediscovering them, without suppressing usage-bearing duplicates or later appended usage (partial fix for #3316; #3402). Thanks @mauriciopolvora!

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -677,6 +677,18 @@ struct MenuDescriptor {
         {
             return true
         }
+        // CLI quota reads can succeed without identity. Retained history or failed refreshes do not prove this.
+        if target == .claude,
+           snapshot?.hasRateLimitWindows == true,
+           store.error(for: .claude) == nil,
+           store.lastSourceLabels[.claude] == "claude",
+           let attempt = store.fetchAttempts(for: .claude).last,
+           attempt.kind == .cli,
+           attempt.wasAvailable,
+           attempt.errorDescription == nil
+        {
+            return true
+        }
         let metadata = store.metadata(for: target)
         if metadata.usesAccountFallback,
            let fallback = account.email?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
@@ -18,15 +18,29 @@ struct ClaudeWebRecoveryMenuTests {
                 "Sign in to claude.ai (or refresh Claude cookies) to load usage data.")
     }
 
-    private func makeSettings() -> SettingsStore {
-        let suite = "ClaudeWebRecoveryMenuTests-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        return SettingsStore(
-            userDefaults: defaults,
-            configStore: testConfigStore(suiteName: suite),
+    private func makeSettings(root: URL) -> SettingsStore {
+        SettingsStore(
+            userDefaults: InMemoryUserDefaults(),
+            configStore: CodexBarConfigStore(fileURL: root.appendingPathComponent("config.json")),
             zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore(fileURL: root.appendingPathComponent("accounts.json")),
+            antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore(
+                fileURL: root.appendingPathComponent("antigravity.json")),
+            keychainAccessPolicy: SettingsStoreKeychainAccessPolicy(
+                setDisabled: { _ in }, isExplicitlyDisabled: { false }),
+            performInitialProviderDetection: false)
     }
 
     private static func claudeSwapAccounts(count: Int) -> [ProviderAccountUsageSnapshot] {
@@ -57,11 +71,21 @@ struct ClaudeWebRecoveryMenuTests {
         selectedSessionKey: Bool = false,
         authenticatedAccountEmail: String? = nil,
         authenticatedOAuthWithoutEmail: Bool = false,
+        snapshot: UsageSnapshot? = nil,
+        rawSourceLabel: String? = nil,
         claudeSwapAccountCount: Int = 0,
+        showSingleSwapAccount: Bool = false,
         attempts: [ProviderFetchAttempt] = []) -> [(String, MenuDescriptor.MenuAction)]
     {
-        let settings = self.makeSettings()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeWebRecoveryMenuTests-\(UUID().uuidString)", isDirectory: true)
+        let settings = self.makeSettings(root: root)
+        defer {
+            settings.configFileWatcher?.stop()
+            try? FileManager.default.removeItem(at: root)
+        }
         settings.claudeUsageDataSource = source
+        settings.claudeSwapShowSingleAccount = showSingleSwapAccount
         if selectedSessionKey {
             settings.addTokenAccount(provider: .claude, label: "Session", token: "sk-ant-session-token")
         }
@@ -72,7 +96,9 @@ struct ClaudeWebRecoveryMenuTests {
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings)
         store.claudeSwapAccountSnapshots = Self.claudeSwapAccounts(count: claudeSwapAccountCount)
-        if authenticatedAccountEmail != nil || authenticatedOAuthWithoutEmail {
+        if let snapshot {
+            store._setSnapshotForTesting(snapshot, provider: .claude)
+        } else if authenticatedAccountEmail != nil || authenticatedOAuthWithoutEmail {
             store._setSnapshotForTesting(
                 UsageSnapshot(
                     primary: authenticatedOAuthWithoutEmail
@@ -92,13 +118,14 @@ struct ClaudeWebRecoveryMenuTests {
                 provider: .claude)
         }
         store.errors[.claude] = error
+        store.lastSourceLabels[.claude] = rawSourceLabel
         store.lastFetchAttempts[.claude] = attempts
 
         return MenuDescriptor.build(
             provider: .claude,
             store: store,
             settings: settings,
-            account: fetcher.loadAccountInfo(),
+            account: AccountInfo(email: nil, plan: nil),
             updateReady: false)
             .sections
             .flatMap(\.entries)
@@ -106,6 +133,109 @@ struct ClaudeWebRecoveryMenuTests {
                 guard case let .action(label, action) = entry else { return nil }
                 return (label, action)
             }
+    }
+
+    private static func identitylessCLIUsage(hasRateLimits: Bool = true) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: hasRateLimits
+                ? RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+                : nil,
+            secondary: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_782_000_000),
+            dataConfidence: .percentOnly)
+    }
+
+    private static let successfulCLI = ProviderFetchAttempt(
+        strategyID: "claude.cli", kind: .cli, wasAvailable: true, errorDescription: nil)
+
+    @Test(arguments: [ClaudeUsageDataSource.auto, .cli])
+    func `successful identity-less CLI usage offers switch account`(source: ClaudeUsageDataSource) {
+        let actions = self.actions(
+            source: source,
+            snapshot: Self.identitylessCLIUsage(),
+            rawSourceLabel: "claude",
+            attempts: [
+                ProviderFetchAttempt(
+                    strategyID: "claude.oauth",
+                    kind: .oauth,
+                    wasAvailable: true,
+                    errorDescription: "OAuth credentials not found"),
+                Self.successfulCLI,
+            ])
+
+        #expect(actions.contains { $0.0 == "Switch Account..." && $0.1 == .switchAccount(.claude) })
+        #expect(!actions.contains { $0.0 == "Sign in with Claude Code..." || $0.0 == "Add Account..." })
+    }
+
+    @Test(arguments: [nil, "history", "oauth", "cli"] as [String?])
+    func `CLI attempts without a published CLI source do not authenticate history`(sourceLabel: String?) {
+        let actions = self.actions(
+            source: .auto,
+            snapshot: Self.identitylessCLIUsage(),
+            rawSourceLabel: sourceLabel,
+            attempts: [Self.successfulCLI])
+
+        #expect(actions.contains { $0.0 == "Sign in with Claude Code..." })
+    }
+
+    @Test
+    func `retained CLI usage after failed unavailable or absent attempts still offers sign in`() {
+        let attempts: [[ProviderFetchAttempt]] = [
+            [],
+            [.init(strategyID: "claude.cli", kind: .cli, wasAvailable: false, errorDescription: nil)],
+            [.init(strategyID: "claude.cli", kind: .cli, wasAvailable: true, errorDescription: "Timed out")],
+            [
+                Self.successfulCLI,
+                .init(strategyID: "claude.web", kind: .web, wasAvailable: true, errorDescription: nil),
+            ],
+        ]
+        for attempt in attempts {
+            let actions = self.actions(
+                source: .auto, snapshot: Self.identitylessCLIUsage(), rawSourceLabel: "claude", attempts: attempt)
+
+            #expect(actions.contains { $0.0 == "Sign in with Claude Code..." })
+            #expect(!actions.contains { $0.0 == "Switch Account..." })
+        }
+    }
+
+    @Test
+    func `CLI success without a quota snapshot does not authenticate an account`() {
+        for snapshot in [nil, Self.identitylessCLIUsage(hasRateLimits: false)] {
+            let actions = self.actions(
+                source: .cli, snapshot: snapshot, rawSourceLabel: "claude", attempts: [Self.successfulCLI])
+
+            #expect(actions.contains { $0.0 == "Sign in with Claude Code..." })
+        }
+    }
+
+    @Test
+    func `current recovery errors retain priority over an earlier CLI success`() {
+        let actions = self.actions(
+            error: ClaudeOAuthUnreadableCredentialsError.descriptionPrefix,
+            source: .auto,
+            snapshot: Self.identitylessCLIUsage(),
+            rawSourceLabel: "claude",
+            attempts: [Self.successfulCLI])
+
+        #expect(actions.contains {
+            $0.0 == "Allow reading Claude Code's credentials in Settings…" &&
+                $0.1 == .providerSettings(.claude)
+        })
+        #expect(!actions.contains { $0.0 == "Switch Account..." })
+    }
+
+    @Test(arguments: [1, 2])
+    func `swap account presentation keeps ambient sign in after CLI success`(count: Int) {
+        let actions = self.actions(
+            source: .auto,
+            snapshot: Self.identitylessCLIUsage(),
+            rawSourceLabel: "claude",
+            claudeSwapAccountCount: count,
+            showSingleSwapAccount: true,
+            attempts: [Self.successfulCLI])
+
+        #expect(actions.contains { $0.0 == "Sign in with Claude Code..." && $0.1 == .switchAccount(.claude) })
+        #expect(!actions.contains { $0.0 == "Switch Account..." })
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2176,12 +2176,16 @@ struct ProviderArchitectureGatekeeperTests {
             line: 667,
             anchor: "let target = provider ?? store.enabledFirstPartyProviders().first ?? .codex",
             expectedProviderIDs: ["claude", "codex"],
-            expectedReferenceCount: 4,
-            expectedReferenceFingerprint: ["codex@0", "codex@4", "claude@11", "claude@12"],
-            reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
+            expectedReferenceCount: 9,
+            expectedReferenceFingerprint: [
+                "codex@0", "codex@4", "claude@11", "claude@12", "claude@18", "claude@20", "claude@21", "claude@21",
+                "claude@22",
+            ],
+            reason: "Claude account actions accept proven CLI quota success without inventing identity; " +
+                "Codex retains its default-provider fallback."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 695,
+            line: 707,
             anchor: "if provider == .factory, snapshot.tertiary != nil {",
             expectedProviderIDs: ["alibabatokenplan", "amp", "codex", "crof", "doubao", "factory", "grok", "sub2api"],
             expectedReferenceCount: 11,
@@ -2201,7 +2205,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuDescriptor.swift",
-            line: 770,
+            line: 782,
             anchor: "let cleaned = if provider == .codex {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -223,6 +223,7 @@ Model-scoped weekly-window proof (synthetic data, no real accounts or credential
   - Extracts percent left/used and reset text near those headers.
   - When a reset date cannot be parsed, the menu preserves its description and normalizes leading `Reset` or `Resets` labels once, including scoped weekly limits.
   - Parses `Account:` and `Org:` lines when present.
+  - A successful CLI quota read keeps the menu's Switch Account action even when optional identity fields are absent. Restored history and failed refreshes do not count as a successful sign-in.
   - Surfaces CLI errors (e.g. token expired) directly.
   - Some Education and organization-managed subscriptions return only a subscription notice, with no numeric
     session or weekly quota fields. CodexBar reports those limits as unavailable, keeps local cost/token history


### PR DESCRIPTION
A successful Claude CLI quota read can omit optional identity fields. The menu then offered “Sign in with Claude Code…” despite showing fresh usage. Recognize that published CLI success and retain the normal Switch Account action without manufacturing an email or plan.

The decision requires rate windows, the raw CLI source, no current error, and the final available, successful CLI attempt. Restored history and retained snapshots after failed refreshes do not qualify. Existing recovery and claude-swap actions keep their priority. The touched tests now use dictionary-backed settings and isolated stores.

Partial fix for #3395; external-login recovery remains open. Thanks @PoroGramr for the report.

Validation: the new regression failed on main in Auto and explicit CLI modes, then passed with the fix. All 22 Claude menu tests pass; combined focused tests pass with QuickJS (47 tests), and z.ai/parity tests pass with JavaScriptCore (25 tests). `make check` passes. Scoped Codex review found no blocking findings. Full `make test` passed: 1,003 selections in 84 groups, zero failures/retries/timeouts. The first full run caught the architecture inventory needing its exact fingerprint and shifted anchors updated; enforcement is retained, and the final 73-test focused run includes that gate.

Live proof: freshly built Developer ID signed native app, production `MenuContent`/`MenuDescriptor`, synthetic isolated stores and inert action callbacks. Clicking Switch Account dispatches `switchAccount(.claude)`. Auto and explicit CLI work; restored history and failed refreshes retain Sign in; a current OAuth error retains its recovery action. The adjacent z.ai card is the other independently scoped fix in this test batch.

| Before | After |
| --- | --- |
| ![Successful CLI still offered Sign in; synthetic native fixture](https://github.com/user-attachments/assets/55edb885-2749-41a0-bd02-d2224484e902) | ![Successful CLI offers Switch Account; synthetic native fixture](https://github.com/user-attachments/assets/881b0538-bb28-4efe-89a9-7293df99543e) |

