### PR TITLE
fix(antigravity): skip steps without stepUUID during token scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.56.8 — Unreleased
 
+### Fixed
+- Antigravity: skip auxiliary and lifecycle steps lacking a step UUID during local token scans instead of invalidating the entire database history.
+
 ## 0.56.7 — 2026-09-06
 
 ### Highlights

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -331,18 +331,18 @@ extension AntigravityLocalReader {
                 rowsAreValid = false
                 continue
             }
+            if let botID = parsed.botID {
+                self.recordExactBotID(
+                    botID,
+                    stepUUID: parsed.stepUUID,
+                    timestampMs: parsed.timestampMs,
+                    exact: &exactByBotID,
+                    ambiguous: &ambiguousBotIDs)
+            }
             // Auxiliary/lifecycle steps in the steps table may legitimately lack a stepUUID.
             // Skip them rather than failing the entire database scan.
             guard let stepUUID = parsed.stepUUID, !stepUUID.isEmpty else {
                 continue
-            }
-            if let botID = parsed.botID {
-                self.recordExactBotID(
-                    botID,
-                    stepUUID: stepUUID,
-                    timestampMs: parsed.timestampMs,
-                    exact: &exactByBotID,
-                    ambiguous: &ambiguousBotIDs)
             }
             if neededStepUUIDCounts[stepUUID] != nil {
                 stepTimestamps[stepUUID, default: []].append(StepTimestamp(
@@ -372,13 +372,13 @@ extension AntigravityLocalReader {
 
     private static func recordExactBotID(
         _ botID: String,
-        stepUUID: String,
+        stepUUID: String?,
         timestampMs: Int64?,
         exact: inout [String: ExactStepTimestamp],
         ambiguous: inout Set<String>)
     {
         guard !ambiguous.contains(botID) else { return }
-        guard let timestampMs else {
+        guard let timestampMs, let stepUUID, !stepUUID.isEmpty else {
             exact.removeValue(forKey: botID)
             ambiguous.insert(botID)
             return

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -331,8 +331,9 @@ extension AntigravityLocalReader {
                 rowsAreValid = false
                 continue
             }
+            // Auxiliary/lifecycle steps in the steps table may legitimately lack a stepUUID.
+            // Skip them rather than failing the entire database scan.
             guard let stepUUID = parsed.stepUUID, !stepUUID.isEmpty else {
-                rowsAreValid = false
                 continue
             }
             if let botID = parsed.botID {

--- a/Tests/CodexBarTests/AntigravityBotIDValidationTests.swift
+++ b/Tests/CodexBarTests/AntigravityBotIDValidationTests.swift
@@ -160,6 +160,26 @@ struct AntigravityBotIDValidationTests {
         #expect(source.events.isEmpty)
     }
 
+    @Test(arguments: [false, true], [false, true])
+    func `UUID-less duplicate step IDs invalidate exact evidence in either order`(
+        withTimestamp: Bool,
+        missingFirst: Bool) throws
+    {
+        let fixture = try Fixture()
+        let valid = Fixture.stepMetadataBlob(stepUUID: "local", botID: "duplicate", seconds: Self.early)
+        let uuidLess = withTimestamp
+            ? Fixture.stepMetadataBlob(stepUUID: nil, botID: "duplicate", seconds: Self.late)
+            : Fixture.message(9, Fixture.message(7, Array("duplicate".utf8)))
+        let url = try fixture.database(blobs: [
+            Fixture.blobWithRootEnvelope(stepUUID: "local", botID: "duplicate", seconds: nil),
+        ], stepBlobs: missingFirst ? [uuidLess, valid] : [valid, uuidLess])
+
+        let source = try Self.read(url)
+
+        #expect(!source.isComplete)
+        #expect(source.events.isEmpty)
+    }
+
     enum InvalidID: CaseIterable {
         case utf8
         case wire

--- a/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalReaderTests.swift
@@ -594,7 +594,7 @@ struct AntigravityLocalReaderTests {
     }
 
     @Test(arguments: [String?.none, ""])
-    func `unidentified step occurrence cannot turn one timestamp into shared coverage`(
+    func `step row without stepUUID is skipped and does not block shared coverage`(
         unidentifiedStepUUID: String?) throws
     {
         let fixture = try Fixture()
@@ -608,12 +608,12 @@ struct AntigravityLocalReaderTests {
 
         let report = try fixture.report()
 
-        #expect(report.coverage == .partial)
-        #expect(report.report.data.isEmpty)
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.totalTokens == 396)
     }
 
     @Test
-    func `unidentified timestamp-less step occurrence cannot turn one timestamp into shared coverage`() throws {
+    func `timestamp-less step row without stepUUID is skipped and does not block shared coverage`() throws {
         let fixture = try Fixture()
         let stepUUID = "unidentified-timestamp-less-step-uuid"
         let turns = (0..<2).map { _ in Fixture.blobWithRootEnvelope(stepUUID: stepUUID, seconds: nil) }
@@ -623,8 +623,8 @@ struct AntigravityLocalReaderTests {
 
         let report = try fixture.report()
 
-        #expect(report.coverage == .partial)
-        #expect(report.report.data.isEmpty)
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.totalTokens == 396)
     }
 
     @Test
@@ -765,5 +765,33 @@ struct AntigravityLocalReaderTests {
         let snapshot = try await fixture.snapshot()
         #expect(!snapshot.historyCoverageIsEstablished)
         #expect(snapshot.last30DaysTokens == nil)
+    }
+
+    @Test
+    func `steps table row without stepUUID is skipped without invalidating coverage`() async throws {
+        let fixture = try Fixture()
+        let stepUUID = "uuid-turn-1"
+        let genBlob = Fixture.blobWithRootEnvelope(
+            stepUUID: stepUUID,
+            seconds: nil)
+        let stepWithoutUUIDBytes: [UInt8] = [
+            0x0A, 0x0C, 0x08, 0xA7, 0x8C, 0xE6, 0xD4, 0x06, 0x10, 0xC0, 0xD5, 0xA0, 0xCB, 0x03, 0x18, 0x05, 0xD2, 0x01,
+            0x00,
+        ]
+        let stepBlob = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID,
+            seconds: 1_787_832_000)
+
+        try fixture.database(
+            blobs: [genBlob],
+            stepBlobs: [stepWithoutUUIDBytes, stepBlob])
+
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.first?.totalTokens == 198)
+
+        let snapshot = try await fixture.snapshot()
+        #expect(snapshot.historyCoverageIsEstablished)
+        #expect(snapshot.last30DaysTokens == 198)
     }
 }

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -301,8 +301,10 @@ cross-UUID, or timestamp-less duplicate step IDs cannot supply exact or position
 in a UUID needing recovery must agree with available generation-unique exact matches; unrelated UUIDs retain their
 embedded timestamps. Missing or malformed auxiliary IDs retain the guarded legacy positional fallback, as do repeated
 generation IDs: ordered step timestamps must agree with embedded generation timestamps, and ambiguous positions are
-never removed or compressed. Malformed auxiliary IDs do not discard otherwise valid embedded usage or relax token-counter
-and protobuf framing validation. Session creation, file modification, and refresh time are never substitutes.
+never removed or compressed. Steps in `steps` lacking a step UUID (such as internal lifecycle markers or auxiliary
+events) are skipped and do not fail database coverage. Malformed auxiliary IDs do not discard otherwise valid
+embedded usage or relax token-counter and protobuf framing validation. Session creation, file modification, and refresh
+time are never substitutes.
 The opaque agy 1.1.18 timestamp layout remains unsupported: the pinned parser
 explicitly labels its newer interpretation an inference. See [the session-start misattribution report](https://github.com/junhoyeo/tokscale/issues/1184).
 


### PR DESCRIPTION
### Summary
I've been wanting to see Antigravity usage and cost tracking in CodexBar work just like Codex does. I saw the recent improvements in #3403 to fix token counts and the ongoing work in #3412 to pull dollar amounts. However, on my machine, local Antigravity token counts were still not showing up at all, withholding with:
```text
Antigravity Token History
Local token history is unavailable or incomplete.
Local token history · dollar costs unavailable
```
In anticipation of full Antigravity cost support landing, I dug into why token history was still withheld and found a false-positive check during SQLite step scanning that this PR fixes.

### Problem
In `readStepTimestamps` (`Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift`), encountering a row in the `steps` table without a `stepUUID` set `rowsAreValid = false`.

Antigravity legitimately logs non-conversational steps in its SQLite `steps` table (such as internal lifecycle markers, model config transitions, or auxiliary events). These records have timestamp fields (field 1) and step types (field 3), but omit field 12 (`stepUUID`) because they are not LLM turns.

When `readStepTimestamps` encounters any such step row without a `stepUUID`:
1. It flags `rowsAreValid = false`.
2. `stepScan.isComplete` evaluates to `false`.
3. The database is marked `isComplete = false`.
4. Because `result.isComplete` across all historical databases is an aggregate boolean `AND`, a single auxiliary step in any conversation database cascades to invalidate all databases across the entire machine, completely withholding token history.

### Solution
- Skip `steps` table rows without a `stepUUID` instead of invalidating the entire database scan.
- Generation rows in `gen_metadata` that actually depend on external step timestamps remain fully protected by the existing `recoveredCount < rows.pendingTimestampRows.count` check.
- Track `botID` ambiguity before skipping UUID-less rows: if an auxiliary step row carries a `botID` but lacks a `stepUUID` or timestamp, it is recorded as ambiguous so it cannot be mistakenly used as exact timestamp evidence.
- Added regression test with synthetic auxiliary step bytes matching production traces (`[0x0A, 0x0C, 0x08, 0xA7, 0x8C, 0xE6, 0xD4, 0x06, 0x10, 0xC0, 0xD5, 0xA0, 0xCB, 0x03, 0x18, 0x05, 0xD2, 0x01, 0x00]`), and tests for duplicate bot IDs on UUID-less rows in either row order.
- Updated documentation in `docs/antigravity.md` and `CHANGELOG.md`.

### Real Behavior Proof

#### Before Fix
Token history was withheld across the entire machine with coverage marked incomplete:
```text
Antigravity Token History
Local token history is unavailable or incomplete.
Local token history · dollar costs unavailable
```

#### After Fix
Local SQLite scan recovers full token history across all conversations:
```text
➜  CodexBar git:(fix/antigravity-step-uuid-withholding) swift run CodexBarCLI cost --provider antigravity
[1/1] Planning build
Building for debugging...
[5/5] Emitting module CodexBarCLI
Build of product 'CodexBarCLI' complete! (8.86s)
Antigravity Token History
Today: 73M tokens
Last 30 days: 1.1B tokens
Local token history · dollar costs unavailable
```

### Validation
```bash
swift test --filter AntigravityLocalReaderTests
swift test --filter AntigravityBotIDValidationTests
swift test --filter Antigravity
make check
```
All 403 Antigravity-focused tests and `make check` (SwiftFormat, SwiftLint, Oxlint) pass cleanly.