### PR TITLE
fix(cost): preserve Pi session caches across Linux refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Widgets: keep snapshot and stale token-history age labels advancing between timeline reloads, so paused widgets no longer retain fresh-looking timestamps (partial fix for #3339).
+- Pi and OMP cost history: keep the session cache intact across Linux refreshes by replacing it with one atomic write, preserving saved scan state, provider totals, pricing metadata, and timezone information.
 - Model pricing: keep the cached catalog readable when refreshing it on Linux, using one atomic write instead of a redundant file-replacement sequence (extracted from #3412). Thanks @WeGoToMars!
 - ElevenLabs: distinguish a missing API key from a rejected key, missing subscription-read permission, or access restrictions, including current and legacy API error formats (#3437). Thanks @benmillerat!
 - Command Code: keep the resolved subscription plan in memory for its billing period so a timed-out plan lookup still sizes the monthly credits row from fresh credits, and report that row as unavailable rather than untouched when no plan is known; rolling five-hour and weekly usage stay unaffected (#3441). Thanks @enieuwy!

--- a/Sources/CodexBarCore/PiSessionCostCache.swift
+++ b/Sources/CodexBarCore/PiSessionCostCache.swift
@@ -38,18 +38,8 @@ enum PiSessionCostCacheIO {
 
         var cache = cache
         cache.timeZoneIdentifier = calendar.timeZone.identifier
-        let tmp = dir.appendingPathComponent(".tmp-\(UUID().uuidString).json", isDirectory: false)
-        let data = (try? JSONEncoder().encode(cache)) ?? Data()
-        do {
-            try data.write(to: tmp, options: [.atomic])
-            if FileManager.default.fileExists(atPath: url.path) {
-                _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
-            } else {
-                try FileManager.default.moveItem(at: tmp, to: url)
-            }
-        } catch {
-            try? FileManager.default.removeItem(at: tmp)
-        }
+        guard let data = try? JSONEncoder().encode(cache) else { return }
+        try? data.write(to: url, options: [.atomic])
     }
 }
 

--- a/TestsLinux/PiSessionCostCacheReplacementTests.swift
+++ b/TestsLinux/PiSessionCostCacheReplacementTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct PiSessionCostCacheReplacementTests {
+    @Test
+    func `repeated Pi cache saves preserve scan state and provider totals`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pi-cache-replacement-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let url = PiSessionCostCacheIO.cacheFileURL(cacheRoot: root)
+
+        for revision in 1...10 {
+            var cache = PiSessionCostCache()
+            cache.lastScanUnixMs = Int64(revision)
+            cache.pricingKey = "pricing-\(revision)"
+            cache.daysByProvider = ["codex": ["2026-09-06": ["sample-model": PiPackedUsage(
+                inputTokens: revision, totalTokens: revision, costNanos: Int64(revision))]]]
+            PiSessionCostCacheIO.save(cache: cache, cacheRoot: root, calendar: calendar)
+
+            let persisted = try JSONDecoder().decode(PiSessionCostCache.self, from: Data(contentsOf: url))
+            #expect(persisted.lastScanUnixMs == cache.lastScanUnixMs)
+            #expect(persisted.pricingKey == cache.pricingKey)
+            #expect(persisted.daysByProvider == cache.daysByProvider)
+            #expect(persisted.timeZoneIdentifier == calendar.timeZone.identifier)
+            #expect(PiSessionCostCacheIO.load(cacheRoot: root).lastScanUnixMs == cache.lastScanUnixMs)
+        }
+
+        let files = try FileManager.default.contentsOfDirectory(atPath: url.deletingLastPathComponent().path)
+        #expect(files == [url.lastPathComponent])
+    }
+}

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -255,7 +255,7 @@ Model-scoped weekly-window proof (synthetic data, no real accounts or credential
   - Matching assistant entry IDs within the same session are counted once across roots; distinct turns are retained.
 - Cache:
   - Native provider cache: `~/Library/Caches/CodexBar/cost-usage/claude-v6.json`
-  - pi-compatible session cache: `~/Library/Caches/CodexBar/cost-usage/pi-sessions-v7.json`
+  - pi-compatible session cache: `~/Library/Caches/CodexBar/cost-usage/pi-sessions-v8.json`
 
 ## Key files
 - OAuth: `Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/*`

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -226,6 +226,7 @@ is limited, using additional rows when needed.
 - Cache:
   - Native session store: `~/Library/Caches/CodexBar/cost-usage/cost-usage.sqlite`
   - pi-compatible session cache: `~/Library/Caches/CodexBar/cost-usage/pi-sessions-v8.json`
+    is replaced atomically on macOS and Linux, retaining complete cached scan state across refreshes.
   - Catch-up status reads progress metadata without loading historical usage JSON or replay bodies. Cached reports
     retain row-level pricing evidence and project/session details, but omit raw token snapshots, accumulator state,
     and replay bodies. File cursor metadata, including JSONL resume state, remains available for progress tracking.


### PR DESCRIPTION
Pi-compatible session-cost caching had the same Linux replacement failure fixed for pricing catalogs in #3444: the second save could remove the cache file. A subsequent cached read then lost its saved scan state and totals and needed another scan.

This replaces the remaining temporary-write/replace sequence with one atomic destination write. The schema, cache path, timezone assignment, and best-effort save contract stay intact; an encoding failure also leaves the previous file untouched. Production is **net −10 lines** (2 added, 12 removed). The change includes a portable regression, an Unreleased changelog entry, and correction of the stale Claude documentation path to the existing v8 cache.

Validation:
- Linux x86_64 with the official Swift 6.3.3 container: unchanged production code fails on save 2 with the cache file missing; the candidate passes 100 saves with independent disk/readback, scan timestamp, pricing-key, provider-total, timezone, and staging-file checks.
- All 23 focused Pi cache/scanner/compatibility tests pass.
- `make check` passes, and `make test` passes all 1,026 selections across 86 groups on the first run without retries.
- [CI](https://github.com/steipete/CodexBar/actions/runs/34023767538) passes all nine checks, including both macOS shards and Linux x64, arm64, and musl.

This is a follow-up from auditing the remaining production use of `FileManager.replaceItemAt`; it repairs the existing Pi/OMP history used by Codex and Claude cost reporting.
