### PR TITLE
test: anchor OpenCode Go history fixtures to local days

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoLocalUsageReader.swift
@@ -329,12 +329,8 @@ public struct OpenCodeGoLocalUsageReader: Sendable {
             let key = CostUsageScanner.CostUsageDayRange.dayKey(from: date)
             let trimmedModel = row.model.trimmingCharacters(in: .whitespacesAndNewlines)
             let model = trimmedModel.isEmpty ? Self.unknownModelName : trimmedModel
-            var dayTotals = totalsByModel[key] ?? [:]
-            var bucket = dayTotals[model] ?? (cost: 0, requestCount: 0)
-            bucket.cost += row.cost
-            bucket.requestCount += row.requestCount
-            dayTotals[model] = bucket
-            totalsByModel[key] = dayTotals
+            totalsByModel[key, default: [:]][model, default: (0, 0)].cost += row.cost
+            totalsByModel[key, default: [:]][model, default: (0, 0)].requestCount += row.requestCount
         }
 
         return totalsByModel.keys.sorted().compactMap { key in

--- a/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoLocalUsageReaderTests.swift
@@ -70,18 +70,22 @@ struct OpenCodeGoLocalUsageReaderTests {
 
         try Self.writeAuth(to: env.authURL)
         try Self.createDatabase(at: env.databaseURL)
-        // Expected keys below use the same device-local calendar convention as production.
+        // Fixed UTC hours can straddle local midnight, for example in Sydney.
+        let reference = Date(timeIntervalSince1970: TimeInterval(Self.ms("2026-03-06T15:00:00.000Z")) / 1000)
+        let currentDay = Calendar.current.startOfDay(for: reference)
+        let previousDay = try #require(Calendar.current.date(byAdding: .day, value: -1, to: currentDay))
+        let now = currentDay.addingTimeInterval(12 * 3600)
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-03-06T12:00:00.000Z"),
+            createdMs: Self.ms(currentDay.addingTimeInterval(3600)),
             cost: 3.0)
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-03-06T13:00:00.000Z"),
+            createdMs: Self.ms(currentDay.addingTimeInterval(2 * 3600)),
             cost: 1.5)
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-03-05T12:00:00.000Z"),
+            createdMs: Self.ms(previousDay.addingTimeInterval(3600)),
             cost: 6.0)
         try Self.insertMessage(
             databaseURL: env.databaseURL,
@@ -89,13 +93,10 @@ struct OpenCodeGoLocalUsageReaderTests {
             cost: 100.0)
 
         let reader = OpenCodeGoLocalUsageReader(authURL: env.authURL, databaseURL: env.databaseURL)
-        let now = Date(timeIntervalSince1970: TimeInterval(Self.ms("2026-03-06T15:00:00.000Z")) / 1000)
         let snapshot = try reader.fetch(now: now, historyDays: 30)
 
-        let previousDayKey = CostUsageScanner.CostUsageDayRange.dayKey(
-            from: Date(timeIntervalSince1970: TimeInterval(Self.ms("2026-03-05T12:00:00.000Z")) / 1000))
-        let currentDayKey = CostUsageScanner.CostUsageDayRange.dayKey(
-            from: Date(timeIntervalSince1970: TimeInterval(Self.ms("2026-03-06T12:00:00.000Z")) / 1000))
+        let previousDayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: previousDay)
+        let currentDayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: currentDay)
         #expect(snapshot.daily.map(\.date) == [previousDayKey, currentDayKey])
         #expect(snapshot.daily.first?.costUSD == 6.0)
         #expect(snapshot.daily.first?.requestCount == 1)
@@ -260,24 +261,26 @@ struct OpenCodeGoLocalUsageReaderTests {
 
         try Self.writeAuth(to: env.authURL)
         try Self.createDatabase(at: env.databaseURL)
+        let reference = Date(timeIntervalSince1970: TimeInterval(Self.ms("2026-03-06T15:00:00.000Z")) / 1000)
+        let day = Calendar.current.startOfDay(for: reference)
+        let now = day.addingTimeInterval(12 * 3600)
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-03-06T11:00:00.000Z"),
+            createdMs: Self.ms(day.addingTimeInterval(3600)),
             cost: 3.0,
             model: "claude-sonnet-4-5")
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-03-06T12:00:00.000Z"),
+            createdMs: Self.ms(day.addingTimeInterval(2 * 3600)),
             cost: 2.0,
             model: "gpt-5.1-codex")
         try Self.insertMessage(
             databaseURL: env.databaseURL,
-            createdMs: Self.ms("2026-03-06T13:00:00.000Z"),
+            createdMs: Self.ms(day.addingTimeInterval(3 * 3600)),
             cost: 1.0,
             model: "claude-sonnet-4-5")
 
         let reader = OpenCodeGoLocalUsageReader(authURL: env.authURL, databaseURL: env.databaseURL)
-        let now = Date(timeIntervalSince1970: TimeInterval(Self.ms("2026-03-06T15:00:00.000Z")) / 1000)
         let snapshot = try reader.fetch(now: now, historyDays: 30)
 
         #expect(snapshot.daily.count == 1)


### PR DESCRIPTION
Two OpenCode Go history tests failed in time zones such as Australia/Sydney: their fixed 11:00–13:00 UTC timestamps crossed local midnight even though the fixtures expected one day. Build same-day and previous-day fixture timestamps from local calendar boundaries, preserving every cost, request-count, and model assertion and the existing cross-midnight coverage.

Simplify the same daily aggregation loop to mutate dictionary buckets in place, removing four production lines while retaining per-row floating-point addition order and device-local day grouping. This is a test reliability fix and behavior-preserving cleanup; no user-visible accounting policy changes.

Validation: reproduced two failing tests under TZ=Australia/Sydney on the baseline; all 15 focused tests now pass independently in Australia/Sydney, UTC, and America/Los_Angeles. make check passed and independent P0–P2 review found no actionable defects. make test passed all 1,031 selections across 86 groups on the first pass, with zero retries or timeouts (867.4 seconds). Exact-head CI passed: https://github.com/steipete/CodexBar/actions/runs/34172821639. All local tests use isolated synthetic stores and suppress Keychain access.
