### PR TITLE
fix(zai): suppress impossible five-hour reset timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- z.ai: omit impossible five-hour Coding Plan reset timestamps and prevent cached resets from restoring them, retaining quota percentages and valid weekly/MCP dates (partial mitigation for #2871). Thanks @carolitascl!
 - Cost history: keep tall charts in a bounded scroll view so switching Token/Cost no longer jumps the native menu or undoes an immediate wheel scroll (#3380). Thanks @Yuxin-Qiao!
 - z.ai: abbreviate large model token totals with M/B while preserving exact hourly and daily chart values (#3308, #3310). Thanks @medpath1024 and @fantasy!
 - Settings: disable iCloud sync sub-options when the main sync switch is off, preserving their saved choices for the next time sync is enabled (#3406). Thanks @elijahfriedman!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 ### Fixed
-- z.ai: omit impossible five-hour Coding Plan reset timestamps and prevent cached resets from restoring them, retaining quota percentages and valid weekly/MCP dates (partial mitigation for #2871). Thanks @carolitascl!
 - Cost history: keep tall charts in a bounded scroll view so switching Token/Cost no longer jumps the native menu or undoes an immediate wheel scroll (#3380). Thanks @Yuxin-Qiao!
 - z.ai: abbreviate large model token totals with M/B while preserving exact hourly and daily chart values (#3308, #3310). Thanks @medpath1024 and @fantasy!
 - Settings: disable iCloud sync sub-options when the main sync switch is off, preserving their saved choices for the next time sync is enabled (#3406). Thanks @elijahfriedman!
@@ -15,6 +14,7 @@
 - Claude: offer Switch Account after a successful CLI quota read without identity fields, while preserving recovery actions for failed refreshes and restored history (partial fix for #3395). Thanks @PoroGramr!
 - Usage & Spend: prefer heatmap tooltips above hovered cells and keep them within narrow grids; retain daily keyboard selection without the extra system focus rectangle (#3407). Thanks @elijahfriedman!
 - Codex: show extra-credit spend and limits with a distinct purchased balance; reconcile cap and balance freshness independently so confirmed zero balances stay cleared and monthly bars agree with their totals (#3296). Thanks @sf-jin-ku!
+- z.ai: omit impossible five-hour Coding Plan reset timestamps and prevent cached resets from restoring them, retaining quota percentages and valid weekly/MCP dates (partial mitigation for #2871). Thanks @carolitascl!
 
 ## 0.56.4 — 2026-09-03
 

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -97,7 +97,10 @@ defineProvider({
       } else if (limit.windowMinutes !== null) {
         result.windowMinutes = limit.windowMinutes;
       }
-      if (limit.reset !== null) result.resetsAt = ctx.date.unixMillis(limit.reset);
+      // A five-hour Coding Plan reset cannot be ten hours away; never guess a timezone correction.
+      const isFiveHourPlan = limit.raw.type !== "TIME_LIMIT" && limit.windowMinutes === 300;
+      const resetIsPlausible = !isFiveHourPlan || limit.reset <= ctx.date.nowMillis() + (5 * 3600 + 60) * 1000;
+      if (limit.reset !== null && resetIsPlausible) result.resetsAt = ctx.date.unixMillis(limit.reset);
       if (limit.raw.type === "TIME_LIMIT") result.resetDescription = "MCP";
       else if (limit.windowMinutes === 300) result.resetDescription = "5-hour";
       else if (limit.windowMinutes !== null) {

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -409,6 +409,19 @@ public struct UsageSnapshot: Codable, Sendable {
     public func backfillingResetTimes(from cached: UsageSnapshot?, now: Date = .init()) -> UsageSnapshot {
         guard let cached else { return self }
         guard Self.identitiesMatch(self.identity, cached.identity) else { return self }
+        func eligibleCachedReset(_ candidate: RateWindow?, for current: RateWindow?) -> RateWindow? {
+            // Provider-specific by design: z.ai's five-hour Coding Plan must not regain an impossible reset.
+            guard self.identity?.providerID == .zai,
+                  current?.windowMinutes == 300, current?.resetDescription == "5-hour"
+            else { return candidate }
+            guard cached.identity?.providerID == self.identity?.providerID,
+                  candidate?.windowMinutes == 300, candidate?.resetDescription == "5-hour",
+                  let reset = candidate?.resetsAt,
+                  reset.timeIntervalSince1970.isFinite,
+                  reset.timeIntervalSince(now) <= 5 * 3600 + 60
+            else { return nil }
+            return candidate
+        }
         // Amp's percentage-based daily quota supersedes the legacy rolling-replenishment cadence. Do not attach
         // that older exact reset to the new daily window; other providers retain the shared backfill behavior.
         // Provider-specific by design: Amp daily quotas must not inherit its obsolete rolling-reset cadence.
@@ -419,9 +432,12 @@ public struct UsageSnapshot: Codable, Sendable {
         } else {
             cached.primary
         }
-        let primary = self.primary?.backfillingResetTime(from: cachedPrimary, now: now)
-        let secondary = self.secondary?.backfillingResetTime(from: cached.secondary, now: now)
-        let tertiary = self.tertiary?.backfillingResetTime(from: cached.tertiary, now: now)
+        let primary = self.primary?.backfillingResetTime(
+            from: eligibleCachedReset(cachedPrimary, for: self.primary), now: now)
+        let secondary = self.secondary?.backfillingResetTime(
+            from: eligibleCachedReset(cached.secondary, for: self.secondary), now: now)
+        let tertiary = self.tertiary?.backfillingResetTime(
+            from: eligibleCachedReset(cached.tertiary, for: self.tertiary), now: now)
         if primary == self.primary, secondary == self.secondary, tertiary == self.tertiary {
             return self
         }

--- a/Tests/CodexBarTests/ClaudeProviderRuntimeTests.swift
+++ b/Tests/CodexBarTests/ClaudeProviderRuntimeTests.swift
@@ -92,10 +92,19 @@ struct ClaudeProviderRuntimeTests {
 
         store.scheduleClaudeSwapAccountRefresh()
         let first = try #require(store.claudeSwapRefreshTask)
-        for _ in 0..<100 where !FileManager.default.fileExists(atPath: fixture.countURL.path) {
-            try await Task.sleep(for: .milliseconds(10))
+        do {
+            let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+            while (try? String(contentsOf: fixture.countURL, encoding: .utf8)) != "1\n",
+                  ContinuousClock.now < deadline
+            {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            try #require(try String(contentsOf: fixture.countURL, encoding: .utf8) == "1\n")
+        } catch {
+            first.cancel()
+            await first.value
+            throw error
         }
-        #expect(FileManager.default.fileExists(atPath: fixture.countURL.path))
 
         store.scheduleClaudeSwapAccountRefresh()
         let replacement = try #require(store.claudeSwapRefreshTask)

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1572,7 +1572,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This tagged diagnostic payload encodes MiniMax details under the matching wire key."),
         SuppressedProviderReference(
             path: "Sources/CodexBarCore/UsageFetcher.swift",
-            line: 1510,
+            line: 1526,
             anchor: "providerID: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific core branch passes its already-selected identity to a shared helper."),

--- a/TestsPlugin/ZaiPluginResetTests.swift
+++ b/TestsPlugin/ZaiPluginResetTests.swift
@@ -1,0 +1,121 @@
+import CodexBarCore
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+
+struct ZaiPluginResetTests {
+    private static let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test(arguments: ["TOKENS_LIMIT", "CREDIT_LIMIT"])
+    func `five hour windows omit impossible resets and preserve quota`(type: String) async throws {
+        for offset in [TimeInterval(36000), 18060.001] {
+            let snapshot = try await Self.fetch(type: type, resetOffset: offset)
+            #expect(snapshot.primary?.resetsAt == nil)
+            #expect(snapshot.primary?.usedPercent == 25)
+            #expect(snapshot.primary?.windowMinutes == 300)
+            #expect(snapshot.primary?.resetDescription == "5-hour")
+            #expect(snapshot.secondary?.resetsAt == Self.now.addingTimeInterval(6 * 86400))
+            #expect(snapshot.extraRateWindows?.first?.window.resetsAt == Self.now.addingTimeInterval(20 * 86400))
+        }
+    }
+
+    @Test(arguments: [TimeInterval(-60), 0, 3600, 18000, 18060])
+    func `valid five hour resets retain their exact timestamp`(offset: TimeInterval) async throws {
+        let snapshot = try await Self.fetch(type: "TOKENS_LIMIT", resetOffset: offset)
+        #expect(snapshot.primary?.resetsAt == Self.now.addingTimeInterval(offset))
+    }
+
+    @Test(arguments: [TimeInterval(3600), 18060, 18061, 36000])
+    func `refresh cannot restore an impossible cached five hour reset`(offset: TimeInterval) async throws {
+        let snapshot = try await Self.fetch(type: "CREDIT_LIMIT", resetOffset: 36000)
+        let cached = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 300,
+                resetsAt: Self.now.addingTimeInterval(offset),
+                resetDescription: "5-hour"),
+            secondary: nil,
+            updatedAt: Self.now.addingTimeInterval(-60),
+            identity: snapshot.identity)
+
+        let published = snapshot.backfillingResetTimes(from: cached, now: Self.now)
+        #expect(published.primary?.resetsAt == (offset <= 18060 ? Self.now.addingTimeInterval(offset) : nil))
+        #expect(published.primary?.usedPercent == 25)
+    }
+
+    @Test
+    func `five hour backfill rejects unrelated window evidence in every quota slot`() {
+        let identity = Self.identity(.zai)
+        let current = RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: "5-hour")
+        let snapshot = UsageSnapshot(
+            primary: current, secondary: current, tertiary: current, updatedAt: Self.now, identity: identity)
+        let reset = Self.now.addingTimeInterval(3600)
+        for (duration, label, provider) in [
+            (Optional(10080), "1 week window", UsageProvider.zai),
+            (nil, "5-hour", .zai),
+            (300, "MCP", .zai),
+            (300, "5-hour", .claude),
+        ] {
+            let candidate = RateWindow(
+                usedPercent: 10, windowMinutes: duration, resetsAt: reset, resetDescription: label)
+            let cached = UsageSnapshot(
+                primary: candidate, secondary: candidate, tertiary: candidate,
+                updatedAt: Self.now, identity: Self.identity(provider))
+            let published = snapshot.backfillingResetTimes(from: cached, now: Self.now)
+            #expect(published.primary?.resetsAt == nil)
+            #expect(published.secondary?.resetsAt == nil)
+            #expect(published.tertiary?.resetsAt == nil)
+        }
+    }
+
+    @Test
+    func `five hour mitigation preserves MCP and other provider backfill`() {
+        let reset = Self.now.addingTimeInterval(36000)
+        for (provider, label) in [(UsageProvider.zai, "MCP"), (.claude, "5-hour")] {
+            let identity = Self.identity(provider)
+            let snapshot = UsageSnapshot(
+                primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: label),
+                secondary: nil, updatedAt: Self.now, identity: identity)
+            let cached = UsageSnapshot(
+                primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: reset, resetDescription: label),
+                secondary: nil, updatedAt: Self.now, identity: identity)
+            #expect(snapshot.backfillingResetTimes(from: cached, now: Self.now).primary?.resetsAt == reset)
+        }
+    }
+
+    private static func identity(_ provider: UsageProvider) -> ProviderIdentitySnapshot {
+        ProviderIdentitySnapshot(
+            providerID: provider.instanceID, accountEmail: nil, accountOrganization: nil, loginMethod: nil)
+    }
+
+    private static func fetch(type: String, resetOffset: TimeInterval) async throws -> UsageSnapshot {
+        let resetMillis = Int64(Self.now.addingTimeInterval(resetOffset).timeIntervalSince1970 * 1000)
+        let weeklyMillis = Int64(Self.now.addingTimeInterval(6 * 86400).timeIntervalSince1970 * 1000)
+        let mcpMillis = Int64(Self.now.addingTimeInterval(20 * 86400).timeIntervalSince1970 * 1000)
+        let body = """
+        {"code":200,"success":true,"data":{"limits":[
+          {"type":"\(type)","unit":3,"number":5,"percentage":25,"nextResetTime":\(resetMillis)},
+          {"type":"\(type)","unit":6,"number":1,"percentage":9,"nextResetTime":\(weeklyMillis)},
+          {"type":"TIME_LIMIT","unit":5,"number":1,"percentage":22,"nextResetTime":\(mcpMillis)}
+        ]}}
+        """
+        let runtime = try ProviderPluginRuntime(
+            bundledPlugin: "zai",
+            transport: ProviderHTTPTransportHandler { request in
+                let url = try #require(request.url)
+                let isQuota = url.path.hasSuffix("/quota/limit")
+                let response = try #require(HTTPURLResponse(
+                    url: url,
+                    statusCode: isQuota ? 200 : 503,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]))
+                return (Data((isQuota ? body : "{}").utf8), response)
+            })
+        return try await runtime.fetchUsage(
+            settings: ["Z_AI_REGION": "global", "Z_AI_USAGE_SCOPE": "personal"],
+            secrets: ["Z_AI_API_KEY": "fixture-key"],
+            now: Self.now)
+    }
+}

--- a/docs/zai.md
+++ b/docs/zai.md
@@ -146,6 +146,7 @@ Copy each value once, on one line. Multi-line or duplicated IDs can make the API
   - Unit + number → minutes/hours/days.
 - Reset:
   - `nextResetTime` (epoch ms) → date.
+  - Five-hour Coding Plan resets more than five hours plus one minute of clock skew in the future are omitted, including incompatible cached resets. Usage percentages remain visible; no timezone correction is guessed. Weekly and MCP reset semantics are unchanged.
 - Usage details:
   - `usageDetails[]` per model (MCP usage list).
   - Hourly and daily model token totals use compact M/B labels from one million upward; smaller totals remain exact. Chart points retain their full numeric values.


### PR DESCRIPTION
z.ai can return a reset timestamp beyond the duration of its five-hour Coding Plan window. The plugin previously displayed that impossible date, and ordinary refresh backfilling could restore it from cache even after parsing omitted it.

Omit five-hour Coding Plan dates more than five hours plus one minute of clock skew ahead of the fetch time. Keep quota percentages and valid dates. Cached evidence must match the provider and five-hour Coding Plan window and satisfy the same bound. Weekly, MCP, and other-provider behavior is preserved. No timezone offset is guessed.

Partial mitigation for #2871; the upstream field mismatch and the reporter's complete payload remain unconfirmed. Keep that issue open. Thanks @carolitascl for the report.

Validation:
- The production bundled-plugin fixture fails on main for impossible timestamps; the candidate passes the plugin-to-backfill path, valid boundary dates, incompatible cache evidence, and MCP/other-provider controls.
- Focused reset, Amp, plugin parity, and architecture suites: 85 Swift Testing tests passed, plus XCTest reset coverage.
- Plugin parity and new regressions also passed under JavaScriptCore (20 tests).
- `make check` passed; `make test` passed 1,009 selections across 85 groups, with one successful standard group retry and no timeouts. No z.ai test failed.
- The retry exposed a Claude version-probe fixture race. The fixture now requires the complete first-probe readiness marker before cancellation/replacement, with bounded waiting and task cleanup on failure. Final focused Claude runtime and z.ai regressions passed; production Claude behavior is unchanged.
- Final-head CI: [run 33860989854](https://github.com/steipete/CodexBar/actions/runs/33860989854), passed; all nine checks are green.
- Independent code review found no actionable issues; required Codex autoreview was scoped-clean at P0.

Tests use synthetic quota responses and an injected fetch clock; no live account or system clock changes were needed. Changelog and provider documentation are updated.
