### PR TITLE
test: prevent Git fixture output deadlocks

### DIFF
--- a/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
@@ -245,7 +245,7 @@ struct CostUsageScannerBreakdownTests {
     }
 
     @Test
-    func `codex project breakdowns group by cwd and preserve daily totals`() throws {
+    func `codex project breakdowns group by cwd and preserve daily totals`() async throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }
 
@@ -260,7 +260,7 @@ struct CostUsageScannerBreakdownTests {
             .appendingPathComponent(".codex/worktrees/abcd/client-a", isDirectory: true)
             .path
 
-        try self.makeGitRepositoryWithWorktree(projectPath: projectA, worktreePath: projectAWorktree)
+        try await self.makeGitRepositoryWithWorktree(projectPath: projectA, worktreePath: projectAWorktree)
 
         func sessionMeta(id: String, cwd: String?) -> [String: Any] {
             var payload: [String: Any] = ["id": id]
@@ -387,43 +387,43 @@ struct CostUsageScannerBreakdownTests {
         #expect(projects.first(where: { $0.path == projectA })?.totalTokens == 52)
     }
 
-    private func makeGitRepositoryWithWorktree(projectPath: String, worktreePath: String) throws {
+    @Test
+    func `git fixtures drain output larger than pipe buffers`() async throws {
+        try await self.runGit([
+            "-c",
+            "alias.codexbar-fixture-output=!printf '%131072s' x; printf '%131072s' x >&2",
+            "codexbar-fixture-output",
+        ])
+    }
+
+    private func makeGitRepositoryWithWorktree(projectPath: String, worktreePath: String) async throws {
         try FileManager.default.createDirectory(
             at: URL(fileURLWithPath: projectPath, isDirectory: true),
             withIntermediateDirectories: true)
-        try self.runGit(["init", projectPath])
-        try self.runGit(["-C", projectPath, "config", "user.email", "codexbar-test@example.com"])
-        try self.runGit(["-C", projectPath, "config", "user.name", "CodexBar Test"])
-        try self.runGit(["-C", projectPath, "config", "commit.gpgsign", "false"])
+        try await self.runGit(["init", projectPath])
+        try await self.runGit(["-C", projectPath, "config", "user.email", "codexbar-test@example.com"])
+        try await self.runGit(["-C", projectPath, "config", "user.name", "CodexBar Test"])
+        try await self.runGit(["-C", projectPath, "config", "commit.gpgsign", "false"])
         try "test\n".write(
             to: URL(fileURLWithPath: projectPath).appendingPathComponent("README.md"),
             atomically: false,
             encoding: .utf8)
-        try self.runGit(["-C", projectPath, "add", "README.md"])
-        try self.runGit(["-C", projectPath, "commit", "-m", "init"])
+        try await self.runGit(["-C", projectPath, "add", "README.md"])
+        try await self.runGit(["-C", projectPath, "commit", "-m", "init"])
         try FileManager.default.createDirectory(
             at: URL(fileURLWithPath: worktreePath).deletingLastPathComponent(),
             withIntermediateDirectories: true)
-        try self.runGit(["-C", projectPath, "worktree", "add", "-b", "codex-test", worktreePath])
+        try await self.runGit(["-C", projectPath, "worktree", "add", "-b", "codex-test", worktreePath])
     }
 
-    private func runGit(_ arguments: [String]) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["git"] + arguments
-        let output = Pipe()
-        process.standardOutput = output
-        process.standardError = output
-        try process.run()
-        process.waitUntilExit()
-        if process.terminationStatus != 0 {
-            let data = output.fileHandleForReading.readDataToEndOfFile()
-            let message = String(data: data, encoding: .utf8) ?? ""
-            throw NSError(
-                domain: "CodexBarTests.Git",
-                code: Int(process.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey: message])
-        }
+    private func runGit(_ arguments: [String]) async throws {
+        _ = try await SubprocessRunner.run(
+            binary: "/usr/bin/env",
+            arguments: ["git"] + arguments,
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 15,
+            maxOutputBytes: 1024 * 1024,
+            label: "git fixture")
     }
 
     @Test


### PR DESCRIPTION
The cost-history test fixture could deadlock when `git init` wrote branch-name advice: the test waited for Git to exit before reading its output. A process sample during the 0.56.6 release preflight confirmed Git blocked in its stderr write while the fixture waited for termination.

Use the existing bounded subprocess runner to drain both streams while Git runs. A regression invokes a Git alias that emits 128 KiB to stdout and another 128 KiB to stderr. This changes test infrastructure only.

Validation: all 96 `CostUsageScannerBreakdownTests` passed, including the output-pressure regression; `make check` and P0 review passed. The [complete CI gate](https://github.com/steipete/CodexBar/actions/runs/33980352849) passed on this head, including both macOS test shards. All 42 CLIEntry tests intentionally excluded from macOS CI passed locally. Local all-in-one runs reached unrelated UI/UsageStore suites before filesystem stalls exhausted their budgets; a stack sample located the delay in an atomic file rename. The clean CI shards and local CLIEntry results provide complete suite coverage.
