### PR TITLE
refactor(localization): share the session label in quota settings

### DIFF
--- a/Sources/CodexBar/QuotaWarningSettingsViews.swift
+++ b/Sources/CodexBar/QuotaWarningSettingsViews.swift
@@ -240,7 +240,7 @@ struct FocusResigningBackground: View {
 extension QuotaWarningWindow {
     var localizedCapitalizedDisplayName: String {
         switch self {
-        case .session: L("quota_warning_session_capitalized")
+        case .session: L("Session")
         case .weekly: L("quota_warning_weekly_capitalized")
         }
     }

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -500,7 +500,6 @@
 "provider_accent_color_reset" = "استخدام الافتراضي";
 "quota_warnings_title" = "تحذيرات الحصص";
 "quota_warning_session" = "الجلسة";
-"quota_warning_session_capitalized" = "الجلسة";
 "quota_warning_weekly" = "أسبوعيا";
 "quota_warning_weekly_capitalized" = "الأسبوعي";
 "quota_warning_notification_title" = "انخفاض حصة %2$@ لدى %1$@";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -498,7 +498,6 @@
 "provider_accent_color_reset" = "Usa el valor predeterminat";
 "quota_warnings_title" = "Avisos de quota";
 "quota_warning_session" = "sessió";
-"quota_warning_session_capitalized" = "Sessió";
 "quota_warning_weekly" = "setmanal";
 "quota_warning_weekly_capitalized" = "Setmanal";
 "quota_warning_warn_at" = "Aviseu al";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -514,7 +514,6 @@
 "provider_accent_color_reset" = "Standard verwenden";
 "quota_warnings_title" = "Kontingentwarnungen";
 "quota_warning_session" = "Sitzung";
-"quota_warning_session_capitalized" = "Sitzung";
 "quota_warning_weekly" = "wöchentlich";
 "quota_warning_weekly_capitalized" = "Wöchentlich";
 "quota_warning_notification_title" = "%1$@ %2$@ Kontingent niedrig";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -481,7 +481,6 @@
 "provider_accent_color_reset" = "Use default";
 "quota_warnings_title" = "Quota warnings";
 "quota_warning_session" = "session";
-"quota_warning_session_capitalized" = "Session";
 "quota_warning_weekly" = "weekly";
 "quota_warning_weekly_capitalized" = "Weekly";
 "quota_warning_notification_title" = "%1$@ %2$@ quota low";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -517,7 +517,6 @@
 "provider_accent_color_reset" = "Usar predeterminado";
 "quota_warnings_title" = "Avisos de cuota";
 "quota_warning_session" = "sesión";
-"quota_warning_session_capitalized" = "Sesión";
 "quota_warning_weekly" = "semanal";
 "quota_warning_weekly_capitalized" = "Semanal";
 "predictive_pace_warnings_title" = "Avisos predictivos de ritmo";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -500,7 +500,6 @@
 "provider_accent_color_reset" = "استفاده از پیش‌فرض";
 "quota_warnings_title" = "هشدارهای سهمیه";
 "quota_warning_session" = "جلسه";
-"quota_warning_session_capitalized" = "جلسه";
 "quota_warning_weekly" = "هفتگی";
 "quota_warning_weekly_capitalized" = "هفتگی";
 "quota_warning_notification_title" = "سهمیه %2$@ در %1$@ رو به اتمام است";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -516,7 +516,6 @@
 "provider_accent_color_reset" = "Utiliser la valeur par défaut";
 "quota_warnings_title" = "Alertes de quota";
 "quota_warning_session" = "session";
-"quota_warning_session_capitalized" = "Session";
 "quota_warning_weekly" = "hebdomadaire";
 "quota_warning_weekly_capitalized" = "Hebdomadaire";
 "quota_warning_notification_title" = "%1$@ %2$@ : quota faible";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -494,7 +494,6 @@
 "provider_accent_color_reset" = "Usar o predeterminado";
 "quota_warnings_title" = "Avisos de cota";
 "quota_warning_session" = "sesión";
-"quota_warning_session_capitalized" = "Sesión";
 "quota_warning_weekly" = "semanal";
 "quota_warning_weekly_capitalized" = "Semanal";
 "quota_warning_warn_at" = "Avisar ao";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -502,7 +502,6 @@
 "provider_accent_color_reset" = "Gunakan bawaan";
 "quota_warnings_title" = "Peringatan kuota";
 "quota_warning_session" = "sesi";
-"quota_warning_session_capitalized" = "Sesi";
 "quota_warning_weekly" = "mingguan";
 "quota_warning_weekly_capitalized" = "Mingguan";
 "quota_warning_notification_title" = "%1$@ kuota %2$@ rendah";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -502,7 +502,6 @@
 "provider_accent_color_reset" = "Usa predefinito";
 "quota_warnings_title" = "Avvisi quota";
 "quota_warning_session" = "sessione";
-"quota_warning_session_capitalized" = "Sessione";
 "quota_warning_weekly" = "settimanale";
 "quota_warning_weekly_capitalized" = "Settimanale";
 "quota_warning_notification_title" = "Quota %2$@ di %1$@ quasi esaurita";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -513,7 +513,6 @@
 "provider_accent_color_reset" = "デフォルトを使用";
 "quota_warnings_title" = "クォータ警告";
 "quota_warning_session" = "セッション";
-"quota_warning_session_capitalized" = "セッション";
 "quota_warning_weekly" = "週間";
 "quota_warning_weekly_capitalized" = "週間";
 "quota_warning_notification_title" = "%1$@ の%2$@クォータが残りわずか";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -512,7 +512,6 @@
 "provider_accent_color_reset" = "기본값 사용";
 "quota_warnings_title" = "할당량 경고";
 "quota_warning_session" = "세션";
-"quota_warning_session_capitalized" = "세션";
 "quota_warning_weekly" = "주간";
 "quota_warning_weekly_capitalized" = "주간";
 "quota_warning_notification_title" = "%1$@ %2$@ 할당량 부족";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -516,7 +516,6 @@
 "provider_accent_color_reset" = "Standaard gebruiken";
 "quota_warnings_title" = "Quotumwaarschuwingen";
 "quota_warning_session" = "sessie";
-"quota_warning_session_capitalized" = "Sessie";
 "quota_warning_weekly" = "wekelijks";
 "quota_warning_weekly_capitalized" = "Wekelijks";
 "quota_warning_notification_title" = "%1$@ %2$@ quotum laag";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -502,7 +502,6 @@
 "provider_accent_color_reset" = "Użyj domyślnego";
 "quota_warnings_title" = "Ostrzeżenia limitu";
 "quota_warning_session" = "sesja";
-"quota_warning_session_capitalized" = "Sesja";
 "quota_warning_weekly" = "tydzień";
 "quota_warning_weekly_capitalized" = "Tydzień";
 "quota_warning_notification_title" = "Niski limit %1$@ (%2$@)";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -513,7 +513,6 @@
 "provider_accent_color_reset" = "Usar padrão";
 "quota_warnings_title" = "Alertas de cota";
 "quota_warning_session" = "sessão";
-"quota_warning_session_capitalized" = "Sessão";
 "quota_warning_weekly" = "semanal";
 "quota_warning_weekly_capitalized" = "Semanal";
 "quota_warning_notification_title" = "%1$@: cota baixa (%2$@)";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -517,7 +517,6 @@
 "provider_accent_color_reset" = "Использовать по умолчанию";
 "quota_warnings_title" = "Предупреждения о квотах";
 "quota_warning_session" = "сеанс";
-"quota_warning_session_capitalized" = "Сеанс";
 "quota_warning_weekly" = "неделя";
 "quota_warning_weekly_capitalized" = "Неделя";
 "quota_warning_notification_title" = "Низкая квота %1$@ %2$@";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -516,7 +516,6 @@
 "provider_accent_color_reset" = "Använd standard";
 "quota_warnings_title" = "Kvotvarningar";
 "quota_warning_session" = "session";
-"quota_warning_session_capitalized" = "Session";
 "quota_warning_weekly" = "veckokvot";
 "quota_warning_weekly_capitalized" = "Veckokvot";
 "quota_warning_notification_title" = "%1$@ %2$@-kvot låg";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -500,7 +500,6 @@
 "provider_accent_color_reset" = "ใช้ค่าเริ่มต้น";
 "quota_warnings_title" = "คําเตือนโควต้า";
 "quota_warning_session" = "เซสชั่น";
-"quota_warning_session_capitalized" = "เซสชั่น";
 "quota_warning_weekly" = "รายสัปดาห์";
 "quota_warning_weekly_capitalized" = "รายสัปดาห์";
 "quota_warning_notification_title" = "โควตา%2$@ของ %1$@ ใกล้หมด";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -500,7 +500,6 @@
 "provider_accent_color_reset" = "Varsayılanı kullan";
 "quota_warnings_title" = "Kota uyarıları";
 "quota_warning_session" = "oturum";
-"quota_warning_session_capitalized" = "Oturum";
 "quota_warning_weekly" = "haftalık";
 "quota_warning_weekly_capitalized" = "Haftalık";
 "quota_warning_notification_title" = "%1$@ %2$@ kotası düşük";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -516,7 +516,6 @@
 "provider_accent_color_reset" = "Використовувати типовий";
 "quota_warnings_title" = "Попередження про квоту";
 "quota_warning_session" = "сесії";
-"quota_warning_session_capitalized" = "Сесія";
 "quota_warning_weekly" = "щотижня";
 "quota_warning_weekly_capitalized" = "Щотижня";
 "quota_warning_notification_title" = "%1$@ %2$@ квота низька";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -512,7 +512,6 @@
 "provider_accent_color_reset" = "Dùng mặc định";
 "quota_warnings_title" = "Hạn mức cảnh báo";
 "quota_warning_session" = "phiên";
-"quota_warning_session_capitalized" = "Phiên";
 "quota_warning_weekly" = "hàng tuần";
 "quota_warning_weekly_capitalized" = "Hàng tuần";
 "quota_warning_notification_title" = "%1$@ %2$@ Hạn mức thấp";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -524,7 +524,6 @@
 "provider_accent_color_reset" = "使用默认值";
 "quota_warnings_title" = "配额预警";
 "quota_warning_session" = "会话";
-"quota_warning_session_capitalized" = "会话";
 "quota_warning_weekly" = "每周";
 "quota_warning_weekly_capitalized" = "每周";
 "quota_warning_warn_at" = "预警阈值";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -521,7 +521,6 @@
 "provider_accent_color_reset" = "使用預設值";
 "quota_warnings_title" = "配額提醒";
 "quota_warning_session" = "工作階段";
-"quota_warning_session_capitalized" = "工作階段";
 "quota_warning_weekly" = "每週";
 "quota_warning_weekly_capitalized" = "每週";
 "quota_warning_notification_title" = "%1$@ %2$@配額偏低";


### PR DESCRIPTION
Quota settings duplicate the existing Session label under a separate localization key. Reuse the canonical key and remove the redundant entry from all 23 catalogs.

Every removed value was compared byte-for-byte with its existing Session translation before and after the change; all 23 match. This is a behavior-preserving cleanup removing 23 production lines. It supplies the deletion budget for z.ai's shared native detail-label validation so valid Unicode labels retain the existing framework rules.

Validation: make check passed; the full 1,028-selection / 86-group suite passed on the first pass without retries or timeouts (885.7 seconds). Isolated P2 autoreview, supplied the exact translation-pair evidence, found no actionable findings. Exact-head CI will be recorded before merge.
