### PR TITLE
fix(claude): refresh expired default-profile cache from changed CLI credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - OpenRouter: reject combined Activity token overflow before publishing history so malformed optional data cannot hide valid credits or key quota; share input/output total validation (extracted from #3272). Thanks @akshayprabhu200!
 - Poe: skip out-of-range history timestamps instead of letting date formatting hide a valid point balance; preserve supported timestamp formats and valid activity.
 - Menu bar: preserve valid saved positions on wide monitors placed left of the primary display while retaining the legacy accepted range for menu-manager compatibility (related to #3355).
+- Claude: recover an expired default-profile cache from changed, fresh CLI credentials when existing read consent and policy permit, preserving explicit-file precedence and custom-profile isolation (related to #3390).
 - Claude: retain quota-warning history for known accounts across credential refreshes, preventing repeat threshold alerts while preserving recovery crossings and separate account state (partial fix for #3450). Thanks @JonLaliberte!
 - Claude local usage: discard stale cached rows when a transcript is atomically replaced, including across process restarts; retain incremental parsing for genuine appends and rebuild legacy cache entries without file identity once.
 - Poe: calculate weekly points, requests, and spend from the last seven elapsed days, so older activity no longer inflates sparse or inactive weeks; share totals aggregation with Today and the 30-day window (#3449). Thanks @Lucenx9!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -323,10 +323,9 @@ public enum ClaudeOAuthCredentialsStore {
                         owner: owner,
                         source: .memoryCache,
                         historyOwnerIdentifier: cachedRecord.historyOwnerIdentifier)
-                    if recovery.shouldAttemptFreshnessSyncFromClaudeKeychain(cached: record),
-                       let synced = recovery.syncWithClaudeKeychainIfChanged(
-                           cached: record,
-                           respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes)
+                    if let synced = recovery.syncWithClaudeKeychainIfChanged(
+                        cached: record,
+                        respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes)
                     {
                         return synced
                     }
@@ -355,19 +354,14 @@ public enum ClaudeOAuthCredentialsStore {
                         if creds.isExpired {
                             expiredRecord = record
                         } else {
-                            if recovery.shouldAttemptFreshnessSyncFromClaudeKeychain(cached: record),
-                               let synced = recovery.syncWithClaudeKeychainIfChanged(
-                                   cached: record,
-                                   respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes)
+                            if let synced = recovery.syncWithClaudeKeychainIfChanged(
+                                cached: record,
+                                respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes)
                             {
                                 return synced
                             }
                             ClaudeOAuthCredentialsStore.writeMemoryCache(
-                                record: ClaudeOAuthCredentialRecord(
-                                    credentials: creds,
-                                    owner: owner,
-                                    source: .memoryCache,
-                                    historyOwnerIdentifier: record.historyOwnerIdentifier),
+                                record: record,
                                 timestamp: Date(),
                                 profileIdentifier: profileIdentifier)
                             return record
@@ -401,10 +395,7 @@ public enum ClaudeOAuthCredentialsStore {
                         expiredRecord = record
                     } else {
                         ClaudeOAuthCredentialsStore.writeMemoryCache(
-                            record: ClaudeOAuthCredentialRecord(
-                                credentials: creds,
-                                owner: .claudeCLI,
-                                source: .memoryCache),
+                            record: record,
                             timestamp: Date(),
                             profileIdentifier: profileIdentifier)
                         if !cacheTemporarilyUnavailable {
@@ -424,14 +415,21 @@ public enum ClaudeOAuthCredentialsStore {
                     lastError = error
                 }
 
-                if allowClaudeKeychainRepairWithoutPrompt, !allowKeychainPrompt {
-                    if let repaired = recovery.repairFromClaudeKeychainWithoutPromptIfAllowed(
-                        now: Date(),
-                        respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes,
-                        allowCacheKeychainWrite: !cacheTemporarilyUnavailable)
-                    {
-                        return repaired
-                    }
+                if !cacheTemporarilyUnavailable, let expiredRecord,
+                   let synced = recovery.syncWithClaudeKeychainIfChanged(
+                       cached: expiredRecord,
+                       respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes)
+                {
+                    return synced
+                }
+
+                if allowClaudeKeychainRepairWithoutPrompt, !allowKeychainPrompt,
+                   let repaired = recovery.repairFromClaudeKeychainWithoutPromptIfAllowed(
+                       now: Date(),
+                       respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes,
+                       allowCacheKeychainWrite: !cacheTemporarilyUnavailable)
+                {
+                    return repaired
                 }
 
                 if let prompted = self.loadFromClaudeKeychainWithPromptIfAllowed(
@@ -1011,7 +1009,10 @@ public enum ClaudeOAuthCredentialsStore {
         let profileIdentifier: String
 
         func shouldAttemptFreshnessSyncFromClaudeKeychain(cached: ClaudeOAuthCredentialRecord) -> Bool {
-            guard !cached.credentials.isExpired else { return false }
+            // The global CLI item cannot identify an expired custom profile.
+            guard !cached.credentials.isExpired
+                || self.profileIdentifier == ClaudeOAuthCredentialsStore.historicalDefaultCredentialsProfileIdentifier
+            else { return false }
             guard cached.owner == .claudeCLI else { return false }
             guard ClaudeOAuthCredentialsStore.keychainAccessAllowed else { return false }
 
@@ -1040,6 +1041,7 @@ public enum ClaudeOAuthCredentialsStore {
             now: Date = Date()) -> ClaudeOAuthCredentialRecord?
         {
             #if os(macOS)
+            guard self.shouldAttemptFreshnessSyncFromClaudeKeychain(cached: cached) else { return nil }
             let mode = ClaudeOAuthKeychainPromptPreference.current()
             guard ClaudeOAuthCredentialsStore
                 .shouldAllowClaudeCodeKeychainAccess(mode: mode, allowKeychainPrompt: false) else { return nil }
@@ -1076,9 +1078,7 @@ public enum ClaudeOAuthCredentialsStore {
                 ClaudeOAuthCredentialsStore.saveClaudeKeychainFingerprint(currentFingerprint)
 
                 guard keychainCreds.accessToken != cached.credentials.accessToken else { return nil }
-                if keychainCreds.isExpired, !cached.credentials.isExpired {
-                    return nil
-                }
+                guard !keychainCreds.isExpired else { return nil }
 
                 ClaudeOAuthCredentialsStore.log.info("Claude keychain credentials changed; syncing OAuth cache")
                 let synced = ClaudeOAuthCredentialRecord(
@@ -1086,10 +1086,7 @@ public enum ClaudeOAuthCredentialsStore {
                     owner: .claudeCLI,
                     source: .claudeKeychain)
                 ClaudeOAuthCredentialsStore.writeMemoryCache(
-                    record: ClaudeOAuthCredentialRecord(
-                        credentials: keychainCreds,
-                        owner: .claudeCLI,
-                        source: .memoryCache),
+                    record: synced,
                     timestamp: now,
                     profileIdentifier: self.profileIdentifier)
                 ClaudeOAuthCredentialsStore.saveToCacheKeychain(

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsProfileCacheTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsProfileCacheTests.swift
@@ -52,6 +52,117 @@ struct ClaudeOAuthCredentialsProfileCacheTests {
         }
     }
 
+    enum FreshnessScenario: CaseIterable {
+        case adopt, customProfile, codexbarOwner, environmentOwner, consentDenied, keychainDisabled, neverPrompt
+        case userActionOnly, cooldown, unchangedFingerprint, unreadable, malformed, expiredReplacement
+        case filePrecedence, environmentPrecedence
+    }
+
+    @Test(arguments: FreshnessScenario.allCases)
+    func `expired cache freshness preserves profile and consent boundaries`(scenario: FreshnessScenario) throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        var environment = ["CLAUDE_CONFIG_DIR": root.path, "HOME": root.path]
+        let profile = scenario == .customProfile ? String(repeating: "b", count: 64)
+            : ClaudeOAuthCredentialsStore.historicalDefaultCredentialsProfileIdentifier
+        let expired = self.makeCredentialsData(
+            accessToken: "expired-default-test-token", expiresAt: Date(timeIntervalSinceNow: -3600))
+        let fresh = self.makeCredentialsData(
+            accessToken: "fresh-default-test-token",
+            expiresAt: Date(timeIntervalSinceNow: scenario == .expiredReplacement ? -60 : 3600))
+        if scenario == .filePrecedence {
+            try self.makeCredentialsData(accessToken: "file-test-token")
+                .write(to: root.appendingPathComponent(".credentials.json"))
+        }
+        if scenario == .environmentPrecedence {
+            environment[ClaudeOAuthCredentialsStore.environmentTokenKey] = "environment-test-token"
+        }
+        let oldFingerprint = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint(
+            modifiedAt: 1, createdAt: 1, persistentRefHash: "old-test-item")
+        let newFingerprint = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprint(
+            modifiedAt: 2, createdAt: 1, persistentRefHash: "new-test-item")
+        let fingerprints = ClaudeOAuthCredentialsStore.ClaudeKeychainFingerprintStore(
+            fingerprint: scenario == .unchangedFingerprint ? newFingerprint : oldFingerprint)
+        let keychain = ClaudeOAuthCredentialsStore.ClaudeKeychainOverrideStore(
+            data: scenario == .unreadable ? nil : (scenario == .malformed ? Data("invalid".utf8) : fresh),
+            fingerprint: newFingerprint)
+        let mode: ClaudeOAuthKeychainPromptMode = switch scenario {
+        case .neverPrompt: .never
+        case .userActionOnly: .onlyOnUserAction
+        default: .always
+        }
+        try self.withIsolatedCache {
+            try ClaudeOAuthCredentialsStore.withCredentialsProfileIdentifierOverrideForTesting(profile) {
+                try ClaudeOAuthDirectKeychainReadConsent.withTaskOverrideForTesting(scenario != .consentDenied) {
+                    try ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(mode) {
+                        try ProviderInteractionContext.$current.withValue(.background) {
+                            try ClaudeOAuthKeychainAccessGate.withShouldAllowPromptOverrideForTesting(
+                                scenario != .cooldown)
+                            {
+                                try ClaudeOAuthCredentialsStore.withClaudeKeychainFingerprintStoreOverrideForTesting(
+                                    fingerprints)
+                                {
+                                    try ClaudeOAuthCredentialsStore.withMutableClaudeKeychainOverrideStoreForTesting(
+                                        keychain)
+                                    {
+                                        let key = ClaudeOAuthCredentialsStore
+                                            .cacheKeyForTesting(profileIdentifier: profile)
+                                        let oldHistory = String(repeating: "a", count: 64)
+                                        KeychainCacheStore.store(
+                                            key: key,
+                                            entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                                data: expired,
+                                                storedAt: Date(),
+                                                owner: scenario == .codexbarOwner ? .codexbar
+                                                    : (scenario == .environmentOwner ? .environment : .claudeCLI),
+                                                historyOwnerIdentifier: oldHistory,
+                                                profileIdentifier: profile))
+                                        let record = KeychainAccessGate.withTaskOverrideForTesting(
+                                            scenario == .keychainDisabled)
+                                        {
+                                            try? ClaudeOAuthCredentialsStore.loadRecord(
+                                                environment: environment,
+                                                allowKeychainPrompt: false,
+                                                respectKeychainPromptCooldown: true,
+                                                allowClaudeKeychainRepairWithoutPrompt: false)
+                                        }
+                                        switch scenario {
+                                        case .adopt, .codexbarOwner:
+                                            let adopted = try #require(record)
+                                            #expect(adopted.credentials.accessToken == "fresh-default-test-token")
+                                            #expect(adopted.owner == .claudeCLI)
+                                            #expect(adopted.source == .claudeKeychain)
+                                            let expectedHistory = try ClaudeOAuthCredentials.parse(data: fresh)
+                                                .historyOwnerIdentifier
+                                            #expect(adopted.historyOwnerIdentifier == expectedHistory)
+                                            #expect(adopted.historyOwnerIdentifier != oldHistory)
+                                            #expect(fingerprints.fingerprint == newFingerprint)
+                                            let second = try ClaudeOAuthCredentialsStore.loadRecord(
+                                                environment: environment,
+                                                allowKeychainPrompt: false,
+                                                allowClaudeKeychainRepairWithoutPrompt: false)
+                                            #expect(second.source == .memoryCache)
+                                            #expect(second.credentials.accessToken == adopted.credentials.accessToken)
+                                        case .filePrecedence:
+                                            #expect(record?.credentials.accessToken == "file-test-token")
+                                        case .environmentPrecedence:
+                                            #expect(record?.credentials.accessToken == "environment-test-token")
+                                        default:
+                                            #expect(record?.credentials.accessToken != "fresh-default-test-token")
+                                        }
+                                        #expect(keychain.data == (scenario == .unreadable ? nil
+                                                : (scenario == .malformed ? Data("invalid".utf8) : fresh)))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     @Test
     func `newer cache from another profile never overrides older credentials file`() throws {
         let tempRoot = FileManager.default.temporaryDirectory

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -65,6 +65,7 @@ Admin API key setup:
   - CodexBar OAuth cache when available.
   - File fallback: `~/.claude/.credentials.json`.
   - Claude CLI Keychain bootstrap/repair fallback: `Claude Code-credentials`.
+- For the default CLI profile, expired cached credentials can adopt a changed, fresh CLI Keychain token after file fallback. Existing direct-read consent, prompt policy, cooldown, and noninteractive-read checks still apply. Custom profiles are not recovered from the unscoped global item, and CLI credentials are never rewritten by this synchronization.
 - On Claude Code 2.1.x, `Claude Code-credentials` may contain only MCP server OAuth state (`mcpOAuth`) with no `claudeAiOauth`. CodexBar treats that as an OAuth configuration error, does not run background delegated `claude /status` refresh, and surfaces re-auth guidance. Use Web or CLI usage source, or restore a valid Claude OAuth keychain entry. See #1844.
 - Requires `user:profile` scope (CLI tokens with only `user:inference` cannot call usage).
 - Endpoints:


### PR DESCRIPTION
Safe-source loading could remain stuck on an expired Claude cache even after Claude Code had already written a fresh token. Expired records skipped the existing changed-fingerprint synchronization, while Auto disabled direct repair and an unchanged CLI touch could not establish another refresh.

Reuse the existing freshness check for expired CLI-owned records after file fallback, restricted to the historical default profile. The global CLI Keychain item cannot identify a custom profile. Preserve direct-read consent, stored/effective prompt policy, cooldown, pre-alert, noninteractive-read gates, and explicit file/environment precedence. Reject expired replacement credentials and derive history ownership from the adopted token. Reuse cached records internally without changing public memory-cache source labels, and flatten the existing repair condition. Production code decreases by three lines.

The synthetic default-profile regression failed five assertions before the fix. All 62 focused tests across five suites pass, including 15 policy/ownership/profile/source scenarios and existing delegation and CLI ownership coverage. `make check` and independent review pass. The final full-suite run passed all 1,028 selections across 86 groups with no retries in 1,273.9 seconds. Exact-head CI run 34111391439 passed on macOS and Linux. An earlier local run failed subprocess fixture startup deadlines; the exact 128-test group and final full rerun passed unchanged. Disk-space warnings during the final run were cleared by deleting idle task build caches, with no assertion failures. Tests use in-memory Keychain collaborators and synthetic files; no real credentials were read or CLI credentials rewritten.

Partial investigation of #3390. The separate partition-ID/prompt allegation is not claimed fixed. Changelog and Claude documentation are updated. Thanks @kerloom for the report and follow-up trace.
