### PR TITLE
fix(antigravity): preserve history around UUID-less bookkeeping steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Poe: calculate weekly points, requests, and spend from the last seven elapsed days, so older activity no longer inflates sparse or inactive weeks; share totals aggregation with Today and the 30-day window (#3449). Thanks @Lucenx9!
 - MiMo: skip malformed local session rows before deduplication so valid usage still refreshes the cache, preserving all token buckets and UTC daily/weekly totals with shared aggregation (#3448). Thanks @Lucenx9!
 - Claude: label model-specific weekly quotas with a translated weekly duration while preserving model names and CLI titles; correct swapped Vietnamese Weekly and missing-version labels (#3447). Thanks @gianpaj!
+- Antigravity local usage: tolerate bookkeeping steps without UUIDs while retaining duplicate bot-ID ambiguity checks, so valid history remains available without assigning uncertain dates (#3462). Thanks @urda!
 
 ## 0.56.7 — 2026-09-06
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -295,6 +295,7 @@ extension AntigravityLocalReader {
         var ambiguousBotIDs = Set<String>()
         var isComplete = false
         var rowsAreValid = true
+        var sawUnidentifiedRows = false
         while true {
             try progress.budget.check()
             let step = sqlite3_step(statement)
@@ -331,8 +332,13 @@ extension AntigravityLocalReader {
                 rowsAreValid = false
                 continue
             }
-            guard let stepUUID = parsed.stepUUID, !stepUUID.isEmpty else {
-                rowsAreValid = false
+            // A row without a step UUID (field 12 absent, or blank per `Field.string()`'s
+            // whitespace-only-is-absent rule) carries no identity: it belongs to no UUID's occurrence
+            // list and can never supply or shift positional evidence, so it is skipped rather than
+            // invalidating the scan. While any such row is present, a single step timestamp does not
+            // stand in for every reused generation occurrence of its UUID (see resolveStepTimestamps).
+            guard let stepUUID = parsed.stepUUID else {
+                sawUnidentifiedRows = true
                 continue
             }
             if let botID = parsed.botID {
@@ -361,7 +367,8 @@ extension AntigravityLocalReader {
         })
         let resolved = self.resolveStepTimestamps(
             positionalEntries,
-            neededStepOccurrences: neededStepOccurrences)
+            neededStepOccurrences: neededStepOccurrences,
+            unidentifiedRowsPresent: sawUnidentifiedRows)
         return StepTimestampScan(
             timestamps: resolved,
             byBotID: exactByBotID,
@@ -413,7 +420,8 @@ extension AntigravityLocalReader {
 
     private static func resolveStepTimestamps(
         _ stepTimestamps: [String: [StepTimestamp]],
-        neededStepOccurrences: [String: [StepOccurrence]]) -> [String: [Int64]]
+        neededStepOccurrences: [String: [StepOccurrence]],
+        unidentifiedRowsPresent: Bool) -> [String: [Int64]]
     {
         var resolved: [String: [Int64]] = [:]
         for (stepUUID, timestamps) in stepTimestamps {
@@ -429,7 +437,14 @@ extension AntigravityLocalReader {
             }
             let orderedTimestamps = sorted.map(\.timestampMs)
             let selected: [Int64]
-            if orderedTimestamps.count == 1, let sharedTimestamp = orderedTimestamps[0] {
+            // A lone step timestamp can stand in for every occurrence of a reused UUID only when the
+            // scan accounted for every step row. An unidentified row breaks that guarantee: it could
+            // have been another occurrence of this same UUID whose identity was lost, so treating one
+            // surviving row as authoritative for all of them would risk publishing a false date. A
+            // single-occurrence UUID (neededCount == 1) has nothing to misattribute either way.
+            if orderedTimestamps.count == 1, neededCount == 1 || !unidentifiedRowsPresent,
+               let sharedTimestamp = orderedTimestamps[0]
+            {
                 selected = Array(repeating: sharedTimestamp, count: neededCount)
             } else {
                 guard orderedTimestamps.count >= neededCount else { continue }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -196,12 +196,6 @@ extension AntigravityLocalReader {
         let botID: String?
     }
 
-    private struct StepTimestamp {
-        let row: Int64
-        let timestampMs: Int64?
-        let botID: String?
-    }
-
     private struct ExactStepTimestamp {
         let stepUUID: String
         let timestampMs: Int64
@@ -242,7 +236,6 @@ extension AntigravityLocalReader {
         guard !neededStepOccurrences.isEmpty else {
             return StepTimestampScan(timestamps: [:], byBotID: [:], ambiguousBotIDs: [], isComplete: true)
         }
-        let neededStepUUIDCounts = neededStepOccurrences.mapValues(\.count)
         let stepProgress = StepScanProgress(progress: progress)
         let registered = sqlite3_create_function_v2(
             database,
@@ -290,7 +283,7 @@ extension AntigravityLocalReader {
         guard prepared == SQLITE_OK, let statement else {
             return StepTimestampScan(timestamps: [:], byBotID: [:], ambiguousBotIDs: [], isComplete: false)
         }
-        var stepTimestamps: [String: [StepTimestamp]] = [:]
+        var stepTimestamps: [String: [StepOccurrence]] = [:]
         var exactByBotID: [String: ExactStepTimestamp] = [:]
         var ambiguousBotIDs = Set<String>()
         var isComplete = false
@@ -332,42 +325,30 @@ extension AntigravityLocalReader {
                 rowsAreValid = false
                 continue
             }
-            // A row without a step UUID (field 12 absent, or blank per `Field.string()`'s
-            // whitespace-only-is-absent rule) carries no identity: it belongs to no UUID's occurrence
-            // list and can never supply or shift positional evidence, so it is skipped rather than
-            // invalidating the scan. While any such row is present, a single step timestamp does not
-            // stand in for every reused generation occurrence of its UUID (see resolveStepTimestamps).
-            guard let stepUUID = parsed.stepUUID else {
-                sawUnidentifiedRows = true
-                continue
-            }
             if let botID = parsed.botID {
                 self.recordExactBotID(
                     botID,
-                    stepUUID: stepUUID,
+                    stepUUID: parsed.stepUUID,
                     timestampMs: parsed.timestampMs,
                     exact: &exactByBotID,
                     ambiguous: &ambiguousBotIDs)
             }
-            if neededStepUUIDCounts[stepUUID] != nil {
-                stepTimestamps[stepUUID, default: []].append(StepTimestamp(
+            // Unidentified rows cannot supply UUID positions, but their bot IDs still count as evidence.
+            guard let stepUUID = parsed.stepUUID else {
+                sawUnidentifiedRows = true
+                continue
+            }
+            if neededStepOccurrences[stepUUID] != nil {
+                stepTimestamps[stepUUID, default: []].append(StepOccurrence(
                     row: sqlite3_column_int64(statement, 0),
                     timestampMs: parsed.timestampMs,
                     botID: parsed.botID))
             }
         }
-        // Preserve ambiguous rows' positions; removing them would shift later timestamps into their slots.
-        let positionalEntries = Dictionary(uniqueKeysWithValues: stepTimestamps.map { entry in
-            (entry.key, entry.value.map { step in
-                StepTimestamp(
-                    row: step.row,
-                    timestampMs: step.botID.map { ambiguousBotIDs.contains($0) } == true ? nil : step.timestampMs,
-                    botID: step.botID)
-            })
-        })
         let resolved = self.resolveStepTimestamps(
-            positionalEntries,
+            stepTimestamps,
             neededStepOccurrences: neededStepOccurrences,
+            ambiguousBotIDs: ambiguousBotIDs,
             unidentifiedRowsPresent: sawUnidentifiedRows)
         return StepTimestampScan(
             timestamps: resolved,
@@ -378,13 +359,13 @@ extension AntigravityLocalReader {
 
     private static func recordExactBotID(
         _ botID: String,
-        stepUUID: String,
+        stepUUID: String?,
         timestampMs: Int64?,
         exact: inout [String: ExactStepTimestamp],
         ambiguous: inout Set<String>)
     {
         guard !ambiguous.contains(botID) else { return }
-        guard let timestampMs else {
+        guard let stepUUID, let timestampMs else {
             exact.removeValue(forKey: botID)
             ambiguous.insert(botID)
             return
@@ -419,8 +400,9 @@ extension AntigravityLocalReader {
     }
 
     private static func resolveStepTimestamps(
-        _ stepTimestamps: [String: [StepTimestamp]],
+        _ stepTimestamps: [String: [StepOccurrence]],
         neededStepOccurrences: [String: [StepOccurrence]],
+        ambiguousBotIDs: Set<String>,
         unidentifiedRowsPresent: Bool) -> [String: [Int64]]
     {
         var resolved: [String: [Int64]] = [:]
@@ -435,13 +417,12 @@ extension AntigravityLocalReader {
             guard !zip(sorted, sorted.dropFirst()).contains(where: { pair in pair.0.row == pair.1.row }) else {
                 continue
             }
-            let orderedTimestamps = sorted.map(\.timestampMs)
+            // Keep ambiguous slots so later timestamps cannot slide into their positions.
+            let orderedTimestamps = sorted.map { step in
+                step.botID.map { ambiguousBotIDs.contains($0) } == true ? nil : step.timestampMs
+            }
             let selected: [Int64]
-            // A lone step timestamp can stand in for every occurrence of a reused UUID only when the
-            // scan accounted for every step row. An unidentified row breaks that guarantee: it could
-            // have been another occurrence of this same UUID whose identity was lost, so treating one
-            // surviving row as authoritative for all of them would risk publishing a false date. A
-            // single-occurrence UUID (neededCount == 1) has nothing to misattribute either way.
+            // Sharing one timestamp across reused UUIDs requires a complete identity census.
             if orderedTimestamps.count == 1, neededCount == 1 || !unidentifiedRowsPresent,
                let sharedTimestamp = orderedTimestamps[0]
             {

--- a/Tests/CodexBarTests/AntigravityStepUUIDConsistencyTests.swift
+++ b/Tests/CodexBarTests/AntigravityStepUUIDConsistencyTests.swift
@@ -44,4 +44,124 @@ struct AntigravityStepUUIDConsistencyTests {
                 : [1_787_875_100_250, 1_787_875_300_000]))
         #expect(report.coverage == (conflicting ? .partial : .complete))
     }
+
+    @Test(arguments: [false, true])
+    func `UUID-less step rows do not invalidate timestamp recovery`(uuidLessRowFirst: Bool) throws {
+        let fixture = try Fixture()
+        let stepUUID = "recoverable-step-uuid"
+        let generations = [
+            Fixture.blobWithRootEnvelope(
+                stepUUID: stepUUID,
+                input: 100,
+                seconds: nil),
+        ]
+        let matchingStep = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID,
+            seconds: 1_787_875_100,
+            nanos: 250_000_000)
+        let uuidLessStep = Fixture.stepMetadataBlob(
+            stepUUID: nil,
+            seconds: 1_787_874_000,
+            nanos: 0)
+        let steps = uuidLessRowFirst ? [uuidLessStep, matchingStep] : [matchingStep, uuidLessStep]
+        let url = try fixture.database(
+            blobs: generations,
+            stepBlobs: steps)
+        let budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {})
+
+        let source = try AntigravityLocalReader.readDatabases([url], budget: budget)
+        let report = try fixture.report()
+
+        #expect(source.isComplete == true)
+        #expect(source.events.map(\.row) == [0])
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_100_250])
+        #expect(report.coverage == .complete)
+    }
+
+    @Test(arguments: [0, 1, 2])
+    func `reused step UUID recovers distinct timestamps despite an unidentified row`(
+        unidentifiedPosition: Int) throws
+    {
+        let fixture = try Fixture()
+        let stepUUID = "reused-uuid-with-unidentified-row"
+        let generations = [
+            Fixture.blobWithRootEnvelope(
+                stepUUID: stepUUID,
+                input: 100,
+                seconds: nil),
+            Fixture.blobWithRootEnvelope(
+                stepUUID: stepUUID,
+                input: 200,
+                seconds: nil),
+        ]
+        let first = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140, nanos: 0)
+        let second = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_260, nanos: 0)
+        let unidentified = Fixture.stepMetadataBlob(stepUUID: nil, seconds: 1_787_874_000, nanos: 0)
+        var steps = [first, second]
+        steps.insert(unidentified, at: unidentifiedPosition)
+        let url = try fixture.database(
+            blobs: generations,
+            stepBlobs: steps)
+        let budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {})
+
+        let source = try AntigravityLocalReader.readDatabases([url], budget: budget)
+        let report = try fixture.report()
+
+        #expect(source.isComplete == true)
+        #expect(source.events.map(\.row) == [0, 1])
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_000, 1_787_875_260_000])
+        #expect(report.coverage == .complete)
+    }
+
+    @Test
+    func `bot ID exact match recovers despite an unidentified step row`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "bot-id-with-unidentified-row"
+        let botID = "bot-uuid-less-mix"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: botID, seconds: nil)
+        let matchingStep = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: botID, seconds: 1_787_875_140, nanos: 0)
+        let unidentified = Fixture.stepMetadataBlob(stepUUID: nil, seconds: 1_787_874_000, nanos: 0)
+        let url = try fixture.database(
+            blobs: [turn],
+            stepBlobs: [matchingStep, unidentified])
+        let budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {})
+
+        let source = try AntigravityLocalReader.readDatabases([url], budget: budget)
+        let report = try fixture.report()
+
+        #expect(source.isComplete == true)
+        #expect(source.events.map(\.row) == [0])
+        #expect(source.events.map(\.turn.timestampMs) == [1_787_875_140_000])
+        #expect(report.coverage == .complete)
+    }
+
+    @Test
+    func `reused step UUID with only one identified step row stays partial alongside an unidentified row`() throws {
+        let fixture = try Fixture()
+        let stepUUID = "reused-uuid-single-identified-row"
+        let generations = [
+            Fixture.blobWithRootEnvelope(
+                stepUUID: stepUUID,
+                input: 100,
+                seconds: nil),
+            Fixture.blobWithRootEnvelope(
+                stepUUID: stepUUID,
+                input: 200,
+                seconds: nil),
+        ]
+        let identified = Fixture.stepMetadataBlob(stepUUID: stepUUID, seconds: 1_787_875_140, nanos: 0)
+        let unidentified = Fixture.stepMetadataBlob(stepUUID: nil, seconds: 1_787_874_000, nanos: 0)
+        let url = try fixture.database(
+            blobs: generations,
+            stepBlobs: [identified, unidentified])
+        let budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {})
+
+        let source = try AntigravityLocalReader.readDatabases([url], budget: budget)
+        let report = try fixture.report()
+
+        #expect(source.isComplete == false)
+        #expect(source.events.isEmpty)
+        #expect(report.coverage == .partial)
+    }
 }

--- a/Tests/CodexBarTests/AntigravityStepUUIDConsistencyTests.swift
+++ b/Tests/CodexBarTests/AntigravityStepUUIDConsistencyTests.swift
@@ -5,6 +5,30 @@ import Testing
 struct AntigravityStepUUIDConsistencyTests {
     private typealias Fixture = AntigravityLocalFixture
 
+    @Test(arguments: [false, true], [UInt64?(1_787_875_140), 1_787_875_260, nil])
+    func `UUID-less duplicate bot IDs cannot establish an exact date`(
+        unidentifiedFirst: Bool, unidentifiedSeconds: UInt64?) throws
+    {
+        let fixture = try Fixture()
+        let stepUUID = "identified-uuid"
+        let botID = "shared-bot"
+        let turn = Fixture.blobWithRootEnvelope(stepUUID: stepUUID, botID: botID, seconds: nil)
+        let matching = Fixture.stepMetadataBlob(
+            stepUUID: stepUUID, botID: botID, seconds: 1_787_875_140, nanos: 0)
+        let unidentified = if let unidentifiedSeconds {
+            Fixture.stepMetadataBlob(stepUUID: nil, botID: botID, seconds: unidentifiedSeconds, nanos: 0)
+        } else {
+            Fixture.message(9, Fixture.message(7, Array(botID.utf8)))
+        }
+        let url = try fixture.database(
+            blobs: [turn], stepBlobs: unidentifiedFirst ? [unidentified, matching] : [matching, unidentified])
+        let budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {})
+        let source = try AntigravityLocalReader.readDatabases([url], budget: budget)
+        #expect(!source.isComplete)
+        #expect(source.events.isEmpty)
+        #expect(try fixture.report().coverage == .partial)
+    }
+
     @Test(arguments: [false, true])
     func `pure UUID evidence must agree with embedded generation timestamps`(conflicting: Bool) throws {
         let fixture = try Fixture()

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -296,13 +296,17 @@ Inspection uses `sqlite_master` and `table_xinfo`; SQLite builds without that pr
 Supported SQLite event time is `chatModel.#9.#4` containing protobuf seconds/nanos. When it is absent, the reader can
 recover the standard seconds/nanos timestamp from `steps.metadata.#1`, joining the generation's root step UUID (`#4`)
 to `steps.metadata.#12`. A unique generation usage `bot_id` (`chatModel.#4.#7`) first selects the matching
-`steps.metadata.#9.#7` within that UUID, so auxiliary or reordered steps do not shift a turn's date. Conflicting,
-cross-UUID, or timestamp-less duplicate step IDs cannot supply exact or positional evidence. Embedded timestamps
-in a UUID needing recovery must agree with available generation-unique exact matches; unrelated UUIDs retain their
-embedded timestamps. Missing or malformed auxiliary IDs retain the guarded legacy positional fallback, as do repeated
-generation IDs: ordered step timestamps must agree with embedded generation timestamps, and ambiguous positions are
-never removed or compressed. Malformed auxiliary IDs do not discard otherwise valid embedded usage or relax token-counter
-and protobuf framing validation. Session creation, file modification, and refresh time are never substitutes.
+`steps.metadata.#9.#7` within that UUID, so auxiliary or reordered steps do not shift a turn's date. A row with no
+`steps.metadata.#12` (field 12 absent, or blank per the reader's whitespace-only-is-absent rule) carries no identity:
+it is skipped rather than invalidating the scan, since it belongs to no UUID's occurrence list and cannot supply or
+shift positional evidence. While any such row is present, a single step timestamp no longer stands in for every reused
+generation occurrence of its UUID; a UUID used by only one generation is unaffected. Conflicting, cross-UUID, or
+timestamp-less duplicate step IDs cannot supply exact or positional evidence. Embedded timestamps in a UUID needing
+recovery must agree with available generation-unique exact matches; unrelated UUIDs retain their embedded timestamps.
+Missing or malformed auxiliary IDs retain the guarded legacy positional fallback, as do repeated generation IDs:
+ordered step timestamps must agree with embedded generation timestamps, and ambiguous positions are never removed or
+compressed. Malformed auxiliary IDs do not discard otherwise valid embedded usage or relax token-counter and protobuf
+framing validation. Session creation, file modification, and refresh time are never substitutes.
 The opaque agy 1.1.18 timestamp layout remains unsupported: the pinned parser
 explicitly labels its newer interpretation an inference. See [the session-start misattribution report](https://github.com/junhoyeo/tokscale/issues/1184).
 

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -297,10 +297,10 @@ Supported SQLite event time is `chatModel.#9.#4` containing protobuf seconds/nan
 recover the standard seconds/nanos timestamp from `steps.metadata.#1`, joining the generation's root step UUID (`#4`)
 to `steps.metadata.#12`. A unique generation usage `bot_id` (`chatModel.#4.#7`) first selects the matching
 `steps.metadata.#9.#7` within that UUID, so auxiliary or reordered steps do not shift a turn's date. A row with no
-`steps.metadata.#12` (field 12 absent, or blank per the reader's whitespace-only-is-absent rule) carries no identity:
+`steps.metadata.#12` (field 12 absent, or blank per the reader's whitespace-only-is-absent rule) supplies no UUID position:
 it is skipped rather than invalidating the scan, since it belongs to no UUID's occurrence list and cannot supply or
 shift positional evidence. While any such row is present, a single step timestamp no longer stands in for every reused
-generation occurrence of its UUID; a UUID used by only one generation is unaffected. Conflicting, cross-UUID, or
+generation occurrence of its UUID; a UUID used by only one generation is unaffected. A bot ID on an unidentified row still makes that bot ambiguous for exact and positional recovery, even if another row supplies the same timestamp. Conflicting, cross-UUID, or
 timestamp-less duplicate step IDs cannot supply exact or positional evidence. Embedded timestamps in a UUID needing
 recovery must agree with available generation-unique exact matches; unrelated UUIDs retain their embedded timestamps.
 Missing or malformed auxiliary IDs retain the guarded legacy positional fallback, as do repeated generation IDs:


### PR DESCRIPTION
Antigravity bookkeeping rows without a step UUID caused the entire local history provider to be withheld as incomplete. Permit those rows after charging their row and byte budgets, while keeping malformed data and exhausted budgets as hard failures. A lone identified timestamp cannot stand for every occurrence of a reused UUID when unidentified rows are present.

Rows without UUIDs can still carry bot identity. Record that evidence before skipping UUID positioning: a duplicate bot ID with unknown UUID permanently invalidates exact and positional matches, regardless of scan order, matching timestamps, or absent timestamps. This addresses the review finding on the original revision. Keep ambiguous positional slots intact so later timestamps never move into them.

Share the identical step-occurrence structs, remove an unused counts projection, and apply positional ambiguity during timestamp selection. The final PR reduces production code by four lines. Token counts, pricing, credentials, discovery roots, and stored data remain unchanged. Changelog and documentation are updated; thanks @urda.

Maintainer validation: six synthetic duplicate-bot combinations failed 18 assertions on the original PR and pass after repair. All 406 focused Antigravity tests across 34 suites pass, including harmless bookkeeping, reused UUIDs, embedded timestamps, malformed rows, and budgets. `make check` passes and independent review is clean. The full `make test` suite passed all 1,028 selections across 86 groups without retries. The main integration preserves the tested Antigravity source, tests, and documentation byte-for-byte; integration `make check` also passes. Exact-head CI must pass before merge.

Contributor live evidence, collected on the original proposal: @urda compared the shipped 0.56.6 CLI and a rebuilt CLI against the same 211 stable local session databases from agy 1.1.27, using read-only scratch copies with WAL sidecars. Complete coverage increased from 208 to 211; the three recovered sessions contained 80,067, 48,183, and 5,299,395 tokens. Removing UUID-less bookkeeping rows from copies also made the shipped CLI return complete coverage, isolating the original cause. One previously passing session's output, excluding updatedAt, matched byte-for-byte. Three actively written sessions were excluded because both binaries reported them incomplete until checkpointing. This is contributor-reported live evidence; the maintainer's final ambiguity repair uses synthetic native SQLite fixtures.

This builds on #3266, #3396, and #3403. It is distinct from #3412's cost-estimation changes. Earlier proposal #3451 remains related; no unrelated issue is claimed resolved.
