### PR TITLE
fix(commandcode): remember resolved plan for billing period

### DIFF
--- a/.github/pr-proof/commandcode-monthly-grant-flake.log
+++ b/.github/pr-proof/commandcode-monthly-grant-flake.log
@@ -1,0 +1,47 @@
+Command Code monthly grant flake - before/after proof
+
+A throwaway Swift Testing harness drove the real CommandCodeUsageFetcher against a stubbed
+ProviderHTTPTransport. The credits endpoint always answered. The subscriptions endpoint hung for
+30 s, which is what a lost join grace looks like in production, because the fetcher allows 2 s.
+
+Account under test: individual-go plan, $10 monthly grant. The first refresh reports $9 remaining,
+so the true monthly reading is 10% used. The second and third report $4 remaining, so the true
+reading is 60% used. Rolling caps: five-hour 1.2/10, weekly 30/100.
+
+Command, identical in both states:
+  swift test --filter 'ZZProofBaseline'
+
+Before, at upstream 28b8dcbe8:
+  PROOF healthy refresh: plan=Optional("individual-go") monthly=Optional(10.0) (true value 10)
+  PROOF timeout, $6 of the $10 grant spent: plan=nil monthly=Optional(0.0) (true value 60)
+  PROOF timeout rolling lanes: 5h=Optional(12.0) weekly=Optional(30.0)
+  PROOF timeout with no earlier success: monthly=Optional(0.0) (true value unknown)
+
+The monthly lane reports 0% used, an untouched bar, while $6 of the $10 grant is spent. The two
+rolling lanes stay correct, which is why only one lane looks wrong on screen.
+
+After this change:
+  PROOF healthy refresh: plan=Optional("individual-go") monthly=Optional(10.0) (true value 10)
+  PROOF timeout, $6 of the $10 grant spent: plan=Optional("individual-go") monthly=Optional(60.0) (true value 60)
+  PROOF timeout rolling lanes: 5h=Optional(12.0) weekly=Optional(30.0)
+  PROOF timeout with no earlier success: monthly=nil (true value unknown)
+
+The kept plan supplies the grant size and the fresh credits response supplies the spend, so the
+lane reports the true 60%. With no earlier success for that credential the lane is unavailable
+rather than untouched.
+
+The harness was deleted after this capture. Each line above is pinned by a committed test:
+  line 2 (kept plan sizes the lane from fresh credits)
+    Tests/CodexBarTests/CommandCodePlanCacheTests.swift
+    `remembered plan sizes the monthly lane from fresh credits after a failure`
+  line 3 (rolling lanes unaffected)
+    Tests/CodexBarTests/CommandCodeQuotaTransitionTests.swift
+    `subscription enrichment failure preserves rolling windows`
+  line 4 (no kept plan means an unavailable lane)
+    Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+    `subscription failure leaves the projected monthly window unavailable`
+
+Every case where the kept plan must not apply is pinned in CommandCodePlanCacheTests.swift: the
+billing period ends, a day passes with no refresh confirming it, another credential asks, a lookup
+verifies the free tier, a lookup reports a plan id this build cannot size, and a subscription
+arrives without a period end.

--- a/.github/pr-proof/commandcode-monthly-grant-flake.log
+++ b/.github/pr-proof/commandcode-monthly-grant-flake.log
@@ -1,47 +1,96 @@
-Command Code monthly grant flake - before/after proof
+Command Code monthly grant flake - real-transport before/after proof
 
-A throwaway Swift Testing harness drove the real CommandCodeUsageFetcher against a stubbed
-ProviderHTTPTransport. The credits endpoint always answered. The subscriptions endpoint hung for
-30 s, which is what a lost join grace looks like in production, because the fetcher allows 2 s.
+The real `codexbar serve` binary ran against a local stand-in for api.commandcode.ai over real
+HTTP, through the production `ProviderHTTPClient` and `URLSession`. Nothing was stubbed inside the
+app: only the base URL moved, through `COMMANDCODE_API_URL`, the documented test override that
+`MIMO_API_URL` and `CODEXBAR_BEDROCK_API_URL` already use. No live account, no Keychain read, no
+real credential: the config held a manual placeholder cookie.
 
-Account under test: individual-go plan, $10 monthly grant. The first refresh reports $9 remaining,
-so the true monthly reading is 10% used. The second and third report $4 remaining, so the true
-reading is 60% used. Rolling caps: five-hour 1.2/10, weekly 30/100.
+Account under test: individual-go, $10 monthly grant.
+  fresh fixture: $9 remaining, true monthly reading 10% used
+  spent fixture: $4 remaining, true monthly reading 60% used
+Rolling caps in the spent fixture: five-hour 1.2/10, weekly 30/100.
 
-Command, identical in both states:
-  swift test --filter 'ZZProofBaseline'
+The stand-in served /internal/billing/credits immediately every time. It served
+/internal/billing/subscriptions immediately in "answer" mode, and slept 30 s in "hang" mode. The
+fetcher allows that optional request a 2 s join grace, so "hang" is a production timeout. Every
+capture below returned in about 2.1 s, which confirms the grace expired rather than the request
+answering late.
 
-Before, at upstream 28b8dcbe8:
-  PROOF healthy refresh: plan=Optional("individual-go") monthly=Optional(10.0) (true value 10)
-  PROOF timeout, $6 of the $10 grant spent: plan=nil monthly=Optional(0.0) (true value 60)
-  PROOF timeout rolling lanes: 5h=Optional(12.0) weekly=Optional(30.0)
-  PROOF timeout with no earlier success: monthly=Optional(0.0) (true value unknown)
+Commands, identical in both states:
 
-The monthly lane reports 0% used, an untouched bar, while $6 of the $10 grant is spent. The two
-rolling lanes stay correct, which is why only one lane looks wrong on screen.
+  python3 stub.py 54139                     # local stand-in, loopback only
+  CODEXBAR_CONFIG=<temp config> \
+  COMMANDCODE_API_URL=http://127.0.0.1:54139 \
+    .build/debug/CodexBarCLI serve --host 127.0.0.1 --port <port> --refresh-interval 0
+  curl -s http://127.0.0.1:<port>/usage     # one refresh per request
+
+Before, at upstream eecb7e3a3 with only the endpoint override cherry-picked:
+
+  healthy refresh (answer + fresh)
+    {"loginMethod":"Go · $1.00 of $10.00","primary":{"usedPercent":4,"windowMinutes":300},
+     "secondary":{"usedPercent":12,"windowMinutes":10080},
+     "tertiary":{"usedPercent":10,"windowMinutes":43200,"resetsAt":"2096-10-02T07:06:40Z"}}
+
+  timeout after an earlier success (hang + spent), same process
+    {"loginMethod":"$4.00 remaining","primary":{"usedPercent":12,"windowMinutes":300},
+     "secondary":{"usedPercent":30,"windowMinutes":10080},
+     "tertiary":{"usedPercent":0,"windowMinutes":43200}}
+
+  timeout with no earlier success (hang + spent), fresh process
+    {"loginMethod":"$4.00 remaining","primary":{"windowMinutes":300,"usedPercent":12},
+     "secondary":{"windowMinutes":10080,"usedPercent":30},
+     "tertiary":{"windowMinutes":43200,"usedPercent":0}}
+
+The monthly lane reports 0% used, an untouched bar, while $6 of the $10 grant is spent. Both
+rolling lanes stay correct, which is why only one lane looks wrong on screen. The rendered card
+shows what the user sees, from `codexbar cards --provider commandcode` in the same state:
+
+  │ Command Code [manual] PLAN $4.00 R… │
+  │ 5-hour                     88% left │
+  │ Weekly                     70% left │
+  │ Monthly                   100% left │
+  │ [ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ] │
 
 After this change:
-  PROOF healthy refresh: plan=Optional("individual-go") monthly=Optional(10.0) (true value 10)
-  PROOF timeout, $6 of the $10 grant spent: plan=Optional("individual-go") monthly=Optional(60.0) (true value 60)
-  PROOF timeout rolling lanes: 5h=Optional(12.0) weekly=Optional(30.0)
-  PROOF timeout with no earlier success: monthly=nil (true value unknown)
 
-The kept plan supplies the grant size and the fresh credits response supplies the spend, so the
-lane reports the true 60%. With no earlier success for that credential the lane is unavailable
-rather than untouched.
+  healthy refresh (answer + fresh)
+    {"loginMethod":"Go · $1.00 of $10.00","primary":{"usedPercent":4,"windowMinutes":300},
+     "secondary":{"usedPercent":12,"windowMinutes":10080},
+     "tertiary":{"usedPercent":10,"windowMinutes":43200,"resetsAt":"2096-10-02T07:06:40Z"}}
 
-The harness was deleted after this capture. Each line above is pinned by a committed test:
-  line 2 (kept plan sizes the lane from fresh credits)
+  timeout after an earlier success (hang + spent), same process
+    {"loginMethod":"Go · $6.00 of $10.00","primary":{"usedPercent":12,"windowMinutes":300},
+     "secondary":{"usedPercent":30,"windowMinutes":10080},
+     "tertiary":{"usedPercent":60,"windowMinutes":43200,"resetsAt":"2096-10-02T07:06:40Z"}}
+
+  timeout with no earlier success (hang + spent), fresh process
+    {"loginMethod":"$4.00 remaining","primary":{"windowMinutes":300,"usedPercent":12},
+     "secondary":{"windowMinutes":10080,"usedPercent":30},
+     "tertiary":null}
+
+The remembered plan supplies the grant size and the fresh credits response supplies the spend, so
+the lane reports the true 60%. With no earlier success for that credential the lane is
+unavailable, and the one-shot card drops the row instead of drawing a full bar:
+
+  │ Command Code [manual] PLAN $4.00 R… │
+  │ 5-hour                     88% left │
+  │ Weekly                     70% left │
+
+The stand-in and the temp config live outside the repository and were deleted after this capture.
+Every line above is pinned by a committed test:
+
+  remembered plan sizes the lane from fresh credits
     Tests/CodexBarTests/CommandCodePlanCacheTests.swift
     `remembered plan sizes the monthly lane from fresh credits after a failure`
-  line 3 (rolling lanes unaffected)
+  rolling lanes unaffected by a failed lookup
     Tests/CodexBarTests/CommandCodeQuotaTransitionTests.swift
     `subscription enrichment failure preserves rolling windows`
-  line 4 (no kept plan means an unavailable lane)
+  no remembered plan means an unavailable lane
     Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
     `subscription failure leaves the projected monthly window unavailable`
 
-Every case where the kept plan must not apply is pinned in CommandCodePlanCacheTests.swift: the
-billing period ends, a day passes with no refresh confirming it, another credential asks, a lookup
-verifies the free tier, a lookup reports a plan id this build cannot size, and a subscription
-arrives without a period end.
+Every case where the remembered plan must not apply is pinned in CommandCodePlanCacheTests.swift:
+the billing period ends, a day passes with no refresh confirming it, another credential asks, a
+lookup verifies the free tier, a lookup reports a plan id this build cannot size, and a
+subscription arrives without a period end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.56.7 — Unreleased
 
+### Fixed
+- Command Code: keep the resolved subscription plan in memory for its billing period so a timed-out plan lookup still sizes the monthly credits row from fresh credits, and report that row as unavailable rather than untouched when no plan is known; rolling five-hour and weekly usage stay unaffected (#3441). Thanks @enieuwy!
+
 ## 0.56.6 — 2026-09-05
 
 ### Highlights

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodePlanCache.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodePlanCache.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Remembers the Command Code subscription plan for the billing period it belongs to.
+///
+/// The monthly grant size lives only in `/internal/billing/subscriptions`, which the fetcher joins
+/// under a short grace so a slow optional request cannot hold the credits result. That grace is
+/// lost several times a day in practice. The plan is constant for a whole billing period, so a
+/// remembered plan lets a timed-out refresh size the monthly lane from the fresh credits response
+/// instead of publishing an unknown grant.
+///
+/// Entries are in-memory only, scoped to a credential fingerprint so one account can never size
+/// another account's lane, dropped at `currentPeriodEnd`, and dropped again once no refresh has
+/// confirmed them for a day.
+actor CommandCodePlanCache {
+    struct Entry: Sendable {
+        let plan: CommandCodePlanCatalog.Plan
+        let periodEnd: Date
+        let storedAt: Date
+    }
+
+    /// Distinct credentials retained at once. A rotated session cookie yields a new fingerprint,
+    /// so the bound only exists to keep rotations from growing the map without limit.
+    private static let capacity = 4
+
+    /// How long an entry survives without a successful lookup confirming it. Successful lookups
+    /// dominate in practice, so this bounds retention after the credential goes away - a cleared
+    /// cookie cache, a disabled provider - without ever expiring an entry a live account still
+    /// refreshes. It also bounds a server-supplied `currentPeriodEnd` far in the future.
+    private static let maximumUnconfirmedAge: TimeInterval = 24 * 60 * 60
+
+    private var entries: [String: Entry] = [:]
+
+    /// Remembers a resolved plan whose billing period has a known future end.
+    ///
+    /// Retention ignores the subscription status, because the live path sizes the lane from any
+    /// resolved plan: a trialing, past-due, or cancel-at-period-end account keeps its grant until
+    /// the period ends. A subscription without `currentPeriodEnd` is not retained, because an entry
+    /// that cannot expire would keep sizing the lane after the grant refills.
+    func store(
+        plan: CommandCodePlanCatalog.Plan,
+        periodEnd: Date?,
+        fingerprint: String,
+        now: Date)
+    {
+        guard let periodEnd, periodEnd > now else {
+            self.entries[fingerprint] = nil
+            return
+        }
+        self.entries[fingerprint] = Entry(plan: plan, periodEnd: periodEnd, storedAt: now)
+        self.prune(now: now)
+    }
+
+    /// Forgets the remembered plan once a lookup proves it wrong: a verified free tier, or a plan
+    /// id this build cannot size.
+    ///
+    /// A verdict older than the entry it would remove is ignored, so a slow response cannot revoke
+    /// a plan that a later refresh already confirmed.
+    func clear(fingerprint: String, now: Date) {
+        guard let entry = self.entries[fingerprint], entry.storedAt <= now else { return }
+        self.entries[fingerprint] = nil
+    }
+
+    /// The remembered plan for this credential, or nil once it expires.
+    ///
+    /// An entry recorded after the instant being reported cannot describe that instant, so a
+    /// backdated read never sees it.
+    func entry(fingerprint: String, now: Date) -> Entry? {
+        guard let entry = self.entries[fingerprint] else { return nil }
+        guard entry.storedAt <= now else { return nil }
+        guard entry.periodEnd > now,
+              now.timeIntervalSince(entry.storedAt) < Self.maximumUnconfirmedAge
+        else {
+            self.entries[fingerprint] = nil
+            return nil
+        }
+        return entry
+    }
+
+    private func prune(now: Date) {
+        self.entries = self.entries.filter { $0.value.periodEnd > now }
+        guard self.entries.count > Self.capacity else { return }
+        let stale = self.entries
+            .sorted { $0.value.storedAt < $1.value.storedAt }
+            .prefix(self.entries.count - Self.capacity)
+        for (key, _) in stale {
+            self.entries[key] = nil
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
@@ -17,6 +17,13 @@ public enum CommandCodeUsageFetcher {
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
 
+    private static let sharedPlanCache = CommandCodePlanCache()
+    @TaskLocal private static var planCacheOverrideForTesting: CommandCodePlanCache?
+
+    private static var planCache: CommandCodePlanCache {
+        self.planCacheOverrideForTesting ?? self.sharedPlanCache
+    }
+
     public static func fetchUsage(
         cookieHeader: String,
         session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
@@ -42,6 +49,18 @@ public enum CommandCodeUsageFetcher {
             subscriptionGrace: subscriptionGrace)
     }
 
+    #if DEBUG
+    /// Runs `operation` against a plan memory of its own, so a test can neither read nor write the
+    /// process-wide one.
+    static func withIsolatedPlanCacheForTesting<T>(
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$planCacheOverrideForTesting.withValue(CommandCodePlanCache()) {
+            try await operation()
+        }
+    }
+    #endif
+
     private static func fetchUsage(
         cookieHeader: String,
         transport: any ProviderHTTPTransport,
@@ -61,8 +80,19 @@ public enum CommandCodeUsageFetcher {
         // explicitly rather than silently dropping the totals row.
         if let sub = subscription, sub.status.lowercased() == "active", plan == nil {
             Self.log.error("Unknown CommandCode planId: \(sub.planID)")
+            // That answer also proves any remembered plan is superseded, so a later timed-out
+            // refresh must not keep sizing the lane from it.
+            await self.planCache.clear(
+                fingerprint: CookieHeaderCache.credentialFingerprint(cookieHeader),
+                now: now)
             throw CommandCodeUsageError.unknownPlan(sub.planID)
         }
+
+        let resolved = await self.resolveSubscription(
+            subscription: subscription,
+            enrichmentUnavailable: subscriptionEnrichmentUnavailable,
+            cookieHeader: cookieHeader,
+            now: now)
 
         return CommandCodeUsageSnapshot(
             monthlyCreditsRemaining: credits.monthlyCredits,
@@ -71,11 +101,47 @@ public enum CommandCodeUsageFetcher {
             opensourceMonthlyCredits: credits.opensourceMonthlyCredits,
             fiveHourWindow: credits.fiveHourWindow,
             weeklyWindow: credits.weeklyWindow,
-            plan: plan,
-            billingPeriodEnd: subscription?.currentPeriodEnd,
-            subscriptionStatus: subscription?.status,
+            plan: resolved.plan,
+            billingPeriodEnd: resolved.periodEnd,
+            subscriptionStatus: resolved.status,
             subscriptionEnrichmentUnavailable: subscriptionEnrichmentUnavailable,
             updatedAt: now)
+    }
+
+    /// Sizes the monthly grant from this refresh when the subscription lookup answered, and from the
+    /// plan remembered for this billing period when it did not. The percentage always comes from the
+    /// fresh credits response, so a remembered plan reports current spend rather than a stale reading.
+    ///
+    /// Only the grant size and its period are remembered. `subscriptionStatus` describes the current
+    /// subscription, so the remembered path reports it as unknown rather than repeating an old value.
+    private static func resolveSubscription(
+        subscription: SubscriptionPayload?,
+        enrichmentUnavailable: Bool,
+        cookieHeader: String,
+        now: Date) async -> (plan: CommandCodePlanCatalog.Plan?, periodEnd: Date?, status: String?)
+    {
+        let fingerprint = CookieHeaderCache.credentialFingerprint(cookieHeader)
+        guard enrichmentUnavailable else {
+            guard let subscription,
+                  let plan = CommandCodePlanCatalog.plan(forID: subscription.planID)
+            else {
+                // The lookup succeeded and reported no subscription: the free tier owns this account
+                // until a later refresh says otherwise.
+                await self.planCache.clear(fingerprint: fingerprint, now: now)
+                return (nil, subscription?.currentPeriodEnd, subscription?.status)
+            }
+            await self.planCache.store(
+                plan: plan,
+                periodEnd: subscription.currentPeriodEnd,
+                fingerprint: fingerprint,
+                now: now)
+            return (plan, subscription.currentPeriodEnd, subscription.status)
+        }
+        guard let remembered = await self.planCache.entry(fingerprint: fingerprint, now: now) else {
+            return (nil, nil, nil)
+        }
+        Self.log.debug("Command Code monthly grant sized from the remembered plan")
+        return (remembered.plan, remembered.periodEnd, nil)
     }
 
     private static func fetchPayloads(

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
@@ -9,7 +9,10 @@ public enum CommandCodeUsageFetcher {
     private static let log = CodexBarLog.logger(LogCategories.provider(.commandcode, scope: "usage"))
     private static let requestTimeoutSeconds: TimeInterval = 15
     private static let subscriptionGraceSeconds: TimeInterval = 2
-    private static let apiBase = URL(string: "https://api.commandcode.ai")!
+    private static let defaultAPIBase = URL(string: "https://api.commandcode.ai")!
+    /// Test override for the billing endpoint, matching `MIMO_API_URL` and `WAYFINDER_GATEWAY_URL`.
+    /// HTTPS anywhere, or plain HTTP on loopback, so a local stub can drive the real transport.
+    static let apiURLEnvironmentKey = "COMMANDCODE_API_URL"
     private static let creditsPath = "/internal/billing/credits"
     private static let subscriptionsPath = "/internal/billing/subscriptions"
     private static let webOrigin = "https://commandcode.ai"
@@ -208,7 +211,7 @@ public enum CommandCodeUsageFetcher {
         cookieHeader: String,
         transport: any ProviderHTTPTransport) async throws -> CreditsPayload
     {
-        let url = self.apiBase.appendingPathComponent(self.creditsPath)
+        let url = self.apiBase().appendingPathComponent(self.creditsPath)
         let data = try await self.send(url: url, cookieHeader: cookieHeader, transport: transport)
         return try self.parseCredits(data: data)
     }
@@ -217,9 +220,23 @@ public enum CommandCodeUsageFetcher {
         cookieHeader: String,
         transport: any ProviderHTTPTransport) async throws -> SubscriptionPayload?
     {
-        let url = self.apiBase.appendingPathComponent(self.subscriptionsPath)
+        let url = self.apiBase().appendingPathComponent(self.subscriptionsPath)
         let data = try await self.send(url: url, cookieHeader: cookieHeader, transport: transport)
         return try self.parseSubscription(data: data)
+    }
+
+    /// The billing endpoint for this process. An invalid override falls back to production, the
+    /// same way `WayfinderSettingsReader.baseURL` treats a rejected value.
+    static func apiBase(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> URL
+    {
+        guard let raw = environment[self.apiURLEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty
+        else {
+            return self.defaultAPIBase
+        }
+        return ProviderEndpointOverrideValidator()
+            .validatedURLAllowingLoopbackHTTP(raw) ?? self.defaultAPIBase
     }
 
     private static func send(

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageSnapshot.swift
@@ -84,7 +84,12 @@ public struct CommandCodeUsageSnapshot: Sendable {
 
     private func makeMonthlyWindow() -> RateWindow? {
         guard let total = self.monthlyCreditsTotal, total > 0 else {
-            // Free / unknown plan with no allowance — surface 100% so the bar renders empty.
+            // The grant size comes from the optional subscription lookup. When that lookup times out
+            // or fails, the plan is unknown rather than absent: reporting the free-tier reading below
+            // would show an untouched monthly bar for a paid plan that is partly or fully spent.
+            guard !self.subscriptionEnrichmentUnavailable else { return nil }
+            // Free tier: no monthly allowance exists to consume, so report 0% used while any
+            // spendable balance remains.
             if self.monthlyCreditsRemaining > 0 || self.purchasedCredits > 0 {
                 return RateWindow(
                     usedPercent: 0,

--- a/Tests/CodexBarTests/CommandCodePlanCacheTests.swift
+++ b/Tests/CodexBarTests/CommandCodePlanCacheTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Command Code sizes its monthly grant from the optional `/internal/billing/subscriptions`
+/// lookup, which loses its bounded join grace several times a day. These tests pin how a
+/// remembered plan sizes the monthly lane from the fresh credits response, and every case where
+/// the remembered plan must not apply.
+struct CommandCodePlanCacheTests {
+    /// $10 Go plan with $4 left, so the monthly lane must read 60% used.
+    private static let spentCreditsJSON = """
+    {"credits":{"monthlyCredits":4,"purchasedCredits":0,"premiumMonthlyCredits":0,\
+    "opensourceMonthlyCredits":4}}
+    """
+
+    /// $10 Go plan with $9 left, so the monthly lane must read 10% used.
+    private static let freshCreditsJSON = """
+    {"credits":{"monthlyCredits":9,"purchasedCredits":0,"premiumMonthlyCredits":0,\
+    "opensourceMonthlyCredits":9}}
+    """
+
+    private static let now = Date(timeIntervalSince1970: 1_800_000_000)
+    private static let periodEnd = Date(timeIntervalSince1970: 4_000_000_000)
+
+    private static let activeSubscriptionJSON = """
+    {"success":true,"data":{"id":"sub_1","status":"active","planId":"individual-go",\
+    "currentPeriodEnd":"2096-10-02T07:06:40.000Z"}}
+    """
+
+    private static let undatedSubscriptionJSON = """
+    {"success":true,"data":{"id":"sub_1","status":"active","planId":"individual-go"}}
+    """
+
+    private static let unknownPlanJSON = """
+    {"success":true,"data":{"id":"sub_1","status":"active","planId":"individual-unreleased",\
+    "currentPeriodEnd":"2096-10-02T07:06:40.000Z"}}
+    """
+
+    private static let freeTierJSON = #"{"success":true,"data":null}"#
+
+    @Test
+    func `remembered plan sizes the monthly lane from fresh credits after a failure`() async throws {
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let resolved = try await Self.fetch(
+                credits: Self.freshCreditsJSON,
+                subscription: Self.activeSubscriptionJSON)
+            #expect(resolved.toUsageSnapshot().tertiary?.usedPercent == 10)
+
+            let repaired = try await Self.fetch(
+                credits: Self.spentCreditsJSON,
+                subscription: nil)
+
+            // The grant size is remembered; the percentage still comes from this refresh.
+            #expect(repaired.subscriptionEnrichmentUnavailable)
+            #expect(repaired.plan?.id == "individual-go")
+            #expect(repaired.toUsageSnapshot().tertiary?.usedPercent == 60)
+            #expect(repaired.toUsageSnapshot().tertiary?.resetsAt == Self.periodEnd)
+            // Only the grant size is remembered, never the observed subscription state.
+            #expect(repaired.subscriptionStatus == nil)
+        }
+    }
+
+    @Test
+    func `remembered plan stops applying once its billing period ends`() async throws {
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            _ = try await Self.fetch(
+                credits: Self.freshCreditsJSON,
+                subscription: Self.activeSubscriptionJSON)
+
+            let afterPeriod = try await Self.fetch(
+                credits: Self.spentCreditsJSON,
+                subscription: nil,
+                now: Self.periodEnd.addingTimeInterval(1))
+
+            #expect(afterPeriod.plan == nil)
+            #expect(afterPeriod.toUsageSnapshot().tertiary == nil)
+        }
+    }
+
+    @Test
+    func `remembered plan expires without a refresh that confirms it`() async throws {
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            _ = try await Self.fetch(
+                credits: Self.freshCreditsJSON,
+                subscription: Self.activeSubscriptionJSON)
+
+            // Bounds retention after the credential goes away, well inside the billing period.
+            let aDayLater = try await Self.fetch(
+                credits: Self.spentCreditsJSON,
+                subscription: nil,
+                now: Self.now.addingTimeInterval(25 * 60 * 60))
+
+            #expect(aDayLater.plan == nil)
+            #expect(aDayLater.toUsageSnapshot().tertiary == nil)
+        }
+    }
+
+    @Test
+    func `remembered plan never sizes another credential`() async throws {
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            _ = try await Self.fetch(
+                credits: Self.freshCreditsJSON,
+                subscription: Self.activeSubscriptionJSON,
+                cookieHeader: "session=first")
+
+            let other = try await Self.fetch(
+                credits: Self.spentCreditsJSON,
+                subscription: nil,
+                cookieHeader: "session=second")
+
+            #expect(other.plan == nil)
+            #expect(other.toUsageSnapshot().tertiary == nil)
+        }
+    }
+
+    @Test
+    func `verified free tier forgets the remembered plan`() async throws {
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            _ = try await Self.fetch(
+                credits: Self.freshCreditsJSON,
+                subscription: Self.activeSubscriptionJSON)
+            _ = try await Self.fetch(
+                credits: Self.freshCreditsJSON,
+                subscription: Self.freeTierJSON)
+
+            let afterDowngrade = try await Self.fetch(
+                credits: Self.spentCreditsJSON,
+                subscription: nil)
+
+            #expect(afterDowngrade.plan == nil)
+            #expect(afterDowngrade.toUsageSnapshot().tertiary == nil)
+        }
+    }
+
+    @Test
+    func `a plan id this build cannot size forgets the remembered plan`() async throws {
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            _ = try await Self.fetch(
+                credits: Self.freshCreditsJSON,
+                subscription: Self.activeSubscriptionJSON)
+
+            await #expect(throws: CommandCodeUsageError.self) {
+                _ = try await Self.fetch(
+                    credits: Self.freshCreditsJSON,
+                    subscription: Self.unknownPlanJSON)
+            }
+
+            // The rejected answer proves the remembered grant is superseded.
+            let afterRename = try await Self.fetch(
+                credits: Self.spentCreditsJSON,
+                subscription: nil)
+
+            #expect(afterRename.plan == nil)
+            #expect(afterRename.toUsageSnapshot().tertiary == nil)
+        }
+    }
+
+    @Test
+    func `subscription without a period end is not remembered`() async throws {
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let undated = try await Self.fetch(
+                credits: Self.freshCreditsJSON,
+                subscription: Self.undatedSubscriptionJSON)
+            #expect(undated.plan?.id == "individual-go")
+
+            // An entry that cannot expire would keep sizing the lane after the grant refills.
+            let repaired = try await Self.fetch(
+                credits: Self.spentCreditsJSON,
+                subscription: nil)
+
+            #expect(repaired.plan == nil)
+            #expect(repaired.toUsageSnapshot().tertiary == nil)
+        }
+    }
+
+    /// Runs one refresh. A nil `subscription` body makes the optional lookup fail, which is what a
+    /// lost join grace produces.
+    private static func fetch(
+        credits: String,
+        subscription: String?,
+        cookieHeader: String = "session=valid",
+        now: Date = Self.now) async throws -> CommandCodeUsageSnapshot
+    {
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            if path.hasSuffix("/credits") {
+                return try Self.response(request: request, statusCode: 200, body: credits)
+            }
+            guard let subscription else {
+                return try Self.response(request: request, statusCode: 503, body: #"{"error":"unavailable"}"#)
+            }
+            return try Self.response(request: request, statusCode: 200, body: subscription)
+        }
+        return try await CommandCodeUsageFetcher._fetchUsageForTesting(
+            cookieHeader: cookieHeader,
+            transport: transport,
+            now: now,
+            subscriptionGrace: .seconds(5))
+    }
+
+    private static func response(
+        request: URLRequest,
+        statusCode: Int,
+        body: String) throws -> (Data, URLResponse)
+    {
+        let url = try #require(request.url)
+        let response = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil))
+        return (Data(body.utf8), response)
+    }
+}

--- a/Tests/CodexBarTests/CommandCodeQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/CommandCodeQuotaTransitionTests.swift
@@ -17,7 +17,9 @@ struct CommandCodeQuotaTransitionTests {
         let freeTier = self.snapshot(remaining: 0, plan: nil)
         let freeTierWithPurchasedCredits = self.snapshot(remaining: 0, purchasedCredits: 5, plan: nil)
 
-        #expect(missingSubscription.tertiary?.usedPercent == 0)
+        // An unknown grant size must not borrow the free-tier reading: that renders an untouched
+        // monthly bar for a paid plan whose spend is unknown for this refresh.
+        #expect(missingSubscription.tertiary == nil)
         #expect(freeTierWithPurchasedCredits.tertiary?.usedPercent == 0)
 
         let stabilized = UsageStore.commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
@@ -33,12 +35,12 @@ struct CommandCodeQuotaTransitionTests {
         let startupFailure = UsageStore.commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
             current: missingSubscription,
             previous: nil)
-        #expect(startupFailure.tertiary?.usedPercent == 0)
+        #expect(startupFailure.tertiary == nil)
 
         let freeTierFailure = UsageStore.commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
             current: missingSubscription,
             previous: freeTierWithPurchasedCredits)
-        #expect(freeTierFailure.tertiary?.usedPercent == 0)
+        #expect(freeTierFailure.tertiary == nil)
 
         let validFreeTier = UsageStore.commandCodeSnapshotResolvingDepletionOnEnrichmentFailure(
             current: freeTier,

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -500,6 +500,20 @@ struct CommandCodeUsageFetcherTests {
         }
     }
 
+    @Test
+    func `endpoint override accepts loopback HTTP and rejects other plain HTTP hosts`() throws {
+        let key = CommandCodeUsageFetcher.apiURLEnvironmentKey
+        let production = try #require(URL(string: "https://api.commandcode.ai"))
+        let loopback = try #require(URL(string: "http://127.0.0.1:8080"))
+        let secure = try #require(URL(string: "https://billing.test"))
+
+        #expect(CommandCodeUsageFetcher.apiBase(environment: [:]) == production)
+        #expect(CommandCodeUsageFetcher.apiBase(environment: [key: loopback.absoluteString]) == loopback)
+        #expect(CommandCodeUsageFetcher.apiBase(environment: [key: secure.absoluteString]) == secure)
+        // A plain HTTP endpoint off the loopback would send the session cookie in the clear.
+        #expect(CommandCodeUsageFetcher.apiBase(environment: [key: "http://billing.test"]) == production)
+    }
+
     private static func response(
         request: URLRequest,
         statusCode: Int,

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -91,49 +91,53 @@ struct CommandCodeUsageFetcherTests {
 
     @Test
     func `successful free tier lookup has no usage window`() async throws {
-        let transport = ProviderHTTPTransportStub { request in
-            let path = try #require(request.url?.path)
-            let body = if path.hasSuffix("/credits") {
-                """
-                {"credits":{"monthlyCredits":0,"purchasedCredits":0,
-                "premiumMonthlyCredits":0,"opensourceMonthlyCredits":0}}
-                """
-            } else {
-                #"{"success":true,"data":null}"#
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let transport = ProviderHTTPTransportStub { request in
+                let path = try #require(request.url?.path)
+                let body = if path.hasSuffix("/credits") {
+                    """
+                    {"credits":{"monthlyCredits":0,"purchasedCredits":0,
+                    "premiumMonthlyCredits":0,"opensourceMonthlyCredits":0}}
+                    """
+                } else {
+                    #"{"success":true,"data":null}"#
+                }
+                return try Self.response(request: request, statusCode: 200, body: body)
             }
-            return try Self.response(request: request, statusCode: 200, body: body)
+
+            let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "session=valid",
+                session: transport)
+
+            #expect(snapshot.subscriptionEnrichmentUnavailable == false)
+            #expect(snapshot.toUsageSnapshot().primary == nil)
         }
-
-        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
-            cookieHeader: "session=valid",
-            session: transport)
-
-        #expect(snapshot.subscriptionEnrichmentUnavailable == false)
-        #expect(snapshot.toUsageSnapshot().primary == nil)
     }
 
     @Test
     func `subscription failure envelope preserves required credits`() async throws {
-        let transport = ProviderHTTPTransportStub { request in
-            let path = try #require(request.url?.path)
-            if path.hasSuffix("/credits") {
-                return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let transport = ProviderHTTPTransportStub { request in
+                let path = try #require(request.url?.path)
+                if path.hasSuffix("/credits") {
+                    return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+                }
+                return try Self.response(
+                    request: request,
+                    statusCode: 200,
+                    body: #"{"success":false,"error":"temporarily unavailable"}"#)
             }
-            return try Self.response(
-                request: request,
-                statusCode: 200,
-                body: #"{"success":false,"error":"temporarily unavailable"}"#)
+
+            let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "session=valid",
+                session: transport,
+                now: Date(timeIntervalSince1970: 123))
+
+            #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+            #expect(snapshot.plan == nil)
+            #expect(snapshot.subscriptionEnrichmentUnavailable)
+            #expect(snapshot.updatedAt == Date(timeIntervalSince1970: 123))
         }
-
-        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
-            cookieHeader: "session=valid",
-            session: transport,
-            now: Date(timeIntervalSince1970: 123))
-
-        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
-        #expect(snapshot.plan == nil)
-        #expect(snapshot.subscriptionEnrichmentUnavailable)
-        #expect(snapshot.updatedAt == Date(timeIntervalSince1970: 123))
     }
 
     @Test
@@ -147,78 +151,84 @@ struct CommandCodeUsageFetcherTests {
 
     @Test
     func `subscription failure preserves required credits`() async throws {
-        let transport = ProviderHTTPTransportStub { request in
-            let path = try #require(request.url?.path)
-            if path.hasSuffix("/credits") {
-                return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let transport = ProviderHTTPTransportStub { request in
+                let path = try #require(request.url?.path)
+                if path.hasSuffix("/credits") {
+                    return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+                }
+                return try Self.response(request: request, statusCode: 503, body: #"{"error":"unavailable"}"#)
             }
-            return try Self.response(request: request, statusCode: 503, body: #"{"error":"unavailable"}"#)
+
+            let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "session=valid",
+                session: transport,
+                now: Date(timeIntervalSince1970: 123))
+
+            #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+            #expect(snapshot.plan == nil)
+            #expect(snapshot.billingPeriodEnd == nil)
+            #expect(snapshot.subscriptionEnrichmentUnavailable)
+            #expect(snapshot.updatedAt == Date(timeIntervalSince1970: 123))
         }
-
-        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
-            cookieHeader: "session=valid",
-            session: transport,
-            now: Date(timeIntervalSince1970: 123))
-
-        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
-        #expect(snapshot.plan == nil)
-        #expect(snapshot.billingPeriodEnd == nil)
-        #expect(snapshot.subscriptionEnrichmentUnavailable)
-        #expect(snapshot.updatedAt == Date(timeIntervalSince1970: 123))
     }
 
     @Test
     func `subscription timeout does not hold credits for full request timeout`() async throws {
-        let transport = ProviderHTTPTransportStub { request in
-            let path = try #require(request.url?.path)
-            if path.hasSuffix("/credits") {
-                return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let transport = ProviderHTTPTransportStub { request in
+                let path = try #require(request.url?.path)
+                if path.hasSuffix("/credits") {
+                    return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+                }
+                try await Task.sleep(for: .seconds(10))
+                return try Self.response(request: request, statusCode: 200, body: Self.subscriptionJSON)
             }
-            try await Task.sleep(for: .seconds(10))
-            return try Self.response(request: request, statusCode: 200, body: Self.subscriptionJSON)
+
+            let startedAt = ContinuousClock.now
+            let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "session=valid",
+                session: transport)
+            let elapsed = startedAt.duration(to: .now)
+
+            #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+            #expect(snapshot.plan == nil)
+            #expect(snapshot.subscriptionEnrichmentUnavailable)
+            #expect(elapsed < .seconds(3), "Subscription enrichment delayed credits: \(elapsed)")
         }
-
-        let startedAt = ContinuousClock.now
-        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
-            cookieHeader: "session=valid",
-            session: transport)
-        let elapsed = startedAt.duration(to: .now)
-
-        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
-        #expect(snapshot.plan == nil)
-        #expect(snapshot.subscriptionEnrichmentUnavailable)
-        #expect(elapsed < .seconds(3), "Subscription enrichment delayed credits: \(elapsed)")
     }
 
     @Test
     func `subscription grace does not wait for transport that ignores cancellation`() async throws {
-        let transport = ProviderHTTPTransportStub { request in
-            let path = try #require(request.url?.path)
-            if path.hasSuffix("/credits") {
-                return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
-            }
-            let response = try Self.response(request: request, statusCode: 200, body: Self.subscriptionJSON)
-            return await withCheckedContinuation { continuation in
-                DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
-                    continuation.resume(returning: response)
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let transport = ProviderHTTPTransportStub { request in
+                let path = try #require(request.url?.path)
+                if path.hasSuffix("/credits") {
+                    return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+                }
+                let response = try Self.response(request: request, statusCode: 200, body: Self.subscriptionJSON)
+                return await withCheckedContinuation { continuation in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                        continuation.resume(returning: response)
+                    }
                 }
             }
+
+            let startedAt = ContinuousClock.now
+            let snapshot = try await CommandCodeUsageFetcher._fetchUsageForTesting(
+                cookieHeader: "session=valid",
+                transport: transport,
+                subscriptionGrace: .milliseconds(20))
+            let elapsed = startedAt.duration(to: .now)
+
+            #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+            #expect(snapshot.plan == nil)
+            #expect(snapshot.subscriptionEnrichmentUnavailable)
+            #expect(elapsed < .milliseconds(300), "Subscription enrichment delayed credits: \(elapsed)")
+
+            // Let the deliberately cancellation-ignoring test task drain before the test exits.
+            try await Task.sleep(for: .milliseconds(550))
         }
-
-        let startedAt = ContinuousClock.now
-        let snapshot = try await CommandCodeUsageFetcher._fetchUsageForTesting(
-            cookieHeader: "session=valid",
-            transport: transport,
-            subscriptionGrace: .milliseconds(20))
-        let elapsed = startedAt.duration(to: .now)
-
-        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
-        #expect(snapshot.plan == nil)
-        #expect(snapshot.subscriptionEnrichmentUnavailable)
-        #expect(elapsed < .milliseconds(300), "Subscription enrichment delayed credits: \(elapsed)")
-
-        // Let the deliberately cancellation-ignoring test task drain before the test exits.
-        try await Task.sleep(for: .milliseconds(550))
     }
 
     @Test
@@ -324,19 +334,21 @@ struct CommandCodeUsageFetcherTests {
 
     @Test
     func `successful unknown active subscription still fails explicitly`() async {
-        let unknownPlanJSON = Self.subscriptionJSON.replacingOccurrences(
-            of: #""planId":"individual-go""#,
-            with: #""planId":"individual-future""#)
-        let transport = ProviderHTTPTransportStub { request in
-            let path = try #require(request.url?.path)
-            let body = path.hasSuffix("/credits") ? Self.creditsJSON : unknownPlanJSON
-            return try Self.response(request: request, statusCode: 200, body: body)
-        }
+        await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let unknownPlanJSON = Self.subscriptionJSON.replacingOccurrences(
+                of: #""planId":"individual-go""#,
+                with: #""planId":"individual-future""#)
+            let transport = ProviderHTTPTransportStub { request in
+                let path = try #require(request.url?.path)
+                let body = path.hasSuffix("/credits") ? Self.creditsJSON : unknownPlanJSON
+                return try Self.response(request: request, statusCode: 200, body: body)
+            }
 
-        await #expect(throws: CommandCodeUsageError.unknownPlan("individual-future")) {
-            try await CommandCodeUsageFetcher.fetchUsage(
-                cookieHeader: "session=valid",
-                session: transport)
+            await #expect(throws: CommandCodeUsageError.unknownPlan("individual-future")) {
+                try await CommandCodeUsageFetcher.fetchUsage(
+                    cookieHeader: "session=valid",
+                    session: transport)
+            }
         }
     }
 
@@ -391,25 +403,27 @@ struct CommandCodeUsageFetcherTests {
 
     @Test
     func `active pro-v1 subscription resolves to the eighty dollar plan`() async throws {
-        let proV1JSON = Self.subscriptionJSON.replacingOccurrences(
-            of: #""planId":"individual-go""#,
-            with: #""planId":"individual-pro-v1""#)
-        let transport = ProviderHTTPTransportStub { request in
-            let path = try #require(request.url?.path)
-            let body = path.hasSuffix("/credits") ? Self.creditsJSON : proV1JSON
-            return try Self.response(request: request, statusCode: 200, body: body)
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let proV1JSON = Self.subscriptionJSON.replacingOccurrences(
+                of: #""planId":"individual-go""#,
+                with: #""planId":"individual-pro-v1""#)
+            let transport = ProviderHTTPTransportStub { request in
+                let path = try #require(request.url?.path)
+                let body = path.hasSuffix("/credits") ? Self.creditsJSON : proV1JSON
+                return try Self.response(request: request, statusCode: 200, body: body)
+            }
+
+            let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "session=valid",
+                session: transport)
+
+            let plan = try #require(snapshot.plan)
+            #expect(plan.id == "individual-pro-v1")
+            #expect(plan.monthlyCreditsUSD == 80)
+            #expect(snapshot.monthlyCreditsTotal == 80)
+            #expect(abs((snapshot.monthlyCreditsUsed ?? -1) - 71.2216) < 0.0001)
+            #expect(snapshot.subscriptionEnrichmentUnavailable == false)
         }
-
-        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
-            cookieHeader: "session=valid",
-            session: transport)
-
-        let plan = try #require(snapshot.plan)
-        #expect(plan.id == "individual-pro-v1")
-        #expect(plan.monthlyCreditsUSD == 80)
-        #expect(snapshot.monthlyCreditsTotal == 80)
-        #expect(abs((snapshot.monthlyCreditsUsed ?? -1) - 71.2216) < 0.0001)
-        #expect(snapshot.subscriptionEnrichmentUnavailable == false)
     }
 
     @Test
@@ -461,6 +475,29 @@ struct CommandCodeUsageFetcherTests {
         #expect(CommandCodeCookieHeader.override(from: nil) == nil)
         #expect(CommandCodeCookieHeader.override(from: "") == nil)
         #expect(CommandCodeCookieHeader.override(from: "   ") == nil)
+    }
+
+    @Test
+    func `subscription failure leaves the projected monthly window unavailable`() async throws {
+        try await CommandCodeUsageFetcher.withIsolatedPlanCacheForTesting {
+            let transport = ProviderHTTPTransportStub { request in
+                let path = try #require(request.url?.path)
+                if path.hasSuffix("/credits") {
+                    return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+                }
+                return try Self.response(request: request, statusCode: 503, body: #"{"error":"unavailable"}"#)
+            }
+
+            let snapshot = try await CommandCodeUsageFetcher._fetchUsageForTesting(
+                cookieHeader: "session=valid",
+                transport: transport,
+                subscriptionGrace: .seconds(5))
+
+            // An unknown grant size must not borrow the free-tier reading: that renders an untouched
+            // monthly bar for a plan that is partly spent.
+            #expect(snapshot.toUsageSnapshot().tertiary == nil)
+            #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+        }
     }
 
     private static func response(

--- a/docs/command-code.md
+++ b/docs/command-code.md
@@ -38,11 +38,24 @@ On Linux, browser import is unavailable. Set `cookieSource` to `manual` and
 provide the Command Code `Cookie` header in `cookieHeader`; both `auto` and
 `web` CLI source modes then use the billing API.
 
+The monthly grant size comes only from the subscription lookup, and that optional
+request loses its short join grace several times a day. The plan is fixed for a
+billing period, so CodexBar keeps the resolved plan in memory, scoped to the
+credential that produced it. A kept plan is dropped at `currentPeriodEnd`, a day
+after the last refresh that confirmed it, when a lookup reports the free tier,
+and when a lookup reports a plan this build cannot size. Nothing is written to
+disk, so a one-shot `codexbar usage` run starts with an empty memory.
+
 ## Display
 
 - The menu bar item and provider card use the Command Code icon and label.
 - The primary and secondary rows show 5-hour and weekly rolling usage.
 - The tertiary row shows monthly credits used/remaining.
+- The monthly row is sized from the kept plan when the subscription lookup fails,
+  and from the fresh credits response in every case. With no kept plan the row is
+  unavailable rather than shown as untouched, which is what a one-shot
+  `codexbar usage` run reports after a failed lookup. The rolling rows stay
+  available either way.
 - Widgets do not expose Command Code in the provider picker yet.
 
 ## Related files

--- a/docs/command-code.md
+++ b/docs/command-code.md
@@ -46,6 +46,9 @@ after the last refresh that confirmed it, when a lookup reports the free tier,
 and when a lookup reports a plan this build cannot size. Nothing is written to
 disk, so a one-shot `codexbar usage` run starts with an empty memory.
 
+Test override: `COMMANDCODE_API_URL` replaces the billing base URL; use HTTPS or
+loopback HTTP.
+
 ## Display
 
 - The menu bar item and provider card use the Command Code icon and label.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -509,6 +509,7 @@ provider-specific cookie validation, endpoints, login detection, and error trans
 - Linux CLI supports configured manual cookies; automatic browser import remains macOS-only.
 - Reads 5-hour and weekly rolling limits plus monthly USD credits and billing-cycle usage from `api.commandcode.ai`.
 - Automatic import looks for better-auth session cookies from `commandcode.ai` / `www.commandcode.ai`.
+- Override the billing base URL with `COMMANDCODE_API_URL` for tests.
 - Status: none yet.
 - Details: `docs/command-code.md`.
 


### PR DESCRIPTION
When Command Code returns credits but its optional subscription lookup times out, the monthly meter currently reports 0% used even for a partly spent paid allowance. For example, $4 remaining from a $10 grant appears as 100% left.

This change keeps the last confirmed allowance in bounded, credential-scoped memory and calculates usage from each fresh credits response. The same timeout then reports 60% used. Without a usable allowance, the provider leaves the monthly window unavailable. Five-hour and weekly usage stay available; the app's existing stabilization of proven monthly depletion is preserved.

Allowance reuse ends at the billing-period boundary or after 24 hours without confirmation. Verified free-tier and unknown-plan responses invalidate it. All cache mutations are ordered by refresh start time, including cleared verdicts, so delayed responses cannot replace a newer allowance or resurrect a superseded plan. The cache retains at most four credential observations and writes nothing to disk.

Synthetic transport proof uses a DEBUG-only loopback endpoint override. Release builds always use the official billing endpoint. Documentation and the Unreleased changelog are updated. Thanks @enieuwy for the diagnosis, original fix, and before/after capture.

### Behavior proof

The rebuilt CLI ran `codexbar serve` through `ProviderHTTPClient` and `URLSession` against a loopback billing fixture, using a temporary synthetic manual cookie. No real account or Keychain access was used. The fixture delayed subscriptions for six seconds; CLI responses completed in about two seconds through the production enrichment grace.

| Scenario | Monthly usage |
| --- | --- |
| Healthy refresh | 10% used |
| Timeout after successful lookup, with fresh spending | 60% used |
| Verified free tier | 0% used with positive credits |
| Timeout after verified free tier | Unavailable |
| Timeout in a fresh process | Unavailable |

Both rolling windows stayed at 12% and 30% in all five cases. The contributor's before-fix capture and maintainer after-fix results are recorded in `.github/pr-proof/commandcode-monthly-grant-flake.log`. The synthetic config was removed and the test processes were stopped.

### Validation

- `make check`: passed, zero SwiftLint violations across 2,126 files.
- Independent source review: cache ordering and endpoint-scope findings addressed.
- Final managed Codex autoreview: scoped clean at the default P0 threshold.
- `swift test --no-parallel --filter CommandCode`: 47 tests across four suites passed, including ordering, expiry, account isolation, endpoint restrictions, rolling windows, and depletion transitions.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/33986119333): passed both macOS shards, Linux x64/ARM64/musl builds, lint, and aggregate gate.
- `make test`: 1,022 selections / 86 groups selected; stopped during group 60 after complete CI passed. 58 groups passed initially and one recovered on the runner's retry; no group timed out. The local run was incomplete, not a full local pass. A sampled compiler was blocked in filesystem `rename` during the slow local build.
- All 42 local `CLIEntryTests` methods passed; macOS CI intentionally skips that suite. The unchanged OpenAI dashboard scraper test initially missed its non-English-title diagnostic and passed on the full-group retry.
