### PR TITLE
fix(copilot): keep verified identity ahead of legacy names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.8 — Unreleased
 
 ### Fixed
+- Copilot: keep verified GitHub user IDs authoritative when matching legacy token accounts, preventing a matching login or display label from replacing a different resolved account.
 - OpenRouter: reject combined Activity token overflow before publishing history so malformed optional data cannot hide valid credits or key quota; share input/output total validation (extracted from #3272). Thanks @akshayprabhu200!
 - Poe: skip out-of-range history timestamps instead of letting date formatting hide a valid point balance; preserve supported timestamp formats and valid activity.
 - Claude: retain quota-warning history for known accounts across credential refreshes, preventing repeat threshold alerts while preserving recovery crossings and separate account state (partial fix for #3450). Thanks @JonLaliberte!

--- a/Sources/CodexBar/Providers/Copilot/CopilotLoginFlow.swift
+++ b/Sources/CodexBar/Providers/Copilot/CopilotLoginFlow.swift
@@ -185,20 +185,19 @@ struct CopilotLoginFlow {
             return byLegacyLogin
         }
 
-        let legacyAccounts = existingAccounts.filter { $0.externalIdentifier == nil }
-        for account in legacyAccounts {
-            guard let resolvedIdentity = await legacyIdentityResolver(account) else { continue }
-            if resolvedIdentity.id == identity.id ||
-                self.normalizedGitHubLogin(resolvedIdentity.login) == login
+        var labelFallback: ProviderTokenAccount?
+        for account in existingAccounts where account.externalIdentifier == nil {
+            if let resolvedIdentity = await legacyIdentityResolver(account) {
+                if resolvedIdentity.id == identity.id {
+                    return account
+                }
+            } else if labelFallback == nil,
+                      self.displayLabelPrefix(account.label) == self.displayLabelPrefix(label)
             {
-                return account
+                labelFallback = account
             }
         }
-
-        let usernamePrefix = self.displayLabelPrefix(label)
-        return legacyAccounts.first { account in
-            self.displayLabelPrefix(account.label) == usernamePrefix
-        }
+        return labelFallback
     }
 
     static func externalIdentifier(for identity: CopilotUsageFetcher.GitHubUserIdentity) -> String {

--- a/Tests/CodexBarTests/CopilotMultiAccountTests.swift
+++ b/Tests/CodexBarTests/CopilotMultiAccountTests.swift
@@ -174,6 +174,40 @@ struct CopilotEnvironmentPrecedenceTests {
 
 @MainActor
 struct CopilotExternalIdentifierTests {
+    @Test(arguments: ["octocat", "different-user"])
+    func `resolved different user cannot match a legacy account by login or label`(storedLogin: String) async {
+        let legacy = Self.makeAccount(label: "octocat (Pro)", token: "old-token", externalIdentifier: nil)
+        let matched = await CopilotLoginFlow.matchExistingAccount(
+            existingAccounts: [legacy],
+            identity: Self.identity(id: 123, login: "octocat"),
+            label: "octocat (Pro)",
+            legacyIdentityResolver: { _ in Self.identity(id: 456, login: storedLogin) })
+
+        #expect(matched == nil)
+    }
+
+    @Test
+    func `resolved stable identity wins over an unresolved label fallback`() async {
+        let unresolved = Self.makeAccount(label: "octocat", token: "expired", externalIdentifier: nil)
+        let identified = Self.makeAccount(label: "Renamed account", token: "known", externalIdentifier: nil)
+        for accounts in [[unresolved, identified], [identified, unresolved]] {
+            let matched = await CopilotLoginFlow.matchExistingAccount(
+                existingAccounts: accounts,
+                identity: Self.identity(id: 123, login: "octocat"),
+                label: "octocat (Pro)",
+                legacyIdentityResolver: { account in
+                    account.token == "known" ? Self.identity(id: 123, login: "former-login") : nil
+                })
+            #expect(matched?.id == identified.id)
+        }
+        let fallback = await CopilotLoginFlow.matchExistingAccount(
+            existingAccounts: [unresolved],
+            identity: Self.identity(id: 123, login: "octocat"),
+            label: "octocat (Pro)",
+            legacyIdentityResolver: { _ in nil })
+        #expect(fallback?.id == unresolved.id)
+    }
+
     @Test
     func `addTokenAccount persists external identifier`() throws {
         let settings = Self.makeSettingsStore(suite: "copilot-ext-id-add")

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -24,6 +24,7 @@ Copilot uses GitHub OAuth device flow and the Copilot internal usage API for pri
    - Token stored in config:
      - `~/.codexbar/config.json` → `providers[].apiKey` for `copilot`
      - token accounts use `providers[].tokenAccounts`
+     - Legacy token matching honors a resolved stable GitHub user ID; display-label fallback is used only when token identity is unavailable and no verified match exists.
 
 2) **Usage fetch**
    - `GET https://api.github.com/copilot_internal/user`


### PR DESCRIPTION
A legacy Copilot token account can resolve to a different stable GitHub user ID and still be selected for reauthentication because its login or display label matches. The login flow then updates that saved account with the new token.

Keep resolved stable IDs authoritative. Search all token-resolved legacy accounts before accepting a label fallback, and retain that fallback only for accounts whose identity could not be resolved. The single-pass matcher removes one production line and preserves existing stable-ID and legacy external-login migration paths.

This narrower defect was found while investigating #3341; it does not resolve that PR's Enterprise-host routing scope.

Validation:

- Both baseline cases reproduced wrong account selection: equal login with a different ID, and a different login with a matching display label.
- 12 focused tests passed, including verified matches later in either account order, renamed users, unresolved fallback, stable-ID priority and legacy migration.
- `make check` passed with zero violations. Isolated P2 autoreview found no actionable findings.
- Full make test passed all 1,028 selections / 86 groups on the first pass without retries or timeouts (1,193.9 seconds). [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34080675080) passed.

Tests use injected synthetic identities and token stores; no real account requests or credentials were used. Changelog and provider documentation describe the identity precedence.
