### PR TITLE
fix(codex): preserve permission errors across authenticated requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Claude: retain quota-warning history for known accounts across credential refreshes, preventing repeat threshold alerts while preserving recovery crossings and separate account state (partial fix for #3450). Thanks @JonLaliberte!
 - Poe: calculate weekly points, requests, and spend from the last seven elapsed days, so older activity no longer inflates sparse or inactive weeks; share totals aggregation with Today and the 30-day window (#3449). Thanks @Lucenx9!
 - MiMo: skip malformed local session rows before deduplication so valid usage still refreshes the cache, preserving all token buckets and UTC daily/weekly totals with shared aggregation (#3448). Thanks @Lucenx9!
+- Codex: retain HTTP 403 permission failures instead of treating them as expired credentials and launching Auto recovery; share status/cancellation handling across OAuth and PAT requests (extracted from #3379). Thanks @Yuxin-Qiao!
 - Claude: label model-specific weekly quotas with a translated weekly duration while preserving model names and CLI titles; correct swapped Vietnamese Weekly and missing-version labels (#3447). Thanks @gianpaj!
 - Packaging: select the bundled iCloud provisioning profile only for its upstream signing team, preserving alternate-team app/widget groups without incompatible CloudKit entitlements (extracted from #3372). Thanks @krazybean!
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexAuthenticatedHTTPTransport.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexAuthenticatedHTTPTransport.swift
@@ -15,6 +15,30 @@ enum CodexAuthenticatedHTTPTransport {
         return self.shared
     }
 
+    static func perform(request: URLRequest, transport: any ProviderHTTPTransport) async throws -> Data {
+        do {
+            let response = try await transport.response(for: request)
+            switch response.statusCode {
+            case 200...299:
+                return response.data
+            case 401:
+                throw CodexOAuthFetchError.unauthorized
+            default:
+                let body = String(data: response.data, encoding: .utf8)
+                throw CodexOAuthFetchError.serverError(response.statusCode, body)
+            }
+        } catch let error as CodexOAuthFetchError {
+            throw error
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if Task.isCancelled || (error as? URLError)?.code == .cancelled {
+                throw CancellationError()
+            }
+            throw CodexOAuthFetchError.networkError(error)
+        }
+    }
+
     static func makeConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.urlCache = nil

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -426,32 +426,11 @@ public enum CodexOAuthUsageFetcher {
             request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
         }
 
+        let data = try await CodexAuthenticatedHTTPTransport.perform(request: request, transport: transport)
         do {
-            let response = try await transport.response(for: request)
-            let data = response.data
-
-            switch response.statusCode {
-            case 200...299:
-                do {
-                    return try JSONDecoder().decode(CodexUsageResponse.self, from: data)
-                } catch {
-                    throw CodexOAuthFetchError.invalidResponse
-                }
-            case 401, 403:
-                throw CodexOAuthFetchError.unauthorized
-            default:
-                let body = String(data: data, encoding: .utf8)
-                throw CodexOAuthFetchError.serverError(response.statusCode, body)
-            }
-        } catch let error as CodexOAuthFetchError {
-            throw error
-        } catch is CancellationError {
-            throw CancellationError()
+            return try JSONDecoder().decode(CodexUsageResponse.self, from: data)
         } catch {
-            if Task.isCancelled || (error as? URLError)?.code == .cancelled {
-                throw CancellationError()
-            }
-            throw CodexOAuthFetchError.networkError(error)
+            throw CodexOAuthFetchError.invalidResponse
         }
     }
 
@@ -503,30 +482,11 @@ public enum CodexOAuthUsageFetcher {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
 
+        let data = try await CodexAuthenticatedHTTPTransport.perform(request: request, transport: transport)
         do {
-            let response = try await transport.response(for: request)
-            switch response.statusCode {
-            case 200...299:
-                do {
-                    return try JSONDecoder().decode(CodexSpendControlsMonthlyUsageResponse.self, from: response.data)
-                } catch {
-                    throw CodexOAuthFetchError.invalidResponse
-                }
-            case 401, 403:
-                throw CodexOAuthFetchError.unauthorized
-            default:
-                let body = String(data: response.data, encoding: .utf8)
-                throw CodexOAuthFetchError.serverError(response.statusCode, body)
-            }
-        } catch let error as CodexOAuthFetchError {
-            throw error
-        } catch is CancellationError {
-            throw CancellationError()
+            return try JSONDecoder().decode(CodexSpendControlsMonthlyUsageResponse.self, from: data)
         } catch {
-            if Task.isCancelled || (error as? URLError)?.code == .cancelled {
-                throw CancellationError()
-            }
-            throw CodexOAuthFetchError.networkError(error)
+            throw CodexOAuthFetchError.invalidResponse
         }
     }
 
@@ -553,41 +513,20 @@ public enum CodexOAuthUsageFetcher {
             request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-ID")
         }
 
+        let data = try await CodexAuthenticatedHTTPTransport.perform(request: request, transport: transport)
         do {
-            let response = try await transport.response(for: request)
-            let data = response.data
-
-            switch response.statusCode {
-            case 200...299:
-                do {
-                    let decoder = JSONDecoder()
-                    decoder.dateDecodingStrategy = .custom(Self.decodeISO8601Date)
-                    let payload = try decoder.decode(RateLimitResetCreditsResponse.self, from: data)
-                    guard payload.availableCount >= 0 else {
-                        throw CodexOAuthFetchError.invalidResponse
-                    }
-                    return CodexRateLimitResetCreditsSnapshot(
-                        credits: payload.credits.map(\.model),
-                        availableCount: payload.availableCount,
-                        updatedAt: Date())
-                } catch {
-                    throw CodexOAuthFetchError.invalidResponse
-                }
-            case 401, 403:
-                throw CodexOAuthFetchError.unauthorized
-            default:
-                let body = String(data: data, encoding: .utf8)
-                throw CodexOAuthFetchError.serverError(response.statusCode, body)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .custom(Self.decodeISO8601Date)
+            let payload = try decoder.decode(RateLimitResetCreditsResponse.self, from: data)
+            guard payload.availableCount >= 0 else {
+                throw CodexOAuthFetchError.invalidResponse
             }
-        } catch let error as CodexOAuthFetchError {
-            throw error
-        } catch is CancellationError {
-            throw CancellationError()
+            return CodexRateLimitResetCreditsSnapshot(
+                credits: payload.credits.map(\.model),
+                availableCount: payload.availableCount,
+                updatedAt: Date())
         } catch {
-            if Task.isCancelled || (error as? URLError)?.code == .cancelled {
-                throw CancellationError()
-            }
-            throw CodexOAuthFetchError.networkError(error)
+            throw CodexOAuthFetchError.invalidResponse
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexPAT/CodexPATUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexPAT/CodexPATUsageFetcher.swift
@@ -65,7 +65,7 @@ enum CodexPATUsageFetcher {
         request.httpMethod = "GET"
         Self.applyPATHeaders(to: &request, token: token, userAgent: userAgent)
 
-        let data = try await self.perform(request: request, session: transport)
+        let data = try await CodexAuthenticatedHTTPTransport.perform(request: request, transport: transport)
         do {
             return try JSONDecoder().decode(WhoamiResponse.self, from: data).model
         } catch {
@@ -90,7 +90,7 @@ enum CodexPATUsageFetcher {
             request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
         }
 
-        let data = try await self.perform(request: request, session: transport)
+        let data = try await CodexAuthenticatedHTTPTransport.perform(request: request, transport: transport)
         do {
             return try JSONDecoder().decode(CodexUsageResponse.self, from: data)
         } catch {
@@ -105,33 +105,6 @@ enum CodexPATUsageFetcher {
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(CodexCLIUserAgent.originator, forHTTPHeaderField: "originator")
-    }
-
-    private static func perform(
-        request: URLRequest,
-        session transport: any ProviderHTTPTransport) async throws -> Data
-    {
-        do {
-            let response = try await transport.response(for: request)
-            switch response.statusCode {
-            case 200...299:
-                return response.data
-            case 401, 403:
-                throw CodexOAuthFetchError.unauthorized
-            default:
-                let body = String(data: response.data, encoding: .utf8)
-                throw CodexOAuthFetchError.serverError(response.statusCode, body)
-            }
-        } catch let error as CodexOAuthFetchError {
-            throw error
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            if Task.isCancelled || (error as? URLError)?.code == .cancelled {
-                throw CancellationError()
-            }
-            throw CodexOAuthFetchError.networkError(error)
-        }
     }
 
     private static func firstNonEmpty(_ candidates: String?...) -> String? {

--- a/Tests/CodexBarTests/CodexOAuthExpiryPipelineTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthExpiryPipelineTests.swift
@@ -4,6 +4,56 @@ import Testing
 
 @Suite(CodexCredentialFixtures())
 struct CodexOAuthExpiryPipelineTests {
+    @Test(arguments: ["reset", "spend", "pat-whoami", "pat-usage"], [401, 403])
+    func `Codex endpoints distinguish authentication failures from permission denials`(
+        endpoint: String,
+        code: Int) async throws
+    {
+        let home = CodexCredentialFixtures.root
+        let env = ["CODEX_HOME": home.path]
+        let context = Self.context(mode: .auto, managed: false, home: home)
+        let transport = ProviderHTTPTransportStub { request in
+            if endpoint == "pat-usage", request.url?.path.hasSuffix("/whoami") == true {
+                return try Self.response(request, body: #"{"chatgpt_account_id":"fixture-account"}"#)
+            }
+            return try Self.response(request, code: code, body: "fixture refusal")
+        }
+        do {
+            switch endpoint {
+            case "reset":
+                _ = try await CodexOAuthUsageFetcher.fetchRateLimitResetCredits(
+                    accessToken: "fixture-token", accountId: "fixture-account", env: env, session: transport)
+            case "spend":
+                _ = try await CodexOAuthUsageFetcher.fetchSpendControlsMonthlyUsage(
+                    accessToken: "fixture-token", accountId: "fixture-account", env: env, session: transport)
+            default:
+                _ = try await CodexPATUsageFetcher.fetchUsage(
+                    credentials: CodexPATCredentials(token: "at-fixture"),
+                    cliVersion: "1.0.0",
+                    env: env,
+                    session: transport)
+            }
+            Issue.record("Expected a rejected response")
+        } catch let error as CodexOAuthFetchError {
+            if code == 401 {
+                guard case .unauthorized = error else {
+                    Issue.record("Expected authentication failure")
+                    return
+                }
+            } else {
+                guard case let .serverError(statusCode, body) = error else {
+                    Issue.record("A permission denial must retain its HTTP status")
+                    return
+                }
+                #expect(statusCode == 403)
+                #expect(body == "fixture refusal")
+            }
+            #expect(CodexOAuthFetchStrategy().shouldFallback(on: error, context: context) == (code == 401))
+            #expect(CodexPATFetchStrategy().shouldFallback(on: error, context: context) == (code == 401))
+        }
+        #expect(await transport.requests().count == (endpoint == "pat-usage" ? 2 : 1))
+    }
+
     @Test(arguments: [ProviderSourceMode.auto, .oauth], [false, true])
     func `future expiry keeps OAuth model windows and account scope despite old refresh age`(
         mode: ProviderSourceMode,
@@ -84,13 +134,15 @@ struct CodexOAuthExpiryPipelineTests {
         let transport = ProviderHTTPTransportStub { request in
             #expect(request.httpMethod == "GET")
             #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(fixture.token)")
-            if failure == "network" { throw URLError(.timedOut) }
+            if failure == "network" {
+                throw URLError(.timedOut)
+            }
             return try Self.response(request, code: Int(failure) ?? 200, body: "not-json")
         }
         let outcome = await CodexAuthenticatedHTTPTransport.$overrideForTesting.withValue(transport) {
             await Self.pipeline.fetch(context: context, provider: .codex)
         }
-        let unauthorized = failure == "401" || failure == "403"
+        let unauthorized = failure == "401"
         let expectsCLI = unauthorized && mode == .auto && !managed
         guard case let .failure(error) = outcome.result else {
             Issue.record("An expiry hint cannot authenticate a rejected token")
@@ -103,7 +155,7 @@ struct CodexOAuthExpiryPipelineTests {
             let oauthError = try #require(error as? CodexOAuthFetchError)
             switch oauthError {
             case .unauthorized: #expect(unauthorized)
-            case .serverError: #expect(failure == "500")
+            case .serverError: #expect(failure == "403" || failure == "500")
             case .invalidResponse: #expect(failure == "decode")
             case .networkError: #expect(failure == "network")
             }

--- a/docs/codex-oauth.md
+++ b/docs/codex-oauth.md
@@ -271,7 +271,7 @@ public enum CodexOAuthUsageFetcher {
             } catch {
                 throw CodexOAuthFetchError.invalidResponse
             }
-        case 401, 403:
+        case 401:
             throw CodexOAuthFetchError.unauthorized
         default:
             let body = String(data: data, encoding: .utf8)
@@ -312,6 +312,9 @@ implementation instead of copying an OAuth-only fetch example:
 4. Auto mode falls back to the CLI only for recoverable native OAuth or credential errors. Stale
    external sources, managed workspace scope, transient API errors, decode failures, and network
    failures remain visible instead of launching an unrelated or unscoped CLI recovery.
+
+HTTP 401 remains an authentication failure. HTTP 403 retains its status as a terminal API permission failure for
+OAuth and PAT requests, including reset-credit and spend-control endpoints; it does not trigger automatic CLI recovery.
 
 The key invariant is that the credential snapshot used for the usage request is also passed to
 reset-credit enrichment; reloading `auth.json` after a refresh would reintroduce the shared-file


### PR DESCRIPTION
HTTP 403 from Codex OAuth and PAT endpoints was treated as expired authentication. In Auto mode this could trigger CLI recovery for a permission denial. Preserve the status and response body as a terminal server error; HTTP 401 retains authentication recovery.

Share request status, network-error, and cancellation handling across usage, reset-credit, spend-control, and PAT requests. Requests and decoding contracts remain unchanged. Production code decreases by 64 lines.

The actual fetcher-to-pipeline regression failed before the change, including Auto selecting the CLI fallback sentinel. All 93 focused tests across five suites pass, covering OAuth/PAT endpoints, 401 controls, and terminal 403 behavior. `make check` and the full `make test` suite pass (1,028 selections across 86 groups; no retries). Independent review found no actionable P0–P2 findings. Tests use synthetic responses; no live account access is claimed.

This extracts the status distinction discussed in #3379; the broader managed credential renewal work remains open. Thanks @Yuxin-Qiao for that work. Changelog and OAuth documentation are updated.
