### PR TITLE
fix(kiro): preserve unavailable usage in CLI plan summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.6 — Unreleased
 
 ### Fixed
+- Kiro: accept CLI plan summaries without treating them as format errors, preserve unavailable credit metrics instead of showing false zero usage, and allow existing optional API enrichment to supply valid plan numbers (partial fix for #3359). Thanks @zucram!
 - Codex cost: skip loading raw token histories for unchanged sessions while preserving exact request pricing, reasoning totals, and fork accounting; concurrent cache changes safely request a retry (#3297). Thanks @estevecastells!
 - Codex cost: price GPT-6 Astra sessions, including cached tokens and long-context Fast usage, and reprice saved rows without rebuilding token history (#3423, #3425).
 - Hooks: show only the configured threshold, executable, and arguments in Settings; keep examples inside empty fields instead of displaying them as duplicate labels (#3424). Thanks @kedryte!

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -18,6 +18,8 @@ public struct KiroUsageSnapshot: Sendable {
     public let creditsUsed: Double
     public let creditsTotal: Double
     public let creditsPercent: Double
+    /// False when the CLI reports a plan but withholds its credit metrics.
+    public let hasUsageMetrics: Bool
     public let bonusCreditsUsed: Double?
     public let bonusCreditsTotal: Double?
     public let bonusExpiryDays: Int?
@@ -39,6 +41,7 @@ public struct KiroUsageSnapshot: Sendable {
         creditsUsed: Double,
         creditsTotal: Double,
         creditsPercent: Double,
+        hasUsageMetrics: Bool = true,
         bonusCreditsUsed: Double?,
         bonusCreditsTotal: Double?,
         bonusExpiryDays: Int?,
@@ -58,6 +61,7 @@ public struct KiroUsageSnapshot: Sendable {
         self.creditsUsed = creditsUsed
         self.creditsTotal = creditsTotal
         self.creditsPercent = creditsPercent
+        self.hasUsageMetrics = hasUsageMetrics
         self.bonusCreditsUsed = bonusCreditsUsed
         self.bonusCreditsTotal = bonusCreditsTotal
         self.bonusExpiryDays = bonusExpiryDays
@@ -74,16 +78,17 @@ public struct KiroUsageSnapshot: Sendable {
     /// Returns a copy carrying the API's plan/overage ceilings.
     func withUsageLimits(_ usageLimits: KiroUsageLimits?) -> Self {
         guard let usageLimits else { return self }
+        let hasPlanMetrics = !usageLimits.hasUnseparatedBonus && usageLimits.planLimit > 0
         return Self(
             planName: self.planName,
             displayPlanName: self.displayPlanName,
             accountEmail: self.accountEmail,
             authMethod: self.authMethod,
-            creditsUsed: usageLimits.hasUnseparatedBonus ? self.creditsUsed : usageLimits.planUsed,
-            creditsTotal: usageLimits.hasUnseparatedBonus ? self.creditsTotal : usageLimits.planLimit,
-            creditsPercent: usageLimits.hasUnseparatedBonus || usageLimits.planLimit <= 0
-                ? self.creditsPercent
-                : (usageLimits.planUsed / usageLimits.planLimit) * 100.0,
+            creditsUsed: hasPlanMetrics ? usageLimits.planUsed : self.creditsUsed,
+            creditsTotal: hasPlanMetrics ? usageLimits.planLimit : self.creditsTotal,
+            creditsPercent: hasPlanMetrics ? (usageLimits.planUsed / usageLimits.planLimit) * 100.0 : self
+                .creditsPercent,
+            hasUsageMetrics: self.hasUsageMetrics || hasPlanMetrics,
             bonusCreditsUsed: self.bonusCreditsUsed,
             bonusCreditsTotal: self.bonusCreditsTotal,
             bonusExpiryDays: self.bonusExpiryDays,
@@ -101,11 +106,13 @@ public struct KiroUsageSnapshot: Sendable {
     }
 
     public func toUsageSnapshot() -> UsageSnapshot {
-        let primary = RateWindow(
-            usedPercent: self.creditsPercent,
-            windowMinutes: nil,
-            resetsAt: self.resetsAt,
-            resetDescription: nil)
+        let primary: RateWindow? = self.hasUsageMetrics
+            ? RateWindow(
+                usedPercent: self.creditsPercent,
+                windowMinutes: nil,
+                resetsAt: self.resetsAt,
+                resetDescription: nil)
+            : nil
 
         var secondary: RateWindow?
         if let bonusUsed = self.bonusCreditsUsed,
@@ -132,10 +139,14 @@ public struct KiroUsageSnapshot: Sendable {
 
         var detailRows: [ProviderDetailSection.Row] = [
             .makeRow(label: "Plan", value: self.displayPlanName),
-            .makeRow(label: "Credits left", value: UsageFormatter.kiroCreditNumber(self.creditsRemaining)),
-            .makeRow(label: "Credits used", value: UsageFormatter.kiroCreditNumber(self.creditsUsed)),
-            .makeRow(label: "Credits total", value: UsageFormatter.kiroCreditNumber(self.creditsTotal)),
         ]
+        if self.hasUsageMetrics {
+            detailRows.append(contentsOf: [
+                .makeRow(label: "Credits left", value: UsageFormatter.kiroCreditNumber(self.creditsRemaining)),
+                .makeRow(label: "Credits used", value: UsageFormatter.kiroCreditNumber(self.creditsUsed)),
+                .makeRow(label: "Credits total", value: UsageFormatter.kiroCreditNumber(self.creditsTotal)),
+            ])
+        }
         if let remaining = self.bonusCreditsRemaining, let total = self.bonusCreditsTotal {
             detailRows.append(.makeRow(
                 label: "Bonus credits left",
@@ -970,10 +981,8 @@ public struct KiroStatusProbe: Sendable {
             in: stripped,
             pattern: #"https://app\.kiro\.dev/account/usage"#)
 
-        // Managed plans in new format may omit usage metrics. Only fall back to zeros when
-        // we did not parse any usage values, so we do not mask real metrics.
-        if matchedNewFormat, isManagedPlan, !matchedPercent, !matchedCredits {
-            // Managed plans don't expose credits; return snapshot with plan name only
+        // A managed report or explicit breakdown summary can withhold metrics without being a format error.
+        if matchedNewFormat, isManagedPlan || parsedPlan.isSummary, !matchedPercent, !matchedCredits {
             return KiroUsageSnapshot(
                 planName: planName,
                 displayPlanName: Self.displayPlanName(planName),
@@ -982,6 +991,7 @@ public struct KiroStatusProbe: Sendable {
                 creditsUsed: 0,
                 creditsTotal: 0,
                 creditsPercent: 0,
+                hasUsageMetrics: false,
                 bonusCreditsUsed: bonusCredits.used,
                 bonusCreditsTotal: bonusCredits.total,
                 bonusExpiryDays: bonusCredits.expiryDays,
@@ -1048,7 +1058,14 @@ public struct KiroStatusProbe: Sendable {
         return regex.stringByReplacingMatches(in: text, options: [], range: range, withTemplate: "")
     }
 
-    private static func parsePlanName(from text: String) -> (name: String, matchedNewFormat: Bool) {
+    private static func parsePlanName(from text: String) -> (name: String, matchedNewFormat: Bool, isSummary: Bool) {
+        if let name = firstCapture(
+            in: text,
+            pattern: #"(?m)^[ \t]*Plan:[ \t]*([^|\r\n]+?)[ \t]*\|[ \t]*[0-9]+[ \t]+usage breakdowns?[ \t]*$"#)?
+            .trimmingCharacters(in: .whitespaces), !name.isEmpty
+        {
+            return (name, true, true)
+        }
         var planName = "Kiro"
         var matchedNewFormat = false
 
@@ -1082,7 +1099,7 @@ public struct KiroStatusProbe: Sendable {
             }
         }
 
-        return (planName, matchedNewFormat)
+        return (planName, matchedNewFormat, false)
     }
 
     private static func parseResetDate(in text: String) -> Date? {

--- a/Tests/CodexBarTests/KiroSummaryTests.swift
+++ b/Tests/CodexBarTests/KiroSummaryTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct KiroSummaryTests {
+    @Test(arguments: ["0", "1", "2"])
+    func `summary preserves the plan without inventing usage`(count: String) throws {
+        let snapshot = try KiroStatusProbe().parse(
+            output: "\u{001B}[32mPlan: KIRO PRO MAX | \(count) usage breakdowns\u{001B}[0m\n")
+        #expect(snapshot.planName == "KIRO PRO MAX")
+        Self.expectPlanOnly(snapshot.toUsageSnapshot())
+    }
+
+    @Test
+    func `managed plan without metrics does not publish zero usage`() throws {
+        let snapshot = try KiroStatusProbe().parse(output: """
+        Plan: Q Developer Pro
+        Your plan is managed by admin
+        """)
+        Self.expectPlanOnly(snapshot.toUsageSnapshot())
+    }
+
+    @Test(arguments: [
+        "Plan: KIRO PRO MAX",
+        "Plan: KIRO PRO MAX | usage breakdowns",
+        "Plan: KIRO PRO MAX | -1 usage breakdowns",
+        "Plan: KIRO PRO MAX | 1.5 usage breakdowns",
+        "Plan: KIRO PRO MAX | 1 usage breakdowns failed",
+        "Plan: | 1 usage breakdowns",
+        "echo Plan: KIRO PRO MAX | 1 usage breakdowns",
+        "Plan: KIRO PRO MAX |\n1 usage breakdowns",
+    ])
+    func `incomplete and malformed summaries remain errors`(output: String) {
+        #expect(throws: KiroStatusProbeError.self) {
+            try KiroStatusProbe().parse(output: output)
+        }
+    }
+
+    @Test
+    func `summary with real zero usage keeps the reported allowance`() throws {
+        let snapshot = try KiroStatusProbe().parse(output: """
+        Plan: KIRO PRO MAX | 1 usage breakdowns
+        Credits (0 of 5000 covered in plan)
+        """)
+        #expect(snapshot.planName == "KIRO PRO MAX")
+        #expect(snapshot.creditsTotal == 5000)
+        #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 0)
+        #expect(snapshot.toUsageSnapshot().details.flatMap(\.rows).contains { $0.label == "Credits total" })
+    }
+
+    @Test(arguments: [false, true])
+    func `CLI summary reaches optional enrichment and survives its failure`(apiSucceeds: Bool) async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-kiro-summary-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cli = root.appendingPathComponent("kiro-cli")
+        try """
+        #!/bin/sh
+        if [ "$1" = "whoami" ]; then
+          printf 'Logged in with Google\\nEmail: person@example.com\\n'
+          exit 0
+        fi
+        if [ "$1" = "chat" ] && [ "$3" = "/usage" ]; then
+          printf 'Plan: KIRO PRO MAX | 1 usage breakdowns\\n'
+          exit 0
+        fi
+        if [ "$1" = "chat" ] && [ "$3" = "/context" ]; then
+          exit 0
+        fi
+        exit 1
+        """.write(to: cli, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cli.path)
+        let snapshot = try await KiroStatusProbe(
+            cliBinaryResolver: { cli.path },
+            usageLimitsFetcher: {
+                guard apiSucceeds else { throw KiroUsageLimitsError.requestFailed("Synthetic unavailable API") }
+                return Self.limits()
+            }).fetch()
+        let usage = snapshot.toUsageSnapshot()
+        #expect(snapshot.planName == "KIRO PRO MAX")
+        #expect(snapshot.accountEmail == "person@example.com")
+        if apiSucceeds {
+            #expect(snapshot.creditsUsed == 282.49)
+            #expect(snapshot.creditsTotal == 5000)
+            #expect(abs((usage.primary?.usedPercent ?? -1) - 5.6498) < 0.0001)
+        } else {
+            Self.expectPlanOnly(usage)
+        }
+    }
+
+    @Test
+    func `ambiguous bonus enrichment cannot invent a plan gauge`() throws {
+        let snapshot = try KiroStatusProbe().parse(output: "Plan: KIRO PRO MAX | 1 usage breakdowns")
+        Self.expectPlanOnly(snapshot.withUsageLimits(Self.limits(hasUnseparatedBonus: true)).toUsageSnapshot())
+    }
+
+    @Test
+    func `zero API allowance preserves unknown or existing CLI metrics`() throws {
+        let unknown = try KiroStatusProbe().parse(output: "Plan: KIRO PRO MAX | 1 usage breakdowns")
+        Self.expectPlanOnly(unknown.withUsageLimits(Self.limits(planLimit: 0)).toUsageSnapshot())
+        let known = try KiroStatusProbe().parse(output: "Credits (20 of 50 covered in plan)")
+            .withUsageLimits(Self.limits(planLimit: 0))
+        #expect(known.creditsUsed == 20)
+        #expect(known.creditsTotal == 50)
+        #expect(known.toUsageSnapshot().primary?.usedPercent == 40)
+    }
+
+    private static func expectPlanOnly(_ snapshot: UsageSnapshot) {
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.secondary == nil)
+        #expect(snapshot.details.flatMap(\.rows).map(\.label) == ["Plan"])
+    }
+
+    private static func limits(hasUnseparatedBonus: Bool = false, planLimit: Double = 5000) -> KiroUsageLimits {
+        KiroUsageLimits(
+            planLimit: planLimit,
+            planUsed: planLimit == 0 ? 0 : 282.49,
+            overageUsed: 0,
+            overageCap: nil,
+            overageCharges: nil,
+            overageRate: nil,
+            currencyCode: "USD",
+            resetsAt: Date(timeIntervalSince1970: 1_790_812_800),
+            hasUnseparatedBonus: hasUnseparatedBonus)
+    }
+}

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -20,6 +20,8 @@ Kiro uses the AWS `kiro-cli` tool to fetch usage data. No browser cookies or OAu
      pipe output falls back to a pseudo-terminal within the same overall command deadline for older releases.
    - Requires `kiro-cli` installed and logged in via AWS Builder ID.
    - Output is ANSI-decorated; CodexBar strips escape sequences before parsing.
+   - Kiro CLI 2.20 summary output such as `Plan: KIRO PRO MAX | 1 usage breakdowns` is accepted
+     as a plan-only report. A breakdown count does not imply zero usage or an available allowance.
 
 2) **`GetUsageLimits` API** (overage enrichment, best effort)
    - The CLI report states credits against the plan alone and **omits the overage section entirely for
@@ -32,7 +34,9 @@ Kiro uses the AWS `kiro-cli` tool to fetch usage data. No browser cookies or OAu
      - `auth_kv` key `kirocli:odic:token` → `access_token`
      - `state` key `api.codewhisperer.profile` → `arn`
    - Runs after the CLI probe, so a token the CLI refreshed along the way is already in place.
-   - Failure is non-fatal: the plan-relative numbers the CLI produced stand. The API path depends on the CLI's
+   - Failure is non-fatal: the plan-relative numbers the CLI produced stand, or a plan-only report keeps
+     usage unavailable. An unambiguous positive API allowance can supply the missing plan metrics.
+     The API path depends on the CLI's
      private token store, which a Kiro release can move, whereas the CLI reads only its own published output.
 
 ## Output format (example)
@@ -52,6 +56,9 @@ Kiro uses the AWS `kiro-cli` tool to fetch usage data. No browser cookies or OAu
 ## Snapshot mapping
 
 - **Primary window**: Monthly plan credits percentage (bar meter).
+  - Omitted, along with numeric plan-credit rows, when a managed report or breakdown summary withholds
+    metrics and usable API enrichment is unavailable. The plan name remains visible. Bonus-inclusive API
+    totals and zero allowances do not replace the CLI plan metrics or invent a missing plan gauge.
   - `usedPercent`: extracted from `███...█ X%` pattern, or `planUsed / planLimit` when the API answered.
   - `resetsAt`: parsed from `resets on MM/DD` (assumes current or next year), or `nextDateReset` from the API.
 - **Secondary window**: Bonus credits (when present).


### PR DESCRIPTION
Kiro CLI 2.20.2 can return `Plan: KIRO PRO MAX | 1 usage breakdowns` without numeric usage. CodexBar rejected that valid summary before optional API enrichment could run. Older managed-plan responses also published a false 0%-used quota and zero credit totals when the CLI withheld metrics.

Recognize an explicit, line-anchored breakdown summary and retain the clean plan name. Track metric availability separately from numeric values: plan-only reports omit the primary quota and numeric plan-credit rows. Existing optional enrichment can fill them when it supplies an unambiguous positive allowance. Failed enrichment, bonus-inclusive totals, and zero API allowances preserve the CLI's available or unavailable plan metrics; bonus and overage handling stays independent.

This is a partial fix for #3359. Regional endpoint routing and credential ownership are unchanged; the issue remains open for the reported non-default-region enrichment failure. Thanks @zucram for the detailed report and proposed parser direction.

Validation:
- New parser/publication/subprocess regressions fail on unchanged main with nine issues.
- All 99 focused Kiro tests passed, including real fake-CLI subprocesses with injected API success/failure. No real account, credential store, or network request was used.
- `make check` passed with zero violations.
- Independent source review found no production correctness issue and identified one test-fixture correction, which is included.
- Codex autoreview found no actionable P0 findings in the final diff.
- Full `make test` passed all 85 groups on the first attempt, with zero retries or timeouts (1,095.2 seconds). The corrected fixture also passed a final focused run of all seven summary tests.
- All nine exact-head checks passed in [CI](https://github.com/steipete/CodexBar/actions/runs/33944643325), including both macOS shards, Linux builds, lint, and GitGuardian.
- Fresh ClawSweeper review of the exact head found no correctness or security findings.

Kiro documentation and the Unreleased changelog are updated. The older managed-plan false-zero behavior traces to 9c229d803b32, which added plan-only zero-valued snapshots while conversion already created a quota unconditionally.
