### PR TITLE
fix: let WidgetKit own usage content margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Codex local costs: reuse model pricing resolution across daily, project, and session report rows without changing token accounting, tariffs, or refresh cadence (#3476). Thanks @brzvsk!
 
 ### Fixed
+- Widgets: remove redundant outer padding from Usage, Switcher, History, and Metric views so WidgetKit alone controls their content margins (extracted from #3137). Thanks @iamenahs!
 - Kiro: route existing overage enrichment to the CLI profile’s supported region instead of always using US East; reject invalid profile ARNs before sending credentials and retain CLI fallback (#3359). Thanks @zucram!
 - Settings: observe rapid external config replacements and edits that restore earlier app-written contents, while keeping successful app writes out of the external-change sync path.
 - Local usage: honor the app’s Low Power Mode interval for automatic Codex catch-up passes in both usage and Spend Dashboard, while retaining manual acceleration and system thermal pauses.

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -45,7 +45,6 @@ struct CodexBarUsageWidgetView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
-        .padding(12)
     }
 }
 
@@ -75,7 +74,6 @@ struct CodexBarHistoryWidgetView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
-        .padding(12)
     }
 }
 
@@ -104,7 +102,6 @@ struct CodexBarCompactWidgetView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
-        .padding(12)
     }
 }
 
@@ -127,7 +124,6 @@ struct CodexBarSwitcherWidgetView: View {
                 self.emptyState
             }
         }
-        .padding(12)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .containerBackground(.fill.tertiary, for: .widget)
         .environment(\.widgetUsageShowsUsed, self.entry.snapshot.usageBarsShowUsed)
@@ -182,7 +178,6 @@ private struct CompactMetricView: View {
                 }
             }
         }
-        .padding(12)
     }
 }
 
@@ -464,7 +459,6 @@ private struct SmallUsageView: View {
                 balance
             }
         }
-        .padding(12)
     }
 }
 
@@ -501,7 +495,6 @@ private struct MediumUsageView: View {
                 balance
             }
         }
-        .padding(12)
     }
 }
 
@@ -557,7 +550,6 @@ private struct LargeUsageView: View {
                 currencyCode: self.entry.tokenUsage?.currencyCode)
                 .frame(height: 50)
         }
-        .padding(12)
     }
 }
 
@@ -800,7 +792,6 @@ private struct HistoryView: View {
                         currencyCode: token.currencyCode))
             }
         }
-        .padding(12)
     }
 }
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -35,6 +35,7 @@ also lets persistence integration tests count reload attempts without calling Wi
 
 ## Extension
 - `Sources/CodexBarWidget` contains timeline + views.
+- Usage, Switcher, History, and Metric widgets use WidgetKit's content margins; their views do not add a second outer inset.
 - `WidgetExtension/CodexBarWidgetExtension.xcodeproj` builds those sources as the packaged macOS WidgetKit app extension.
 - Keep data shape in sync with `WidgetSnapshot` in the main app.
 


### PR DESCRIPTION
Usage, History, Metric, and Switcher widgets added 12-point outer padding to WidgetKit's existing content margins. Switcher compounded that with the nested usage view's padding, wasting space in already narrow tiles.

Remove those nine padding modifiers and let WidgetKit own the content boundary. The existing provider chips, quota ordering, percentages, history, empty states, and internal spacing remain. Burn Down is unchanged. This extracts the concrete inset bug from #3137; its broader appearance and binding-quota design decision remains open. Thanks @iamenahs for identifying the issue and discussing the system-owned margin option.

Native proof uses Developer ID signed baseline and candidate extensions in macOS 26.5 WidgetKit, with five synthetic providers, identical quotas/credits/costs, and seven fixed history points. Both fresh fixture identities read the same persisted snapshot. Relative age labels continue advancing between captures. These are cropped native gallery captures, not headless ImageRenderer approximations. They show Small, Medium, and Large Switcher families; the preexisting five-provider chip wrapping is still visible and is not claimed fixed. Initial cached previews were discarded before the matched capture.

Before:

![Native WidgetKit baseline](https://github.com/user-attachments/assets/0b692052-277d-42ca-93f8-831260c1b100)

After:

![Native WidgetKit with system-owned margins](https://github.com/user-attachments/assets/b9dcbd41-fbfe-4bdf-8829-7dfd2131d6c7)

`make check` passes with zero violations. Independent P0–P2 review is clean. The full local suite passes all 1,031 selections across 86 groups on the first attempt, without retries or timeouts, in 937.6 seconds. After #3341 landed, a changelog-only conflict was resolved by retaining both entries. Widget source and documentation remain byte-identical to the tested candidate; the integration review is clean. Exact-head CI [34163165352](https://github.com/steipete/CodexBar/actions/runs/34163165352) passes all macOS tests, Linux builds, lint, and security checks on 1d37bb22f7c978653c20144aaf033da5830d7361. The earlier run was superseded by the main synchronization, with no test or assertion weakened. The patch removes nine production lines and updates the widget documentation and Unreleased changelog.
