### PR TITLE
fix(packaging): scope CloudKit provisioning to the signing team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Poe: calculate weekly points, requests, and spend from the last seven elapsed days, so older activity no longer inflates sparse or inactive weeks; share totals aggregation with Today and the 30-day window (#3449). Thanks @Lucenx9!
 - MiMo: skip malformed local session rows before deduplication so valid usage still refreshes the cache, preserving all token buckets and UTC daily/weekly totals with shared aggregation (#3448). Thanks @Lucenx9!
 - Claude: label model-specific weekly quotas with a translated weekly duration while preserving model names and CLI titles; correct swapped Vietnamese Weekly and missing-version labels (#3447). Thanks @gianpaj!
+- Packaging: select the bundled iCloud provisioning profile only for its upstream signing team, preserving alternate-team app/widget groups without incompatible CloudKit entitlements (extracted from #3372). Thanks @krazybean!
 
 ## 0.56.7 — 2026-09-06
 

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -230,10 +230,7 @@ if [[ "$SIGNING_MODE" == "adhoc" ]]; then
 fi
 WIDGET_BUNDLE_ID="${BUNDLE_ID}.widget"
 APP_TEAM_ID="${APP_TEAM_ID:-Y5PE65HELJ}"
-APP_GROUP_ID="${APP_TEAM_ID}.com.steipete.codexbar"
-if [[ "$BUNDLE_ID" == *".debug"* ]]; then
-  APP_GROUP_ID="${APP_TEAM_ID}.com.steipete.codexbar.debug"
-fi
+APP_GROUP_ID="${APP_TEAM_ID}.${BUNDLE_ID}"
 ENTITLEMENTS_DIR="$ROOT/.build/entitlements"
 APP_ENTITLEMENTS="${ENTITLEMENTS_DIR}/CodexBar.entitlements"
 WIDGET_ENTITLEMENTS="${ENTITLEMENTS_DIR}/CodexBarWidget.entitlements"
@@ -243,12 +240,12 @@ if [[ "$ALLOW_LLDB" == "1" && "$LOWER_CONF" != "debug" ]]; then
   exit 1
 fi
 # iCloud sync (CloudKit) requires restricted entitlements authorized by an embedded
-# Developer ID provisioning profile. Only identity-signed release builds of the primary
-# bundle ID carry them; adhoc/debug builds run with sync unavailable.
+# Developer ID provisioning profile. Only upstream-team identity-signed release builds of the primary
+# bundle ID carry them; other teams and adhoc/debug builds run with sync unavailable.
 PROVISIONING_PROFILE_SOURCE="$ROOT/Scripts/profiles/CodexBar-DeveloperID.provisionprofile"
 EMBED_PROVISIONING_PROFILE=0
 ICLOUD_ENTITLEMENT_KEYS=""
-if [[ "$SIGNING_MODE" == "identity" && "$LOWER_CONF" == "release" && "$BUNDLE_ID" == "com.steipete.codexbar" ]]; then
+if [[ "$SIGNING_MODE" == "identity" && "$LOWER_CONF" == "release" && "$BUNDLE_ID" == "com.steipete.codexbar" && "$APP_TEAM_ID" == "Y5PE65HELJ" ]]; then
   if [[ ! -f "$PROVISIONING_PROFILE_SOURCE" ]]; then
     echo "ERROR: Missing $PROVISIONING_PROFILE_SOURCE (required for iCloud entitlements in release builds)" >&2
     exit 1

--- a/Scripts/test_package_signing.sh
+++ b/Scripts/test_package_signing.sh
@@ -76,4 +76,62 @@ if verify_packaged_app_integrity "$APP" 2>/dev/null; then
 fi
 unset MOCK_CODESIGN_STATUS
 
+python3 - "$PACKAGE_SCRIPT" <<'PY'
+import itertools
+import os
+import plistlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+start = source.index('BUNDLE_ID="com.steipete.codexbar"')
+end = source.index('BUILD_TIMESTAMP=', start)
+generation = source[start:end]
+start = source.index('if [[ "$EMBED_PROVISIONING_PROFILE" == "1" ]]; then')
+end = source.index('\nfi', start) + len('\nfi')
+embedding = source[start:end]
+
+for team, configuration, signing, profile_present in itertools.product(
+    ['Y5PE65HELJ', 'TESTTEAM01'], ['release', 'debug'], ['identity', 'adhoc'], [False, True],
+):
+    with tempfile.TemporaryDirectory(prefix='codexbar-entitlement-test-') as directory:
+        root = Path(directory)
+        app = root / 'CodexBar.app'
+        (app / 'Contents').mkdir(parents=True)
+        profile = root / 'Scripts/profiles/CodexBar-DeveloperID.provisionprofile'
+        if profile_present:
+            profile.parent.mkdir(parents=True)
+            # Marker tests selection/copying only, not certificate or profile validity.
+            profile.write_text('synthetic profile selection marker\n')
+        env = dict(os.environ, ROOT=str(root), APP=str(app), APP_TEAM_ID=team,
+                   LOWER_CONF=configuration, SIGNING_MODE=signing, ALLOW_LLDB='0')
+        result = subprocess.run(['bash', '-eu', '-c', generation + '\n' + embedding],
+                                env=env, capture_output=True, text=True)
+        cloudkit = team == 'Y5PE65HELJ' and configuration == 'release' and signing == 'identity'
+        if cloudkit and not profile_present:
+            assert result.returncode != 0 and 'Missing' in result.stderr, result.stderr
+            continue
+        assert result.returncode == 0, (team, configuration, signing, profile_present, result.stderr)
+        bundle = 'com.steipete.codexbar' + ('.debug' if configuration == 'debug' else '')
+        expected_group = f'{team}.{bundle}'
+        app_entitlements = plistlib.loads((root / '.build/entitlements/CodexBar.entitlements').read_bytes())
+        widget_entitlements = plistlib.loads((root / '.build/entitlements/CodexBarWidget.entitlements').read_bytes())
+        assert app_entitlements['com.apple.security.application-groups'] == [expected_group]
+        assert widget_entitlements['com.apple.security.application-groups'] == [expected_group]
+        assert widget_entitlements['com.apple.security.app-sandbox'] is True
+        embedded = app / 'Contents/embedded.provisionprofile'
+        assert embedded.exists() == cloudkit
+        if cloudkit:
+            assert embedded.read_bytes() == profile.read_bytes()
+            assert app_entitlements['com.apple.application-identifier'] == expected_group
+            assert app_entitlements['com.apple.developer.team-identifier'] == team
+            assert app_entitlements['com.apple.developer.icloud-services'] == ['CloudKit']
+            assert app_entitlements['com.apple.developer.icloud-container-identifiers'] == [f'iCloud.{bundle}']
+        else:
+            assert set(app_entitlements) == {'com.apple.security.application-groups'}
+print('16 entitlement/profile configuration cases passed.')
+PY
+
 echo "Package signing tests passed."

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -9,6 +9,7 @@ read_when:
 
 ## Scripts
 - `Scripts/package_app.sh`: builds host arch with ad-hoc signing by default; set `ARCHES="arm64 x86_64"` for universal. Verifies slices. Stable-certificate packaging requires explicit `CODEXBAR_SIGNING=identity` plus `APP_IDENTITY`.
+- The bundled Developer ID provisioning profile and CloudKit entitlements apply only to upstream-team release builds. An alternate resolved `APP_TEAM_ID` retains its matching app/widget groups without that upstream profile; direct callers remain responsible for selecting a team consistent with their identity.
 - `Scripts/compile_and_run.sh`: uses host arch; pass `--release-universal` or `--release-arches="arm64 x86_64"` for release packaging.
 - `Scripts/sign-and-notarize.sh`: explicitly selects Developer ID signing, notarizes, staples, and zips (accepts `ARCHES` for universal).
 - `Scripts/make_appcast.sh`: wrapper around the shared `mac-release make-appcast` helper; app metadata comes from `.mac-release.env`.


### PR DESCRIPTION
Packaging embeds the upstream Developer ID provisioning profile and CloudKit entitlements for every identity-signed release, even when APP_TEAM_ID has already been resolved to another team. That can require or embed a profile that does not authorize the selected team's app.

Restrict the bundled profile and CloudKit entitlements to the upstream team. Derive the shared app/widget group directly from the resolved bundle ID, removing duplicated debug suffix handling. Net production delta: -3 lines in package_app.sh.

Extracted the profile-selection repair from #3372, with @krazybean's contributor credit preserved. Direct APP_IDENTITY calls without a matching resolved APP_TEAM_ID remain a separate scope; this does not claim complete alternate-identity discovery. Required widget builds, timestamping, hardened runtime, signature verification and sandbox smoke checks remain enforced.

Validation:

- Baseline execution of the actual entitlement-generation block failed for a configured alternate-team release because it required the upstream profile.
- All 16 configuration cases now pass: upstream/alternate team, debug/release, identity/ad-hoc, and profile present/absent. Tests inspect generated app/widget plist groups, CloudKit fields, required-profile failure and actual profile-copy selection.
- Fixture profile contents are a selection marker, not a fabricated certificate or claim of valid signing.
- Existing package signature/quarantine tests and `make check` passed. Isolated P2 autoreview found no actionable findings.
- Full make test passed all 1,028 selections / 86 groups on the first pass without retries or timeouts (1,288.6 seconds). [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34080676504) passed.

The source regression is traceable to the unscoped CloudKit gate added in #2597. Changelog and packaging documentation describe the repaired team boundary.
