### PR TITLE
fix(widgets): keep freshness labels live between timeline reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.7 — Unreleased
 
 ### Fixed
+- Widgets: keep snapshot and stale token-history age labels advancing between timeline reloads, so paused widgets no longer retain fresh-looking timestamps (partial fix for #3339).
 - Model pricing: keep the cached catalog readable when refreshing it on Linux, using one atomic write instead of a redundant file-replacement sequence (extracted from #3412). Thanks @WeGoToMars!
 - ElevenLabs: distinguish a missing API key from a rejected key, missing subscription-read permission, or access restrictions, including current and legacy API error formats (#3437). Thanks @benmillerat!
 - Command Code: keep the resolved subscription plan in memory for its billing period so a timed-out plan lookup still sizes the monthly credits row from fresh credits, and report that row as unavailable rather than untouched when no plan is known; rolling five-hour and weekly usage stay unaffected (#3441). Thanks @enieuwy!

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -169,7 +169,10 @@ private struct CompactMetricView: View {
                 Text(display.value)
                     .font(.title2)
                     .fontWeight(.semibold)
-                Text(display.label)
+                WidgetFormat.tokenRowTitle(
+                    display.label,
+                    summary: self.metric == .credits ? nil : self.entry.tokenUsage,
+                    entryUpdatedAt: self.entry.updatedAt)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                 if let detail = display.detail {
@@ -207,10 +210,7 @@ enum CompactMetricFormatter {
             } ?? "—"
             let detail = entry.tokenUsage?.sessionTokens.map(WidgetFormat.tokenCount)
             let label = entry.tokenUsage.map {
-                WidgetFormat.tokenRowTitle(
-                    Self.costMetricLabel($0.sessionLabel, provider: entry.provider),
-                    summary: $0,
-                    entryUpdatedAt: entry.updatedAt)
+                Self.costMetricLabel($0.sessionLabel, provider: entry.provider)
             } ?? "Today cost"
             return CompactMetricDisplay(value: value, label: label, detail: detail)
         case .last30DaysCost:
@@ -219,10 +219,7 @@ enum CompactMetricFormatter {
             } ?? "—"
             let detail = entry.tokenUsage?.last30DaysTokens.map(WidgetFormat.tokenCount)
             let label = entry.tokenUsage.map {
-                WidgetFormat.tokenRowTitle(
-                    Self.costMetricLabel($0.last30DaysLabel, provider: entry.provider),
-                    summary: $0,
-                    entryUpdatedAt: entry.updatedAt)
+                Self.costMetricLabel($0.last30DaysLabel, provider: entry.provider)
             } ?? "30d cost"
             return CompactMetricDisplay(value: value, label: label, detail: detail)
         }
@@ -255,7 +252,7 @@ private struct ProviderSwitcherRow: View {
             }
             if self.showsTimestamp {
                 Spacer(minLength: 6)
-                Text(WidgetFormat.relativeDate(self.updatedAt))
+                Text(self.updatedAt, style: .relative)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
@@ -356,7 +353,7 @@ private struct SwitcherMediumUsageView: View {
                     color: WidgetColors.color(for: self.entry.provider))
             }
             if let credits = entry.creditsRemaining {
-                ValueLine(title: "Credits", value: WidgetFormat.credits(credits))
+                ValueLine(title: Text("Credits"), value: WidgetFormat.credits(credits))
             }
             if let token = entry.tokenUsage {
                 ValueLine(
@@ -394,7 +391,7 @@ private struct SwitcherLargeUsageView: View {
                     color: WidgetColors.color(for: self.entry.provider))
             }
             if let credits = entry.creditsRemaining {
-                ValueLine(title: "Credits", value: WidgetFormat.credits(credits))
+                ValueLine(title: Text("Credits"), value: WidgetFormat.credits(credits))
             }
             if let token = entry.tokenUsage {
                 VStack(alignment: .leading, spacing: 4) {
@@ -486,7 +483,7 @@ private struct MediumUsageView: View {
                     color: WidgetColors.color(for: self.entry.provider))
             }
             if let credits = entry.creditsRemaining {
-                ValueLine(title: "Credits", value: WidgetFormat.credits(credits))
+                ValueLine(title: Text("Credits"), value: WidgetFormat.credits(credits))
             }
             if let token = entry.tokenUsage {
                 ValueLine(
@@ -526,7 +523,7 @@ private struct LargeUsageView: View {
                     color: WidgetColors.color(for: self.entry.provider))
             }
             if let credits = entry.creditsRemaining {
-                ValueLine(title: "Credits", value: WidgetFormat.credits(credits))
+                ValueLine(title: Text("Credits"), value: WidgetFormat.credits(credits))
             }
             if let token = entry.tokenUsage {
                 VStack(alignment: .leading, spacing: 4) {
@@ -817,7 +814,7 @@ private struct HeaderView: View {
                 .font(.body)
                 .fontWeight(.semibold)
             Spacer()
-            Text(WidgetFormat.relativeDate(self.updatedAt))
+            Text(self.updatedAt, style: .relative)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
         }
@@ -854,12 +851,12 @@ private struct UsageBarRow: View {
 }
 
 private struct ValueLine: View {
-    let title: String
+    let title: Text
     let value: String
 
     var body: some View {
         HStack(spacing: 6) {
-            Text(self.title)
+            self.title
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
@@ -961,7 +958,7 @@ enum WidgetBalanceFormatter {
 
 private func extraUsageBalanceLine(for entry: WidgetSnapshot.ProviderEntry) -> ValueLine? {
     guard let line = WidgetBalanceFormatter.extraUsageBalance(for: entry) else { return nil }
-    return ValueLine(title: line.title, value: line.value)
+    return ValueLine(title: Text(line.title), value: line.value)
 }
 
 enum WidgetFormat {
@@ -999,21 +996,16 @@ enum WidgetFormat {
         "\(UsageFormatter.tokenCountString(value)) tokens"
     }
 
-    static func relativeDate(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        formatter.unitsStyle = .short
-        return formatter.localizedString(for: date, relativeTo: Date())
-    }
-
     /// Suffixes the title with the token snapshot's own age once it lags the entry's
     /// freshness signal past `TokenUsageSummary.staleLagThreshold`.
     static func tokenRowTitle(
         _ base: String,
-        summary: WidgetSnapshot.TokenUsageSummary,
-        entryUpdatedAt: Date) -> String
+        summary: WidgetSnapshot.TokenUsageSummary?,
+        entryUpdatedAt: Date) -> Text
     {
-        guard summary.isStale(comparedTo: entryUpdatedAt), let updatedAt = summary.updatedAt else { return base }
-        return "\(base) · \(self.relativeDate(updatedAt))"
+        guard let summary, summary.isStale(comparedTo: entryUpdatedAt), let updatedAt = summary.updatedAt else {
+            return Text(base)
+        }
+        return Text("\(base) · \(Text(updatedAt, style: .relative))")
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -255,6 +255,7 @@ private struct ProviderSwitcherRow: View {
                 Text(self.updatedAt, style: .relative)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.trailing)
             }
         }
     }
@@ -817,6 +818,7 @@ private struct HeaderView: View {
             Text(self.updatedAt, style: .relative)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
         }
     }
 }

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -923,7 +923,7 @@ extension CodexBarWidgetProviderTests {
     }
 
     @Test
-    func `widget token titles disclose stale age for today and history rows`() {
+    func `compact cost labels retain billing disclosure without baking in a stale age`() {
         let entryUpdatedAt = Date()
         let staleToken = WidgetSnapshot.TokenUsageSummary(
             sessionCostUSD: 1.25,
@@ -931,29 +931,6 @@ extension CodexBarWidgetProviderTests {
             last30DaysCostUSD: 12.50,
             last30DaysTokens: 42000,
             updatedAt: entryUpdatedAt.addingTimeInterval(-45 * 60))
-        let freshToken = WidgetSnapshot.TokenUsageSummary(
-            sessionCostUSD: 1.25,
-            sessionTokens: 4200,
-            last30DaysCostUSD: 12.50,
-            last30DaysTokens: 42000,
-            updatedAt: entryUpdatedAt.addingTimeInterval(-5 * 60))
-
-        let todayTitle = WidgetFormat.tokenRowTitle(
-            staleToken.sessionLabel,
-            summary: staleToken,
-            entryUpdatedAt: entryUpdatedAt)
-        let historyTitle = WidgetFormat.tokenRowTitle(
-            staleToken.last30DaysLabel,
-            summary: staleToken,
-            entryUpdatedAt: entryUpdatedAt)
-
-        #expect(todayTitle.hasPrefix("Today · "))
-        #expect(historyTitle.hasPrefix("30d · "))
-        #expect(WidgetFormat.tokenRowTitle(
-            freshToken.sessionLabel,
-            summary: freshToken,
-            entryUpdatedAt: entryUpdatedAt) == "Today")
-
         let entry = WidgetSnapshot.ProviderEntry(
             provider: .codex,
             updatedAt: entryUpdatedAt,
@@ -967,8 +944,8 @@ extension CodexBarWidgetProviderTests {
         let todayMetric = CompactMetricFormatter.display(for: entry, metric: .todayCost)
         let historyMetric = CompactMetricFormatter.display(for: entry, metric: .last30DaysCost)
 
-        #expect(todayMetric.label.hasPrefix("Today API est. · not billed · "))
-        #expect(historyMetric.label.hasPrefix("30d API est. · not billed · "))
+        #expect(todayMetric.label == "Today API est. · not billed")
+        #expect(historyMetric.label == "30d API est. · not billed")
         #expect(CompactMetricFormatter.costMetricLabel("7d", provider: .codex) == "7d API est. · not billed")
         #expect(CompactMetricFormatter.costMetricLabel("90d", provider: .codex) == "90d API est. · not billed")
         #expect(CompactMetricFormatter.costMetricLabel("This month", provider: .codex) ==

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -11,6 +11,7 @@ read_when:
 ## Snapshot pipeline
 - `WidgetSnapshotStore` writes compact JSON snapshots to the app-group container.
 - Widgets read the snapshot and render usage/credits/history states.
+- Snapshot age labels advance between timeline reloads. Stale token-cost rows track their own saved timestamp once they lag quota data by more than ten minutes. Fetching new usage still depends on app refresh and WidgetKit accepting a timeline.
 - The app writes snapshots after the main refresh pipeline and token-usage refreshes; narrow single-provider refresh paths may wait for the next snapshot write.
 - Scheduled provider refreshes trigger regular token/cost refreshes; the token/cost TTL determines eligibility when
   that refresh runs. Timer-driven local-history refreshes have a 15-minute minimum (30 minutes in low-power mode).


### PR DESCRIPTION
Widget freshness labels were formatted into strings when WidgetKit accepted a timeline. A stalled widget could therefore keep showing “6 sec. ago” several minutes later. This keeps snapshot dates in SwiftUI's live relative-date Text representation and preserves the separate token-history timestamp for stale cost rows.

The compact metric model now holds the stable cost/billing label, and the view uses the shared token-title helper to add its live age. This removes the duplicated formatter and keeps production sources **net −6 lines** (23 added, 29 removed). Documentation and the Unreleased changelog are included.

Partial fix for #3339; the separate chronod timeline-acceptance/recovery investigation stays open. Thanks @zhulijin1991 for the detailed report.

Validation:
- All 48 focused widget tests passed. The final `make test` run passed all 1,025 selections across 86 groups on the first run, without retries. `make check` passes with zero violations.
- Signed production widget sources tested in a macOS 26.5 VM with synthetic usage and a minimal publisher app. The baseline retained “6 sec. ago” several minutes after publication. The new widget uses separate live ages for the quota snapshot and token history.
- Final aligned widget: header age advanced from 4 min, 11 sec to 8 min, 50 sec; token age advanced from 49 min, 5 sec to 53 min, 44 sec. Snapshot hash and mtime stayed unchanged, with no accepted timeline replacement between captures. Fresh token rows keep the plain Today label; Credits stays plain.
- Live proof caught and corrected the header alignment change introduced by dynamic Text. Both header views retain trailing alignment.
- [CI](https://github.com/steipete/CodexBar/actions/runs/34020950807) passes all nine checks, including both macOS shards and Linux x64, arm64, and musl. Public image downloads were hash-verified after attachment.

Before: the old widget retained a fresh-looking label several minutes after publication.

![Before: frozen widget freshness label](https://github.com/user-attachments/assets/1bbbe4b1-6e06-4c4d-9af8-aafb3bb62f2d)

After: elapsed age advances while the saved data remains unchanged.

![After: live widget freshness labels](https://github.com/user-attachments/assets/bf602206-0908-4b16-9cb4-c41f7cb2394a)

The captures contain synthetic usage only. macOS desktop tint varies with focus; the comparison concerns the age labels.
