### PR TITLE
refactor(kiro): share probe defaults and overage fallback

### DIFF
--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -162,15 +162,8 @@ public struct KiroUsageSnapshot: Sendable {
         // The API states whether overage is enabled. The CLI omits the whole overage section for
         // organization accounts, so its status line is only consulted when the API is unavailable.
         let overageCap = self.usageLimits?.overageCap
-        let overagesEnabled: Bool = if let limits = self.usageLimits {
-            if let enabled = limits.overageEnabled {
-                enabled && overageCap != nil
-            } else {
-                self.overagesStatus?
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .lowercased()
-                    .hasPrefix("enabled") == true
-            }
+        let overagesEnabled: Bool = if let enabled = self.usageLimits?.overageEnabled {
+            enabled && overageCap != nil
         } else {
             self.overagesStatus?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -337,13 +330,9 @@ public struct KiroStatusProbe: Sendable {
     private let usageLimitsFetcher: @Sendable () async throws -> KiroUsageLimits
 
     public init() {
-        self.cliBinaryResolver = { TTYCommandRunner.which("kiro-cli") }
-        self.accountProbeTimeout = 3.0
-        self.usageProbeTimeout = 20.0
-        self.contextProbeTimeout = 8.0
-        self.pipeTimeoutCap = 5.0
-        self.pipeProcessRegistry = .live
-        self.usageLimitsFetcher = { try await KiroUsageLimitsAPI.fetch() }
+        self.init(
+            cliBinaryResolver: { TTYCommandRunner.which("kiro-cli") },
+            usageLimitsFetcher: { try await KiroUsageLimitsAPI.fetch() })
     }
 
     init(

--- a/Sources/CodexBarCore/Providers/Kiro/KiroUsageLimitsAPI.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroUsageLimitsAPI.swift
@@ -96,8 +96,6 @@ public enum KiroUsageLimitsAPI: Sendable {
     /// this range is a unit change, not a date — milliseconds would land far beyond any real reset.
     private static let resetRange: ClosedRange<Double> = 1_000_000_000...4_102_444_800
 
-    private static let logger = CodexBarLog.logger(LogCategories.provider(.kiro, scope: "usage-api"))
-
     public static func stateDatabaseURL(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
         environment: [String: String] = ProcessInfo.processInfo.environment,


### PR DESCRIPTION
Share Kiro's existing constructor defaults while explicitly supplying the live CLI resolver and API fetcher. Collapse the duplicated CLI overage-status fallback, preserving explicit API status and cap precedence, and remove an unused API logger.

This is behavior-preserving cleanup that removes 13 production lines and funds a separate regional-enrichment bug fix. All 99 focused Kiro tests across nine suites pass, `make check` passes, and independent review is clean. The full suite passed all 86 groups in 1,812.8 seconds; two timed-out groups recovered through isolated selection retries. Exact-head CI run 34108675137 passed on macOS and Linux. No credentials or live provider requests were used.
