### PR TITLE
Share menu quota pace and reset presentation

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -776,25 +776,7 @@ extension UsageMenuCardView.Model {
         showUsed: Bool) -> PaceDetail?
     {
         guard let detail = UsagePaceText.sessionDetail(provider: provider, window: window, now: now) else { return nil }
-        let expectedUsed = detail.expectedUsedPercent
-        let actualUsed = window.usedPercent
-        let expectedPercent = showUsed ? expectedUsed : (100 - expectedUsed)
-        let actualPercent = showUsed ? actualUsed : (100 - actualUsed)
-        if expectedPercent.isFinite == false || actualPercent.isFinite == false {
-            return nil
-        }
-        let paceOnTop = actualUsed <= expectedUsed
-        let pacePercent: Double? = if detail.stage == .onTrack {
-            nil
-        } else {
-            expectedPercent
-        }
-        return PaceDetail(
-            leftLabel: detail.leftLabel,
-            rightLabel: detail.rightLabel,
-            pacePercent: pacePercent,
-            paceOnTop: paceOnTop,
-            isPaceDerived: true)
+        return self.paceDetail(detail, window: window, showUsed: showUsed)
     }
 
     static func weeklyPaceDetail(
@@ -806,24 +788,21 @@ extension UsageMenuCardView.Model {
     {
         guard let pace, window.remainingPercent > 0 else { return nil }
         let detail = UsagePaceText.weeklyDetail(provider: provider, pace: pace, now: now)
-        let expectedUsed = detail.expectedUsedPercent
-        let actualUsed = window.usedPercent
-        let expectedPercent = showUsed ? expectedUsed : (100 - expectedUsed)
-        let actualPercent = showUsed ? actualUsed : (100 - actualUsed)
-        if expectedPercent.isFinite == false || actualPercent.isFinite == false {
-            return nil
-        }
-        let paceOnTop = actualUsed <= expectedUsed
-        let pacePercent: Double? = if detail.stage == .onTrack {
-            nil
-        } else {
-            expectedPercent
-        }
+        return self.paceDetail(detail, window: window, showUsed: showUsed)
+    }
+
+    private static func paceDetail(
+        _ detail: UsagePaceText.WeeklyDetail,
+        window: RateWindow,
+        showUsed: Bool) -> PaceDetail?
+    {
+        guard detail.expectedUsedPercent.isFinite, window.usedPercent.isFinite else { return nil }
+        let expectedPercent = showUsed ? detail.expectedUsedPercent : (100 - detail.expectedUsedPercent)
         return PaceDetail(
             leftLabel: detail.leftLabel,
             rightLabel: detail.rightLabel,
-            pacePercent: pacePercent,
-            paceOnTop: paceOnTop,
+            pacePercent: detail.stage == .onTrack ? nil : expectedPercent,
+            paceOnTop: window.usedPercent <= detail.expectedUsedPercent,
             isPaceDerived: true)
     }
 
@@ -1045,13 +1024,8 @@ extension UsageMenuCardView.Model {
         namedWindow: NamedRateWindow,
         input: Input) -> String?
     {
-        if namedWindow.window.resetsAt != nil {
-            return self.resetText(
-                for: namedWindow.window,
-                style: input.resetTimeDisplayStyle,
-                now: input.now)
-        }
         if input.provider == .antigravity,
+           namedWindow.window.resetsAt == nil,
            self.isAntigravityQuotaSummaryWindow(namedWindow)
         {
             return self.antigravityQuotaSummaryResetText(namedWindow.window.resetDescription)
@@ -1118,28 +1092,14 @@ extension UsageMenuCardView.Model {
         input: Input) -> PaceDetail?
     {
         guard input.provider == .antigravity else { return nil }
-        switch window.windowMinutes {
-        case nil, 300:
+        if window.windowMinutes == nil {
             return self.sessionPaceDetail(
                 provider: input.provider,
                 window: window,
                 now: input.now,
                 showUsed: input.usageBarsShowUsed)
-        case 10080:
-            let pace = Self.displayableWeeklyPace(UsagePace.weekly(
-                window: window,
-                now: input.now,
-                defaultWindowMinutes: 10080,
-                workDays: input.workDaysPerWeek))
-            return Self.weeklyPaceDetail(
-                provider: input.provider,
-                window: window,
-                now: input.now,
-                pace: pace,
-                showUsed: input.usageBarsShowUsed)
-        default:
-            return nil
         }
+        return self.extraRateWindowPaceDetail(provider: input.provider, window: window, input: input)
     }
 
     static func antigravityMetric(

--- a/Tests/CodexBarTests/MenuCardAntigravityTests.swift
+++ b/Tests/CodexBarTests/MenuCardAntigravityTests.swift
@@ -332,7 +332,7 @@ struct MenuCardAntigravityTests {
                     window: RateWindow(
                         usedPercent: 9,
                         windowMinutes: 300,
-                        resetsAt: nil,
+                        resetsAt: now.addingTimeInterval(7200),
                         resetDescription: "You have used some of your 5-hour limit, it will fully refresh in "
                             + "4 hours.")),
                 NamedRateWindow(
@@ -407,6 +407,7 @@ struct MenuCardAntigravityTests {
             "73% left",
             "64% left",
         ])
+        #expect(model.metrics[0].resetText == "Resets in 2h")
         #expect(model.metrics[2].resetText == "Resets in 3 hours")
     }
 

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1934,7 +1934,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 932,
+            line: 911,
             anchor: "if input.provider == .codex, !input.showOptionalCreditsAndExtraUsage {",
             expectedProviderIDs: ["claude", "codex", "copilot"],
             expectedReferenceCount: 4,
@@ -1942,7 +1942,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 957,
+            line: 936,
             anchor: "let resetText = input.provider == .sub2api && namedWindow.window.resetsAt == nil",
             expectedProviderIDs: ["doubao", "sub2api"],
             expectedReferenceCount: 3,
@@ -1950,7 +1950,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1020,
+            line: 999,
             anchor: "guard provider == .kiro, namedWindow.id == \"kiro-overage\",",
             expectedProviderIDs: ["kiro"],
             expectedReferenceCount: 1,
@@ -1958,7 +1958,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1054,
+            line: 1027,
             anchor: "if input.provider == .antigravity,",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,
@@ -1966,7 +1966,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1088,
+            line: 1062,
             anchor: "if provider == .claude, window.windowMinutes != 10080 {",
             expectedProviderIDs: ["antigravity", "claude", "codex"],
             expectedReferenceCount: 4,
@@ -1974,7 +1974,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared renderer maps provider-owned presentation data into the generic UI model."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/MenuCardView+ModelHelpers.swift",
-            line: 1120,
+            line: 1094,
             anchor: "guard input.provider == .antigravity else { return nil }",
             expectedProviderIDs: ["antigravity"],
             expectedReferenceCount: 1,


### PR DESCRIPTION
Session and weekly quota pace rendering duplicate the same projection into menu-card details. Antigravity also repeats the explicit-duration pace dispatch and reset-text fallback already available in shared helpers.

Share those paths while preserving each caller’s eligibility rules, nil-duration handling, workday configuration, and actual reset-date precedence. The cleanup removes 40 production lines. It is a separate behavior-preserving PR that will provide the LOC budget for the model-specific weekly-label localization fix in #3447.

Validation at `b0b0f0ff346`:

- 197 focused tests across 27 suites passed, covering pace visibility/text, used/remaining display, workdays, Antigravity nil/session/weekly windows, menu models, and provider architecture.
- Strengthened the existing Antigravity summary test with a real two-hour reset date and conflicting four-hour prose; the date remains authoritative, while another row retains prose fallback.
- Six architecture line anchors were relocated only where the source text was unchanged. Expected provider IDs, fingerprints, counts, and architectural rules remain intact.
- `make check` passed. Full `make test` passed all 1,027 selections / 86 groups on the first pass, without retries or timeouts (988.5 seconds). [CI](https://github.com/steipete/CodexBar/actions/runs/34072623495) passed on this exact head.
- Independent P2 review and isolated autoreview found no actionable findings in their selected scopes.

No public model/API shape, provider fetching, preferences, or user-facing wording changes are included. The label fix will remain a separate PR, and its measured additions must fit the deletion budget after this cleanup lands.
