### PR TITLE
Update provider branding color palettes

### DIFF
--- a/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
@@ -43,9 +43,9 @@ public enum AbacusProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .abacus),
                 iconResourceName: "ProviderIcon-abacus",
-                color: ProviderColor(red: 56 / 255, green: 189 / 255, blue: 248 / 255),
+                color: ProviderColor(red: 129 / 255, green: 78 / 255, blue: 232 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x35BEE2),
+                    ProviderColor(hex: 0x814EE8),
                     ProviderColor(hex: 0xC64AF9),
                     ProviderColor(hex: 0xFFFFFF),
                 ]),

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
@@ -48,7 +48,8 @@ public enum AbacusProviderDescriptor {
                     ProviderColor(hex: 0x814EE8),
                     ProviderColor(hex: 0xC64AF9),
                     ProviderColor(hex: 0xFFFFFF),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 56 / 255, green: 189 / 255, blue: 248 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Abacus AI cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/AiAnd/AiAndProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/AiAnd/AiAndProviderDescriptor.swift
@@ -34,7 +34,8 @@ public enum AiAndProviderDescriptor {
                     ProviderColor(hex: 0xC70007),
                     ProviderColor(hex: 0xF2A17E),
                     ProviderColor(hex: 0x33231C),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 226 / 255, green: 92 / 255, blue: 43 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "ai& spend is summed from the request logs API." }),

--- a/Sources/CodexBarCore/Providers/AiAnd/AiAndProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/AiAnd/AiAndProviderDescriptor.swift
@@ -29,9 +29,9 @@ public enum AiAndProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .aiand),
                 iconResourceName: "ProviderIcon-aiand",
-                color: ProviderColor(red: 226 / 255, green: 92 / 255, blue: 43 / 255),
+                color: ProviderColor(red: 199 / 255, green: 0 / 255, blue: 7 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0xE25C2B),
+                    ProviderColor(hex: 0xC70007),
                     ProviderColor(hex: 0xF2A17E),
                     ProviderColor(hex: 0x33231C),
                 ]),

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -38,7 +38,8 @@ public enum AmpProviderDescriptor {
                     ProviderColor(hex: 0x091C1E),
                     ProviderColor(hex: 0xDFDFC1),
                     ProviderColor(hex: 0xF34E3F),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 220 / 255, green: 38 / 255, blue: 38 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Amp cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -33,11 +33,11 @@ public enum AmpProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .amp),
                 iconResourceName: "ProviderIcon-amp",
-                color: ProviderColor(red: 220 / 255, green: 38 / 255, blue: 38 / 255),
+                color: ProviderColor(red: 243 / 255, green: 78 / 255, blue: 63 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x091C1E),
                     ProviderColor(hex: 0xDFDFC1),
-                    ProviderColor(hex: 0xD97706),
+                    ProviderColor(hex: 0xF34E3F),
                 ]),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,

--- a/Sources/CodexBarCore/Providers/Augment/AugmentProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentProviderDescriptor.swift
@@ -70,7 +70,8 @@ public enum AugmentProviderDescriptor {
                     ProviderColor(hex: 0x1AA049),
                     ProviderColor(hex: 0x111111),
                     ProviderColor(hex: 0xFFF7ED),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 99 / 255, green: 102 / 255, blue: 241 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Augment cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Augment/AugmentProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentProviderDescriptor.swift
@@ -65,9 +65,9 @@ public enum AugmentProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .augment),
                 iconResourceName: "ProviderIcon-augment",
-                color: ProviderColor(red: 99 / 255, green: 102 / 255, blue: 241 / 255),
+                color: ProviderColor(red: 26 / 255, green: 160 / 255, blue: 73 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0xF97316),
+                    ProviderColor(hex: 0x1AA049),
                     ProviderColor(hex: 0x111111),
                     ProviderColor(hex: 0xFFF7ED),
                 ]),

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderDescriptor.swift
@@ -53,7 +53,8 @@ public enum BedrockProviderDescriptor {
                     ProviderColor(hex: 0x01A88D),
                     ProviderColor(hex: 0x232F3E),
                     ProviderColor(hex: 0xFF9900),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 1, green: 0.6, blue: 0)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: true,
                 noDataMessage: { "No AWS Bedrock cost data available. Check your AWS access keys "

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderDescriptor.swift
@@ -48,7 +48,7 @@ public enum BedrockProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .bedrock),
                 iconResourceName: "ProviderIcon-bedrock",
-                color: ProviderColor(red: 1, green: 0.6, blue: 0),
+                color: ProviderColor(red: 1 / 255, green: 168 / 255, blue: 141 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x01A88D),
                     ProviderColor(hex: 0x232F3E),

--- a/Sources/CodexBarCore/Providers/Chutes/ChutesProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Chutes/ChutesProviderDescriptor.swift
@@ -33,7 +33,7 @@ public enum ChutesProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .chutes),
                 iconResourceName: "ProviderIcon-chutes",
-                color: ProviderColor(red: 49 / 255, green: 132 / 255, blue: 255 / 255),
+                color: ProviderColor(red: 99 / 255, green: 210 / 255, blue: 151 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x121212),
                     ProviderColor(hex: 0xFFFFFF),

--- a/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
@@ -32,10 +32,10 @@ public enum ClawRouterProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .clawrouter),
                 iconResourceName: "ProviderIcon-clawrouter",
-                color: ProviderColor(red: 89 / 255, green: 110 / 255, blue: 246 / 255),
+                color: ProviderColor(red: 31 / 255, green: 90 / 255, blue: 224 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x332CB3),
-                    ProviderColor(hex: 0x456FDD),
+                    ProviderColor(hex: 0x1F5AE0),
                     ProviderColor(hex: 0xFFFFFF),
                 ]),
             tokenCost: ProviderTokenCostConfig(

--- a/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterProviderDescriptor.swift
@@ -37,7 +37,8 @@ public enum ClawRouterProviderDescriptor {
                     ProviderColor(hex: 0x332CB3),
                     ProviderColor(hex: 0x1F5AE0),
                     ProviderColor(hex: 0xFFFFFF),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 89 / 255, green: 110 / 255, blue: 246 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "ClawRouter spend is reported by its usage API." }),

--- a/Sources/CodexBarCore/Providers/ClinePass/ClinePassProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ClinePass/ClinePassProviderDescriptor.swift
@@ -38,7 +38,8 @@ public enum ClinePassProviderDescriptor {
                     ProviderColor(hex: 0x5487C8),
                     ProviderColor(hex: 0x111111),
                     ProviderColor(hex: 0xFFFFFF),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 0.38, green: 0.64, blue: 0.98)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "ClinePass cost history is not available via the usage-limits API." }),

--- a/Sources/CodexBarCore/Providers/ClinePass/ClinePassProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ClinePass/ClinePassProviderDescriptor.swift
@@ -33,9 +33,9 @@ public enum ClinePassProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .clinepass),
                 iconResourceName: "ProviderIcon-clinepass",
-                color: ProviderColor(red: 0.38, green: 0.64, blue: 0.98),
+                color: ProviderColor(red: 84 / 255, green: 135 / 255, blue: 200 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x61A3FA),
+                    ProviderColor(hex: 0x5487C8),
                     ProviderColor(hex: 0x111111),
                     ProviderColor(hex: 0xFFFFFF),
                 ]),

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
@@ -48,9 +48,9 @@ public enum CodebuffProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .codebuff),
                 iconResourceName: "ProviderIcon-codebuff",
-                color: ProviderColor(red: 68 / 255, green: 255 / 255, blue: 0 / 255),
+                color: ProviderColor(red: 0 / 255, green: 255 / 255, blue: 149 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x9EFC62),
+                    ProviderColor(hex: 0x00FF95),
                     ProviderColor(hex: 0xFFFFFF),
                     ProviderColor(hex: 0x000000),
                 ]),

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
@@ -53,7 +53,8 @@ public enum CodebuffProviderDescriptor {
                     ProviderColor(hex: 0x00FF95),
                     ProviderColor(hex: 0xFFFFFF),
                     ProviderColor(hex: 0x000000),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 68 / 255, green: 255 / 255, blue: 0 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Codebuff cost summary is not yet supported." }),

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeProviderDescriptor.swift
@@ -33,11 +33,11 @@ public enum CommandCodeProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .commandcode),
                 iconResourceName: "ProviderIcon-commandcode",
-                color: ProviderColor(hex: 0xA04DFD),
+                color: ProviderColor(hex: 0x8C4EDD),
                 confettiPalette: [
                     ProviderColor(hex: 0x000000),
                     ProviderColor(hex: 0xFFFFFF),
-                    ProviderColor(hex: 0x7B5BFF),
+                    ProviderColor(hex: 0x8C4EDD),
                 ],
                 widgetColor: ProviderColor(hex: 0x000000)),
             tokenCost: ProviderTokenCostConfig(

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
@@ -65,7 +65,8 @@ public enum CopilotProviderDescriptor {
                     ProviderColor(hex: 0x8534F3),
                     ProviderColor(hex: 0xF08A3A),
                     ProviderColor(hex: 0xC898FD),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 168 / 255, green: 85 / 255, blue: 247 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Copilot cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
@@ -60,7 +60,7 @@ public enum CopilotProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .copilot),
                 iconResourceName: "ProviderIcon-copilot",
-                color: ProviderColor(red: 168 / 255, green: 85 / 255, blue: 247 / 255),
+                color: ProviderColor(red: 133 / 255, green: 52 / 255, blue: 243 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x8534F3),
                     ProviderColor(hex: 0xF08A3A),

--- a/Sources/CodexBarCore/Providers/Crof/CrofProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Crof/CrofProviderDescriptor.swift
@@ -35,7 +35,7 @@ public enum CrofProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .crof),
                 iconResourceName: "ProviderIcon-crof",
-                color: ProviderColor(red: 0.18, green: 0.67, blue: 0.58),
+                color: ProviderColor(red: 139 / 255, green: 124 / 255, blue: 255 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x0A0A0A),
                     ProviderColor(hex: 0x8B7CFF),

--- a/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
@@ -66,7 +66,8 @@ public enum CursorProviderDescriptor {
                     ProviderColor(hex: 0xF54E00),
                     ProviderColor(hex: 0x1B1913),
                     ProviderColor(hex: 0xEDECEC),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 0 / 255, green: 191 / 255, blue: 165 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: true,
                 noDataMessage: { "No Cursor cost usage found. Sign in to Cursor in your browser or the Cursor app." },

--- a/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
@@ -61,8 +61,9 @@ public enum CursorProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .cursor),
                 iconResourceName: "ProviderIcon-cursor",
-                color: ProviderColor(red: 0 / 255, green: 191 / 255, blue: 165 / 255),
+                color: ProviderColor(red: 245 / 255, green: 78 / 255, blue: 0 / 255),
                 confettiPalette: [
+                    ProviderColor(hex: 0xF54E00),
                     ProviderColor(hex: 0x1B1913),
                     ProviderColor(hex: 0xEDECEC),
                 ]),

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderDescriptor.swift
@@ -95,7 +95,7 @@ public enum DeepSeekProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .deepseek),
                 iconResourceName: "ProviderIcon-deepseek",
-                color: ProviderColor(red: 0.32, green: 0.49, blue: 0.94),
+                color: ProviderColor(red: 77 / 255, green: 107 / 255, blue: 254 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x4D6BFE),
                     ProviderColor(hex: 0x3982FF),

--- a/Sources/CodexBarCore/Providers/Deepgram/DeepgramProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Deepgram/DeepgramProviderDescriptor.swift
@@ -50,11 +50,11 @@ public enum DeepgramProviderDescriptor {
                 iconStyle: .init(provider: .deepgram),
                 iconResourceName: "ProviderIcon-deepgram",
                 color: ProviderColor(
-                    red: 100 / 255,
-                    green: 103 / 255,
-                    blue: 242 / 255),
+                    red: 19 / 255,
+                    green: 239 / 255,
+                    blue: 147 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x13EF95),
+                    ProviderColor(hex: 0x13EF93),
                     ProviderColor(hex: 0x149AFB),
                     ProviderColor(hex: 0x1A1A1F),
                 ],

--- a/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
@@ -46,10 +46,10 @@ public enum DevinProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .devin),
                 iconResourceName: "ProviderIcon-devin",
-                color: ProviderColor(red: 70 / 255, green: 180 / 255, blue: 130 / 255),
+                color: ProviderColor(red: 49 / 255, green: 124 / 255, blue: 255 / 255),
                 confettiPalette: [
+                    ProviderColor(hex: 0x317CFF),
                     ProviderColor(hex: 0x000000),
-                    ProviderColor(hex: 0x626870),
                     ProviderColor(hex: 0xFFFFFF),
                 ]),
             tokenCost: ProviderTokenCostConfig(

--- a/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
@@ -51,7 +51,8 @@ public enum DevinProviderDescriptor {
                     ProviderColor(hex: 0x317CFF),
                     ProviderColor(hex: 0x000000),
                     ProviderColor(hex: 0xFFFFFF),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 70 / 255, green: 180 / 255, blue: 130 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Devin cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoProviderDescriptor.swift
@@ -52,7 +52,7 @@ public enum DoubaoProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .doubao),
                 iconResourceName: "ProviderIcon-doubao",
-                color: ProviderColor(red: 51 / 255, green: 112 / 255, blue: 255 / 255),
+                color: ProviderColor(red: 0 / 255, green: 87 / 255, blue: 255 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x0057FF),
                     ProviderColor(hex: 0xEFC5BA),

--- a/Sources/CodexBarCore/Providers/Fireworks/FireworksProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Fireworks/FireworksProviderDescriptor.swift
@@ -37,9 +37,9 @@ public enum FireworksProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .fireworks),
                 iconResourceName: "ProviderIcon-fireworks",
-                color: ProviderColor(red: 242 / 255, green: 91 / 255, blue: 28 / 255),
+                color: ProviderColor(red: 103 / 255, green: 32 / 255, blue: 255 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0xE65618),
+                    ProviderColor(hex: 0x6720FF),
                     ProviderColor(hex: 0xFF9A3C),
                     ProviderColor(hex: 0x2B2B2E),
                 ]),

--- a/Sources/CodexBarCore/Providers/Fireworks/FireworksProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Fireworks/FireworksProviderDescriptor.swift
@@ -42,7 +42,8 @@ public enum FireworksProviderDescriptor {
                     ProviderColor(hex: 0x6720FF),
                     ProviderColor(hex: 0xFF9A3C),
                     ProviderColor(hex: 0x2B2B2E),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 242 / 255, green: 91 / 255, blue: 28 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Fireworks spend comes from the billing summary API; cost history is not tracked." }),

--- a/Sources/CodexBarCore/Providers/Groq/GroqProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqProviderDescriptor.swift
@@ -40,9 +40,9 @@ public enum GroqProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .groq),
                 iconResourceName: "ProviderIcon-groq",
-                color: ProviderColor(red: 245 / 255, green: 104 / 255, blue: 68 / 255),
+                color: ProviderColor(red: 245 / 255, green: 80 / 255, blue: 54 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0xF43E01),
+                    ProviderColor(hex: 0xF55036),
                     ProviderColor(hex: 0xFFFFFF),
                     ProviderColor(hex: 0x97FCA7),
                 ]),

--- a/Sources/CodexBarCore/Providers/Groq/GroqProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqProviderDescriptor.swift
@@ -45,7 +45,8 @@ public enum GroqProviderDescriptor {
                     ProviderColor(hex: 0xF55036),
                     ProviderColor(hex: 0xFFFFFF),
                     ProviderColor(hex: 0x97FCA7),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 245 / 255, green: 104 / 255, blue: 68 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Sign in at console.groq.com to show Groq spend and token usage." },

--- a/Sources/CodexBarCore/Providers/JetBrains/JetBrainsProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/JetBrains/JetBrainsProviderDescriptor.swift
@@ -31,9 +31,9 @@ public enum JetBrainsProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .jetbrains),
                 iconResourceName: "ProviderIcon-jetbrains",
-                color: ProviderColor(red: 255 / 255, green: 51 / 255, blue: 153 / 255),
+                color: ProviderColor(red: 149 / 255, green: 90 / 255, blue: 224 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x6B57FF),
+                    ProviderColor(hex: 0x955AE0),
                     ProviderColor(hex: 0x21D789),
                     ProviderColor(hex: 0x000000),
                 ]),

--- a/Sources/CodexBarCore/Providers/JetBrains/JetBrainsProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/JetBrains/JetBrainsProviderDescriptor.swift
@@ -36,7 +36,8 @@ public enum JetBrainsProviderDescriptor {
                     ProviderColor(hex: 0x955AE0),
                     ProviderColor(hex: 0x21D789),
                     ProviderColor(hex: 0x000000),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 255 / 255, green: 51 / 255, blue: 153 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "JetBrains AI cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
@@ -52,9 +52,9 @@ public enum KiloProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .kilo),
                 iconResourceName: "ProviderIcon-kilo",
-                color: ProviderColor(red: 242 / 255, green: 112 / 255, blue: 39 / 255),
+                color: ProviderColor(red: 250 / 255, green: 247 / 255, blue: 79 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0xFA483A),
+                    ProviderColor(hex: 0xFAF74F),
                     ProviderColor(hex: 0xAC1D0E),
                     ProviderColor(hex: 0x121212),
                 ]),

--- a/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
@@ -57,7 +57,8 @@ public enum KiloProviderDescriptor {
                     ProviderColor(hex: 0xFAF74F),
                     ProviderColor(hex: 0xAC1D0E),
                     ProviderColor(hex: 0x121212),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 242 / 255, green: 112 / 255, blue: 39 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Kilo cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -63,7 +63,8 @@ public enum KimiProviderDescriptor {
                     ProviderColor(hex: 0x000000),
                     ProviderColor(hex: 0x007CFF),
                     ProviderColor(hex: 0xFFFFFF),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 254 / 255, green: 96 / 255, blue: 60 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Kimi Code cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -58,10 +58,10 @@ public enum KimiProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .kimi),
                 iconResourceName: "ProviderIcon-kimi",
-                color: ProviderColor(red: 254 / 255, green: 96 / 255, blue: 60 / 255),
+                color: ProviderColor(red: 0 / 255, green: 124 / 255, blue: 255 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x000000),
-                    ProviderColor(hex: 0x4E6EF2),
+                    ProviderColor(hex: 0x007CFF),
                     ProviderColor(hex: 0xFFFFFF),
                 ]),
             tokenCost: ProviderTokenCostConfig(

--- a/Sources/CodexBarCore/Providers/Kiro/KiroProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroProviderDescriptor.swift
@@ -28,9 +28,9 @@ public enum KiroProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .kiro),
                 iconResourceName: "ProviderIcon-kiro",
-                color: ProviderColor(red: 255 / 255, green: 153 / 255, blue: 0 / 255),
+                color: ProviderColor(red: 144 / 255, green: 70 / 255, blue: 255 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x8F4AFF),
+                    ProviderColor(hex: 0x9046FF),
                     ProviderColor(hex: 0xCAA9FF),
                     ProviderColor(hex: 0x2B2B2B),
                 ]),

--- a/Sources/CodexBarCore/Providers/Kiro/KiroProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroProviderDescriptor.swift
@@ -33,7 +33,8 @@ public enum KiroProviderDescriptor {
                     ProviderColor(hex: 0x9046FF),
                     ProviderColor(hex: 0xCAA9FF),
                     ProviderColor(hex: 0x2B2B2B),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 255 / 255, green: 153 / 255, blue: 0 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Kiro cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
@@ -45,7 +45,8 @@ public enum LiteLLMProviderDescriptor {
                     ProviderColor(hex: 0x191938),
                     ProviderColor(hex: 0x5B3FD1),
                     ProviderColor(hex: 0xC5B9F6),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 76 / 255, green: 137 / 255, blue: 240 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "LiteLLM spend is reported by the provider API." }),

--- a/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
@@ -40,10 +40,10 @@ public enum LiteLLMProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .litellm),
                 iconResourceName: "ProviderIcon-litellm",
-                color: ProviderColor(red: 76 / 255, green: 137 / 255, blue: 240 / 255),
+                color: ProviderColor(red: 91 / 255, green: 63 / 255, blue: 209 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x191938),
-                    ProviderColor(hex: 0x8258F2),
+                    ProviderColor(hex: 0x5B3FD1),
                     ProviderColor(hex: 0xC5B9F6),
                 ]),
             tokenCost: ProviderTokenCostConfig(

--- a/Sources/CodexBarCore/Providers/LongCat/LongCatProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/LongCat/LongCatProviderDescriptor.swift
@@ -42,9 +42,9 @@ public enum LongCatProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .longcat),
                 iconResourceName: "ProviderIcon-longcat",
-                color: ProviderColor(red: 255 / 255, green: 209 / 255, blue: 0 / 255),
+                color: ProviderColor(red: 41 / 255, green: 225 / 255, blue: 84 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0xFFD100),
+                    ProviderColor(hex: 0x29E154),
                     ProviderColor(hex: 0x111111),
                     ProviderColor(hex: 0xFFFFFF),
                 ]),

--- a/Sources/CodexBarCore/Providers/LongCat/LongCatProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/LongCat/LongCatProviderDescriptor.swift
@@ -47,7 +47,8 @@ public enum LongCatProviderDescriptor {
                     ProviderColor(hex: 0x29E154),
                     ProviderColor(hex: 0x111111),
                     ProviderColor(hex: 0xFFFFFF),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 255 / 255, green: 209 / 255, blue: 0 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "LongCat cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -49,9 +49,9 @@ public enum MistralProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .mistral),
                 iconResourceName: "ProviderIcon-mistral",
-                color: ProviderColor(red: 255 / 255, green: 80 / 255, blue: 15 / 255),
+                color: ProviderColor(red: 255 / 255, green: 82 / 255, blue: 41 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0xFA500F),
+                    ProviderColor(hex: 0xFF5229),
                     ProviderColor(hex: 0xFFAF01),
                     ProviderColor(hex: 0xFFE000),
                 ]),

--- a/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralProviderDescriptor.swift
@@ -54,7 +54,8 @@ public enum MistralProviderDescriptor {
                     ProviderColor(hex: 0xFF5229),
                     ProviderColor(hex: 0xFFAF01),
                     ProviderColor(hex: 0xFFE000),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 255 / 255, green: 80 / 255, blue: 15 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: true,
                 noDataMessage: { "Mistral cost history needs a billing web session." },

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
@@ -66,7 +66,8 @@ public enum MoonshotProviderDescriptor {
                     ProviderColor(hex: 0x000000),
                     ProviderColor(hex: 0x305140),
                     ProviderColor(hex: 0x9F9F9F),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 32 / 255, green: 93 / 255, blue: 235 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Moonshot / Kimi Open Platform cost summary is not available." }),

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
@@ -61,9 +61,9 @@ public enum MoonshotProviderDescriptor {
                 // Provider-specific by design: Moonshot's Open Platform product deliberately uses Kimi branding.
                 iconStyle: .init(provider: .kimi),
                 iconResourceName: "ProviderIcon-kimi",
-                color: ProviderColor(red: 32 / 255, green: 93 / 255, blue: 235 / 255),
+                color: ProviderColor(red: 0 / 255, green: 0 / 255, blue: 0 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x121212),
+                    ProviderColor(hex: 0x000000),
                     ProviderColor(hex: 0x305140),
                     ProviderColor(hex: 0x9F9F9F),
                 ]),

--- a/Sources/CodexBarCore/Providers/NeuralWatt/NeuralWattProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/NeuralWatt/NeuralWattProviderDescriptor.swift
@@ -42,9 +42,9 @@ public enum NeuralWattProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .neuralwatt),
                 iconResourceName: "ProviderIcon-neuralwatt",
-                color: ProviderColor(red: 0.22, green: 0.85, blue: 0.55),
+                color: ProviderColor(red: 213 / 255, green: 89 / 255, blue: 52 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x38D98C),
+                    ProviderColor(hex: 0xD55934),
                     ProviderColor(hex: 0x17243A),
                     ProviderColor(hex: 0xFFFFFF),
                 ],

--- a/Sources/CodexBarCore/Providers/Notion/NotionProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Notion/NotionProviderDescriptor.swift
@@ -65,7 +65,8 @@ public enum NotionProviderDescriptor {
                     ProviderColor(hex: 0x2EAADC),
                     ProviderColor(hex: 0xE16259),
                     ProviderColor(hex: 0x37352F),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 51 / 255, green: 126 / 255, blue: 169 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Notion AI cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Notion/NotionProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Notion/NotionProviderDescriptor.swift
@@ -60,9 +60,9 @@ public enum NotionProviderDescriptor {
                 iconResourceName: "ProviderIcon-notion",
                 // Notion's UI accent blue, not its near-black brand ink: the ink is
                 // indistinguishable from the unfilled track in a usage gauge.
-                color: ProviderColor(red: 51 / 255, green: 126 / 255, blue: 169 / 255),
+                color: ProviderColor(red: 46 / 255, green: 170 / 255, blue: 220 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x337EA9),
+                    ProviderColor(hex: 0x2EAADC),
                     ProviderColor(hex: 0xE16259),
                     ProviderColor(hex: 0x37352F),
                 ]),

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
@@ -65,7 +65,8 @@ public enum OpenCodeProviderDescriptor {
                     ProviderColor(hex: 0x211E1E),
                     ProviderColor(hex: 0xCFCECD),
                     ProviderColor(hex: 0x3B7DD8),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 59 / 255, green: 130 / 255, blue: 246 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "OpenCode cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
@@ -60,11 +60,11 @@ public enum OpenCodeProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .opencode),
                 iconResourceName: "ProviderIcon-opencode",
-                color: ProviderColor(red: 59 / 255, green: 130 / 255, blue: 246 / 255),
+                color: ProviderColor(red: 59 / 255, green: 125 / 255, blue: 216 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x211E1E),
                     ProviderColor(hex: 0xCFCECD),
-                    ProviderColor(hex: 0xFAB283),
+                    ProviderColor(hex: 0x3B7DD8),
                 ]),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
@@ -47,9 +47,9 @@ public enum PerplexityProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .perplexity),
                 iconResourceName: "ProviderIcon-perplexity",
-                color: ProviderColor(red: 32 / 255, green: 178 / 255, blue: 170 / 255),
+                color: ProviderColor(red: 32 / 255, green: 128 / 255, blue: 141 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x016A71),
+                    ProviderColor(hex: 0x20808D),
                     ProviderColor(hex: 0x313131),
                     ProviderColor(hex: 0xFDFBFA),
                 ]),

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityProviderDescriptor.swift
@@ -52,7 +52,8 @@ public enum PerplexityProviderDescriptor {
                     ProviderColor(hex: 0x20808D),
                     ProviderColor(hex: 0x313131),
                     ProviderColor(hex: 0xFDFBFA),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 32 / 255, green: 178 / 255, blue: 170 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Perplexity cost tracking is not supported." }),

--- a/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
@@ -54,7 +54,8 @@ public enum QoderProviderDescriptor {
                     ProviderColor(hex: 0x2ADB5C),
                     ProviderColor(hex: 0x111113),
                     ProviderColor(hex: 0xFFFFFF),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 16 / 255, green: 185 / 255, blue: 129 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Qoder cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Qoder/QoderProviderDescriptor.swift
@@ -49,7 +49,7 @@ public enum QoderProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .qoder),
                 iconResourceName: "ProviderIcon-qoder",
-                color: ProviderColor(red: 16 / 255, green: 185 / 255, blue: 129 / 255),
+                color: ProviderColor(red: 42 / 255, green: 219 / 255, blue: 92 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x2ADB5C),
                     ProviderColor(hex: 0x111113),

--- a/Sources/CodexBarCore/Providers/Sakana/SakanaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Sakana/SakanaProviderDescriptor.swift
@@ -39,9 +39,9 @@ public enum SakanaProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .sakana),
                 iconResourceName: "ProviderIcon-sakana",
-                color: ProviderColor(red: 0.16, green: 0.46, blue: 0.86),
+                color: ProviderColor(red: 204 / 255, green: 43 / 255, blue: 43 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0xE10600),
+                    ProviderColor(hex: 0xCC2B2B),
                     ProviderColor(hex: 0x0D0D0D),
                     ProviderColor(hex: 0xFFFFFF),
                 ],

--- a/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
@@ -67,7 +67,8 @@ public enum Sub2APIProviderDescriptor {
                 ProviderColor(hex: 0x1F62FF),
                 ProviderColor(hex: 0x14B8A6),
                 ProviderColor(hex: 0x74F9B0),
-            ]),
+            ],
+            widgetColor: ProviderColor(red: 45 / 255, green: 198 / 255, blue: 216 / 255)),
         tokenCost: ProviderTokenCostConfig(
             supportsTokenCost: false,
             noDataMessage: { "sub2api spend is reported by its usage API." }),

--- a/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Sub2API/Sub2APIProviderDescriptor.swift
@@ -62,10 +62,10 @@ public enum Sub2APIProviderDescriptor {
         branding: ProviderBranding(
             iconStyle: .init(provider: .sub2api),
             iconResourceName: "ProviderIcon-sub2api",
-            color: ProviderColor(red: 45 / 255, green: 198 / 255, blue: 216 / 255),
+            color: ProviderColor(red: 20 / 255, green: 184 / 255, blue: 166 / 255),
             confettiPalette: [
                 ProviderColor(hex: 0x1F62FF),
-                ProviderColor(hex: 0x60EDF6),
+                ProviderColor(hex: 0x14B8A6),
                 ProviderColor(hex: 0x74F9B0),
             ]),
         tokenCost: ProviderTokenCostConfig(

--- a/Sources/CodexBarCore/Providers/T3Chat/T3ChatProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/T3Chat/T3ChatProviderDescriptor.swift
@@ -37,7 +37,8 @@ public enum T3ChatProviderDescriptor {
                     ProviderColor(hex: 0xA3004C),
                     ProviderColor(hex: 0xE6229C),
                     ProviderColor(hex: 0xFEA0F6),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 245 / 255, green: 102 / 255, blue: 71 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "T3 Chat cost summary is not supported." }),

--- a/Sources/CodexBarCore/Providers/T3Chat/T3ChatProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/T3Chat/T3ChatProviderDescriptor.swift
@@ -32,9 +32,9 @@ public enum T3ChatProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .t3chat),
                 iconResourceName: "ProviderIcon-t3chat",
-                color: ProviderColor(red: 245 / 255, green: 102 / 255, blue: 71 / 255),
+                color: ProviderColor(red: 163 / 255, green: 0 / 255, blue: 76 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0x970B72),
+                    ProviderColor(hex: 0xA3004C),
                     ProviderColor(hex: 0xE6229C),
                     ProviderColor(hex: 0xFEA0F6),
                 ]),

--- a/Sources/CodexBarCore/Providers/Venice/VeniceProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceProviderDescriptor.swift
@@ -40,7 +40,7 @@ public enum VeniceProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .venice),
                 iconResourceName: "ProviderIcon-venice",
-                color: ProviderColor(red: 0.2, green: 0.6, blue: 1.0),
+                color: ProviderColor(red: 60 / 255, green: 143 / 255, blue: 221 / 255),
                 confettiPalette: [
                     ProviderColor(hex: 0x0E2942),
                     ProviderColor(hex: 0xF7F5ED),

--- a/Sources/CodexBarCore/Providers/Venice/VeniceProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceProviderDescriptor.swift
@@ -45,7 +45,8 @@ public enum VeniceProviderDescriptor {
                     ProviderColor(hex: 0x0E2942),
                     ProviderColor(hex: 0xF7F5ED),
                     ProviderColor(hex: 0x3C8FDD),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 0.2, green: 0.6, blue: 1.0)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Venice per-day cost history is not available via API." }),

--- a/Sources/CodexBarCore/Providers/Warp/WarpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Warp/WarpProviderDescriptor.swift
@@ -32,9 +32,9 @@ public enum WarpProviderDescriptor {
             branding: ProviderBranding(
                 iconStyle: .init(provider: .warp),
                 iconResourceName: "ProviderIcon-warp",
-                color: ProviderColor(red: 147 / 255, green: 139 / 255, blue: 180 / 255),
+                color: ProviderColor(red: 1 / 255, green: 164 / 255, blue: 255 / 255),
                 confettiPalette: [
-                    ProviderColor(hex: 0xC7AEFF),
+                    ProviderColor(hex: 0x01A4FF),
                     ProviderColor(hex: 0x1C1A26),
                     ProviderColor(hex: 0xFFFFFF),
                 ]),

--- a/Sources/CodexBarCore/Providers/Warp/WarpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Warp/WarpProviderDescriptor.swift
@@ -37,7 +37,8 @@ public enum WarpProviderDescriptor {
                     ProviderColor(hex: 0x01A4FF),
                     ProviderColor(hex: 0x1C1A26),
                     ProviderColor(hex: 0xFFFFFF),
-                ]),
+                ],
+                widgetColor: ProviderColor(red: 147 / 255, green: 139 / 255, blue: 180 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
                 noDataMessage: { "Warp cost summary is not available." }),

--- a/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
+++ b/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
@@ -30,7 +30,7 @@ struct MenuCardProviderRegressionTests {
     @Test
     func `command code progress color uses its contrasting brand accent`() {
         let branding = ProviderDescriptorRegistry.descriptor(for: .commandcode).branding.color
-        let expected = ProviderColor(hex: 0xA04DFD)
+        let expected = ProviderColor(hex: 0x8C4EDD)
 
         #expect(branding == expected)
         #expect(UsageMenuCardView.Model.progressColor(for: .commandcode) == Color(


### PR DESCRIPTION
## Summary
- Update provider branding colors across 37 provider descriptors to better match current provider identities.
- Align confetti palettes with the refreshed primary branding colors while preserving supporting neutral/secondary palette colors.
- Keep provider registry constraints intact by ensuring every confetti palette remains 2-3 colors.
- Preserve existing widget palettes by adding explicit `widgetColor` values where descriptors previously derived them from the old accent color.
- Update the Command Code regression expectation to the refreshed `0x8C4EDD` accent.

## Details
A table of updated colors:

| Provider | Old Color | New Color |
|---|---:|---:|
| Abacus AI | `#38BDF8` | `#814EE8` |
| ai& | `#E25C2B` | `#C70007` |
| Amp | `#DC2626` | `#F34E3F` |
| Augment | `#6366F1` | `#1AA049` |
| AWS Bedrock | `#FF9900` | `#01A88D` |
| Chutes | `#3184FF` | `#63D297` |
| ClawRouter | `#596EF6` | `#1F5AE0` |
| ClinePass | `#61A3FA` | `#5487C8` |
| Codebuff | `#44FF00` | `#00FF95` |
| Command Code | `#A04DFD` | `#8C4EDD` |
| Copilot | `#A855F7` | `#8534F3` |
| Crof | `#2EAB94` | `#8B7CFF` |
| Cursor | `#00BFA5` | `#F54E00` |
| DeepSeek | `#527DF0` | `#4D6BFE` |
| Deepgram | `#6467F2` | `#13EF93` |
| Devin | `#46B482` | `#317CFF` |
| Doubao | `#3370FF` | `#0057FF` |
| Fireworks | `#F25B1C` | `#6720FF` |
| Groq | `#F56844` | `#F55036` |
| JetBrains AI | `#FF3399` | `#955AE0` |
| Kilo | `#F27027` | `#FAF74F` |
| Kimi Code | `#FE603C` | `#007CFF` |
| Kiro | `#FF9900` | `#9046FF` |
| LiteLLM | `#4C89F0` | `#5B3FD1` |
| LongCat | `#FFD100` | `#29E154` |
| Mistral | `#FF500F` | `#FF5229` |
| Moonshot | `#205DEB` | `#000000` |
| Neuralwatt | `#38D98C` | `#D55934` |
| Notion AI | `#337EA9` | `#2EAADC` |
| OpenCode | `#3B82F6` | `#3B7DD8` |
| Perplexity | `#20B2AA` | `#20808D` |
| Qoder | `#10B981` | `#2ADB5C` |
| Sakana AI | `#2975DB` | `#CC2B2B` |
| sub2api | `#2DC6D8` | `#14B8A6` |
| T3 Chat | `#F56647` | `#A3004C` |
| Venice | `#3399FF` | `#3C8FDD` |
| Warp | `#938BB4` | `#01A4FF` |

## Testing
- `make check` passes
- `swift test --filter MenuCardProviderRegressionTests --filter ProviderArchitectureGatekeeperTests` passes
- `swift test --filter ProviderArchitectureGatekeeperTests` passes

## Screenshots
<img width="828" height="108" alt="Screenshot 2026-09-04 at 9 47 37 AM" src="https://github.com/user-attachments/assets/2db2785e-73a1-426e-96f7-f251162d1de8" />