### PR TITLE
fix(hooks): remove duplicate input labels from Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.6 — Unreleased
 
 ### Fixed
+- Hooks: show only the configured threshold, executable, and arguments in Settings; keep examples inside empty fields instead of displaying them as duplicate labels (#3424). Thanks @kedryte!
 - Codex: recover subscription renewal and expiration dates through optional OpenAI web billing capture, without delaying app usage or allowing late results to replace newer dashboards or cross accounts (#3373). Thanks @emanuelst!
 
 ## 0.56.5 — 2026-09-04

--- a/Sources/CodexBar/PreferencesHooksPane.swift
+++ b/Sources/CodexBar/PreferencesHooksPane.swift
@@ -59,7 +59,7 @@ struct HooksPane: View {
 }
 
 @MainActor
-private struct HookRuleRow: View {
+struct HookRuleRow: View {
     @Binding var rule: HookRule
     let onDelete: () -> Void
     @State private var argumentRows: [ArgumentRow]
@@ -107,7 +107,13 @@ private struct HookRuleRow: View {
                 HStack {
                     Text(L("hooks_threshold"))
                         .foregroundStyle(.secondary)
-                    TextField(L("hooks_threshold_placeholder"), value: self.thresholdPercentBinding, format: .number)
+                    TextField(
+                        L("hooks_threshold"),
+                        value: self.thresholdPercentBinding,
+                        format: .number,
+                        prompt: Text(L("hooks_threshold_placeholder")))
+                        .labelsHidden()
+                        .accessibilityLabel(L("hooks_threshold"))
                         .frame(width: 60)
                     Text(verbatim: "%")
                         .foregroundStyle(.secondary)
@@ -115,7 +121,12 @@ private struct HookRuleRow: View {
                 .font(.caption)
             }
 
-            TextField(L("hooks_executable_placeholder"), text: self.$rule.executable)
+            TextField(
+                L("hooks_executable"),
+                text: self.$rule.executable,
+                prompt: Text(L("hooks_executable_placeholder")))
+                .labelsHidden()
+                .accessibilityLabel(L("hooks_executable"))
                 .textFieldStyle(.roundedBorder)
                 .font(.system(.caption, design: .monospaced))
 
@@ -137,7 +148,12 @@ private struct HookRuleRow: View {
 
                 ForEach(self.$argumentRows) { $argument in
                     HStack {
-                        TextField(L("hooks_argument_placeholder"), text: $argument.value)
+                        TextField(
+                            L("hooks_argument_placeholder"),
+                            text: $argument.value,
+                            prompt: Text(L("hooks_argument_placeholder")))
+                            .labelsHidden()
+                            .accessibilityLabel(L("hooks_argument_placeholder"))
                             .textFieldStyle(.roundedBorder)
                             .font(.system(.caption, design: .monospaced))
                         Button {

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -566,6 +566,7 @@
 "hooks_any_provider" = "أي مزود";
 "hooks_threshold" = "التشغيل عند الاستخدام ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "الملف التنفيذي";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "الوسائط";
 "hooks_argument_placeholder" = "الوسيطة";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -546,6 +546,7 @@
 "hooks_any_provider" = "Qualsevol proveïdor";
 "hooks_threshold" = "Activa amb ús ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Executable";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Arguments";
 "hooks_argument_placeholder" = "Argument";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "Beliebiger Anbieter";
 "hooks_threshold" = "Auslösen bei Nutzung ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Ausführbare Datei";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argumente";
 "hooks_argument_placeholder" = "Argument";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -548,6 +548,7 @@
 "hooks_any_provider" = "Any provider";
 "hooks_threshold" = "Fire at usage ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Executable";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Arguments";
 "hooks_argument_placeholder" = "Argument";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "Cualquier proveedor";
 "hooks_threshold" = "Ejecutar con uso ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Ejecutable";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argumentos";
 "hooks_argument_placeholder" = "Argumento";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -566,6 +566,7 @@
 "hooks_any_provider" = "هر ارائه‌دهنده";
 "hooks_threshold" = "اجرا در مصرف ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "فایل اجرایی";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "آرگومان‌ها";
 "hooks_argument_placeholder" = "آرگومان";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "Tout fournisseur";
 "hooks_threshold" = "Déclencher à l’utilisation ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Exécutable";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Arguments";
 "hooks_argument_placeholder" = "Argument";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -540,6 +540,7 @@
 "hooks_any_provider" = "Calquera provedor";
 "hooks_threshold" = "Activar cun uso ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Executable";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argumentos";
 "hooks_argument_placeholder" = "Argumento";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -567,6 +567,7 @@
 "hooks_any_provider" = "Penyedia apa pun";
 "hooks_threshold" = "Picu saat penggunaan ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Berkas yang dapat dijalankan";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argumen";
 "hooks_argument_placeholder" = "Argumen";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -567,6 +567,7 @@
 "hooks_any_provider" = "Qualsiasi provider";
 "hooks_threshold" = "Attiva a utilizzo ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Eseguibile";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argomenti";
 "hooks_argument_placeholder" = "Argomento";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "すべてのプロバイダー";
 "hooks_threshold" = "使用率 ≥ で実行";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "実行ファイル";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "引数";
 "hooks_argument_placeholder" = "引数";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "모든 공급자";
 "hooks_threshold" = "사용량 ≥ 에서 실행";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "실행 파일";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "인수";
 "hooks_argument_placeholder" = "인수";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "Elke provider";
 "hooks_threshold" = "Uitvoeren bij gebruik ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Uitvoerbaar bestand";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argumenten";
 "hooks_argument_placeholder" = "Argument";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -567,6 +567,7 @@
 "hooks_any_provider" = "Dowolny dostawca";
 "hooks_threshold" = "Uruchom przy użyciu ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Plik wykonywalny";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argumenty";
 "hooks_argument_placeholder" = "Argument";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "Qualquer provedor";
 "hooks_threshold" = "Executar com uso ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Executável";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argumentos";
 "hooks_argument_placeholder" = "Argumento";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "Любой провайдер";
 "hooks_threshold" = "Запускать при использовании ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Исполняемый файл";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Аргументы";
 "hooks_argument_placeholder" = "Аргумент";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "Valfri leverantör";
 "hooks_threshold" = "Kör vid användning ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Körbar fil";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argument";
 "hooks_argument_placeholder" = "Argument";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -566,6 +566,7 @@
 "hooks_any_provider" = "ผู้ให้บริการใดก็ได้";
 "hooks_threshold" = "เรียกใช้เมื่อการใช้งาน ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "ไฟล์ปฏิบัติการ";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "อาร์กิวเมนต์";
 "hooks_argument_placeholder" = "อาร์กิวเมนต์";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -565,6 +565,7 @@
 "hooks_any_provider" = "Herhangi bir sağlayıcı";
 "hooks_threshold" = "Şu kullanım düzeyinde tetikle: ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Çalıştırılabilir dosya";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Argümanlar";
 "hooks_argument_placeholder" = "Argüman";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "Будь-який провайдер";
 "hooks_threshold" = "Запускати за використання ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Виконуваний файл";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Аргументи";
 "hooks_argument_placeholder" = "Аргумент";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "Nhà cung cấp bất kỳ";
 "hooks_threshold" = "Chạy khi mức sử dụng ≥";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "Tệp thực thi";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "Đối số";
 "hooks_argument_placeholder" = "Đối số";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "任意提供商";
 "hooks_threshold" = "使用率 ≥ 时运行";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "可执行文件";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "参数";
 "hooks_argument_placeholder" = "参数";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -45,6 +45,7 @@
 "hooks_any_provider" = "任何提供者";
 "hooks_threshold" = "使用率 ≥ 時執行";
 "hooks_threshold_placeholder" = "90";
+"hooks_executable" = "執行檔";
 "hooks_executable_placeholder" = "/usr/local/bin/my-command";
 "hooks_arguments_placeholder" = "引數";
 "hooks_argument_placeholder" = "引數";

--- a/Tests/CodexBarTests/HooksPaneNativeProofTests.swift
+++ b/Tests/CodexBarTests/HooksPaneNativeProofTests.swift
@@ -1,0 +1,85 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+import XCTest
+@testable import CodexBar
+
+@MainActor
+final class HooksPaneNativeProofTests: XCTestCase {
+    func test_groupedHookEditorLabels() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["CODEXBAR_HOOKS_NATIVE_PROOF"] == "1" else {
+            throw XCTSkip("Set CODEXBAR_HOOKS_NATIVE_PROOF=1 for synthetic Hooks UI proof")
+        }
+        guard environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment[CodexCredentialFileAccess.isolationEnvironmentKey] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1"
+        else { return XCTFail("Native proof requires credential and session isolation") }
+        let output = try XCTUnwrap(environment["CODEXBAR_HOOKS_PROOF_PATH"])
+        let application = NSApplication.shared
+        guard application.delegate == nil else { return XCTFail("Requires a standalone test application") }
+        let previousPolicy = application.activationPolicy()
+        let previousApplication = NSWorkspace.shared.frontmostApplication
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 680, height: 850),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        window.isReleasedWhenClosed = false
+        window.title = "CodexBar Hooks — synthetic settings fixture"
+        window.contentView = NSHostingView(rootView: HooksProofForm().preferredColorScheme(.dark))
+        defer {
+            window.close()
+            _ = application.setActivationPolicy(previousPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApplication?.activate()
+            }
+        }
+        _ = application.setActivationPolicy(.regular)
+        application.finishLaunching()
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        application.activate(ignoringOtherApps: true)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 1))
+        let capture = Process()
+        capture.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+        capture.arguments = ["-x", "-o", "-l", String(window.windowNumber), output]
+        try capture.run()
+        capture.waitUntilExit()
+        XCTAssertEqual(capture.terminationStatus, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: output))
+    }
+}
+
+/// Production row bindings with no SettingsStore, config persistence, provider, or hook runner.
+@MainActor
+private struct HooksProofForm: View {
+    @State private var rules: [HookRule] = [90, 95, 98].map { percent in
+        HookRule(
+            id: "fixture-\(percent)",
+            enabled: false,
+            event: .quotaLow,
+            provider: "codex",
+            threshold: Double(percent) / 100,
+            executable: "/fixture/quota-alert",
+            arguments: ["--message", "Quota warning"])
+    } + [HookRule(id: "fixture-empty", enabled: false, event: .quotaLow, executable: "", arguments: [""])]
+
+    var body: some View {
+        Form {
+            Section {
+                Text("Synthetic rules only. No commands can run from this fixture.")
+                    .font(.caption)
+            } header: {
+                Text("Hooks settings — populated and empty fields")
+            }
+            Section {
+                ForEach(self.$rules) { $rule in
+                    HookRuleRow(rule: $rule, onDelete: {})
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,8 @@ API keys, manual cookie headers, source selection, ordering, and token accounts 
 
 Hooks are local, explicit opt-in automation. Configure them in Settings > Hooks or in this local config file; no
 HTTP or remote-config endpoint can create or enable hook rules. The top-level `hooks.enabled` switch defaults to
-`false`, and each rule also has its own `enabled` switch.
+`false`, and each rule also has its own `enabled` switch. The editor shows thresholds as percentages; example
+values and command paths appear only as prompts in empty fields.
 
 ```json
 {


### PR DESCRIPTION
Hooks settings currently displays the example threshold `90` beside every configured value, so a 95% rule reads like “90 95%”. The executable and argument fields also expose their placeholder text as separate labels. SwiftUI's grouped Form renders the TextField title separately from its value.

Use explicit prompts and hide those visual labels, while retaining meaningful accessibility labels. Populated rows now show one threshold and one command/argument value; empty fields retain their examples. All supported locales include the executable accessibility label. The bindings, validation, stored rules, and hook dispatch are unchanged. Thanks @kedryte for the precise report.

Fixes #3424.

Validation:

- 40 focused hook/config/CLI and localization tests passed.
- Signed native rendering of the production HookRuleRow in a grouped Form reproduced the report before the fix and verified 90/95/98 values, populated executable/arguments, and empty prompts afterward. The opt-in fixture uses synthetic bindings with no SettingsStore, persistence, provider, or hook runner.
- Independent review found no further issues; the required Codex review found no actionable P0 findings.
- Full `make test` passed all 85 groups on the first attempt, with zero retries or timeouts. `make check` passed with zero lint violations. [CI run 33926466819](https://github.com/steipete/CodexBar/actions/runs/33926466819) passed all eight workflow checks, and GitGuardian passed, on head `6948258f6a138d08ce44778086cf39b054b8a20b`.

Before — synthetic production rows reproduce the duplicate examples:

![Hooks settings before](https://github.com/user-attachments/assets/95644160-22cb-4ed6-a17b-ae1529ceae92)

After — one configured value per field, with prompts confined to empty fields:

![Hooks settings after](https://github.com/user-attachments/assets/488d5ead-2016-4faf-9158-da4fe5176b53)
