### PR TITLE
Add optional colors for menu bar quota pace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.58.1 — Unreleased
 
 ### Added
+- Menu bar: optionally color Session, Weekly, and Auto pace indicators green when behind pace and red when ahead, preserving signed values, neutral unavailable values, and existing layouts (#3429, fixes #3428). Thanks @jb510!
 - Plugins: opt into first-class provider switcher tabs with selected-plugin refresh, plugin-only menus, and continued access to appended plugin cards (#3516, fixes #2988). Thanks @harjothkhara!
 
 ### Performance

--- a/Sources/CodexBar/MenuBarLayoutEditor.swift
+++ b/Sources/CodexBar/MenuBarLayoutEditor.swift
@@ -949,7 +949,8 @@ struct MenuBarLayoutPreview: View {
                 appearanceName: "preview",
                 isDebugApp: false,
                 now: minute,
-                verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment))
+                verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment,
+                colorPace: self.settings.menuBarColorPace))
         MenuBarLayoutPreviewText(rendered: rendered)
     }
 

--- a/Sources/CodexBar/MenuBarLayoutRenderer.swift
+++ b/Sources/CodexBar/MenuBarLayoutRenderer.swift
@@ -90,6 +90,7 @@ struct MenuBarLayoutRenderData: Hashable {
 
 struct MenuBarLayoutRenderOptions: Hashable {
     let size: MenuBarLayoutSize
+    let colorPace: Bool
     let highContrast: Bool
     let showUsed: Bool
     let conditionals: [MenuBarLayoutConditional]
@@ -114,9 +115,11 @@ struct MenuBarLayoutRenderOptions: Hashable {
         isDebugApp: Bool,
         isStale: Bool = false,
         now: Date,
-        verticalAdjustment: Int = 0)
+        verticalAdjustment: Int = 0,
+        colorPace: Bool = false)
     {
         self.size = size
+        self.colorPace = colorPace
         self.highContrast = highContrast
         self.showUsed = showUsed
         self.conditionals = conditionals
@@ -132,6 +135,7 @@ struct MenuBarLayoutRenderKey: Hashable {
     let layout: MenuBarLayout
     let data: MenuBarLayoutRenderData
     let size: MenuBarLayoutSize
+    let colorPace: Bool
     let highContrast: Bool
     let showUsed: Bool
     let conditionals: [MenuBarLayoutConditional]
@@ -264,6 +268,7 @@ final class MenuBarLayoutRenderer {
             layout: layout,
             data: data,
             size: options.size,
+            colorPace: options.colorPace,
             highContrast: options.highContrast,
             showUsed: options.showUsed,
             conditionals: options.conditionals,
@@ -408,7 +413,7 @@ final class MenuBarLayoutRenderer {
             leadingIcon: leadingIcon,
             statusImage: !options.highContrast && !options.isStale && !isStacked
                 && !renderedLines.joined().contains(.icon)
-                ? Self.statusImage(title: result)
+                ? Self.statusImage(title: result, foregroundColor: foregroundColor)
                 : nil)
     }
 
@@ -455,14 +460,17 @@ final class MenuBarLayoutRenderer {
         }.filter { !$0.isEmpty }
     }
 
-    private static func statusImage(title: NSAttributedString) -> NSImage? {
+    private static func statusImage(title: NSAttributedString, foregroundColor: NSColor) -> NSImage? {
         guard title.length > 0, !title.string.contains(where: \.isNewline) else { return nil }
-        // Inspect resolved fonts: an ordinary system-font title can fall back to colored emoji glyphs.
+        // Templates discard color. Preserve both explicitly colored text and fallback emoji glyphs.
         let line = CTLineCreateWithAttributedString(title)
         guard let runs = CTLineGetGlyphRuns(line) as? [CTRun] else { return nil }
         for run in runs {
             let attributes = CTRunGetAttributes(run) as NSDictionary
-            guard let font = attributes[kCTFontAttributeName] as? NSFont,
+            let range = CTRunGetStringRange(run)
+            let color = title.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+            guard color == foregroundColor,
+                  let font = attributes[kCTFontAttributeName] as? NSFont,
                   !CTFontGetSymbolicTraits(font as CTFont).contains(.traitColorGlyphs)
             else { return nil }
         }
@@ -559,11 +567,18 @@ final class MenuBarLayoutRenderer {
             return self.renderPercent(window, data: data, style: style, options: options)
         case let .pace(window):
             let accessibilityPrefix = Self.paceAccessibilityPrefix(window, data: data)
+            var attributes = style.attributes
+            if options.colorPace, let delta = Self.paceDelta(window, data: data), delta.isFinite, delta != 0 {
+                // Use the same rounded numeric delta as the displayed text, never its localized sign.
+                let color: NSColor = delta < 0 ? .systemGreen : .systemRed
+                attributes[.foregroundColor] = options.isStale && !options.highContrast ? color
+                    .withAlphaComponent(0.5) : color
+            }
             return self.optionalTextToken(
                 Self.pace(window, data: data),
                 unavailableLabel: L("%@ unavailable", accessibilityPrefix),
                 accessibilityPrefix: accessibilityPrefix,
-                attributes: style.attributes)
+                attributes: attributes)
         case .usageBar:
             guard let window = data.automatic else {
                 return self.textToken(
@@ -883,6 +898,18 @@ final class MenuBarLayoutRenderer {
         case .weekly: data.weeklyPace
         case .scopedWeekly: nil
         case .automatic: data.automaticPace
+        }
+    }
+
+    private static func paceDelta(
+        _ window: PercentWindow,
+        data: MenuBarLayoutRenderData) -> Double?
+    {
+        switch window {
+        case .session: data.metrics.sessionPaceDelta
+        case .weekly: data.metrics.weeklyPaceDelta
+        case .automatic: data.metrics.automaticPaceDelta
+        case .scopedWeekly: nil
         }
     }
 

--- a/Sources/CodexBar/PreferencesMenuBarPane.swift
+++ b/Sources/CodexBar/PreferencesMenuBarPane.swift
@@ -18,6 +18,14 @@ struct MenuBarPane: View {
     }
 
     var body: some View {
+        let paceColorSubtitle = L(
+            "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)")
+            + "\n" + L("menu_bar_layout_title") + ": " + [
+                L("menu_bar_layout_token_session_pace"),
+                L("menu_bar_layout_token_weekly_pace"),
+                L("menu_bar_layout_token_auto_pace"),
+            ].joined(separator: ", ")
+
         Form {
             Section {
                 SettingsMenuPicker(
@@ -39,6 +47,13 @@ struct MenuBarPane: View {
                             + L("menu_bar_inactive_display_contrast_subtitle"))
                 }
                 .disabled(!Self.inactiveDisplayContrastAvailable(for: self.settings.menuBarIconStyle))
+
+                Toggle(isOn: self.$settings.menuBarColorPace) {
+                    SettingsRowLabel(
+                        L("Color Pace Indicator"),
+                        subtitle: paceColorSubtitle)
+                }
+                .disabled(self.settings.menuBarIconStyle != .iconAndPercent)
             } header: {
                 Text(L("section_icon"))
             }

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1550,4 +1550,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "اختر صفوف الاستخدام التي تظهر في قائمة هذا المزوّد ومعاينة الإعدادات والنظرة العامة.";
 "%@ (unavailable)" = "%@ (غير متوفر)";
 "Spending cap, not balance" = "حد الإنفاق، وليس الرصيد";
+
+"Color Pace Indicator" = "تلوين وتيرة الاستخدام";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "أخضر عندما يكون الاستخدام أبطأ من الوتيرة المتوقعة (احتياطي)؛ وأحمر عندما يكون أسرع (خطر النفاد مبكرًا).";
 "%@ weekly" = "%@ أسبوعيًا";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1548,4 +1548,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Trieu quines files d'ús es mostren al menú d'aquest proveïdor, a la previsualització de Configuració i a la vista general.";
 "%@ (unavailable)" = "%@ (no disponible)";
 "Spending cap, not balance" = "Límit de despesa, no saldo";
+
+"Color Pace Indicator" = "Acoloreix el ritme";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verd quan l’ús va per sota del ritme previst (reserva); vermell quan va per sobre (risc d’esgotar la quota abans d’hora).";
 "%@ weekly" = "%@ setmanal";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1546,4 +1546,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Wähle aus, welche Nutzungszeilen im Menü dieses Anbieters, in der Einstellungsvorschau und in der Übersicht angezeigt werden.";
 "%@ (unavailable)" = "%@ (nicht verfügbar)";
 "Spending cap, not balance" = "Ausgabenlimit, kein Guthaben";
+
+"Color Pace Indicator" = "Nutzungstempo einfärben";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Grün bei langsamerem Verbrauch als erwartet (Reserve); Rot bei schnellerem Verbrauch (Risiko einer vorzeitigen Ausschöpfung).";
 "%@ weekly" = "%@ wöchentlich";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1549,4 +1549,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Choose which usage rows appear in this provider's menu, Settings preview, and Overview.";
 "%@ (unavailable)" = "%@ (unavailable)";
 "Spending cap, not balance" = "Spending cap, not balance";
+
+"Color Pace Indicator" = "Color Pace Indicator";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)";
 "%@ weekly" = "%@ weekly";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1544,4 +1544,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Elige qué filas de uso aparecen en el menú de este proveedor, en la vista previa de Ajustes y en Resumen.";
 "%@ (unavailable)" = "%@ (no disponible)";
 "Spending cap, not balance" = "Límite de gasto, no saldo";
+
+"Color Pace Indicator" = "Colorear el ritmo";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verde cuando el uso va por debajo del ritmo previsto (reserva); rojo cuando va por encima (riesgo de agotar la cuota antes de tiempo).";
 "%@ weekly" = "%@ semanal";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1550,4 +1550,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "انتخاب کنید کدام ردیف‌های استفاده در منوی این ارائه‌دهنده، پیش‌نمایش تنظیمات و نمای کلی نمایش داده شوند.";
 "%@ (unavailable)" = "%@ (در دسترس نیست)";
 "Spending cap, not balance" = "سقف هزینه، نه موجودی";
+
+"Color Pace Indicator" = "رنگ‌بندی آهنگ مصرف";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "سبز وقتی مصرف از آهنگ مورد انتظار عقب‌تر است (ذخیره)؛ قرمز وقتی جلوتر است (خطر تمام شدن زودهنگام سهمیه).";
 "%@ weekly" = "%@ هفتگی";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1545,4 +1545,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Choisissez les lignes d’utilisation affichées dans le menu de ce fournisseur, l’aperçu des réglages et la vue d’ensemble.";
 "%@ (unavailable)" = "%@ (indisponible)";
 "Spending cap, not balance" = "Plafond de dépenses, pas le solde";
+
+"Color Pace Indicator" = "Colorer le rythme";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Vert si la consommation est inférieure au rythme prévu (réserve) ; rouge si elle est supérieure (risque d’épuisement anticipé).";
 "%@ weekly" = "%@ hebdomadaire";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1545,4 +1545,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Escolle as filas de uso que aparecen no menú deste provedor, na vista previa de Configuración e na Vista xeral.";
 "%@ (unavailable)" = "%@ (non dispoñible)";
 "Spending cap, not balance" = "Límite de gasto, non saldo";
+
+"Color Pace Indicator" = "Colorear o ritmo";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verde cando o uso vai por debaixo do ritmo previsto (reserva); vermello cando vai por riba (risco de esgotar a cota antes de tempo).";
 "%@ weekly" = "%@ semanal";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1549,4 +1549,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Pilih baris penggunaan yang muncul di menu penyedia ini, pratinjau Pengaturan, dan Ringkasan.";
 "%@ (unavailable)" = "%@ (tidak tersedia)";
 "Spending cap, not balance" = "Batas pengeluaran, bukan saldo";
+
+"Color Pace Indicator" = "Warnai laju penggunaan";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Hijau saat penggunaan lebih lambat dari laju perkiraan (cadangan); merah saat lebih cepat (risiko kuota habis lebih awal).";
 "%@ weekly" = "%@ mingguan";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1549,4 +1549,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Scegli quali righe di utilizzo mostrare nel menu di questo provider, nell’anteprima delle Impostazioni e nella Panoramica.";
 "%@ (unavailable)" = "%@ (non disponibile)";
 "Spending cap, not balance" = "Limite di spesa, non saldo";
+
+"Color Pace Indicator" = "Colora il ritmo";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verde quando il consumo è inferiore al ritmo previsto (riserva); rosso quando è superiore (rischio di esaurimento anticipato).";
 "%@ weekly" = "%@ settimanale";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1546,4 +1546,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "このプロバイダーのメニュー、設定プレビュー、概要に表示する使用量の行を選択します。";
 "%@ (unavailable)" = "%@（利用不可）";
 "Spending cap, not balance" = "利用上限額（残高ではありません）";
+
+"Color Pace Indicator" = "使用ペースを色分け";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "想定より使用が遅い場合は緑（余裕あり）、速い場合は赤（上限に早く達するおそれ）で表示します。";
 "%@ weekly" = "%@（週間）";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1515,4 +1515,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "이 제공업체의 메뉴, 설정 미리보기 및 개요에 표시할 사용량 행을 선택합니다.";
 "%@ (unavailable)" = "%@(사용할 수 없음)";
 "Spending cap, not balance" = "지출 한도이며 잔액이 아닙니다";
+
+"Color Pace Indicator" = "사용 속도 색상 표시";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "사용량이 예상 속도보다 낮으면 초록색(여유), 높으면 빨간색(조기 소진 위험)으로 표시합니다.";
 "%@ weekly" = "%@ 주간";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1545,4 +1545,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Kies welke gebruiksrijen worden weergegeven in het menu van deze provider, het instellingenvoorbeeld en het overzicht.";
 "%@ (unavailable)" = "%@ (niet beschikbaar)";
 "Spending cap, not balance" = "Uitgavenlimiet, geen saldo";
+
+"Color Pace Indicator" = "Gebruikstempo kleuren";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Groen als het verbruik achterloopt op het verwachte tempo (reserve); rood als het voorloopt (risico op vroegtijdige uitputting).";
 "%@ weekly" = "%@ wekelijks";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1549,4 +1549,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Wybierz wiersze użycia wyświetlane w menu tego dostawcy, podglądzie ustawień i przeglądzie.";
 "%@ (unavailable)" = "%@ (niedostępne)";
 "Spending cap, not balance" = "Limit wydatków, nie saldo";
+
+"Color Pace Indicator" = "Koloruj tempo zużycia";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Zielony, gdy zużycie jest wolniejsze od oczekiwanego (rezerwa); czerwony, gdy jest szybsze (ryzyko wcześniejszego wyczerpania limitu).";
 "%@ weekly" = "%@ tygodniowo";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1546,4 +1546,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Escolha quais linhas de uso aparecem no menu deste provedor, na prévia dos Ajustes e na Visão geral.";
 "%@ (unavailable)" = "%@ (indisponível)";
 "Spending cap, not balance" = "Limite de gastos, não saldo";
+
+"Color Pace Indicator" = "Colorir o ritmo";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verde quando o uso está abaixo do ritmo previsto (reserva); vermelho quando está acima (risco de esgotar a cota antes da hora).";
 "%@ weekly" = "%@ semanal";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1547,4 +1547,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Выберите, какие строки использования отображаются в меню этого провайдера, в предпросмотре настроек и в обзоре.";
 "%@ (unavailable)" = "%@ (недоступно)";
 "Spending cap, not balance" = "Лимит расходов, не баланс";
+
+"Color Pace Indicator" = "Цветовая индикация темпа";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Зелёный — расход ниже ожидаемого темпа (есть запас); красный — выше (риск досрочного исчерпания квоты).";
 "%@ weekly" = "%@ за неделю";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1545,4 +1545,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Välj vilka användningsrader som visas i den här leverantörens meny, förhandsvisningen i Inställningar och Översikt.";
 "%@ (unavailable)" = "%@ (inte tillgänglig)";
 "Spending cap, not balance" = "Utgiftstak, inte saldo";
+
+"Color Pace Indicator" = "Färglägg förbrukningstakten";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Grönt när förbrukningen ligger under förväntad takt (reserv); rött när den ligger över (risk att kvoten tar slut i förtid).";
 "%@ weekly" = "%@ per vecka";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1550,4 +1550,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "เลือกแถวการใช้งานที่จะแสดงในเมนูของผู้ให้บริการนี้ ตัวอย่างการตั้งค่า และภาพรวม";
 "%@ (unavailable)" = "%@ (ไม่พร้อมใช้งาน)";
 "Spending cap, not balance" = "เพดานการใช้จ่าย ไม่ใช่ยอดคงเหลือ";
+
+"Color Pace Indicator" = "แสดงสีอัตราการใช้งาน";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "สีเขียวเมื่อใช้งานช้ากว่าอัตราที่คาดไว้ (มีโควตาสำรอง) สีแดงเมื่อเร็วกว่า (เสี่ยงหมดโควตาก่อนเวลา)";
 "%@ weekly" = "%@ รายสัปดาห์";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1548,4 +1548,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Bu sağlayıcının menüsünde, Ayarlar önizlemesinde ve Genel Bakış'ta hangi kullanım satırlarının görüneceğini seçin.";
 "%@ (unavailable)" = "%@ (kullanılamıyor)";
 "Spending cap, not balance" = "Harcama sınırı, bakiye değil";
+
+"Color Pace Indicator" = "Kullanım hızını renklendir";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Kullanım beklenen hızın gerisindeyse yeşil (rezerv); ilerisindeyse kırmızı (kotanın erken tükenme riski).";
 "%@ weekly" = "%@ haftalık";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1546,4 +1546,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Виберіть, які рядки використання відображатимуться в меню цього постачальника, попередньому перегляді налаштувань і огляді.";
 "%@ (unavailable)" = "%@ (недоступний)";
 "Spending cap, not balance" = "Ліміт витрат, не баланс";
+
+"Color Pace Indicator" = "Кольорова індикація темпу";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Зелений — витрати нижчі за очікуваний темп (є запас); червоний — вищі (ризик дострокового вичерпання квоти).";
 "%@ weekly" = "%@ за тиждень";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1547,4 +1547,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "Chọn các hàng sử dụng xuất hiện trong menu của nhà cung cấp này, bản xem trước Cài đặt và Tổng quan.";
 "%@ (unavailable)" = "%@ (không khả dụng)";
 "Spending cap, not balance" = "Hạn mức chi tiêu, không phải số dư";
+
+"Color Pace Indicator" = "Tô màu nhịp sử dụng";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Xanh khi mức sử dụng chậm hơn nhịp dự kiến (còn dư); đỏ khi nhanh hơn (nguy cơ hết hạn mức sớm).";
 "%@ weekly" = "%@ hàng tuần";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1558,4 +1558,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "选择要在此提供商的菜单、设置预览和概览中显示的用量行。";
 "%@ (unavailable)" = "%@（不可用）";
 "Spending cap, not balance" = "支出上限，并非余额";
+
+"Color Pace Indicator" = "用颜色显示使用节奏";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "使用量低于预期进度时显示绿色（有余量）；高于预期时显示红色（可能提前耗尽配额）。";
 "%@ weekly" = "%@ 每周";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1577,4 +1577,7 @@
 "Choose which usage rows appear in this provider's menu, Settings preview, and Overview." = "選擇要在此供應商的選單、設定預覽與概覽中顯示的用量列。";
 "%@ (unavailable)" = "%@（無法使用）";
 "Spending cap, not balance" = "支出上限，並非餘額";
+
+"Color Pace Indicator" = "以顏色顯示使用節奏";
+"Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "使用量低於預期進度時顯示綠色（有餘裕）；高於預期時顯示紅色（可能提前用盡配額）。";
 "%@ weekly" = "%@ 每週";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -325,6 +325,14 @@ extension SettingsStore {
         }
     }
 
+    var menuBarColorPace: Bool {
+        get { self.defaultsState.menuBarColorPace }
+        set {
+            self.defaultsState.menuBarColorPace = newValue
+            self.userDefaults.set(newValue, forKey: "menuBarColorPace")
+        }
+    }
+
     var menuBarHighContrastOnInactiveDisplays: Bool {
         get { self.defaultsState.menuBarHighContrastOnInactiveDisplays }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -30,6 +30,7 @@ extension SettingsStore {
         _ = self.providerChangelogLinksEnabled
         _ = self.menuBarShowsBrandIconWithPercent
         _ = self.menuBarHidesCritters
+        _ = self.menuBarColorPace
         _ = self.menuBarHighContrastOnInactiveDisplays
         _ = self.menuBarShowsHighestUsage
         _ = self.menuBarDisplayMode

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -688,6 +688,7 @@ extension SettingsStore {
             providerChangelogLinksEnabled: providerChangelogLinksEnabled,
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,
             menuBarHidesCritters: menuBarHidesCritters,
+            menuBarColorPace: userDefaults.bool(forKey: "menuBarColorPace"),
             menuBarHighContrastOnInactiveDisplays: menuBarHighContrastOnInactiveDisplays,
             menuBarDisplayModeRaw: menuBarDisplayModeRaw,
             menuBarShowsResetTimeWhenExhausted: menuBarShowsResetTimeWhenExhausted,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -31,6 +31,7 @@ struct SettingsDefaultsState {
     var providerChangelogLinksEnabled: Bool
     var menuBarShowsBrandIconWithPercent: Bool
     var menuBarHidesCritters: Bool
+    var menuBarColorPace: Bool
     var menuBarHighContrastOnInactiveDisplays: Bool
     var menuBarDisplayModeRaw: String?
     var menuBarShowsResetTimeWhenExhausted: Bool

--- a/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
+++ b/Sources/CodexBar/StatusItemController+MenuBarLayout.swift
@@ -66,7 +66,8 @@ extension StatusItemController {
             isDebugApp: Self.isDebugApp(bundleIdentifier: Bundle.main.bundleIdentifier),
             isStale: self.store.isStale(provider: provider),
             now: now,
-            verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment)
+            verticalAdjustment: self.settings.menuBarLayoutVerticalAdjustment,
+            colorPace: self.settings.menuBarColorPace)
         let rendered = self.menuBarLayoutRenderer.render(
             layout: resolution.layout,
             data: data,

--- a/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutRendererTests.swift
@@ -1476,6 +1476,146 @@ struct MenuBarLayoutRendererTests {
                 threshold: threshold))
     }
 
+    @Test
+    func `pace colors follow reserve and ahead values and toggle invalidates cache`() {
+        let renderer = MenuBarLayoutRenderer()
+        let cases: [(PercentWindow, NSColor)] = [
+            (.session, .systemGreen), (.weekly, .systemRed), (.automatic, .controlTextColor),
+        ]
+        for (window, expectedColor) in cases {
+            let layout = MenuBarLayout(lines: [[.pace(window: window)]])
+            let plain = renderer.render(layout: layout, data: self.data(), icon: nil, options: self.options())
+            let colored = renderer.render(
+                layout: layout, data: self.data(), icon: nil, options: self.options(colorPace: true))
+            #expect(plain.attributedTitle.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+                == .controlTextColor)
+            #expect(colored.attributedTitle.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+                == expectedColor)
+            #expect(colored.attributedTitle.string == plain.attributedTitle.string)
+            #expect(plain.statusImage?.isTemplate == true)
+            #expect((colored.statusImage == nil) == (window != .automatic))
+            let button = NSButton()
+            for output in [plain, colored] {
+                _ = StatusItemController.applyMenuBarLayoutContent(output, for: button, gap: .regular)
+            }
+            if window != .automatic {
+                #expect(button.image == nil)
+                #expect(button.attributedTitle.isEqual(to: colored.attributedTitle))
+            }
+            #expect(button.accessibilityTitle() == colored.accessibilityLabel)
+            let restored = renderer.render(layout: layout, data: self.data(), icon: nil, options: self.options())
+            #expect(restored.attributedTitle.isEqual(to: plain.attributedTitle))
+            _ = StatusItemController.applyMenuBarLayoutContent(restored, for: button, gap: .regular)
+            #expect(button.image?.isTemplate == true)
+            #expect(button.attributedTitle.length == 0)
+        }
+    }
+
+    @Test
+    func `pace color leaves other tokens and missing metrics neutral`() {
+        let renderer = MenuBarLayoutRenderer()
+        for token: MenuBarLayoutToken in [.percent(window: .session), .providerName, .pace(window: .scopedWeekly)] {
+            let rendered = renderer.render(
+                layout: MenuBarLayout(lines: [[token]]),
+                data: self.data(),
+                icon: nil,
+                options: self.options(colorPace: true))
+            #expect(rendered.attributedTitle.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+                == .controlTextColor)
+            #expect(rendered.statusImage?.isTemplate == true)
+        }
+        let missing = renderer.render(
+            layout: MenuBarLayout(lines: [[.pace(window: .session)]]),
+            data: self.data(metrics: .unavailable),
+            icon: nil,
+            options: self.options(colorPace: true))
+        #expect(missing.attributedTitle.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+            == .controlTextColor)
+        #expect(missing.statusImage?.isTemplate == true)
+    }
+
+    @Test(arguments: [MenuBarLayoutToken.hidden, .percent(window: .automatic)])
+    func `resolved conditionals choose native colors only for visible pace`(fallback: MenuBarLayoutToken) {
+        let conditional = MenuBarLayoutConditional(
+            clauses: [self.clause(metric: .automatic, comparison: .greaterThan, threshold: 0, direction: .remaining)],
+            thenToken: .pace(window: .weekly),
+            elseToken: fallback)
+        let renderer = MenuBarLayoutRenderer()
+        let layout = MenuBarLayout(lines: [[.providerName, .conditional(id: conditional.id)]])
+        let options = self.options(conditionals: [conditional], colorPace: true)
+        let colored = renderer.render(layout: layout, data: self.data(), icon: nil, options: options)
+        #expect(colored.statusImage == nil)
+        #expect(colored.attributedTitle.string.contains("+11%"))
+        let neutral = renderer.render(
+            layout: layout, data: self.data(automaticUsedPercent: 100), icon: nil, options: options)
+        #expect(neutral.statusImage?.isTemplate == true)
+        #expect(!neutral.attributedTitle.string.contains("+11%"))
+    }
+
+    @Test(arguments: ["aqua", "darkAqua"], ["regular", "stale", "highContrast", "staleHighContrast"])
+    func `colored pace reaches native button across supported layouts`(appearance: String, mode: String) throws {
+        let renderer = MenuBarLayoutRenderer()
+        let icon = NSImage(size: NSSize(width: 16, height: 16))
+        icon.isTemplate = true
+        let button = NSButton()
+        let options = self.options(
+            isStale: mode == "stale" || mode == "staleHighContrast",
+            colorPace: true,
+            highContrast: mode == "highContrast" || mode == "staleHighContrast",
+            appearanceName: appearance)
+        for lines: [[MenuBarLayoutToken]] in [
+            [[.pace(window: .weekly)]],
+            [[.icon, .pace(window: .weekly)]],
+            [[.providerName], [.pace(window: .weekly)]],
+        ] {
+            let output = renderer.render(
+                layout: MenuBarLayout(lines: lines),
+                data: self.data(),
+                icon: icon,
+                options: options)
+            #expect(output.statusImage == nil)
+            _ = StatusItemController.applyMenuBarLayoutContent(output, for: button, gap: .regular)
+            let range = (button.attributedTitle.string as NSString).range(of: "+11%")
+            try #require(range.location != NSNotFound)
+            let expected = mode == "stale" ? NSColor.systemRed.withAlphaComponent(0.5) : .systemRed
+            #expect(button.attributedTitle.attribute(
+                .foregroundColor,
+                at: range.location,
+                effectiveRange: nil) as? NSColor
+                == expected)
+            #expect(button.accessibilityTitle() == output.accessibilityLabel)
+        }
+    }
+
+    @Test
+    func `stale pace colors remain dimmed`() {
+        let rendered = MenuBarLayoutRenderer().render(
+            layout: MenuBarLayout(lines: [[.pace(window: .weekly)]]),
+            data: self.data(),
+            icon: nil,
+            options: self.options(isStale: true, colorPace: true))
+        #expect(rendered.attributedTitle.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+            == NSColor.systemRed.withAlphaComponent(0.5))
+    }
+
+    @Test(arguments: [false, true])
+    func `high contrast preserves pace color without recoloring neutral tokens`(stale: Bool) {
+        let renderer = MenuBarLayoutRenderer()
+        for (token, expected): (MenuBarLayoutToken, NSColor) in [
+            (.pace(window: .weekly), .systemRed),
+            (.pace(window: .automatic), .labelColor),
+            (.percent(window: .session), .labelColor),
+        ] {
+            let output = renderer.render(
+                layout: MenuBarLayout(lines: [[token]]),
+                data: self.data(),
+                icon: nil,
+                options: self.options(isStale: stale, colorPace: true, highContrast: true))
+            #expect(output.attributedTitle.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+                == expected)
+        }
+    }
+
     func data(
         automaticUsedPercent: Double = 50,
         provider: UsageProvider = .codex,
@@ -1556,6 +1696,7 @@ struct MenuBarLayoutRendererTests {
         isStale: Bool = false,
         conditionals: [MenuBarLayoutConditional] = [],
         isDebugApp: Bool = false,
+        colorPace: Bool = false,
         highContrast: Bool = false,
         appearanceName: String = "aqua") -> MenuBarLayoutRenderOptions
     {
@@ -1568,7 +1709,8 @@ struct MenuBarLayoutRendererTests {
             isDebugApp: isDebugApp,
             isStale: isStale,
             now: now ?? self.now,
-            verticalAdjustment: verticalAdjustment)
+            verticalAdjustment: verticalAdjustment,
+            colorPace: colorPace)
     }
 
     private func averageBrightness(

--- a/Tests/CodexBarTests/MenuBarPaceColorSettingsTests.swift
+++ b/Tests/CodexBarTests/MenuBarPaceColorSettingsTests.swift
@@ -1,0 +1,72 @@
+import CodexBarCore
+import Foundation
+import Observation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct MenuBarPaceColorSettingsTests {
+    private final class ObservationFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+
+        func set() {
+            self.lock.lock()
+            self.value = true
+            self.lock.unlock()
+        }
+
+        func get() -> Bool {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.value
+        }
+    }
+
+    @Test
+    func `pace color defaults off persists and triggers menu observation`() {
+        let defaults = InMemoryUserDefaults()
+        let store = testSettingsStore(suiteName: "pace-color", userDefaults: defaults)
+        #expect(!store.menuBarColorPace)
+        let changed = ObservationFlag()
+        withObservationTracking {
+            _ = store.menuObservationToken
+        } onChange: {
+            changed.set()
+        }
+        store.menuBarColorPace = true
+        #expect(changed.get())
+        #expect(defaults.bool(forKey: "menuBarColorPace"))
+        let restored = testSettingsStore(suiteName: "pace-color-restored", userDefaults: defaults)
+        #expect(restored.menuBarColorPace)
+    }
+
+    @Test(arguments: [false, true])
+    func `upgraded preferences keep their layout and default to monochrome`(storedLayout: Bool) {
+        let defaults = InMemoryUserDefaults()
+        let previous = testSettingsStore(suiteName: "pace-color-upgrade", userDefaults: defaults)
+        previous.menuBarDisplayMode = .both
+        previous.menuBarLayoutGap = .tight
+        if storedLayout {
+            previous.menuBarLayout = MenuBarLayout(lines: [[.pace(window: .weekly)]])
+            previous.setMenuBarLayout(MenuBarLayout(lines: [[.pace(window: .session)]]), for: .claude)
+        }
+        let originalLayout = previous.menuBarLayout
+        let originalOverrides = previous.menuBarLayoutOverrides
+        #expect(defaults.object(forKey: "menuBarColorPace") == nil)
+
+        let upgraded = testSettingsStore(suiteName: "pace-color-upgraded", userDefaults: defaults)
+        #expect(!upgraded.menuBarColorPace)
+        #expect(defaults.object(forKey: "menuBarColorPace") == nil)
+        for enabled in [true, false] {
+            upgraded.menuBarColorPace = enabled
+            let restored = testSettingsStore(suiteName: "pace-color-reloaded", userDefaults: defaults)
+            #expect(restored.menuBarColorPace == enabled)
+            #expect(restored.hasStoredMenuBarLayout == storedLayout)
+            #expect(restored.menuBarLayout == originalLayout)
+            #expect(restored.menuBarLayoutOverrides == originalOverrides)
+            #expect(restored.menuBarDisplayMode == .both)
+            #expect(restored.menuBarLayoutGap == .tight)
+        }
+    }
+}

--- a/Tests/CodexBarTests/PaceColorNativeProofTests.swift
+++ b/Tests/CodexBarTests/PaceColorNativeProofTests.swift
@@ -1,0 +1,283 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+final class PaceColorNativeProofTests: XCTestCase {
+    private static let phases = [
+        "default-off", "on", "leading-icon", "stale", "high-contrast", "stale-high-contrast", "multiline", "off-again",
+    ]
+
+    func test_paceColorsInStatusItemAndSettings() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["CODEXBAR_PACE_COLOR_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_PACE_COLOR_PROOF_DIR for signed synthetic UI proof")
+        }
+        let output = URL(fileURLWithPath: path, isDirectory: true)
+        guard SettingsStore.isRunningTests,
+              environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment[CodexCredentialFileAccess.isolationEnvironmentKey] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1",
+              environment["CODEXBAR_TEST_CODEX_FILE_FIXTURES"] == nil,
+              NSHomeDirectory().hasPrefix(output.deletingLastPathComponent().path + "/")
+        else { return XCTFail("Use a contained home and credential/session isolation") }
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let root = output.appendingPathComponent("fixture", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let defaults = InMemoryUserDefaults()
+        defaults.set(MenuBarDisplayMode.both.rawValue, forKey: "menuBarDisplayMode")
+        let settings = testSettingsStore(
+            suiteName: "PaceColorNativeProof",
+            userDefaults: defaults,
+            config: testConfigWithAllProvidersDisabled())
+        defer { settings.configFileWatcher?.stop() }
+        settings.menuBarIconStyle = .iconAndPercent
+        let oldResolution = settings.menuBarLayoutResolution(for: .codex)
+        XCTAssertTrue(oldResolution.usesLegacyRendering)
+        XCTAssertFalse(settings.menuBarColorPace)
+        XCTAssertFalse(settings.hasStoredMenuBarLayout)
+        let store = self.makeStore(root: root, settings: settings)
+        defer { store.stopSharedSpendDashboardPublication() }
+
+        let app = NSApplication.shared
+        guard app.delegate == nil else { return XCTFail("Use a standalone test host") }
+        let previousApp = NSWorkspace.shared.frontmostApplication
+        let previousPolicy = app.activationPolicy()
+        let host = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 740, height: 850),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        host.title = "CodexBar — Synthetic Pace Color Proof"
+        host.isReleasedWhenClosed = false
+        _ = app.setActivationPolicy(.regular)
+        app.finishLaunching()
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        let button = try XCTUnwrap(item.button)
+        button.setAccessibilityIdentifier("codexbar-synthetic-pace-color-proof")
+        defer {
+            NSStatusBar.system.removeStatusItem(item)
+            host.close()
+            _ = app.setActivationPolicy(previousPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApp?.activate()
+            }
+        }
+        let data = MenuBarLayoutRendererTests().data(accountLabel: nil)
+        let renderer = MenuBarLayoutRenderer()
+        let icon = try XCTUnwrap(NSImage(systemSymbolName: "gauge", accessibilityDescription: "Synthetic provider"))
+        icon.isTemplate = true
+        // This flag changes assertions only. The baseline must be packaged with the actual old renderer.
+        let baseline = environment["CODEXBAR_PACE_COLOR_PROOF_BASELINE"] == "1"
+        var receipts: [[String: Any]] = []
+        let paceTokens: [MenuBarLayoutToken] = [
+            .pace(window: .session), .pace(window: .weekly), .pace(window: .automatic),
+        ]
+        for appearanceName in [NSAppearance.Name.aqua, .darkAqua] {
+            let appearance = try XCTUnwrap(NSAppearance(named: appearanceName))
+            host.appearance = appearance
+            button.appearance = appearance
+            for phase in Self.phases {
+                let enabled = phase != "default-off" && phase != "off-again"
+                settings.menuBarColorPace = enabled
+                settings.menuBarHighContrastOnInactiveDisplays = phase.contains("high-contrast")
+                XCTAssertEqual(defaults.bool(forKey: "menuBarColorPace"), enabled)
+                XCTAssertEqual(settings.menuBarLayoutResolution(for: .codex), oldResolution)
+                XCTAssertFalse(settings.hasStoredMenuBarLayout)
+                XCTAssertEqual(defaults.string(forKey: "menuBarDisplayMode"), MenuBarDisplayMode.both.rawValue)
+                let lines: [[MenuBarLayoutToken]] = switch phase {
+                case "leading-icon": [[.icon] + paceTokens]
+                case "multiline": [[.pace(window: .session)], [.pace(window: .weekly), .pace(window: .automatic)]]
+                default: [paceTokens]
+                }
+                let rendered = renderer.render(
+                    layout: MenuBarLayout(lines: lines),
+                    data: data,
+                    icon: phase == "leading-icon" ? icon : nil,
+                    options: MenuBarLayoutRenderOptions(
+                        size: .regular,
+                        highContrast: phase.contains("high-contrast"),
+                        showUsed: true,
+                        conditionals: [],
+                        appearanceName: appearanceName.rawValue,
+                        isDebugApp: false,
+                        isStale: phase.contains("stale"),
+                        now: Date(timeIntervalSince1970: 1_788_000_000),
+                        colorPace: enabled))
+                item.length = StatusItemController.applyMenuBarLayoutContent(rendered, for: button, gap: .regular)
+                guard self.validate(rendered, button: button, phase: phase, enabled: enabled, baseline: baseline) else {
+                    return
+                }
+                host.contentView = NSHostingView(rootView: self.proofView(
+                    rendered: rendered,
+                    settings: settings,
+                    store: store,
+                    phase: phase,
+                    dark: appearanceName == .darkAqua))
+                host.center()
+                host.makeKeyAndOrderFront(nil)
+                app.activate(ignoringOtherApps: true)
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.7))
+                let stem = "pace-\(appearanceName.rawValue)-\(phase)"
+                try self.capture(window: host, output: output.appendingPathComponent("\(stem)-settings.png"))
+                let statusWindow = try XCTUnwrap(button.window)
+                let buttonRect = statusWindow.convertToScreen(button.convert(button.bounds, to: nil))
+                // Capture only the visible button, never its enclosing menu bar or unrelated desktop.
+                guard statusWindow.windowNumber > 0, statusWindow.isVisible,
+                      !button.isHiddenOrHasHiddenAncestor,
+                      NSScreen.screens.contains(where: { $0.frame.contains(buttonRect) }),
+                      statusWindow.frame.contains(buttonRect),
+                      buttonRect.width <= item.length + 20,
+                      buttonRect.height <= 48,
+                      buttonRect.width > 0, buttonRect.height > 0
+                else { return XCTFail("The native status item did not expose a narrowly bounded onscreen button") }
+                try self.capture(
+                    window: statusWindow,
+                    output: output.appendingPathComponent("\(stem)-status.png"),
+                    buttonRect: buttonRect)
+                receipts.append([
+                    "appearance": appearanceName.rawValue,
+                    "phase": phase,
+                    "enabled": enabled,
+                    "baseline": baseline,
+                    "title": rendered.attributedTitle.string,
+                    "actualTitle": button.attributedTitle.string,
+                    "template": button.image?.isTemplate ?? false,
+                    "statusImage": rendered.statusImage != nil,
+                    "width": item.length,
+                    "statusWindow": statusWindow.windowNumber,
+                    "statusFrame": NSStringFromRect(statusWindow.frame),
+                    "buttonFrame": NSStringFromRect(buttonRect),
+                    "legacyLayoutUnchanged": settings.menuBarLayoutResolution(for: .codex) == oldResolution,
+                ])
+            }
+        }
+        let restored = testSettingsStore(
+            suiteName: "PaceColorNativeProof-restored",
+            userDefaults: defaults,
+            config: testConfigWithAllProvidersDisabled())
+        defer { restored.configFileWatcher?.stop() }
+        XCTAssertFalse(restored.menuBarColorPace)
+        XCTAssertEqual(restored.menuBarDisplayMode, .both)
+        try JSONSerialization.data(withJSONObject: receipts, options: [.sortedKeys, .prettyPrinted])
+            .write(to: output.appendingPathComponent("pace-color-state.json"), options: .atomic)
+    }
+
+    private func proofView(
+        rendered: MenuBarLayoutRenderedTitle,
+        settings: SettingsStore,
+        store: UsageStore,
+        phase: String,
+        dark: Bool) -> some View
+    {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Synthetic pace: −8% reserve · +11% ahead · 0% on pace")
+                .font(.headline)
+            Text("Phase: \(phase) · actual status item and production Settings pane")
+            MenuBarLayoutPreviewText(rendered: rendered)
+                .frame(height: 42)
+            MenuBarPane(settings: settings, store: store)
+        }
+        .padding(20)
+        .preferredColorScheme(dark ? .dark : .light)
+    }
+
+    private func makeStore(root: URL, settings: SettingsStore) -> UsageStore {
+        let isolated = ["HOME": root.path, "CODEX_HOME": root.appendingPathComponent("codex").path]
+        settings._test_codexReconciliationEnvironment = isolated
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: isolated),
+            browserDetection: BrowserDetection(
+                homeDirectory: root.path,
+                cacheTTL: 0,
+                now: Date.init,
+                fileExists: { _ in false },
+                directoryContents: { _ in nil },
+                applicationURLs: { _ in [] },
+                profileAccessIssue: { _ in nil }),
+            costUsageFetcher: CostUsageFetcher(cacheRoot: root.appendingPathComponent("cost")),
+            settings: settings,
+            historicalUsageHistoryStore: HistoricalUsageHistoryStore(fileURL: root.appendingPathComponent("history")),
+            planUtilizationHistoryStore: PlanUtilizationHistoryStore(directoryURL: nil),
+            startupBehavior: .testing,
+            environmentBase: isolated,
+            widgetSnapshotURL: root.appendingPathComponent("widget.json"),
+            widgetTimelineReloader: {})
+        store._test_providerRefreshOverride = { _ in XCTFail("Unexpected provider transport") }
+        store._test_widgetSnapshotSaveOverride = { _ in }
+        return store
+    }
+
+    private func validate(
+        _ rendered: MenuBarLayoutRenderedTitle,
+        button: NSButton,
+        phase: String,
+        enabled: Bool,
+        baseline: Bool) -> Bool
+    {
+        let templateExpected = !enabled || (baseline && phase == "on")
+        XCTAssertEqual(rendered.statusImage != nil, templateExpected)
+        XCTAssertEqual(button.image?.isTemplate == true, templateExpected || phase == "leading-icon")
+        if !templateExpected {
+            XCTAssertTrue(button.attributedTitle.isEqual(to: rendered.attributedTitle))
+        }
+        for (text, color) in [("-8%", NSColor.systemGreen), ("+11%", NSColor.systemRed)] {
+            let range = (rendered.attributedTitle.string as NSString).range(of: text)
+            guard range.location != NSNotFound, range.length > 0 else {
+                XCTFail("Missing synthetic pace text: \(text)")
+                return false
+            }
+            let actual = rendered.attributedTitle.attribute(
+                .foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+            let dimmed = phase.contains("stale") && (baseline || !phase.contains("high-contrast"))
+            let paceColor = dimmed ? color.withAlphaComponent(0.5) : color
+            let expected = enabled ? paceColor : .controlTextColor
+            XCTAssertEqual(actual, expected)
+        }
+        let zeroRange = (rendered.attributedTitle.string as NSString).range(of: "0%")
+        guard zeroRange.location != NSNotFound, zeroRange.length > 0 else {
+            XCTFail("Missing synthetic zero pace text")
+            return false
+        }
+        let zeroColor = rendered.attributedTitle.attribute(
+            .foregroundColor, at: zeroRange.location, effectiveRange: nil) as? NSColor
+        let neutral: NSColor = switch phase {
+        case "high-contrast", "stale-high-contrast": .labelColor
+        case "stale": .secondaryLabelColor
+        default: .controlTextColor
+        }
+        XCTAssertEqual(zeroColor, neutral)
+        return true
+    }
+
+    private func capture(window: NSWindow, output: URL, buttonRect: NSRect? = nil) throws {
+        let capture = Process()
+        capture.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+        if let buttonRect {
+            let screen = try XCTUnwrap(NSScreen.screens.first)
+            // Round inward so the requested pixel region never includes neighboring status items.
+            let x = Int(ceil(buttonRect.minX))
+            let y = Int(ceil(screen.frame.maxY - buttonRect.maxY))
+            let width = Int(floor(buttonRect.maxX)) - x
+            let height = Int(floor(screen.frame.maxY - buttonRect.minY)) - y
+            guard width > 0, height > 0 else {
+                throw NSError(domain: "PaceColorNativeProof", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "The status button has no capturable pixel region",
+                ])
+            }
+            capture.arguments = ["-x", "-R", "\(x),\(y),\(width),\(height)", output.path]
+        } else {
+            capture.arguments = ["-x", "-o", "-l", String(window.windowNumber), output.path]
+        }
+        try capture.run()
+        capture.waitUntilExit()
+        guard capture.terminationStatus == 0 else {
+            throw NSError(domain: "PaceColorNativeProof", code: Int(capture.terminationStatus), userInfo: [
+                NSLocalizedDescriptionKey: "Native capture failed for \(output.lastPathComponent)",
+            ])
+        }
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -947,13 +947,13 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact provider-owned construct passes a fixed identity to shared infrastructure."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/SettingsStore+MenuObservation.swift",
-            line: 103,
+            line: 104,
             anchor: "_ = self[providerConfig: .synthetic, field: .apiKey]",
             expectedProviderIDs: ["synthetic"],
             reason: "This observation touchpoint reads a fixed provider field so UI invalidation tracks that setting."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/SettingsStore+MenuObservation.swift",
-            line: 122,
+            line: 123,
             anchor: "_ = self[providerConfig: .warp, field: .apiKey]",
             expectedProviderIDs: ["warp"],
             reason: "This observation touchpoint reads a fixed provider field so UI invalidation tracks that setting."),
@@ -1809,7 +1809,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuBarLayoutEditor.swift",
-            line: 964,
+            line: 965,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2384,7 +2384,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SettingsStore.swift",
-            line: 1204,
+            line: 1205,
             anchor: "if !seen.contains(.factory), let zaiIndex = ordered.firstIndex(of: .zai) {",
             expectedProviderIDs: ["factory", "minimax", "zai"],
             expectedReferenceCount: 8,
@@ -2601,7 +2601,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+MenuBarLayout.swift",
-            line: 229,
+            line: 230,
             anchor: "if provider == .codex,",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -59,6 +59,12 @@ behind it, `0%` on pace. Each pace token reads its own window, so `Weekly pace` 
 unavailable, including the first 3% of a window. The weekly menu-bar pace token may appear after 1% of its weekly
 window has elapsed; session, automatic, and Runs out tokens keep the 3% threshold. See [Pace tracking](#pace-tracking).
 
+Enable **Color Pace Indicator** under **Menu Bar → Icon** to show usage behind pace (reserve) in green and usage ahead
+of pace (risk of running out early) in red. The option defaults off, applies to all three pace tokens and the layout
+preview, and keeps the signed percentages. Zero and unavailable pace stay neutral; stale pace colors are dimmed unless high-contrast rendering is active.
+It colors **Session pace**, **Weekly pace**, and **Auto pace** in the layout editor. Enabling it does not add tokens,
+rewrite stored layouts, or migrate legacy display modes. Existing installs stay monochrome until the option is enabled.
+
 Balance is available only for OpenRouter and renders the same remaining-credit value shown in its menu card. Auto %
 uses the same provider-aware automatic-window resolution as the legacy menu bar metric setting. For balance-only
 providers, Auto % shows the available money, points, or API spend instead of inventing a quota percentage. Both the


### PR DESCRIPTION
Adds the off-by-default **Color Pace Indicator** preference under **Menu Bar → Icon**. Session, Weekly and Auto pace tokens use green for reserve and red for usage ahead of pace, while retaining signed percentages. Zero and unavailable values stay neutral; the setting leaves existing layouts and legacy display modes intact. Labels cover all supported locales.

Maintainer decision: adopt this narrow opt-in preference. The UI and docs identify the layout tokens it affects.

The maintainer pass repairs the final status-item output: explicitly colored text now keeps native attributed rendering instead of being converted into a monochrome template image. Neutral text retains the template cache. It also preserves high-contrast precedence when a snapshot is stale, and replaces partial production-default stores in the preference tests with isolated stores.

Validation:
- The proposal failed 12 final-output/consumer assertions. A further seven failures reproduced stale/high-contrast dimming. Both root causes are fixed.
- All 118 focused tests pass, including final button transitions, conditionals and hidden branches, icon/multiline output, stale/high-contrast combinations, cache behavior, observation and legacy/stored-layout upgrades.
- `make check` passes with zero SwiftLint violations across 2,177 files. Independent P0–P2 review is clean.
- Developer-ID-signed native baseline and final runs passed. The final run exercises 16 Light/Dark cases on an actual NSStatusItem through the production renderer and consumer, alongside the production Settings pane. It checks positive/negative/zero pace, on/off persistence, leading icons, multiline, stale, high contrast and combined stale/high-contrast. Every case preserves the legacy layout. Captures use only synthetic values and owned windows/button regions.
- Native proof source matches commit `4b59bae990003c857c67763d3025d096b7463324`. Full `make test` passed all 1,066 selections across 89 groups on the first attempt, with no retries or timeouts (868.9 seconds). [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34549089569) passed all Linux x64, Linux ARM64, musl and macOS checks. Merged as `fe7a45ffab530e6b850800fd4a01ef1972709b0d`.

Docs and the Unreleased changelog are updated. Thanks @jb510!

Closes #3428

<details>
<summary>Inspected synthetic native before/after evidence</summary>

The setting is enabled in both status-item captures:

| Proposal: icon-free output loses color | Fixed native output |
| --- | --- |
| ![Before, colors lost](https://github.com/user-attachments/assets/686fb7dd-519a-4d52-a4f5-d10f22052f7a) | ![After, green reserve and red ahead](https://github.com/user-attachments/assets/9f80805d-71f0-426b-8283-f767833ccb57) |

Switching colors off restores monochrome:

![Switching colors off restores monochrome](https://github.com/user-attachments/assets/ae2325b2-72cb-40ba-8bf4-124f11ce922e)

Stale values dim:

![Stale values dim](https://github.com/user-attachments/assets/d8467e6b-f6b6-472e-b485-2c03ee6b870c)

High contrast takes precedence over stale dimming:

![High contrast takes precedence over stale dimming](https://github.com/user-attachments/assets/acc726c4-5a15-4da0-b460-7882e620f919)

Dark appearance:

![Dark appearance](https://github.com/user-attachments/assets/aab96c18-8922-4831-a0f4-9e21e14e2bef)

Dark appearance with stale and high contrast:

![Dark appearance with stale and high contrast](https://github.com/user-attachments/assets/578b1751-07ea-4dda-95a3-1d78cf49677a)

![Upgraded settings default off, legacy layout retained](https://github.com/user-attachments/assets/0c98a735-28af-46a3-9daa-ced161fb0edf)

![Enabled preference and token-scope explanation](https://github.com/user-attachments/assets/cfabf86b-1fca-4b2e-96b9-4fb2545b2b83)

</details>

<img width="236" height="66" alt="CleanShot 2026-09-10 at 18 41 05@2x" src="https://github.com/user-attachments/assets/5cae53c4-07be-44f3-9b20-b0310fc44be2" />
