### PR TITLE
Fix locale-dependent billing and spend tests

### DIFF
--- a/Sources/CodexBar/ShareStatsPayload.swift
+++ b/Sources/CodexBar/ShareStatsPayload.swift
@@ -352,12 +352,11 @@ enum ShareStatsBuilder {
 enum ShareStatsFormatting {
     static func compactCount(_ value: Int) -> String {
         let magnitude = abs(Double(value))
-        let divisor: Double
-        let suffix: String
+        let (divisor, suffix): (Double, String)
         switch magnitude {
-        case 1_000_000_000...: divisor = 1_000_000_000; suffix = "B"
-        case 1_000_000...: divisor = 1_000_000; suffix = "M"
-        case 1000...: divisor = 1000; suffix = "K"
+        case 1_000_000_000...: (divisor, suffix) = (1_000_000_000, "B")
+        case 1_000_000...: (divisor, suffix) = (1_000_000, "M")
+        case 1000...: (divisor, suffix) = (1000, "K")
         default: return value.formatted(.number.grouping(.automatic))
         }
         let scaled = Double(value) / divisor

--- a/Tests/CodexBarTests/MiniMaxMenuCardBillingTests.swift
+++ b/Tests/CodexBarTests/MiniMaxMenuCardBillingTests.swift
@@ -65,9 +65,11 @@ struct MiniMaxMenuCardBillingTests {
             now: now))
 
         #expect(model.inlineUsageDashboard == nil)
-        #expect(model.providerDetails.last?.rows.first?.value == "1,234")
+        #expect(model.providerDetails.last?.rows.first?.value == 1234.formatted())
         #expect(model.providerDetails.last?.chart?.points.count == 2)
-        #expect(model.providerDetails.last?.rows.contains { $0.label == "30d tokens" && $0.value == "5,678" } == true)
+        #expect(model.providerDetails.last?.rows.contains {
+            $0.label == "30d tokens" && $0.value == 5678.formatted()
+        } == true)
 
         let hiddenModel = UsageMenuCardView.Model.make(.init(
             provider: .minimax,

--- a/Tests/CodexBarTests/OverviewSpendSummaryTests.swift
+++ b/Tests/CodexBarTests/OverviewSpendSummaryTests.swift
@@ -41,7 +41,7 @@ struct OverviewSpendSummaryTests {
 
         #expect(summary.primarySpendText == "~$759.56")
         #expect(summary.providerCoverageText == "3 of 4 subscriptions have spend")
-        #expect(summary.tokenText == "~15.7M tokens")
+        #expect(summary.tokenText == "~\(15.7.formatted())M tokens")
         #expect(summary.historyCoverageText == "Coverage: 30 / 30")
         #expect(summary.pricingCoverageText == "Priced 3 · Unpriced 1 · Unmetered 0 · Estimated 0")
         #expect(summary.provenanceText == "List-price equivalent")


### PR DESCRIPTION
MiniMax billing and Overview spend tests assumed US grouping and decimal separators even though the production formatting intentionally follows the current locale. A fresh Swedish test process reproduces all three reported assertion failures; a US control passes.

Keep the exact expected amounts, independently rounded 15.7M total, partial marker, suffix, units, and surrounding dashboard assertions. Derive only the expected number separators from Foundation, without calling the production compact-count helper to generate the expected total. Pair each existing compact-count divisor with its suffix in one tuple, preserving every threshold and removing one production line.

All 22 focused tests across MiniMaxMenuCardBillingTests, OverviewSpendSummaryTests, and ShareStatsTests pass in fresh Swedish and US processes using launch arguments -AppleLocale sv_SE/en_US and -AppleLanguages '(en)'. Locale identifiers and representative formatted values were verified in isolated child processes. No user preferences were changed. The full local suite passed all 1,028 selections across 86 groups on the first attempt, without retries, in 882.7 seconds. `make check` passes and independent review found no actionable P0–P2 findings. Exact-head CI run 34119529398 passed, including both macOS shards and all Linux builds.

Thanks @zucram for reporting the locale-dependent failures in the follow-up to #3359. Production display behavior is unchanged, so no user-facing changelog entry is needed.
