### PR TITLE
Simplify chart menu layout sizing

### DIFF
--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -118,6 +118,7 @@ struct CostHistoryChartMenuView: View {
             historyCoverageIsEstablished: self.historyCoverageIsEstablished)
         let selectedDateKey = self.selectedDateKey.flatMap { model.pointsByDateKey[$0] == nil ? nil : $0 }
             ?? Self.defaultSelectedDateKey(model: model)
+        let detail = self.detailContent(selectedDateKey: selectedDateKey, model: model)
         VStack(alignment: .leading, spacing: Self.outerSpacing) {
             if model.points.isEmpty {
                 Text(L("No data available"))
@@ -232,86 +233,73 @@ struct CostHistoryChartMenuView: View {
                     }
                     .frame(height: Self.metricPickerHeight)
                 }
+            }
 
-                let detail = self.detailContent(selectedDateKey: selectedDateKey, model: model)
-                VStack(alignment: .leading, spacing: Self.detailSpacing) {
-                    Text(detail.primary)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
-                    if model.detailViewportRowCount > 0 {
-                        ScrollView(.vertical) {
-                            VStack(alignment: .leading, spacing: Self.detailSpacing) {
-                                ForEach(detail.rows) { row in
-                                    HStack(alignment: .top, spacing: 8) {
-                                        Rectangle()
-                                            .fill(row.accentColor)
-                                            .frame(
-                                                width: 2,
-                                                height: Self.accentHeight(
-                                                    for: row,
-                                                    rowHeight: model.detailRowHeight))
-                                            .padding(.top, 1)
+            VStack(alignment: .leading, spacing: Self.detailSpacing) {
+                Text(detail.primary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
+                if model.detailViewportRowCount > 0 {
+                    ScrollView(.vertical) {
+                        VStack(alignment: .leading, spacing: Self.detailSpacing) {
+                            ForEach(detail.rows) { row in
+                                HStack(alignment: .top, spacing: 8) {
+                                    Rectangle()
+                                        .fill(row.accentColor)
+                                        .frame(
+                                            width: 2,
+                                            height: Self.accentHeight(for: row, rowHeight: model.detailRowHeight))
+                                        .padding(.top, 1)
 
-                                        VStack(alignment: .leading, spacing: 1) {
-                                            Text(row.title)
-                                                .font(.caption)
-                                                .foregroundStyle(.secondary)
+                                    VStack(alignment: .leading, spacing: 1) {
+                                        Text(row.title)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                            .truncationMode(.tail)
+                                            .frame(height: Self.detailTitleLineHeight, alignment: .leading)
+                                        if let subtitle = row.subtitle {
+                                            Text(subtitle)
+                                                .font(.caption2)
+                                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
-                                                .frame(height: Self.detailTitleLineHeight, alignment: .leading)
-                                            if let subtitle = row.subtitle {
-                                                Text(subtitle)
-                                                    .font(.caption2)
-                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                                                    .lineLimit(1)
-                                                    .truncationMode(.tail)
-                                                    .frame(
-                                                        height: Self.detailSubtitleLineHeight,
-                                                        alignment: .leading)
-                                            }
-                                            if let modeSubtitle = row.modeSubtitle {
-                                                Text(modeSubtitle)
-                                                    .font(.caption2)
-                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                                                    .lineLimit(1)
-                                                    .truncationMode(.tail)
-                                                    .frame(
-                                                        height: Self.detailSubtitleLineHeight,
-                                                        alignment: .leading)
-                                            }
+                                                .frame(height: Self.detailSubtitleLineHeight, alignment: .leading)
+                                        }
+                                        if let modeSubtitle = row.modeSubtitle {
+                                            Text(modeSubtitle)
+                                                .font(.caption2)
+                                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                                .lineLimit(1)
+                                                .truncationMode(.tail)
+                                                .frame(height: Self.detailSubtitleLineHeight, alignment: .leading)
                                         }
                                     }
-                                    .frame(height: model.detailRowHeight, alignment: .leading)
                                 }
+                                .frame(height: model.detailRowHeight, alignment: .leading)
                             }
                         }
-                        .scrollIndicators(
-                            Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
-                        .frame(
-                            height: Self.detailRowsViewportHeight(
-                                rowCount: model.detailViewportRowCount,
-                                rowHeight: model.detailRowHeight),
-                            alignment: .topLeading)
-                        .id(selectedDateKey)
+                    }
+                    .scrollIndicators(
+                        Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
+                    .frame(
+                        height: Self.detailRowsViewportHeight(
+                            rowCount: model.detailViewportRowCount,
+                            rowHeight: model.detailRowHeight),
+                        alignment: .topLeading)
+                    .id(selectedDateKey)
 
-                        if model.hasDetailOverflow {
-                            Text(Self.detailOverflowHint(itemCount: detail.rows.count) ?? " ")
-                                .font(.caption2)
-                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                                .frame(height: Self.detailHintHeight, alignment: .leading)
-                                .accessibilityHidden(!Self.detailRowsNeedScrolling(itemCount: detail.rows.count))
-                        }
+                    if model.hasDetailOverflow {
+                        Text(Self.detailOverflowHint(itemCount: detail.rows.count) ?? " ")
+                            .font(.caption2)
+                            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                            .frame(height: Self.detailHintHeight, alignment: .leading)
+                            .accessibilityHidden(!Self.detailRowsNeedScrolling(itemCount: detail.rows.count))
                     }
                 }
-                .frame(
-                    height: Self.detailBlockHeight(
-                        rowCount: model.detailViewportRowCount,
-                        hasOverflow: model.hasDetailOverflow,
-                        rowHeight: model.detailRowHeight),
-                    alignment: .topLeading)
             }
 
             if let total = self.totalCostUSD {
@@ -370,7 +358,6 @@ struct CostHistoryChartMenuView: View {
                         .frame(height: Self.projectEntryHeight(project), alignment: .topLeading)
                     }
                 }
-                .frame(height: Self.projectBlockHeight(projects: self.projects), alignment: .topLeading)
             }
 
             if !self.sessions.isEmpty {
@@ -437,8 +424,7 @@ struct CostHistoryChartMenuView: View {
     static let verticalPadding: CGFloat = 10
 
     private var sessionsBlock: some View {
-        let visibleCount = min(self.sessions.count, Self.maxVisibleSessionRows)
-        return VStack(alignment: .leading, spacing: Self.sessionRowSpacing) {
+        VStack(alignment: .leading, spacing: Self.sessionRowSpacing) {
             HStack {
                 Text(L("Conversations (%@)", self.windowLabel ?? Self.windowLabel(days: self.historyDays)))
                     .font(.caption)
@@ -451,24 +437,12 @@ struct CostHistoryChartMenuView: View {
             }
             .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
 
-            ScrollView(.vertical) {
-                LazyVStack(alignment: .leading, spacing: Self.sessionRowSpacing) {
-                    ForEach(self.sessions) { session in
-                        self.sessionRow(session)
-                    }
+            LazyVStack(alignment: .leading, spacing: Self.sessionRowSpacing) {
+                ForEach(self.sessions) { session in
+                    self.sessionRow(session)
                 }
             }
-            .scrollIndicators(self.sessions.count > visibleCount ? .visible : .hidden)
-            .frame(
-                height: CGFloat(visibleCount) * Self.sessionRowHeight
-                    + CGFloat(max(visibleCount - 1, 0)) * Self.sessionRowSpacing,
-                alignment: .topLeading)
         }
-        .frame(
-            height: Self.detailPrimaryLineHeight + Self.sessionRowSpacing
-                + CGFloat(visibleCount) * Self.sessionRowHeight
-                + CGFloat(max(visibleCount - 1, 0)) * Self.sessionRowSpacing,
-            alignment: .topLeading)
     }
 
     private func sessionRow(_ session: CostUsageSessionBreakdown) -> some View {
@@ -748,16 +722,6 @@ struct CostHistoryChartMenuView: View {
     private static func detailRowsViewportHeight(rowCount: Int, rowHeight: CGFloat) -> CGFloat {
         guard rowCount > 0 else { return 0 }
         return CGFloat(rowCount) * rowHeight + CGFloat(rowCount - 1) * self.detailSpacing
-    }
-
-    private static func detailBlockHeight(rowCount: Int, hasOverflow: Bool, rowHeight: CGFloat) -> CGFloat {
-        guard rowCount > 0 else { return self.detailPrimaryLineHeight }
-        var height = self.detailPrimaryLineHeight + self.detailSpacing
-        height += self.detailRowsViewportHeight(rowCount: rowCount, rowHeight: rowHeight)
-        if hasOverflow {
-            height += self.detailSpacing + self.detailHintHeight
-        }
-        return height
     }
 
     private static func projectBlockHeight(projects: [CostUsageProjectBreakdown]) -> CGFloat {

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -235,69 +235,77 @@ struct CostHistoryChartMenuView: View {
                 }
             }
 
-            VStack(alignment: .leading, spacing: Self.detailSpacing) {
-                Text(detail.primary)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
-                if model.detailViewportRowCount > 0 {
-                    ScrollView(.vertical) {
-                        VStack(alignment: .leading, spacing: Self.detailSpacing) {
-                            ForEach(detail.rows) { row in
-                                HStack(alignment: .top, spacing: 8) {
-                                    Rectangle()
-                                        .fill(row.accentColor)
-                                        .frame(
-                                            width: 2,
-                                            height: Self.accentHeight(for: row, rowHeight: model.detailRowHeight))
-                                        .padding(.top, 1)
+            if !model.points.isEmpty {
+                VStack(alignment: .leading, spacing: Self.detailSpacing) {
+                    Text(detail.primary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
+                    if model.detailViewportRowCount > 0 {
+                        ScrollView(.vertical) {
+                            VStack(alignment: .leading, spacing: Self.detailSpacing) {
+                                ForEach(detail.rows) { row in
+                                    HStack(alignment: .top, spacing: 8) {
+                                        Rectangle()
+                                            .fill(row.accentColor)
+                                            .frame(
+                                                width: 2,
+                                                height: Self.accentHeight(
+                                                    for: row,
+                                                    rowHeight: model.detailRowHeight))
+                                            .padding(.top, 1)
 
-                                    VStack(alignment: .leading, spacing: 1) {
-                                        Text(row.title)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                            .lineLimit(1)
-                                            .truncationMode(.tail)
-                                            .frame(height: Self.detailTitleLineHeight, alignment: .leading)
-                                        if let subtitle = row.subtitle {
-                                            Text(subtitle)
-                                                .font(.caption2)
-                                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                        VStack(alignment: .leading, spacing: 1) {
+                                            Text(row.title)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
-                                                .frame(height: Self.detailSubtitleLineHeight, alignment: .leading)
-                                        }
-                                        if let modeSubtitle = row.modeSubtitle {
-                                            Text(modeSubtitle)
-                                                .font(.caption2)
-                                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                                .frame(height: Self.detailSubtitleLineHeight, alignment: .leading)
+                                                .frame(height: Self.detailTitleLineHeight, alignment: .leading)
+                                            if let subtitle = row.subtitle {
+                                                Text(subtitle)
+                                                    .font(.caption2)
+                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                                    .lineLimit(1)
+                                                    .truncationMode(.tail)
+                                                    .frame(
+                                                        height: Self.detailSubtitleLineHeight,
+                                                        alignment: .leading)
+                                            }
+                                            if let modeSubtitle = row.modeSubtitle {
+                                                Text(modeSubtitle)
+                                                    .font(.caption2)
+                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                                    .lineLimit(1)
+                                                    .truncationMode(.tail)
+                                                    .frame(
+                                                        height: Self.detailSubtitleLineHeight,
+                                                        alignment: .leading)
+                                            }
                                         }
                                     }
+                                    .frame(height: model.detailRowHeight, alignment: .leading)
                                 }
-                                .frame(height: model.detailRowHeight, alignment: .leading)
                             }
                         }
-                    }
-                    .scrollIndicators(
-                        Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
-                    .frame(
-                        height: Self.detailRowsViewportHeight(
-                            rowCount: model.detailViewportRowCount,
-                            rowHeight: model.detailRowHeight),
-                        alignment: .topLeading)
-                    .id(selectedDateKey)
+                        .scrollIndicators(
+                            Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
+                        .frame(
+                            height: Self.detailRowsViewportHeight(
+                                rowCount: model.detailViewportRowCount,
+                                rowHeight: model.detailRowHeight),
+                            alignment: .topLeading)
+                        .id(selectedDateKey)
 
-                    if model.hasDetailOverflow {
-                        Text(Self.detailOverflowHint(itemCount: detail.rows.count) ?? " ")
-                            .font(.caption2)
-                            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                            .frame(height: Self.detailHintHeight, alignment: .leading)
-                            .accessibilityHidden(!Self.detailRowsNeedScrolling(itemCount: detail.rows.count))
+                        if model.hasDetailOverflow {
+                            Text(Self.detailOverflowHint(itemCount: detail.rows.count) ?? " ")
+                                .font(.caption2)
+                                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                .frame(height: Self.detailHintHeight, alignment: .leading)
+                                .accessibilityHidden(!Self.detailRowsNeedScrolling(itemCount: detail.rows.count))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- The cost/history submenu (`CostHistoryChartMenuView`) had two independent `ScrollView`s stacked vertically: one clipping the per-day model-breakdown rows, one clipping the "Conversations" session list. Combined with the native `NSMenu`'s own scroll gutter (`CostHistoryMenuScrollView`), a user could end up with three nested scrollable regions in one panel.
- Removed the session list's own `ScrollView` and fixed-height clipping (`sessionsBlock` now just flows as plain content). The existing outer `CostHistoryMenuScrollView` — the native `NSScrollView` that already measures and wraps the whole hosted view — is now the single scroll surface for the conversations list.
- Left the model-breakdown rows' `ScrollView` in place: its bounded height is load-bearing, not incidental — `detailViewportRowCount` caps display at a fixed row count regardless of how many models appear on the currently-hovered day, so the menu's height doesn't jump as the user hovers across chart bars. Removing it broke `cost history fitting height stays stable across compact overflow and mode selections`.
- Net effect: down from up to three nested scroll regions to two (native menu scroll + one bounded breakdown-rows scroll), with the session list no longer independently scrolling.
- Guard the hover-detail block (breakdown rows + "Hover a bar for details" fallback) behind `!model.points.isEmpty` so it can't render alongside "No data available" when `daily` has entries but none produce a chartable token/cost value.

## Verification
- `swift build` succeeds
- `swift test --filter CostHistoryChartMenuViewTests` (44/44 passed)

### Screenshots
https://github.com/user-attachments/assets/3739b1a0-a3e1-4c8a-bc79-24caf593b672