### PR TITLE
Fix Poe balance loss from invalid history dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.8 — Unreleased
 
 ### Fixed
+- Poe: skip out-of-range history timestamps instead of letting date formatting hide a valid point balance; preserve supported timestamp formats and valid activity.
 - Claude: retain quota-warning history for known accounts across credential refreshes, preventing repeat threshold alerts while preserving recovery crossings and separate account state (partial fix for #3450). Thanks @JonLaliberte!
 - Poe: calculate weekly points, requests, and spend from the last seven elapsed days, so older activity no longer inflates sparse or inactive weeks; share totals aggregation with Today and the 30-day window (#3449). Thanks @Lucenx9!
 - MiMo: skip malformed local session rows before deduplication so valid usage still refreshes the cache, preserving all token buckets and UTC daily/weekly totals with shared aggregation (#3448). Thanks @Lucenx9!

--- a/Sources/CodexBarCore/Resources/Plugins/poe.js
+++ b/Sources/CodexBarCore/Resources/Plugins/poe.js
@@ -37,18 +37,12 @@ defineProvider({
       });
     }
     function entryDate(value) {
-      if (typeof value === "number" && Number.isFinite(value)) {
-        if (value > 100000000000000) return new Date(value / 1000);
-        if (value > 1000000000000) return new Date(value);
-        return new Date(value * 1000);
-      }
-      if (typeof value === "string" && value.trim()) {
-        const numeric = Number(value);
-        if (Number.isFinite(numeric)) return entryDate(numeric);
-        const date = new Date(value);
-        if (Number.isFinite(date.getTime())) return date;
-      }
-      return null;
+      if (typeof value !== "number" && (typeof value !== "string" || !value.trim())) return null;
+      const numeric = Number(value);
+      const date = Number.isFinite(numeric)
+        ? new Date(numeric > 100000000000000 ? numeric / 1000 : numeric > 1000000000000 ? numeric : numeric * 1000)
+        : new Date(value);
+      return Number.isFinite(date.getTime()) ? date : null;
     }
     function timeString(date) {
       const pad = (value) => String(value).padStart(2, "0");

--- a/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginDetailsParityTests.swift
@@ -331,6 +331,47 @@ struct ProviderPluginDetailsParityTests {
     }
 
     @Test(arguments: Self.parityEngines)
+    func `Poe invalid numeric dates preserve balance and supported history timestamps`(
+        engine: ProviderPluginEngineKind) async throws
+    {
+        let now = Date(timeIntervalSince1970: 1_785_816_000)
+        let validRows = """
+        {"creation_time":1785816000,"cost_points":1},
+        {"creation_time":1785816000000,"cost_points":2},
+        {"creation_time":1785816000000000,"cost_points":4},
+        {"creation_time":"1785816000","cost_points":8},
+        {"creation_time":"2026-08-04T04:00:00Z","cost_points":16}
+        """
+        for invalid in ["1e300", "\"1e300\"", "-1e300", "\"-1e300\""] {
+            for includeValidRows in [false, true] {
+                let valid = includeValidRows ? ",\(validRows)" : ""
+                let history = "{\"data\":[{\"creation_time\":\(invalid),\"cost_points\":999}\(valid)]}"
+                let transport = Self.transport { request in
+                    switch request.url?.path {
+                    case "/usage/current_balance": Self.poeBalance
+                    case "/usage/points_history": history
+                    default: throw FixtureError.unexpectedURL(request.url)
+                    }
+                }
+                let sourceURL = try #require(CodexBarCoreResources.bundle?.url(forResource: "poe", withExtension: "js"))
+                let runtime = try ProviderPluginRuntime(
+                    source: String(contentsOf: sourceURL, encoding: .utf8), transport: transport, engine: engine)
+                let result = try await runtime.fetchUsage(secrets: ["POE_API_KEY": "fixture-key"], now: now)
+                let section = try #require(result.details.first)
+                #expect(try section.rows.first == Self.row("Current balance", "2,500 points"))
+                if includeValidRows {
+                    #expect(try section.rows.first { $0.label == "Today" }
+                        == Self.row("Today", "31 points", "5 requests"))
+                    #expect(section.chart?.points.map(\.value) == [31])
+                } else {
+                    #expect(section.rows.count == 1)
+                    #expect(section.chart == nil)
+                }
+            }
+        }
+    }
+
+    @Test(arguments: Self.parityEngines)
     func `Poe history uses the refresh clock for retention and today totals`(
         engine: ProviderPluginEngineKind) async throws
     {

--- a/docs/poe.md
+++ b/docs/poe.md
@@ -33,6 +33,7 @@ CodexBar requests:
 - `GET https://api.poe.com/usage/points_history`
 
 The current balance request is required. Recent points history is best-effort, so a history error does not hide a valid balance.
+History rows with invalid timestamps are skipped, including numeric timestamps outside the supported date range.
 
 ## Display
 


### PR DESCRIPTION
A finite numeric history timestamp can still be outside JavaScript’s valid date range. Poe’s parser returned that Invalid Date, the retention comparison did not reject it, and later `toISOString()` threw outside the optional-history handler. One malformed history row therefore hid an otherwise valid point balance.

Normalize numeric/string timestamps through one path and validate the resulting date before aggregation. This removes the recursive numeric-string branch and six production lines while preserving seconds, milliseconds, microseconds, numeric strings, ISO strings, and existing timestamp-field precedence. Invalid rows are skipped; valid activity and balance remain available.

Validation at `42a7e3bae48`:

- Current-main Node execution reproduces `RangeError: Invalid time value`; the candidate preserves balance and valid activity.
- 23 focused native tests passed, including QuickJS and JavaScriptCore, positive/negative out-of-range values and numeric strings, invalid-only history, and mixed supported timestamp formats.
- Fresh released Linux CLI 0.56.7 with the baseline/candidate plugin ran through actual HTTPS, QuickJS, Swift decoding and CLI JSON in an isolated AWS environment. All four baseline cases failed after successful HTTP responses; all four candidate cases retained the 1,500-point balance and, when present, 31 points of valid weekly activity. Only the test origin changed; no real vendor credentials or data were used.
- `make check` passed. Full `make test` passed all 1,027 selections / 86 groups on the first pass, without retries or timeouts (1,199.8 seconds). [CI](https://github.com/steipete/CodexBar/actions/runs/34072577768) passed on this exact head.
- Independent P2 review and isolated autoreview found no actionable findings in their selected scopes.

The changelog and Poe provider documentation describe the fix. This is a date-validation bug discovered while reviewing the recent history aggregation work, not a change to provider authentication or billing semantics.
