### PR TITLE
fix(menu): preserve valid placements on left-hand displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 - OpenRouter: reject combined Activity token overflow before publishing history so malformed optional data cannot hide valid credits or key quota; share input/output total validation (extracted from #3272). Thanks @akshayprabhu200!
 - Poe: skip out-of-range history timestamps instead of letting date formatting hide a valid point balance; preserve supported timestamp formats and valid activity.
-- Menu bar: measure placement bounds from display widths rather than global desktop coordinates, preserving valid saved positions on wide monitors placed left of the primary display (related to #3355).
+- Menu bar: preserve valid saved positions on wide monitors placed left of the primary display while retaining the legacy accepted range for menu-manager compatibility (related to #3355).
 - Claude: retain quota-warning history for known accounts across credential refreshes, preventing repeat threshold alerts while preserving recovery crossings and separate account state (partial fix for #3450). Thanks @JonLaliberte!
 - Poe: calculate weekly points, requests, and spend from the last seven elapsed days, so older activity no longer inflates sparse or inactive weeks; share totals aggregation with Today and the 30-day window (#3449). Thanks @Lucenx9!
 - MiMo: skip malformed local session rows before deduplication so valid usage still refreshes the cache, preserving all token buckets and UTC daily/weekly totals with shared aggregation (#3448). Thanks @Lucenx9!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - OpenRouter: reject combined Activity token overflow before publishing history so malformed optional data cannot hide valid credits or key quota; share input/output total validation (extracted from #3272). Thanks @akshayprabhu200!
 - Poe: skip out-of-range history timestamps instead of letting date formatting hide a valid point balance; preserve supported timestamp formats and valid activity.
+- Menu bar: measure placement bounds from display widths rather than global desktop coordinates, preserving valid saved positions on wide monitors placed left of the primary display (related to #3355).
 - Claude: retain quota-warning history for known accounts across credential refreshes, preventing repeat threshold alerts while preserving recovery crossings and separate account state (partial fix for #3450). Thanks @JonLaliberte!
 - Poe: calculate weekly points, requests, and spend from the last seven elapsed days, so older activity no longer inflates sparse or inactive weeks; share totals aggregation with Today and the 30-day window (#3449). Thanks @Lucenx9!
 - MiMo: skip malformed local session rows before deduplication so valid usage still refreshes the cache, preserving all token buckets and UTC daily/weekly totals with shared aggregation (#3448). Thanks @Lucenx9!

--- a/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
+++ b/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
@@ -33,13 +33,9 @@ enum MenuBarStatusItemPlacementPreflight {
     }
 
     static func shouldClearPreferredPosition(_ value: Any, maximumPreferredPosition: Double?) -> Bool {
-        guard let number = value as? NSNumber else { return true }
-        let position = number.doubleValue
-        if !position.isFinite || position <= 0 {
-            return true
-        }
-        guard let maximumPreferredPosition else { return false }
-        return position > maximumPreferredPosition + self.suspiciousPreferredPositionPadding
+        guard let position = (value as? NSNumber)?.doubleValue,
+              position.isFinite, position > 0 else { return true }
+        return maximumPreferredPosition.map { position > $0 + self.suspiciousPreferredPositionPadding } ?? false
     }
 
     private static func clearPreferredPositionIfNeeded(
@@ -55,7 +51,7 @@ enum MenuBarStatusItemPlacementPreflight {
         return true
     }
 
-    private static func currentMaximumPreferredPosition() -> Double? {
-        NSScreen.screens.map { Double($0.frame.maxX) }.max()
+    static func currentMaximumPreferredPosition(screenFrames: [CGRect] = NSScreen.screens.map(\.frame)) -> Double? {
+        screenFrames.map { Double($0.width) }.max()
     }
 }

--- a/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
+++ b/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
@@ -52,6 +52,7 @@ enum MenuBarStatusItemPlacementPreflight {
     }
 
     static func currentMaximumPreferredPosition(screenFrames: [CGRect] = NSScreen.screens.map(\.frame)) -> Double? {
-        screenFrames.map { Double($0.width) }.max()
+        // Preserve the legacy parking range while covering wide displays left of the primary screen.
+        screenFrames.map { Double(max($0.width, $0.maxX)) }.max()
     }
 }

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite(.serialized)
 struct StatusItemControllerSplitLifecycleTests {
     @Test
-    func `placement bounds use display widths independently of desktop origins`() {
+    func `placement bounds cover wide left displays without tightening legacy ranges`() {
         let small = CGRect(x: 0, y: 0, width: 1440, height: 900)
         let wide = CGRect(x: 0, y: 0, width: 3840, height: 2160)
         let layouts = [
@@ -16,13 +16,19 @@ struct StatusItemControllerSplitLifecycleTests {
             [small, wide.offsetBy(dx: 0, dy: 900)],
             [wide, wide.offsetBy(dx: 3840, dy: 0)],
         ]
-        for frames in layouts {
+        for (frames, expectedBound) in zip(layouts, [3840.0, 5280, 3840, 7680]) {
             let bound = MenuBarStatusItemPlacementPreflight.currentMaximumPreferredPosition(screenFrames: frames)
-            #expect(bound == 3840)
+            #expect(bound == expectedBound)
             #expect(!MenuBarStatusItemPlacementPreflight.shouldClearPreferredPosition(
                 2500, maximumPreferredPosition: bound))
-            #expect(MenuBarStatusItemPlacementPreflight.shouldClearPreferredPosition(
-                6247, maximumPreferredPosition: bound))
+            let legacyBound = frames.map { Double($0.maxX) }.max()
+            for position in [1, 42, 2500, 3840, 6247, 8000] where
+                !MenuBarStatusItemPlacementPreflight.shouldClearPreferredPosition(
+                    position, maximumPreferredPosition: legacyBound)
+            {
+                #expect(!MenuBarStatusItemPlacementPreflight.shouldClearPreferredPosition(
+                    position, maximumPreferredPosition: bound))
+            }
         }
     }
 

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -6,6 +6,34 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct StatusItemControllerSplitLifecycleTests {
+    @Test
+    func `placement bounds use display widths independently of desktop origins`() {
+        let small = CGRect(x: 0, y: 0, width: 1440, height: 900)
+        let wide = CGRect(x: 0, y: 0, width: 3840, height: 2160)
+        let layouts = [
+            [small, wide.offsetBy(dx: -3840, dy: 0)],
+            [small, wide.offsetBy(dx: 1440, dy: 0)],
+            [small, wide.offsetBy(dx: 0, dy: 900)],
+            [wide, wide.offsetBy(dx: 3840, dy: 0)],
+        ]
+        for frames in layouts {
+            let bound = MenuBarStatusItemPlacementPreflight.currentMaximumPreferredPosition(screenFrames: frames)
+            #expect(bound == 3840)
+            #expect(!MenuBarStatusItemPlacementPreflight.shouldClearPreferredPosition(
+                2500, maximumPreferredPosition: bound))
+            #expect(MenuBarStatusItemPlacementPreflight.shouldClearPreferredPosition(
+                6247, maximumPreferredPosition: bound))
+        }
+    }
+
+    @Test
+    func `missing displays retain finite positive saved positions`() {
+        let bound = MenuBarStatusItemPlacementPreflight.currentMaximumPreferredPosition(screenFrames: [])
+        #expect(bound == nil)
+        #expect(!MenuBarStatusItemPlacementPreflight.shouldClearPreferredPosition(
+            20000, maximumPreferredPosition: bound))
+    }
+
     private func disableMenuCardsForTesting() {
         StatusItemController.menuCardRenderingEnabled = false
         StatusItemController.setMenuRefreshEnabledForTesting(false)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -131,7 +131,8 @@ See the canonical [provider authoring guide](provider.md#adding-a-new-provider) 
 
 Status-item creation checks the item's saved preferred position and its matching legacy key before assigning the
 autosave name. Malformed, non-finite, non-positive, and out-of-bounds positions are removed; unrelated items are
-untouched. When no display bound is available, finite positive positions are preserved. Isolated placement tests
+untouched. The bound uses the widest connected display's width in points plus the existing safety padding, independent
+of desktop origins. When no display bound is available, finite positive positions are preserved. Isolated placement tests
 cover this cleanup without creating status items or changing the user's saved preferences. Passing these tests does
 not establish the cause of a position that changes again after launch; that requires runtime placement evidence.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -131,8 +131,9 @@ See the canonical [provider authoring guide](provider.md#adding-a-new-provider) 
 
 Status-item creation checks the item's saved preferred position and its matching legacy key before assigning the
 autosave name. Malformed, non-finite, non-positive, and out-of-bounds positions are removed; unrelated items are
-untouched. The bound uses the widest connected display's width in points plus the existing safety padding, independent
-of desktop origins. When no display bound is available, finite positive positions are preserved. Isolated placement tests
+untouched. The bound is at least the widest connected display's width in points and retains any larger legacy global
+coordinate bound, plus the existing safety padding. This avoids newly deleting menu-manager parking positions while
+covering wide displays left of the primary screen. When no display bound is available, finite positive positions are preserved. Isolated placement tests
 cover this cleanup without creating status items or changing the user's saved preferences. Passing these tests does
 not establish the cause of a position that changes again after launch; that requires runtime placement evidence.
 


### PR DESCRIPTION
Startup validation could discard a valid saved position when a wide display sits left of the primary screen: its global right edge underestimated the usable width. A 2,500-point position on a 3,840-point left-hand display could be cleared.

Raise the bound to cover screen width while retaining the complete range accepted by the old global-right-edge calculation. This preserves existing menu-manager parking positions, including 6,247 on a rightward dual-display arrangement. Simplify the finite-positive value guard. Production code decreases by three lines.

The initial width-only proposal tightened the range on rightward layouts. Review caught that compatibility risk, and the final policy is monotonic: it cannot reject any finite positive position the previous policy accepted. Geometry tests cover four arrangements, missing displays, and preservation against the old bound. All 70 focused tests pass; `make check` passes and independent review is clean. The full `make test` suite also passes against the narrowed revision (1,028 selections across 86 groups; no retries).

Related to #3355; that issue remains open because these tests establish startup geometry validation, not the reported post-launch recurrence. No live menu-position repair is claimed. Changelog and development documentation are updated.
