### PR TITLE
fix(menu): honor exhausted quotas in automatic switcher progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Hooks: show only the configured threshold, executable, and arguments in Settings; keep examples inside empty fields instead of displaying them as duplicate labels (#3424). Thanks @kedryte!
 - Codex: recover subscription renewal and expiration dates through optional OpenAI web billing capture, without delaying app usage or allowing late results to replace newer dashboards or cross accounts (#3373). Thanks @emanuelst!
 - Kimi: show API membership and standalone CLI versions, retry rejected automatic web sessions, and preserve completed quotas when optional plan metadata stalls; cancelled refreshes stop before further browser reads (#3414). Thanks @xirong!
+- Menu bar: show an exhausted supported quota in automatic switcher progress instead of healthy weekly capacity, while preserving normal weekly progress and provider-specific quota pools (partial fix for #3349). Thanks @rwese!
 
 ## 0.56.5 — 2026-09-04
 

--- a/Sources/CodexBar/StatusItemController+SwitcherMetrics.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherMetrics.swift
@@ -15,6 +15,16 @@ extension StatusItemController {
                 supportsAverage: false)
         } else if provider == .mistral {
             nil
+        } else if preference == .automatic,
+                  MenuBarMetricWindowResolver.automaticSelectionPrioritizesExhaustedWindow(for: provider),
+                  let automatic = MenuBarMetricWindowResolver.rateWindow(
+                      preference: .automatic,
+                      provider: provider,
+                      snapshot: snapshot,
+                      supportsAverage: false),
+                  automatic.usedPercent >= 100
+        {
+            automatic
         } else {
             snapshot?.switcherWeeklyWindow(for: provider, showUsed: showUsed)
         }

--- a/Tests/CodexBarTests/SwitcherExhaustedQuotaTests.swift
+++ b/Tests/CodexBarTests/SwitcherExhaustedQuotaTests.swift
@@ -1,0 +1,142 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct SwitcherExhaustedQuotaTests {
+    @Test(arguments: [false, true])
+    func `automatic switcher shows exhausted rolling and monthly allowances`(_ showUsed: Bool) {
+        let cases: [(Double, Double?, Double)] = [(20, 40, 100), (20, nil, 100), (100, 40, 30)]
+        for (rolling, weekly, monthly) in cases {
+            let snapshot = Self.snapshot(rolling: rolling, weekly: weekly, monthly: monthly)
+            let percent = StatusItemController.switcherWeeklyMetricPercent(
+                for: .opencodego,
+                snapshot: snapshot,
+                showUsed: showUsed)
+            #expect(percent == (showUsed ? 100 : 0))
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `healthy monthly allowance keeps weekly progress`(_ showUsed: Bool) {
+        let percent = StatusItemController.switcherWeeklyMetricPercent(
+            for: .opencodego,
+            snapshot: Self.snapshot(monthly: 90),
+            showUsed: showUsed)
+        #expect(percent == (showUsed ? 40 : 60))
+    }
+
+    @Test(arguments: [MenuBarMetricPreference.primary, .secondary, .tertiary])
+    func `explicit preferences retain the existing weekly switcher contract`(_ preference: MenuBarMetricPreference) {
+        #expect(StatusItemController.switcherWeeklyMetricPercent(
+            for: .opencodego,
+            snapshot: Self.snapshot(monthly: 100),
+            showUsed: false,
+            preference: preference) == 60)
+    }
+
+    @Test(arguments: [UsageProvider.claude, .codex, .factory, .kimi, .litellm])
+    func `provider policies retain separate tertiary pools`(_ provider: UsageProvider) {
+        #expect(StatusItemController.switcherWeeklyMetricPercent(
+            for: provider,
+            snapshot: Self.snapshot(monthly: 100),
+            showUsed: false) == 60)
+    }
+
+    @MainActor
+    @Test
+    func `native switcher empties the exhausted bar and restores weekly progress after refresh`() throws {
+        var snapshot = Self.snapshot(monthly: 100)
+        let view = Self.switcher(snapshot: { snapshot })
+        view.updateConstraintsForSubtreeIfNeeded()
+        view.layoutSubtreeIfNeeded()
+        #expect(view._test_quotaIndicatorFillRatios().last == 0)
+        #expect(view._test_quotaIndicatorFillFrames().last?.width == 0)
+
+        snapshot = Self.snapshot(monthly: 90)
+        view.updateQuotaIndicators()
+        view.layoutSubtreeIfNeeded()
+        #expect(view._test_quotaIndicatorFillRatios().last == 0.6)
+        #expect(try #require(view._test_quotaIndicatorFillFrames().last).width > 0)
+    }
+
+    @MainActor
+    @Test
+    func `render synthetic exhausted quota switcher`() throws {
+        guard let output = ProcessInfo.processInfo.environment["CODEXBAR_SWITCHER_QUOTA_PROOF_PATH"] else { return }
+        let snapshot = Self.snapshot(monthly: 100)
+        let view = Self.switcher(snapshot: { snapshot })
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 420, height: 150))
+        container.appearance = NSAppearance(named: .aqua)
+        container.wantsLayer = true
+        container.layer?.backgroundColor = NSColor.white.cgColor
+        let title = NSTextField(labelWithString: "OpenCode Go — monthly quota exhausted")
+        title.font = .systemFont(ofSize: 15, weight: .semibold)
+        title.frame = NSRect(x: 20, y: 111, width: 380, height: 22)
+        let detail = NSTextField(labelWithString: "Used: rolling 20% · weekly 40% · monthly 100%")
+        detail.font = .systemFont(ofSize: 12)
+        detail.textColor = .secondaryLabelColor
+        detail.frame = NSRect(x: 20, y: 83, width: 380, height: 20)
+        view.frame.origin = NSPoint(x: 20, y: 33)
+        container.addSubview(title)
+        container.addSubview(detail)
+        container.addSubview(view)
+        container.updateConstraintsForSubtreeIfNeeded()
+        container.layoutSubtreeIfNeeded()
+        let ratio = try #require(view._test_quotaIndicatorFillRatios().last)
+        let frame = try #require(view._test_quotaIndicatorFillFrames().last)
+        #expect(ratio.isFinite && frame.width.isFinite)
+        let bitmap = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: 840,
+            pixelsHigh: 300,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0))
+        bitmap.size = container.bounds.size
+        let context = try #require(NSGraphicsContext(bitmapImageRep: bitmap))
+        container.displayIgnoringOpacity(container.bounds, in: context)
+        let png = try #require(bitmap.representation(using: .png, properties: [:]))
+        try png.write(to: URL(fileURLWithPath: output), options: .atomic)
+        print("[switcher-quota-proof] remaining_fill=\(ratio) fill_width=\(frame.width) image=\(output)")
+    }
+
+    private static func snapshot(
+        rolling: Double = 20,
+        weekly: Double? = 40,
+        monthly: Double) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: RateWindow(usedPercent: rolling, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: weekly.map {
+                RateWindow(usedPercent: $0, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)
+            },
+            tertiary: RateWindow(usedPercent: monthly, windowMinutes: 43200, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_788_480_000))
+    }
+
+    @MainActor
+    private static func switcher(snapshot: @escaping () -> UsageSnapshot) -> ProviderSwitcherView {
+        ProviderSwitcherView(
+            providers: [.claude, .opencodego],
+            selected: .provider(.opencodego),
+            includesOverview: false,
+            width: 380,
+            showsIcons: false,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { provider in
+                provider == .opencodego
+                    ? StatusItemController.switcherWeeklyMetricPercent(
+                        for: provider,
+                        snapshot: snapshot(),
+                        showUsed: false)
+                    : 60
+            },
+            onSelect: { _ in })
+    }
+}

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -15,6 +15,9 @@ read_when:
 ## Menu bar
 - LSUIElement app: no Dock icon; status item uses custom NSImage.
 - Merge Icons toggle combines providers into one status item with a switcher.
+- With the automatic metric selected, switcher progress honors a provider's exhausted-quota selection before
+  showing normal weekly progress. Healthy allowances, explicit metric choices, and separate provider pools
+  retain their existing selection rules.
 - Provider status items use stable autosave names and are reused across provider toggles so macOS can preserve icon
   positions.
 - When Overview has selected providers, the switcher includes an Overview tab that renders up to 6 provider rows.


### PR DESCRIPTION
The merged-menu switcher can show remaining weekly capacity when OpenCode Go's monthly quota is exhausted. With rolling/weekly/monthly usage of 20%/40%/100%, the tab currently shows 60% remaining even though its monthly allowance is empty.

For the automatic metric, honor an exhausted result from the provider's existing automatic-selection policy before falling back to weekly progress. Healthy allowances still show weekly progress. Explicit metric preferences, Mistral's monthly-plan handling, policy opt-outs, and custom resolver exclusions retain their existing behavior; no provider-specific branch or stored setting is added.

This addresses the exhausted-quota case in #3349. The broader request to always show the least remaining allowance is not implemented, so that issue should remain open. Thanks @rwese for the report.

The synthetic proof uses the real metric helper and native `ProviderSwitcherView`, with no account data, settings store, or status bar. The measured OpenCode Go fill changes from 0.6 / 46 points to 0 / 0 points. A quota refresh below monthly exhaustion restores the weekly 0.6 fill.

| Before | After |
| --- | --- |
| ![Before: exhausted monthly allowance still shows 60 percent remaining](https://github.com/user-attachments/assets/50013037-7ace-4470-b835-3c0b19524544) | ![After: exhausted monthly allowance shows an empty progress bar](https://github.com/user-attachments/assets/dfeedfae-ddf3-4894-b5b2-f45c76c3e754) |

Validation:
- Unchanged main fails eight new regression assertions; the final candidate passes all 95 focused model, native-view, provider-policy, and architecture tests.
- `make check` passed with zero violations.
- Independent source review found no actionable correctness issue; Codex autoreview found no actionable P0 findings.
- Full `make test` passed all 85 groups on the first attempt, with zero retries or timeouts (981.8 seconds).
- All nine exact-head checks passed in [CI](https://github.com/steipete/CodexBar/actions/runs/33940307554), including both macOS shards, Linux x64/arm64/musl builds, lint, and GitGuardian.
- Fresh ClawSweeper review of the exact head found no correctness or security findings.

Changelog and UI documentation are updated.
