### PR TITLE
fix(kiro): route existing enrichment through the profile region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.56.8 — Unreleased
 
 ### Fixed
+- Kiro: route existing overage enrichment to the CLI profile’s supported region instead of always using US East; reject invalid profile ARNs before sending credentials and retain CLI fallback (#3359).
 - Local usage: honor the app’s Low Power Mode interval for automatic Codex catch-up passes in both usage and Spend Dashboard, while retaining manual acceleration and system thermal pauses.
 - Copilot: keep verified GitHub user IDs authoritative when matching legacy token accounts, preventing a matching login or display label from replacing a different resolved account.
 - OpenRouter: reject combined Activity token overflow before publishing history so malformed optional data cannot hide valid credits or key quota; share input/output total validation (extracted from #3272). Thanks @akshayprabhu200!

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -162,15 +162,8 @@ public struct KiroUsageSnapshot: Sendable {
         // The API states whether overage is enabled. The CLI omits the whole overage section for
         // organization accounts, so its status line is only consulted when the API is unavailable.
         let overageCap = self.usageLimits?.overageCap
-        let overagesEnabled: Bool = if let limits = self.usageLimits {
-            if let enabled = limits.overageEnabled {
-                enabled && overageCap != nil
-            } else {
-                self.overagesStatus?
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .lowercased()
-                    .hasPrefix("enabled") == true
-            }
+        let overagesEnabled: Bool = if let enabled = self.usageLimits?.overageEnabled {
+            enabled && overageCap != nil
         } else {
             self.overagesStatus?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -337,13 +330,9 @@ public struct KiroStatusProbe: Sendable {
     private let usageLimitsFetcher: @Sendable () async throws -> KiroUsageLimits
 
     public init() {
-        self.cliBinaryResolver = { TTYCommandRunner.which("kiro-cli") }
-        self.accountProbeTimeout = 3.0
-        self.usageProbeTimeout = 20.0
-        self.contextProbeTimeout = 8.0
-        self.pipeTimeoutCap = 5.0
-        self.pipeProcessRegistry = .live
-        self.usageLimitsFetcher = { try await KiroUsageLimitsAPI.fetch() }
+        self.init(
+            cliBinaryResolver: { TTYCommandRunner.which("kiro-cli") },
+            usageLimitsFetcher: { try await KiroUsageLimitsAPI.fetch() })
     }
 
     init(

--- a/Sources/CodexBarCore/Providers/Kiro/KiroUsageLimitsAPI.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroUsageLimitsAPI.swift
@@ -96,8 +96,6 @@ public enum KiroUsageLimitsAPI: Sendable {
     /// this range is a unit change, not a date — milliseconds would land far beyond any real reset.
     private static let resetRange: ClosedRange<Double> = 1_000_000_000...4_102_444_800
 
-    private static let logger = CodexBarLog.logger(LogCategories.provider(.kiro, scope: "usage-api"))
-
     public static func stateDatabaseURL(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
         environment: [String: String] = ProcessInfo.processInfo.environment,

--- a/Sources/CodexBarCore/Providers/Kiro/KiroUsageLimitsAPI.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroUsageLimitsAPI.swift
@@ -84,8 +84,10 @@ public enum KiroUsageLimitsError: LocalizedError, Sendable {
 }
 
 public enum KiroUsageLimitsAPI: Sendable {
-    /// Endpoint the official CLI resolves for `codewhispererruntime`.
-    static let defaultEndpoint = URL(string: "https://codewhisperer.us-east-1.amazonaws.com/")!
+    private static let profileEndpoints = [
+        "us-east-1": URL(string: "https://codewhisperer.us-east-1.amazonaws.com/")!,
+        "eu-central-1": URL(string: "https://q.eu-central-1.amazonaws.com/")!,
+    ]
     private static let target = "AmazonCodeWhispererService.GetUsageLimits"
     private static let contentType = "application/x-amz-json-1.0"
     private static let creditResource = "CREDIT"
@@ -140,16 +142,22 @@ public enum KiroUsageLimitsAPI: Sendable {
     {
         try await self.fetch(
             databaseURL: self.stateDatabaseURL(homeDirectory: homeDirectory),
-            endpoint: self.defaultEndpoint,
             transport: self.isolatedTransport)
     }
 
     static func fetch(
         databaseURL: URL,
-        endpoint: URL,
         transport: any ProviderHTTPTransport) async throws -> KiroUsageLimits
     {
         let identity = try self.readIdentity(databaseURL: databaseURL)
+        let arn = identity.profileARN.split(separator: ":", maxSplits: 5, omittingEmptySubsequences: false)
+        guard arn.count == 6, arn[0] == "arn", arn[1] == "aws", arn[2] == "codewhisperer",
+              arn[5].hasPrefix("profile/"), arn[5].count > "profile/".count,
+              identity.profileARN.rangeOfCharacter(from: .whitespacesAndNewlines.union(.controlCharacters)) == nil,
+              let endpoint = self.profileEndpoints[String(arn[3])]
+        else {
+            throw KiroUsageLimitsError.credentialsUnavailable("unsupported profile ARN")
+        }
         var request = URLRequest(url: endpoint, timeoutInterval: self.requestTimeout)
         request.httpMethod = "POST"
         request.setValue(self.contentType, forHTTPHeaderField: "Content-Type")

--- a/Tests/CodexBarTests/KiroRegionalEnrichmentTests.swift
+++ b/Tests/CodexBarTests/KiroRegionalEnrichmentTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import SQLite3
+import Testing
+@testable import CodexBarCore
+
+struct KiroRegionalEnrichmentTests {
+    @Test(arguments: ["us-east-1", "eu-central-1"])
+    func `existing enrichment follows the CLI profile region`(region: String) async throws {
+        let arn = "arn:aws:codewhisperer:\(region):123456789012:profile/test-profile"
+        let database = try self.makeDatabase(profileARN: arn)
+        defer { try? FileManager.default.removeItem(at: database.deletingLastPathComponent()) }
+        let original = try Data(contentsOf: database)
+        let transport = ProviderHTTPTransportStub { request in
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL, statusCode: 200, httpVersion: nil, headerFields: nil))
+            return (Data(KiroUsageLimitsAPITests.overageInUseResponse.utf8), response)
+        }
+
+        let usage = try await KiroUsageLimitsAPI.fetch(
+            databaseURL: database, transport: transport)
+        let requests = await transport.requests()
+        let request = try #require(requests.first)
+        #expect(requests.count == 1)
+        #expect(request.url?.absoluteString == (region == "us-east-1"
+                ? "https://codewhisperer.us-east-1.amazonaws.com/"
+                : "https://q.eu-central-1.amazonaws.com/"))
+        #expect(request.httpMethod == "POST")
+        #expect(request.timeoutInterval == 10)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer synthetic-kiro-token")
+        #expect(request.value(forHTTPHeaderField: "X-Amz-Target") == "AmazonCodeWhispererService.GetUsageLimits")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-amz-json-1.0")
+        let body = try JSONSerialization.jsonObject(with: #require(request.httpBody)) as? [String: String]
+        #expect(body == ["profileArn": arn])
+        #expect(usage.planUsed == 10000)
+        #expect(try Data(contentsOf: database) == original)
+    }
+
+    @Test(arguments: [
+        "", "not-an-arn", "arn:aws:codewhisperer:eu-central-1:123456789012",
+        "arn:aws-cn:codewhisperer:eu-central-1:123456789012:profile/test",
+        "arn:aws:s3:eu-central-1:123456789012:profile/test",
+        "arn:aws:codewhisperer::123456789012:profile/test",
+        "arn:aws:codewhisperer:ap-southeast-1:123456789012:profile/test",
+        "arn:aws:codewhisperer:EU-CENTRAL-1:123456789012:profile/test",
+        "arn:aws:codewhisperer:eu-central-1.example:123456789012:profile/test",
+        "arn:aws:codewhisperer:-eu-central-1:123456789012:profile/test",
+        "arn:aws:codewhisperer:eu-central-1-:123456789012:profile/test",
+        "arn:aws:codewhisperer:eu-central-1:123456789012:profile/",
+        "arn:aws:codewhisperer:eu-central-1:123456789012:other/test",
+        "arn:aws:codewhisperer:eu-central-1:123456789012:profile/test ",
+    ])
+    func `invalid profile state never sends credentials to a default endpoint`(arn: String) async throws {
+        let database = try self.makeDatabase(profileARN: arn)
+        defer { try? FileManager.default.removeItem(at: database.deletingLastPathComponent()) }
+        let transport = ProviderHTTPTransportStub { _ in throw CancellationError() }
+        do {
+            _ = try await KiroUsageLimitsAPI.fetch(databaseURL: database, transport: transport)
+            Issue.record("Invalid profile unexpectedly fetched usage")
+        } catch is KiroUsageLimitsError {}
+        #expect(await transport.requests().isEmpty)
+    }
+
+    @Test
+    func `regional requests preserve cancellation and missing token behavior`() async throws {
+        let arn = "arn:aws:codewhisperer:eu-central-1:123456789012:profile/test"
+        let database = try self.makeDatabase(profileARN: arn)
+        defer { try? FileManager.default.removeItem(at: database.deletingLastPathComponent()) }
+        let transport = ProviderHTTPTransportStub { _ in throw CancellationError() }
+        await #expect(throws: CancellationError.self) {
+            _ = try await KiroUsageLimitsAPI.fetch(databaseURL: database, transport: transport)
+        }
+        #expect(await transport.requests().count == 1)
+        let missing = try self.makeDatabase(profileARN: arn, token: nil)
+        defer { try? FileManager.default.removeItem(at: missing.deletingLastPathComponent()) }
+        await #expect(throws: KiroUsageLimitsError.self) {
+            _ = try await KiroUsageLimitsAPI.fetch(databaseURL: missing, transport: transport)
+        }
+        #expect(await transport.requests().count == 1)
+    }
+
+    private func makeDatabase(profileARN: String, token: String? = "synthetic-kiro-token") throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("data.sqlite3")
+        var database: OpaquePointer?
+        #expect(sqlite3_open(url.path, &database) == SQLITE_OK)
+        let opened = try #require(database)
+        defer { sqlite3_close(opened) }
+        let tokenJSON = try JSONSerialization.data(withJSONObject: token.map { ["access_token": $0] } ?? [:])
+        let profileJSON = try JSONSerialization.data(withJSONObject: ["arn": profileARN])
+        let tokenText = try #require(String(data: tokenJSON, encoding: .utf8)).replacingOccurrences(of: "'", with: "''")
+        let profileText = try #require(String(data: profileJSON, encoding: .utf8))
+            .replacingOccurrences(of: "'", with: "''")
+        let sql = """
+        CREATE TABLE auth_kv(key TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE state(key TEXT PRIMARY KEY, value TEXT);
+        INSERT INTO auth_kv VALUES ('kirocli:odic:token', '\(tokenText)');
+        INSERT INTO state VALUES ('api.codewhisperer.profile', '\(profileText)');
+        """
+        #expect(sqlite3_exec(opened, sql, nil, nil, nil) == SQLITE_OK)
+        return url
+    }
+}

--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -27,12 +27,14 @@ Kiro uses the AWS `kiro-cli` tool to fetch usage data. No browser cookies or OAu
    - The CLI report states credits against the plan alone and **omits the overage section entirely for
      organization accounts**, so it can never state the overage cap. The API carries the overage allowance
      on top of the plan, which is the ceiling an account actually spends against.
-   - Endpoint: `POST https://codewhisperer.us-east-1.amazonaws.com/`,
-     header `X-Amz-Target: AmazonCodeWhispererService.GetUsageLimits`, body `{"profileArn": ...}`.
+   - Endpoint follows the CLI profile ARN: US East uses `POST https://codewhisperer.us-east-1.amazonaws.com/`;
+     Frankfurt uses `POST https://q.eu-central-1.amazonaws.com/`. Invalid or unsupported profile ARNs skip enrichment.
+     Header `X-Amz-Target: AmazonCodeWhispererService.GetUsageLimits`, body `{"profileArn": ...}`.
    - Credentials come from the CLI's own state, opened **read-only** (the CLI owns the token and its refresh):
      `~/Library/Application Support/kiro-cli/data.sqlite3`
      - `auth_kv` key `kirocli:odic:token` → `access_token`
      - `state` key `api.codewhisperer.profile` → `arn`
+   - Regional endpoints follow [AWS profile-region routing](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/firewall.html), independently of the IAM Identity Center authentication region.
    - Runs after the CLI probe, so a token the CLI refreshed along the way is already in place.
    - Failure is non-fatal: the plan-relative numbers the CLI produced stand, or a plan-only report keeps
      usage unavailable. An unambiguous positive API allowance can supply the missing plan metrics.


### PR DESCRIPTION
Kiro's existing post-CLI overage enrichment always sent GetUsageLimits to US East, even when the CLI state selected a Frankfurt profile. Route that request using the already-read profile ARN: retain the established US East endpoint and use the documented q.eu-central-1 endpoint for Frankfurt.

Use a fixed endpoint map after validating the ARN's partition, service, region, and profile resource shape. Invalid or unsupported routing state fails before transport; the existing best-effort caller retains CLI output. Preserve the bearer token source, exact profileArn body, request method/headers, timeout, cancellation, and read-only SQLite access. No API-first recovery or new credential read is introduced.

The Frankfurt SQLite-to-request regression failed on the old endpoint while the US East control passed. All 29 focused tests across three suites pass, including fixed regional URLs, request metadata, unchanged database bytes, invalid ARN rejection without requests, missing credentials, cancellation, and CLI fallback. The full suite passed all 86 groups in 1,093.5 seconds, with one successful full-group retry. `make check` and independent review pass for the integration with current main; exact-head CI run 34113918209 passed on both macOS shards and every Linux build.

Separate cleanup #3470 has landed and removes 13 production lines. The regional fix itself adds eight lines, leaving five cleanup lines unspent. This branch now includes that landed cleanup and current main.

Fixes the regional-enrichment portion of #3359. Thanks @zucram for the follow-up trace and successful regional response. The change follows [AWS profile-region routing](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/firewall.html) and [supported profile regions](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/q-admin-setup-subscribe-regions.html). Validation used synthetic credentials and transport responses; no live account probe was performed. Changelog and provider documentation are updated.
