### PR TITLE
Add Grok token refresh

### DIFF
--- a/Sources/CodexBarCore/Providers/Grok/GrokAuth.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokAuth.swift
@@ -175,51 +175,6 @@ public enum GrokCredentialsStore {
         return try self.parse(data: data)
     }
 
-    /// Merges refreshed tokens back into auth.json under the credential's scope,
-    /// preserving other scopes and unknown fields. The CLI owns this file, so this
-    /// only runs after an explicit refresh — never speculatively.
-    public static func save(
-        _ credentials: GrokCredentials,
-        env: [String: String] = ProcessInfo.processInfo.environment,
-        fileManager: FileManager = .default) throws
-    {
-        let url = self.authFileURL(env: env, fileManager: fileManager)
-        var root: [String: Any] = [:]
-        if fileManager.fileExists(atPath: url.path) {
-            let data = try Data(contentsOf: url)
-            guard let parsed = try? JSONSerialization.jsonObject(with: data),
-                  let object = parsed as? [String: Any]
-            else {
-                throw GrokCredentialsError.decodeFailed("Invalid JSON (expected object at root)")
-            }
-            root = object
-        } else {
-            try fileManager.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true)
-        }
-        var entry = root[credentials.scope] as? [String: Any] ?? [:]
-        entry["key"] = credentials.accessToken
-        if let refreshToken = credentials.refreshToken?.nilIfEmpty {
-            entry["refresh_token"] = refreshToken
-        }
-        entry["auth_mode"] = credentials.authMode
-        entry["user_id"] = credentials.userId
-        entry["email"] = credentials.email
-        entry["first_name"] = credentials.firstName
-        entry["last_name"] = credentials.lastName
-        entry["team_id"] = credentials.teamId
-        entry["oidc_issuer"] = credentials.oidcIssuer
-        entry["oidc_client_id"] = credentials.oidcClientId
-        entry["expires_at"] = credentials.expiresAt.map { Self.iso8601String($0) }
-        entry["create_time"] = credentials.createTime.map { Self.iso8601String($0) }
-        root[credentials.scope] = entry
-        let data = try JSONSerialization.data(
-            withJSONObject: root,
-            options: [.prettyPrinted, .sortedKeys])
-        try data.write(to: url, options: .atomic)
-    }
-
     public static func parse(data: Data) throws -> GrokCredentials {
         let raw: Any
         do {
@@ -276,12 +231,6 @@ public enum GrokCredentialsStore {
             }
         }
         return oidcCandidate ?? legacyCandidate
-    }
-
-    private static func iso8601String(_ date: Date) -> String {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.string(from: date)
     }
 
     private static func parseDate(_ raw: Any?) -> Date? {

--- a/Sources/CodexBarCore/Providers/Grok/GrokAuth.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokAuth.swift
@@ -79,6 +79,22 @@ public struct GrokCredentials: Sendable {
         return Date() >= expiresAt
     }
 
+    /// Refresh a few minutes before expiry so a fetch never races a dying token.
+    public static let refreshLeeway: TimeInterval = 5 * 60
+
+    /// True when an OIDC refresh token is present and the access token is expired
+    /// or inside the refresh leeway. Credentials without an expiry (pasted tokens,
+    /// legacy sessions) never need refresh.
+    public var needsRefresh: Bool {
+        guard let refreshToken,
+              !refreshToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return false
+        }
+        guard let expiresAt else { return false }
+        return Date() >= expiresAt.addingTimeInterval(-Self.refreshLeeway)
+    }
+
     public var isTeamPrincipal: Bool {
         self.principalType?.trimmingCharacters(in: .whitespacesAndNewlines)
             .caseInsensitiveCompare("team") == .orderedSame
@@ -159,6 +175,51 @@ public enum GrokCredentialsStore {
         return try self.parse(data: data)
     }
 
+    /// Merges refreshed tokens back into auth.json under the credential's scope,
+    /// preserving other scopes and unknown fields. The CLI owns this file, so this
+    /// only runs after an explicit refresh — never speculatively.
+    public static func save(
+        _ credentials: GrokCredentials,
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default) throws
+    {
+        let url = self.authFileURL(env: env, fileManager: fileManager)
+        var root: [String: Any] = [:]
+        if fileManager.fileExists(atPath: url.path) {
+            let data = try Data(contentsOf: url)
+            guard let parsed = try? JSONSerialization.jsonObject(with: data),
+                  let object = parsed as? [String: Any]
+            else {
+                throw GrokCredentialsError.decodeFailed("Invalid JSON (expected object at root)")
+            }
+            root = object
+        } else {
+            try fileManager.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true)
+        }
+        var entry = root[credentials.scope] as? [String: Any] ?? [:]
+        entry["key"] = credentials.accessToken
+        if let refreshToken = credentials.refreshToken?.nilIfEmpty {
+            entry["refresh_token"] = refreshToken
+        }
+        entry["auth_mode"] = credentials.authMode
+        entry["user_id"] = credentials.userId
+        entry["email"] = credentials.email
+        entry["first_name"] = credentials.firstName
+        entry["last_name"] = credentials.lastName
+        entry["team_id"] = credentials.teamId
+        entry["oidc_issuer"] = credentials.oidcIssuer
+        entry["oidc_client_id"] = credentials.oidcClientId
+        entry["expires_at"] = credentials.expiresAt.map { Self.iso8601String($0) }
+        entry["create_time"] = credentials.createTime.map { Self.iso8601String($0) }
+        root[credentials.scope] = entry
+        let data = try JSONSerialization.data(
+            withJSONObject: root,
+            options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
+    }
+
     public static func parse(data: Data) throws -> GrokCredentials {
         let raw: Any
         do {
@@ -215,6 +276,12 @@ public enum GrokCredentialsStore {
             }
         }
         return oidcCandidate ?? legacyCandidate
+    }
+
+    private static func iso8601String(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
     }
 
     private static func parseDate(_ raw: Any?) -> Date? {

--- a/Sources/CodexBarCore/Providers/Grok/GrokTokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokTokenRefresher.swift
@@ -39,7 +39,9 @@ public enum GrokTokenRefresher {
         session transport: any ProviderHTTPTransport,
         now: Date = Date()) async throws -> GrokCredentials
     {
-        guard let refreshToken = credentials.refreshToken, !refreshToken.isEmpty else {
+        guard let refreshToken = credentials.refreshToken?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !refreshToken.isEmpty
+        else {
             throw RefreshError.missingRefreshToken
         }
 
@@ -72,7 +74,7 @@ public enum GrokTokenRefresher {
                 throw RefreshError.invalidResponse("Missing access_token")
             }
             guard let expiresIn = Self.expiresIn(from: json["expires_in"]), expiresIn > 0 else {
-                throw RefreshError.invalidResponse("Missing expires_in")
+                throw RefreshError.invalidResponse("Invalid expires_in")
             }
             let newRefreshToken = Self.nonEmptyString(json["refresh_token"]) ?? refreshToken
 

--- a/Sources/CodexBarCore/Providers/Grok/GrokTokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokTokenRefresher.swift
@@ -1,0 +1,139 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum GrokTokenRefresher {
+    private static let refreshEndpoint = URL(string: "https://auth.x.ai/oauth2/token")!
+    private static let clientID = "b1a00492-073a-47ea-816f-4c329264a828"
+
+    public enum RefreshError: LocalizedError, Sendable {
+        case missingRefreshToken
+        case rejected
+        case networkError(Error)
+        case invalidResponse(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .missingRefreshToken:
+                "Grok credentials have no refresh token. Run `grok login` to authenticate again."
+            case .rejected:
+                "Grok refresh token was rejected. Run `grok login` to authenticate again."
+            case let .networkError(error):
+                "Network error during Grok token refresh: \(error.localizedDescription)"
+            case let .invalidResponse(message):
+                "Invalid Grok token refresh response: \(message)"
+            }
+        }
+    }
+
+    public static func refresh(_ credentials: GrokCredentials) async throws -> GrokCredentials {
+        try await self.refresh(
+            credentials,
+            session: ProviderHTTPClient.shared,
+            now: Date())
+    }
+
+    static func refresh(
+        _ credentials: GrokCredentials,
+        session transport: any ProviderHTTPTransport,
+        now: Date = Date()) async throws -> GrokCredentials
+    {
+        guard let refreshToken = credentials.refreshToken, !refreshToken.isEmpty else {
+            throw RefreshError.missingRefreshToken
+        }
+
+        var request = URLRequest(
+            url: Self.refreshEndpoint,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 30)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        var form = URLComponents()
+        form.queryItems = [
+            URLQueryItem(name: "client_id", value: Self.clientID),
+            URLQueryItem(name: "grant_type", value: "refresh_token"),
+            URLQueryItem(name: "refresh_token", value: refreshToken),
+        ]
+        request.httpBody = form.percentEncodedQuery?.data(using: .utf8)
+
+        do {
+            let response = try await transport.response(for: request)
+            guard response.statusCode == 200 else {
+                if response.statusCode == 400 || response.statusCode == 401 {
+                    throw RefreshError.rejected
+                }
+                throw RefreshError.invalidResponse("HTTP \(response.statusCode)")
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any] else {
+                throw RefreshError.invalidResponse("Invalid JSON")
+            }
+            guard let accessToken = Self.nonEmptyString(json["access_token"]) else {
+                throw RefreshError.invalidResponse("Missing access_token")
+            }
+            guard let expiresIn = Self.expiresIn(from: json["expires_in"]), expiresIn > 0 else {
+                throw RefreshError.invalidResponse("Missing expires_in")
+            }
+            let newRefreshToken = Self.nonEmptyString(json["refresh_token"]) ?? refreshToken
+
+            return GrokCredentials(
+                accessToken: accessToken,
+                refreshToken: newRefreshToken,
+                scope: credentials.scope,
+                authMode: credentials.authMode,
+                userId: credentials.userId,
+                email: credentials.email,
+                firstName: credentials.firstName,
+                lastName: credentials.lastName,
+                teamId: credentials.teamId,
+                oidcIssuer: credentials.oidcIssuer,
+                oidcClientId: credentials.oidcClientId,
+                expiresAt: now.addingTimeInterval(expiresIn),
+                createTime: now)
+        } catch let error as RefreshError {
+            throw error
+        } catch {
+            throw RefreshError.networkError(error)
+        }
+    }
+
+    static func refreshStoredCredentialsIfNeeded(
+        env: [String: String] = ProcessInfo.processInfo.environment) async throws -> GrokCredentials?
+    {
+        let credentials: GrokCredentials
+        do {
+            credentials = try GrokCredentialsStore.load(env: env)
+        } catch GrokCredentialsError.notFound {
+            return nil
+        }
+        guard credentials.needsRefresh,
+              credentials.scope.hasPrefix(GrokCredentialsStore.oidcScopePrefix),
+              credentials.refreshToken != nil
+        else {
+            return credentials
+        }
+
+        let refreshed = try await self.refresh(credentials)
+        try GrokCredentialsStore.save(refreshed, env: env)
+        return refreshed
+    }
+
+    private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let string = value as? String,
+              !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        return string
+    }
+
+    private static func expiresIn(from value: Any?) -> TimeInterval? {
+        if let number = value as? NSNumber {
+            return number.doubleValue
+        }
+        if let string = value as? String {
+            return TimeInterval(string)
+        }
+        return nil
+    }
+}

--- a/Sources/CodexBarCore/Providers/Grok/GrokTokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokTokenRefresher.swift
@@ -100,42 +100,6 @@ public enum GrokTokenRefresher {
         }
     }
 
-    static func refreshStoredCredentialsIfNeeded(
-        env: [String: String] = ProcessInfo.processInfo.environment,
-        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> GrokCredentials?
-    {
-        let credentials: GrokCredentials
-        do {
-            credentials = try GrokCredentialsStore.load(env: env)
-        } catch GrokCredentialsError.notFound {
-            return nil
-        }
-        guard credentials.needsRefresh,
-              credentials.scope.hasPrefix(GrokCredentialsStore.oidcScopePrefix),
-              credentials.refreshToken != nil
-        else {
-            return credentials
-        }
-
-        let refreshed = try await self.refresh(
-            credentials,
-            session: session,
-            now: Date())
-        // The refresh awaited network I/O: only persist when the file still
-        // holds the credentials we refreshed. An intervening `grok login`
-        // (same scope key, new account) or logout must win over our result —
-        // otherwise we would restore a stale account or recreate removed
-        // credentials. A CLI-side rotation is also honored as-is.
-        guard let current = try? GrokCredentialsStore.load(env: env) else {
-            return nil
-        }
-        guard current.accessToken == credentials.accessToken else {
-            return current
-        }
-        try GrokCredentialsStore.save(refreshed, env: env)
-        return refreshed
-    }
-
     private static func nonEmptyString(_ value: Any?) -> String? {
         guard let string = value as? String,
               !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty

--- a/Sources/CodexBarCore/Providers/Grok/GrokTokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokTokenRefresher.swift
@@ -86,6 +86,7 @@ public enum GrokTokenRefresher {
                 firstName: credentials.firstName,
                 lastName: credentials.lastName,
                 teamId: credentials.teamId,
+                principalType: credentials.principalType,
                 oidcIssuer: credentials.oidcIssuer,
                 oidcClientId: credentials.oidcClientId,
                 expiresAt: now.addingTimeInterval(expiresIn),
@@ -98,7 +99,8 @@ public enum GrokTokenRefresher {
     }
 
     static func refreshStoredCredentialsIfNeeded(
-        env: [String: String] = ProcessInfo.processInfo.environment) async throws -> GrokCredentials?
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> GrokCredentials?
     {
         let credentials: GrokCredentials
         do {
@@ -113,7 +115,21 @@ public enum GrokTokenRefresher {
             return credentials
         }
 
-        let refreshed = try await self.refresh(credentials)
+        let refreshed = try await self.refresh(
+            credentials,
+            session: session,
+            now: Date())
+        // The refresh awaited network I/O: only persist when the file still
+        // holds the credentials we refreshed. An intervening `grok login`
+        // (same scope key, new account) or logout must win over our result —
+        // otherwise we would restore a stale account or recreate removed
+        // credentials. A CLI-side rotation is also honored as-is.
+        guard let current = try? GrokCredentialsStore.load(env: env) else {
+            return nil
+        }
+        guard current.accessToken == credentials.accessToken else {
+            return current
+        }
         try GrokCredentialsStore.save(refreshed, env: env)
         return refreshed
     }

--- a/Tests/CodexBarTests/GrokTokenRefresherTests.swift
+++ b/Tests/CodexBarTests/GrokTokenRefresherTests.swift
@@ -135,6 +135,20 @@ struct GrokTokenRefresherTests {
     }
 
     @Test
+    func `whitespace refresh token is rejected as missing`() async {
+        let transport = ProviderHTTPTransportStub { _ in fatalError("must not send") }
+        do {
+            _ = try await GrokTokenRefresher.refresh(
+                Self.credentials(refreshToken: "  "),
+                session: transport)
+            Issue.record("expected missingRefreshToken")
+        } catch GrokTokenRefresher.RefreshError.missingRefreshToken {
+        } catch {
+            Issue.record("wrong error: \(error)")
+        }
+    }
+
+    @Test
     func `refresh preserves team principal`() async throws {
         let responseBody = Data(#"{"access_token":"fresh-access","expires_in":3600}"#.utf8)
         let transport = ProviderHTTPTransportStub { request in

--- a/Tests/CodexBarTests/GrokTokenRefresherTests.swift
+++ b/Tests/CodexBarTests/GrokTokenRefresherTests.swift
@@ -134,10 +134,106 @@ struct GrokTokenRefresherTests {
         #expect(result?.accessToken == nil)
     }
 
+    @Test
+    func `refresh preserves team principal`() async throws {
+        let responseBody = Data(#"{"access_token":"fresh-access","expires_in":3600}"#.utf8)
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+            return (responseBody, response)
+        }
+
+        let refreshed = try await GrokTokenRefresher.refresh(
+            Self.credentials(refreshToken: "team-refresh", principalType: "team"),
+            session: transport,
+            now: Date(timeIntervalSince1970: 1_800_000_000))
+
+        #expect(refreshed.isTeamPrincipal)
+        #expect(refreshed.teamId == "team-id")
+    }
+
+    @Test
+    func `intervening login wins over stale refresh result`() async throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GrokTokenRefresherTests-stale-\(UUID().uuidString)")
+        let env = ["GROK_HOME": home.path]
+        let authURL = home.appendingPathComponent("auth.json")
+        let scope = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"
+        try Self.writeAuthFile(
+            at: authURL,
+            scope: scope,
+            entry: [
+                "key": "a-access",
+                "refresh_token": "a-refresh",
+                "expires_at": "2020-01-01T00:00:00.000Z",
+            ])
+
+        let transport = ProviderHTTPTransportStub { request in
+            // Simulate `grok login` switching to account B mid-flight.
+            try Data(#"{"\#(scope)":{"key":"b-access"}}"#.utf8).write(to: authURL)
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+            return (Data(#"{"access_token":"a-fresh","expires_in":3600}"#.utf8), response)
+        }
+
+        let result = try await GrokTokenRefresher.refreshStoredCredentialsIfNeeded(env: env, session: transport)
+        #expect(result?.accessToken == "b-access")
+        #expect(try GrokCredentialsStore.load(env: env).accessToken == "b-access")
+    }
+
+    @Test
+    func `removed auth file is not recreated by stale refresh`() async throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GrokTokenRefresherTests-removed-\(UUID().uuidString)")
+        let env = ["GROK_HOME": home.path]
+        let authURL = home.appendingPathComponent("auth.json")
+        let scope = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"
+        try Self.writeAuthFile(
+            at: authURL,
+            scope: scope,
+            entry: [
+                "key": "a-access",
+                "refresh_token": "a-refresh",
+                "expires_at": "2020-01-01T00:00:00.000Z",
+            ])
+
+        let transport = ProviderHTTPTransportStub { request in
+            try FileManager.default.removeItem(at: authURL)
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+            return (Data(#"{"access_token":"a-fresh","expires_in":3600}"#.utf8), response)
+        }
+
+        let result = try await GrokTokenRefresher.refreshStoredCredentialsIfNeeded(env: env, session: transport)
+        #expect(result?.accessToken == nil)
+        #expect(!FileManager.default.fileExists(atPath: authURL.path))
+    }
+
+    private static func writeAuthFile(at url: URL, scope: String, entry: [String: String]) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: [scope: entry])
+        try data.write(to: url)
+    }
+
     private static func credentials(
         accessToken: String = "access-token",
         refreshToken: String? = "refresh-token",
-        expiresAt: Date? = Date(timeIntervalSince1970: 1_900_000_000)) -> GrokCredentials
+        expiresAt: Date? = Date(timeIntervalSince1970: 1_900_000_000),
+        principalType: String? = nil) -> GrokCredentials
     {
         GrokCredentials(
             accessToken: accessToken,
@@ -149,6 +245,7 @@ struct GrokTokenRefresherTests {
             firstName: "Ada",
             lastName: "Lovelace",
             teamId: "team-id",
+            principalType: principalType,
             oidcIssuer: "https://auth.x.ai",
             oidcClientId: "b1a00492-073a-47ea-816f-4c329264a828",
             expiresAt: expiresAt,

--- a/Tests/CodexBarTests/GrokTokenRefresherTests.swift
+++ b/Tests/CodexBarTests/GrokTokenRefresherTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct GrokTokenRefresherTests {
+    @Test
+    func `refresh sends OAuth form and rotates credentials`() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let responseBody = Data(
+            #"{"access_token":"fresh-access","refresh_token":"fresh-refresh","expires_in":21600}"#.utf8)
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.url?.absoluteString == "https://auth.x.ai/oauth2/token")
+            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+            let body = try #require(request.httpBody.flatMap { String(data: $0, encoding: .utf8) })
+            let components = URLComponents(string: "?\(body)")
+            let fields = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+            #expect(fields["client_id"] == "b1a00492-073a-47ea-816f-4c329264a828")
+            #expect(fields["grant_type"] == "refresh_token")
+            #expect(fields["refresh_token"] == "old-refresh")
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+            return (responseBody, response)
+        }
+
+        let refreshed = try await GrokTokenRefresher.refresh(
+            Self.credentials(
+                accessToken: "old-access",
+                refreshToken: "old-refresh",
+                expiresAt: now),
+            session: transport,
+            now: now)
+
+        #expect(refreshed.accessToken == "fresh-access")
+        #expect(refreshed.refreshToken == "fresh-refresh")
+        #expect(refreshed.createTime == now)
+        #expect(refreshed.expiresAt == now.addingTimeInterval(21600))
+        #expect(refreshed.email == "user@example.com")
+    }
+
+    @Test
+    func `refresh preserves refresh token when server omits rotation`() async throws {
+        let responseBody = Data(#"{"access_token":"fresh-access","expires_in":"3600"}"#.utf8)
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+            return (responseBody, response)
+        }
+
+        let refreshed = try await GrokTokenRefresher.refresh(
+            Self.credentials(refreshToken: "stable-refresh"),
+            session: transport,
+            now: Date(timeIntervalSince1970: 1_800_000_000))
+
+        #expect(refreshed.refreshToken == "stable-refresh")
+        #expect(refreshed.expiresAt == Date(timeIntervalSince1970: 1_800_003_600))
+    }
+
+    @Test
+    func `refresh rejects unusable token responses`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 400,
+                httpVersion: nil,
+                headerFields: nil))
+            return (Data(#"{"error":"invalid_grant"}"#.utf8), response)
+        }
+
+        await #expect(throws: GrokTokenRefresher.RefreshError.self) {
+            _ = try await GrokTokenRefresher.refresh(
+                Self.credentials(refreshToken: "revoked-refresh"),
+                session: transport)
+        }
+    }
+
+    @Test
+    func `expired credentials need refresh`() {
+        #expect(Self.credentials(expiresAt: Date().addingTimeInterval(-10)).needsRefresh)
+        #expect(Self.credentials(expiresAt: Date().addingTimeInterval(60)).needsRefresh)
+        #expect(!Self.credentials(expiresAt: Date().addingTimeInterval(3600)).needsRefresh)
+        #expect(!Self.credentials(expiresAt: nil).needsRefresh)
+        #expect(!Self.credentials(refreshToken: nil).needsRefresh)
+        #expect(!Self.credentials(refreshToken: "  ").needsRefresh)
+    }
+
+    @Test
+    func `save merges refreshed tokens without dropping sibling scopes`() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GrokTokenRefresherTests-\(UUID().uuidString)")
+        let env = ["GROK_HOME": home.path]
+        let scope = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"
+        let existing = """
+        {"\(scope)":{"key":"old-access","refresh_token":"old-refresh","custom_field":"keep-me"},\
+        "https://accounts.x.ai/sign-in":{"key":"legacy-access"}}
+        """
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try Data(existing.utf8).write(to: home.appendingPathComponent("auth.json"))
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        try GrokCredentialsStore.save(
+            Self.credentials(
+                accessToken: "fresh-access",
+                refreshToken: "fresh-refresh",
+                expiresAt: now),
+            env: env)
+
+        let reloaded = try GrokCredentialsStore.load(env: env)
+        #expect(reloaded.accessToken == "fresh-access")
+        #expect(reloaded.refreshToken == "fresh-refresh")
+        #expect(reloaded.expiresAt == now)
+        #expect(reloaded.email == "user@example.com")
+        let raw = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: home.appendingPathComponent("auth.json"))) as? [String: Any]
+        let entry = raw?[scope] as? [String: Any]
+        #expect(entry?["custom_field"] as? String == "keep-me")
+        #expect((raw?["https://accounts.x.ai/sign-in"] as? [String: Any])?["key"] as? String == "legacy-access")
+    }
+
+    @Test
+    func `refreshStoredCredentialsIfNeeded returns nil without an auth file`() async throws {
+        let env = ["GROK_HOME": FileManager.default.temporaryDirectory
+            .appendingPathComponent("GrokTokenRefresherTests-missing-\(UUID().uuidString)").path]
+        let result = try await GrokTokenRefresher.refreshStoredCredentialsIfNeeded(env: env)
+        #expect(result?.accessToken == nil)
+    }
+
+    private static func credentials(
+        accessToken: String = "access-token",
+        refreshToken: String? = "refresh-token",
+        expiresAt: Date? = Date(timeIntervalSince1970: 1_900_000_000)) -> GrokCredentials
+    {
+        GrokCredentials(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            scope: "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828",
+            authMode: "oidc",
+            userId: "user-id",
+            email: "user@example.com",
+            firstName: "Ada",
+            lastName: "Lovelace",
+            teamId: "team-id",
+            oidcIssuer: "https://auth.x.ai",
+            oidcClientId: "b1a00492-073a-47ea-816f-4c329264a828",
+            expiresAt: expiresAt,
+            createTime: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+}

--- a/Tests/CodexBarTests/GrokTokenRefresherTests.swift
+++ b/Tests/CodexBarTests/GrokTokenRefresherTests.swift
@@ -94,47 +94,6 @@ struct GrokTokenRefresherTests {
     }
 
     @Test
-    func `save merges refreshed tokens without dropping sibling scopes`() throws {
-        let home = FileManager.default.temporaryDirectory
-            .appendingPathComponent("GrokTokenRefresherTests-\(UUID().uuidString)")
-        let env = ["GROK_HOME": home.path]
-        let scope = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"
-        let existing = """
-        {"\(scope)":{"key":"old-access","refresh_token":"old-refresh","custom_field":"keep-me"},\
-        "https://accounts.x.ai/sign-in":{"key":"legacy-access"}}
-        """
-        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
-        try Data(existing.utf8).write(to: home.appendingPathComponent("auth.json"))
-
-        let now = Date(timeIntervalSince1970: 1_800_000_000)
-        try GrokCredentialsStore.save(
-            Self.credentials(
-                accessToken: "fresh-access",
-                refreshToken: "fresh-refresh",
-                expiresAt: now),
-            env: env)
-
-        let reloaded = try GrokCredentialsStore.load(env: env)
-        #expect(reloaded.accessToken == "fresh-access")
-        #expect(reloaded.refreshToken == "fresh-refresh")
-        #expect(reloaded.expiresAt == now)
-        #expect(reloaded.email == "user@example.com")
-        let raw = try JSONSerialization.jsonObject(
-            with: Data(contentsOf: home.appendingPathComponent("auth.json"))) as? [String: Any]
-        let entry = raw?[scope] as? [String: Any]
-        #expect(entry?["custom_field"] as? String == "keep-me")
-        #expect((raw?["https://accounts.x.ai/sign-in"] as? [String: Any])?["key"] as? String == "legacy-access")
-    }
-
-    @Test
-    func `refreshStoredCredentialsIfNeeded returns nil without an auth file`() async throws {
-        let env = ["GROK_HOME": FileManager.default.temporaryDirectory
-            .appendingPathComponent("GrokTokenRefresherTests-missing-\(UUID().uuidString)").path]
-        let result = try await GrokTokenRefresher.refreshStoredCredentialsIfNeeded(env: env)
-        #expect(result?.accessToken == nil)
-    }
-
-    @Test
     func `whitespace refresh token is rejected as missing`() async {
         let transport = ProviderHTTPTransportStub { _ in fatalError("must not send") }
         do {
@@ -168,79 +127,6 @@ struct GrokTokenRefresherTests {
 
         #expect(refreshed.isTeamPrincipal)
         #expect(refreshed.teamId == "team-id")
-    }
-
-    @Test
-    func `intervening login wins over stale refresh result`() async throws {
-        let home = FileManager.default.temporaryDirectory
-            .appendingPathComponent("GrokTokenRefresherTests-stale-\(UUID().uuidString)")
-        let env = ["GROK_HOME": home.path]
-        let authURL = home.appendingPathComponent("auth.json")
-        let scope = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"
-        try Self.writeAuthFile(
-            at: authURL,
-            scope: scope,
-            entry: [
-                "key": "a-access",
-                "refresh_token": "a-refresh",
-                "expires_at": "2020-01-01T00:00:00.000Z",
-            ])
-
-        let transport = ProviderHTTPTransportStub { request in
-            // Simulate `grok login` switching to account B mid-flight.
-            try Data(#"{"\#(scope)":{"key":"b-access"}}"#.utf8).write(to: authURL)
-            let url = try #require(request.url)
-            let response = try #require(HTTPURLResponse(
-                url: url,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil))
-            return (Data(#"{"access_token":"a-fresh","expires_in":3600}"#.utf8), response)
-        }
-
-        let result = try await GrokTokenRefresher.refreshStoredCredentialsIfNeeded(env: env, session: transport)
-        #expect(result?.accessToken == "b-access")
-        #expect(try GrokCredentialsStore.load(env: env).accessToken == "b-access")
-    }
-
-    @Test
-    func `removed auth file is not recreated by stale refresh`() async throws {
-        let home = FileManager.default.temporaryDirectory
-            .appendingPathComponent("GrokTokenRefresherTests-removed-\(UUID().uuidString)")
-        let env = ["GROK_HOME": home.path]
-        let authURL = home.appendingPathComponent("auth.json")
-        let scope = "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"
-        try Self.writeAuthFile(
-            at: authURL,
-            scope: scope,
-            entry: [
-                "key": "a-access",
-                "refresh_token": "a-refresh",
-                "expires_at": "2020-01-01T00:00:00.000Z",
-            ])
-
-        let transport = ProviderHTTPTransportStub { request in
-            try FileManager.default.removeItem(at: authURL)
-            let url = try #require(request.url)
-            let response = try #require(HTTPURLResponse(
-                url: url,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil))
-            return (Data(#"{"access_token":"a-fresh","expires_in":3600}"#.utf8), response)
-        }
-
-        let result = try await GrokTokenRefresher.refreshStoredCredentialsIfNeeded(env: env, session: transport)
-        #expect(result?.accessToken == nil)
-        #expect(!FileManager.default.fileExists(atPath: authURL.path))
-    }
-
-    private static func writeAuthFile(at url: URL, scope: String, entry: [String: String]) throws {
-        try FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(),
-            withIntermediateDirectories: true)
-        let data = try JSONSerialization.data(withJSONObject: [scope: entry])
-        try data.write(to: url)
     }
 
     private static func credentials(


### PR DESCRIPTION
Rotates expired Grok OIDC access tokens via the xAI refresh endpoint (pure refresh call plus a needsRefresh predicate with 5-min leeway).

Previously the parsed refresh token was never used, so expired logins just failed.

Ownership note: CodexBar deliberately does not write auth.json — the CLI remains the sole writer, so there is no cross-process write race by construction. Persistence and live fetch wiring are follow-ups once a CLI coordination contract exists.

Verified: GrokTokenRefresherTests 6/6, ProviderArchitectureGatekeeperTests 41/41, SwiftFormat/SwiftLint clean.