### PR TITLE
fix(openrouter): preserve credits when combined Activity tokens overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.8 — Unreleased
 
 ### Fixed
+- OpenRouter: reject combined Activity token overflow before publishing history so malformed optional data cannot hide valid credits or key quota; share input/output total validation (extracted from #3272). Thanks @akshayprabhu200!
 - Poe: skip out-of-range history timestamps instead of letting date formatting hide a valid point balance; preserve supported timestamp formats and valid activity.
 - Claude: retain quota-warning history for known accounts across credential refreshes, preventing repeat threshold alerts while preserving recovery crossings and separate account state (partial fix for #3450). Thanks @JonLaliberte!
 - Poe: calculate weekly points, requests, and spend from the last seven elapsed days, so older activity no longer inflates sparse or inactive weeks; share totals aggregation with Today and the 30-day window (#3449). Thanks @Lucenx9!

--- a/Sources/CodexBarCore/Resources/Plugins/openrouter.js
+++ b/Sources/CodexBarCore/Resources/Plugins/openrouter.js
@@ -224,12 +224,11 @@ defineProvider({
             aggregateCost += cost;
             aggregateEstimatedCost += estimatedCost;
             if (
-              !Number.isSafeInteger(aggregateInputTokens) ||
-              !Number.isSafeInteger(aggregateOutputTokens) ||
+              !Number.isSafeInteger(aggregateInputTokens + aggregateOutputTokens) ||
               !Number.isSafeInteger(aggregateReasoningTokens) ||
               !Number.isSafeInteger(aggregateRequests)
             ) {
-              throw new TypeError("activity aggregate exceeded the safe integer range");
+              throw new TypeError("activity aggregate must be within the safe integer range");
             }
             if (!Number.isFinite(aggregateCost) || !Number.isFinite(aggregateEstimatedCost)) {
               throw new TypeError("activity spend aggregate overflowed");

--- a/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
+++ b/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
@@ -664,6 +664,35 @@ struct OpenRouterPluginGoldenTests {
 
     private static let defaultCreditsBody = #"{"data":{"total_credits":100,"total_usage":40}}"#
 
+    @Test(arguments: BundledPluginTestSupport.engines)
+    func `combined activity token boundary preserves credits across models and days`(
+        engine: ProviderPluginEngineKind) async throws
+    {
+        for date in ["2026-08-17", "2026-08-16"] {
+            for outputTokens in [4_007_199_254_740_991, 4_007_199_254_740_992, 5_000_000_000_000_000] {
+                let body = """
+                {"data":[
+                  {"date":"2026-08-17","model":"example/input","prompt_tokens":5000000000000000,
+                   "completion_tokens":0,"requests":1,"usage":1},
+                  {"date":"\(date)","model":"example/output","prompt_tokens":0,
+                   "completion_tokens":\(outputTokens),"requests":1,"usage":1}
+                ]}
+                """
+                let usage = try await Self.fetch(activityBody: body, engine: engine)
+                #expect(usage.primary?.usedPercent == 25)
+                #expect(usage.detailRow(label: "Remaining")?.value == "$60.00")
+                if outputTokens == 4_007_199_254_740_991 {
+                    #expect(usage.costUsage?.last30DaysTokens == 9_007_199_254_740_991)
+                    #expect(usage.costUsage?.last30DaysRequests == 2)
+                    #expect(usage.costUsage?.last30DaysCostUSD == 2)
+                } else {
+                    #expect(usage.costUsage == nil)
+                    #expect(usage.detailRow(label: "Last 30 days")?.secondaryValue == "Response was invalid")
+                }
+            }
+        }
+    }
+
     private static func fetch(
         creditsBody: String = Self.defaultCreditsBody,
         creditsStatus: Int = 200,
@@ -682,10 +711,12 @@ struct OpenRouterPluginGoldenTests {
 
     private static func fetch(
         activityBody: String,
+        engine: ProviderPluginEngineKind = .automatic,
         now: Date = Date(timeIntervalSince1970: 1_787_079_600)) async throws -> UsageSnapshot
     {
-        let runtime = try ProviderPluginRuntime(
-            bundledPlugin: "openrouter",
+        let runtime = try BundledPluginTestSupport.runtime(
+            "openrouter",
+            engine: engine,
             transport: ProviderHTTPTransportHandler { request in
                 let body = switch request.url?.path {
                 case let path? where path.hasSuffix("/activity"):

--- a/docs/openrouter.md
+++ b/docs/openrouter.md
@@ -46,6 +46,8 @@ The OpenRouter provider fetches usage data from two API endpoints:
 The Key API is optional enrichment with a one-second production deadline. If it is slow or unavailable, CodexBar still
 shows the credits balance and labels the API key limit as unavailable with a safe timeout, HTTP, or response diagnostic.
 
+Activity history uses the separately configured Management API key and is optional. Malformed activity, including a combined input/output token total outside the safe integer range, leaves valid credits and key quota available and marks history unavailable.
+
 ## Display
 
 The **Usage Dashboard** menu action opens [OpenRouter Activity](https://openrouter.ai/activity) for request and spending history.


### PR DESCRIPTION
Two individually valid OpenRouter Activity rows can push combined input/output tokens outside the safe integer range. The plugin previously checked the two aggregates separately, then Swift rejected their combined total outside the optional-history handler, losing otherwise valid credits and key quota.

Check the combined total before publishing Activity. Since row token counts are nonnegative, this one check also covers each component and removes a production line. Keep malformed Activity inside its existing optional failure path and classify it as an invalid response.

Extracted the aggregate-overflow fix identified in #3272; thanks @akshayprabhu200. The original PR remains open for its broader credential-routing and Activity-card proposal. This repair retains the already-supported separate Management API key configuration.

Validation at `4baaa3d2398`:

- Native baseline reproduces `costUsage token total overflowed` in both QuickJS and JavaScriptCore.
- 39 focused tests passed. The new regression covers the exact safe-integer boundary, boundary +1, and a larger overflow across distinct models on the same or different UTC days. Valid boundary history is retained; overflowing history leaves the $60 credits balance and 25% key quota available.
- Isolated P2 autoreview found no actionable findings.
- `make check` passed with zero violations. Full `make test` passed all 1,027 selections / 86 groups on the first pass, with no retries or timeouts (966.5 seconds). [CI](https://github.com/steipete/CodexBar/actions/runs/34076114623) passed on this exact head.

Changelog and provider documentation describe the repaired optional-history contract. No real vendor credentials or data were used.
