### PR TITLE
fix: share CLI login lifecycle and honor cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Codex local costs: reuse model pricing resolution across daily, project, and session report rows without changing token accounting, tariffs, or refresh cadence (#3476). Thanks @brzvsk!
 
 ### Fixed
+- CLI login: share Codex and Kiro process handling, stop cancelled logins and lingering children, and preserve bounded timeout output and device-flow progress.
 - Widgets: remove redundant outer padding from Usage, Switcher, History, and Metric views so WidgetKit alone controls their content margins (extracted from #3137). Thanks @iamenahs!
 - Copilot: resolve Enterprise sign-in identities on the configured host, keep equal user IDs on different hosts distinct, and skip public GitHub budget enrichment for Enterprise accounts (#3341). Thanks @Fletcher-Alderton!
 - Kiro: route existing overage enrichment to the CLI profile’s supported region instead of always using US East; reject invalid profile ARNs before sending credentials and retain CLI fallback (#3359). Thanks @zucram!

--- a/Sources/CodexBar/CLILoginRunner.swift
+++ b/Sources/CodexBar/CLILoginRunner.swift
@@ -1,0 +1,123 @@
+import CodexBarCore
+import Darwin
+import Foundation
+
+/// Owns the lifecycle of CLI logins that wait for browser approval and retain diagnostic output on failure.
+enum CLILoginRunner {
+    struct Result: Equatable, Sendable {
+        enum Outcome: Equatable, Sendable {
+            case success
+            case cancelled
+            case timedOut
+            case failed(status: Int32)
+            case missingBinary
+            case launchFailed(String)
+        }
+
+        let outcome: Outcome
+        let output: String
+    }
+
+    static func run(
+        executable: String?,
+        environment: [String: String],
+        timeout: TimeInterval,
+        outputDrainTimeout: TimeInterval,
+        onProgress: (@Sendable (String) -> Void)? = nil) async -> Result
+    {
+        guard !Task.isCancelled else { return Result(outcome: .cancelled, output: "") }
+        guard let executable else { return Result(outcome: .missingBinary, output: "") }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [executable, "login"]
+        process.environment = environment
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        let stdoutCapture = ProcessPipeCapture(pipe: stdout)
+        let stderrCapture = ProcessPipeCapture(pipe: stderr)
+        defer {
+            stdoutCapture.stop()
+            stderrCapture.stop()
+            try? stdout.fileHandleForWriting.close()
+            try? stderr.fileHandleForWriting.close()
+        }
+
+        let termination = ProcessTermination()
+        process.terminationHandler = { process in
+            termination.resolve(process.terminationStatus)
+        }
+        do {
+            try process.run()
+        } catch {
+            process.terminationHandler = nil
+            return Result(outcome: .launchFailed(error.localizedDescription), output: "")
+        }
+        let pid = process.processIdentifier
+        let processGroup: pid_t? = setpgid(pid, pid) == 0 ? pid : nil
+        stdoutCapture.start()
+        stderrCapture.start()
+
+        let progressTask = onProgress.map { onProgress in
+            Task {
+                await self.pollProgress(stdout: stdoutCapture, stderr: stderrCapture, onProgress: onProgress)
+            }
+        }
+        let exitTask = Task<Int32, Error> { await termination.wait() }
+        let join = BoundedTaskJoin(sourceTask: exitTask)
+        let outcome: Result.Outcome
+        switch await join.value(joinGrace: self.duration(timeout)) {
+        case let .value(status):
+            outcome = status == 0 ? .success : .failed(status: status)
+        case .failure:
+            outcome = .cancelled
+            SubprocessRunner.terminateProcess(process, processGroup: processGroup)
+        case .timedOut:
+            outcome = .timedOut
+            SubprocessRunner.terminateProcess(process, processGroup: processGroup)
+        }
+        progressTask?.cancel()
+        await progressTask?.value
+
+        async let outData = stdoutCapture.finish(timeout: self.duration(outputDrainTimeout))
+        async let errData = stderrCapture.finish(timeout: self.duration(outputDrainTimeout))
+        let output = await self.combinedOutput(stdout: outData, stderr: errData)
+        return Result(outcome: outcome, output: output.isEmpty ? L("No output captured.") : String(output.prefix(4000)))
+    }
+
+    private static func duration(_ timeout: TimeInterval) -> Duration {
+        // Bound before converting floating-point seconds; infinity and rounded integer limits must not trap.
+        let maximumSeconds = Double(Int64.max / 1_000_000_000)
+        return .seconds(timeout.isFinite ? max(0, min(timeout, maximumSeconds)) : maximumSeconds)
+    }
+
+    private static func combinedOutput(stdout: Data, stderr: Data) -> String {
+        let out = ProcessPipeCapture.decodeUTF8(stdout)
+        let err = ProcessPipeCapture.decodeUTF8(stderr)
+        let merged = out.isEmpty || err.isEmpty ? out + err : out + "\n" + err
+        return merged.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func pollProgress(
+        stdout: ProcessPipeCapture,
+        stderr: ProcessPipeCapture,
+        onProgress: @escaping @Sendable (String) -> Void) async
+    {
+        while !Task.isCancelled {
+            let output = self.combinedOutput(stdout: stdout.currentSnapshot(), stderr: stderr.currentSnapshot())
+            if output.contains("http://") || output.contains("https://") {
+                guard !Task.isCancelled else { return }
+                onProgress(output)
+                return
+            }
+            do {
+                try await Task.sleep(for: .milliseconds(500))
+            } catch {
+                return
+            }
+        }
+    }
+}

--- a/Sources/CodexBar/CodexLoginAlertPresentation.swift
+++ b/Sources/CodexBar/CodexLoginAlertPresentation.swift
@@ -6,9 +6,9 @@ struct CodexLoginAlertInfo: Equatable {
 }
 
 enum CodexLoginAlertPresentation {
-    static func alertInfo(for result: CodexLoginRunner.Result) -> CodexLoginAlertInfo? {
+    static func alertInfo(for result: CLILoginRunner.Result) -> CodexLoginAlertInfo? {
         switch result.outcome {
-        case .success:
+        case .success, .cancelled:
             return nil
         case .missingBinary:
             return CodexLoginAlertInfo(
@@ -27,7 +27,7 @@ enum CodexLoginAlertPresentation {
         }
     }
 
-    static func managedLoginFailureMessage(for result: CodexLoginRunner.Result) -> String {
+    static func managedLoginFailureMessage(for result: CLILoginRunner.Result) -> String {
         let baseMessage = L("managed_login_failed")
         guard let info = self.alertInfo(for: result) else { return baseMessage }
         return "\(baseMessage)\n\n\(L("codex_login_output"))\n\(info.message)"

--- a/Sources/CodexBar/CodexLoginRunner.swift
+++ b/Sources/CodexBar/CodexLoginRunner.swift
@@ -1,193 +1,25 @@
 import CodexBarCore
-import Darwin
 import Foundation
 
-struct CodexLoginRunner {
-    struct Result: Equatable {
-        enum Outcome: Equatable {
-            case success
-            case timedOut
-            case failed(status: Int32)
-            case missingBinary
-            case launchFailed(String)
-        }
-
-        let outcome: Outcome
-        let output: String
-    }
-
+enum CodexLoginRunner {
     static func run(
         homePath: String? = nil,
         timeout: TimeInterval = 120,
         outputDrainTimeout: TimeInterval = 3,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        loginPATH: [String]? = LoginShellPathCache.shared.current) async -> Result
+        loginPATH: [String]? = LoginShellPathCache.shared.current) async -> CLILoginRunner.Result
     {
-        await Task(priority: .userInitiated) {
-            var env = environment
-            env["PATH"] = PathBuilder.effectivePATH(
-                purposes: [.rpc, .tty, .nodeTooling],
-                env: env,
-                loginPATH: loginPATH)
-            env = CodexHomeScope.scopedEnvironment(base: env, codexHome: homePath)
+        var env = environment
+        env["PATH"] = PathBuilder.effectivePATH(
+            purposes: [.rpc, .tty, .nodeTooling],
+            env: env,
+            loginPATH: loginPATH)
+        env = CodexHomeScope.scopedEnvironment(base: env, codexHome: homePath)
 
-            guard let executable = BinaryLocator.resolveCodexBinary(
-                env: env,
-                loginPATH: loginPATH)
-            else {
-                return Result(outcome: .missingBinary, output: "")
-            }
-
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = [executable, "login"]
-            process.environment = env
-
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
-            let stdoutCapture = ProcessPipeCapture(pipe: stdout)
-            let stderrCapture = ProcessPipeCapture(pipe: stderr)
-
-            let termination = ProcessTermination()
-            process.terminationHandler = { _ in
-                termination.resolve(timedOut: false)
-            }
-
-            var processGroup: pid_t?
-            do {
-                try process.run()
-                processGroup = self.attachProcessGroup(process)
-            } catch {
-                return Result(outcome: .launchFailed(error.localizedDescription), output: "")
-            }
-            stdoutCapture.start()
-            stderrCapture.start()
-
-            let timedOut = await self.wait(timeout: timeout, termination: termination)
-            if timedOut {
-                self.terminate(process, processGroup: processGroup)
-            }
-
-            let output = await self.combinedOutput(
-                stdout: stdoutCapture,
-                stderr: stderrCapture,
-                timeout: outputDrainTimeout)
-            if timedOut {
-                return Result(outcome: .timedOut, output: output)
-            }
-
-            let status = process.terminationStatus
-            if status == 0 {
-                return Result(outcome: .success, output: output)
-            }
-            return Result(outcome: .failed(status: status), output: output)
-        }.value
-    }
-
-    private final class ProcessTermination: @unchecked Sendable {
-        private let lock = NSLock()
-        private var timedOut: Bool?
-        private var continuation: CheckedContinuation<Bool, Never>?
-
-        func resolve(timedOut: Bool) {
-            let continuation: CheckedContinuation<Bool, Never>?
-            self.lock.lock()
-            guard self.timedOut == nil else {
-                self.lock.unlock()
-                return
-            }
-            self.timedOut = timedOut
-            continuation = self.continuation
-            self.continuation = nil
-            self.lock.unlock()
-            continuation?.resume(returning: timedOut)
-        }
-
-        func wait() async -> Bool {
-            await withCheckedContinuation { continuation in
-                let timedOut: Bool?
-                self.lock.lock()
-                timedOut = self.timedOut
-                if timedOut == nil {
-                    self.continuation = continuation
-                }
-                self.lock.unlock()
-
-                if let timedOut {
-                    continuation.resume(returning: timedOut)
-                }
-            }
-        }
-    }
-
-    private static func wait(timeout: TimeInterval, termination: ProcessTermination) async -> Bool {
-        let timeoutTask = Task.detached(priority: .userInitiated) {
-            try? await Task.sleep(nanoseconds: self.timeoutNanoseconds(timeout))
-            if Task.isCancelled == false {
-                termination.resolve(timedOut: true)
-            }
-        }
-        let timedOut = await termination.wait()
-        timeoutTask.cancel()
-        return timedOut
-    }
-
-    private static func timeoutNanoseconds(_ timeout: TimeInterval) -> UInt64 {
-        guard timeout.isFinite else { return UInt64.max }
-        let seconds = max(0, min(timeout, Double(UInt64.max) / 1_000_000_000))
-        return UInt64(seconds * 1_000_000_000)
-    }
-
-    private static func terminate(_ process: Process, processGroup: pid_t?) {
-        if let pgid = processGroup {
-            kill(-pgid, SIGTERM)
-        }
-        if process.isRunning {
-            process.terminate()
-        }
-
-        let deadline = Date().addingTimeInterval(2.0)
-        while process.isRunning, Date() < deadline {
-            usleep(100_000)
-        }
-
-        if process.isRunning {
-            if let pgid = processGroup {
-                kill(-pgid, SIGKILL)
-            }
-            kill(process.processIdentifier, SIGKILL)
-        }
-    }
-
-    private static func attachProcessGroup(_ process: Process) -> pid_t? {
-        let pid = process.processIdentifier
-        return setpgid(pid, pid) == 0 ? pid : nil
-    }
-
-    private static func combinedOutput(
-        stdout: ProcessPipeCapture,
-        stderr: ProcessPipeCapture,
-        timeout: TimeInterval) async -> String
-    {
-        let drainTimeout = Duration.seconds(max(0, timeout))
-        async let outData = stdout.finish(timeout: drainTimeout)
-        async let errData = stderr.finish(timeout: drainTimeout)
-        let out = await self.decode(outData)
-        let err = await self.decode(errData)
-
-        let merged: String = if !out.isEmpty, !err.isEmpty {
-            [out, err].joined(separator: "\n")
-        } else {
-            out + err
-        }
-        let trimmed = merged.trimmingCharacters(in: .whitespacesAndNewlines)
-        let limited = trimmed.prefix(4000)
-        return limited.isEmpty ? L("No output captured.") : String(limited)
-    }
-
-    private static func decode(_ data: Data) -> String {
-        ProcessPipeCapture.decodeUTF8(data)
+        return await CLILoginRunner.run(
+            executable: BinaryLocator.resolveCodexBinary(env: env, loginPATH: loginPATH),
+            environment: env,
+            timeout: timeout,
+            outputDrainTimeout: outputDrainTimeout)
     }
 }

--- a/Sources/CodexBar/ManagedCodexAccountService.swift
+++ b/Sources/CodexBar/ManagedCodexAccountService.swift
@@ -8,7 +8,7 @@ protocol ManagedCodexHomeProducing: Sendable {
 }
 
 protocol ManagedCodexLoginRunning: Sendable {
-    func run(homePath: String, timeout: TimeInterval) async -> CodexLoginRunner.Result
+    func run(homePath: String, timeout: TimeInterval) async -> CLILoginRunner.Result
 }
 
 protocol ManagedCodexIdentityReading: Sendable {
@@ -35,7 +35,7 @@ protocol ManagedCodexWorkspaceSelecting: Sendable {
 }
 
 enum ManagedCodexAccountServiceError: Error, Equatable {
-    case loginFailed(CodexLoginRunner.Result)
+    case loginFailed(CLILoginRunner.Result)
     case missingEmail
     case workspaceSelectionCancelled
     case unsafeManagedHome(String)
@@ -92,7 +92,7 @@ struct ManagedCodexHomeFactory: ManagedCodexHomeProducing {
 }
 
 struct DefaultManagedCodexLoginRunner: ManagedCodexLoginRunning {
-    func run(homePath: String, timeout: TimeInterval) async -> CodexLoginRunner.Result {
+    func run(homePath: String, timeout: TimeInterval) async -> CLILoginRunner.Result {
         await CodexLoginRunner.run(homePath: homePath, timeout: timeout)
     }
 }

--- a/Sources/CodexBar/PreferencesCodexAccountsSection.swift
+++ b/Sources/CodexBar/PreferencesCodexAccountsSection.swift
@@ -2,11 +2,11 @@ import Foundation
 import SwiftUI
 
 protocol CodexAmbientLoginRunning: Sendable {
-    func run(timeout: TimeInterval) async -> CodexLoginRunner.Result
+    func run(timeout: TimeInterval) async -> CLILoginRunner.Result
 }
 
 struct DefaultCodexAmbientLoginRunner: CodexAmbientLoginRunning {
-    func run(timeout: TimeInterval) async -> CodexLoginRunner.Result {
+    func run(timeout: TimeInterval) async -> CLILoginRunner.Result {
         await CodexLoginRunner.run(timeout: timeout)
     }
 }

--- a/Sources/CodexBar/Providers/Kiro/KiroLoginAlertPresentation.swift
+++ b/Sources/CodexBar/Providers/Kiro/KiroLoginAlertPresentation.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 enum KiroLoginAlertPresentation {
-    static func alertInfo(for result: KiroLoginRunner.Result) -> CodexLoginAlertInfo? {
+    static func alertInfo(for result: CLILoginRunner.Result) -> CodexLoginAlertInfo? {
         switch result.outcome {
-        case .success:
+        case .success, .cancelled:
             return nil
         case .missingBinary:
             return CodexLoginAlertInfo(

--- a/Sources/CodexBar/Providers/Kiro/KiroLoginRunner.swift
+++ b/Sources/CodexBar/Providers/Kiro/KiroLoginRunner.swift
@@ -1,226 +1,25 @@
 import CodexBarCore
-import Darwin
 import Foundation
 
-/// Spawns `kiro-cli login`, which opens a browser OAuth flow and blocks until it completes.
-/// Mirrors ``CodexLoginRunner`` — same subprocess-lifecycle shape as `codex login`.
-struct KiroLoginRunner {
-    struct Result: Equatable {
-        enum Outcome: Equatable {
-            case success
-            case timedOut
-            case failed(status: Int32)
-            case missingBinary
-            case launchFailed(String)
-        }
-
-        let outcome: Outcome
-        let output: String
-    }
-
-    /// Polling cadence while the login subprocess is still running, used to surface a
-    /// device-flow URL/code before the process exits (`kiro-cli login` prints them, then blocks
-    /// while polling for the browser approval).
-    private static let progressPollInterval: TimeInterval = 0.5
-
+enum KiroLoginRunner {
     static func run(
         timeout: TimeInterval = 120,
         outputDrainTimeout: TimeInterval = 3,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         loginPATH: [String]? = LoginShellPathCache.shared.current,
-        onProgress: (@Sendable (String) -> Void)? = nil) async -> Result
+        onProgress: (@Sendable (String) -> Void)? = nil) async -> CLILoginRunner.Result
     {
-        await Task(priority: .userInitiated) {
-            var env = environment
-            env["PATH"] = PathBuilder.effectivePATH(
-                purposes: [.rpc, .tty, .nodeTooling],
-                env: env,
-                loginPATH: loginPATH)
+        var env = environment
+        env["PATH"] = PathBuilder.effectivePATH(
+            purposes: [.rpc, .tty, .nodeTooling],
+            env: env,
+            loginPATH: loginPATH)
 
-            guard let executable = BinaryLocator.resolveKiroCLIBinary(env: env, loginPATH: loginPATH) else {
-                return Result(outcome: .missingBinary, output: "")
-            }
-
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = [executable, "login"]
-            process.environment = env
-
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
-            let stdoutCapture = ProcessPipeCapture(pipe: stdout)
-            let stderrCapture = ProcessPipeCapture(pipe: stderr)
-
-            let termination = ProcessTermination()
-            process.terminationHandler = { _ in
-                termination.resolve(timedOut: false)
-            }
-
-            var processGroup: pid_t?
-            do {
-                try process.run()
-                processGroup = self.attachProcessGroup(process)
-            } catch {
-                return Result(outcome: .launchFailed(error.localizedDescription), output: "")
-            }
-            stdoutCapture.start()
-            stderrCapture.start()
-
-            let progressTask = onProgress.map { onProgress in
-                Task.detached(priority: .userInitiated) {
-                    await Self.pollProgress(
-                        stdout: stdoutCapture,
-                        stderr: stderrCapture,
-                        interval: self.progressPollInterval,
-                        onProgress: onProgress)
-                }
-            }
-
-            let timedOut = await self.wait(timeout: timeout, termination: termination)
-            progressTask?.cancel()
-            if timedOut {
-                self.terminate(process, processGroup: processGroup)
-            }
-
-            let output = await self.combinedOutput(
-                stdout: stdoutCapture,
-                stderr: stderrCapture,
-                timeout: outputDrainTimeout)
-            if timedOut {
-                return Result(outcome: .timedOut, output: output)
-            }
-
-            let status = process.terminationStatus
-            if status == 0 {
-                return Result(outcome: .success, output: output)
-            }
-            return Result(outcome: .failed(status: status), output: output)
-        }.value
-    }
-
-    private final class ProcessTermination: @unchecked Sendable {
-        private let lock = NSLock()
-        private var timedOut: Bool?
-        private var continuation: CheckedContinuation<Bool, Never>?
-
-        func resolve(timedOut: Bool) {
-            let continuation: CheckedContinuation<Bool, Never>?
-            self.lock.lock()
-            guard self.timedOut == nil else {
-                self.lock.unlock()
-                return
-            }
-            self.timedOut = timedOut
-            continuation = self.continuation
-            self.continuation = nil
-            self.lock.unlock()
-            continuation?.resume(returning: timedOut)
-        }
-
-        func wait() async -> Bool {
-            await withCheckedContinuation { continuation in
-                let timedOut: Bool?
-                self.lock.lock()
-                timedOut = self.timedOut
-                if timedOut == nil {
-                    self.continuation = continuation
-                }
-                self.lock.unlock()
-
-                if let timedOut {
-                    continuation.resume(returning: timedOut)
-                }
-            }
-        }
-    }
-
-    private static func wait(timeout: TimeInterval, termination: ProcessTermination) async -> Bool {
-        let timeoutTask = Task.detached(priority: .userInitiated) {
-            try? await Task.sleep(nanoseconds: self.timeoutNanoseconds(timeout))
-            if Task.isCancelled == false {
-                termination.resolve(timedOut: true)
-            }
-        }
-        let timedOut = await termination.wait()
-        timeoutTask.cancel()
-        return timedOut
-    }
-
-    private static func timeoutNanoseconds(_ timeout: TimeInterval) -> UInt64 {
-        guard timeout.isFinite else { return UInt64.max }
-        let seconds = max(0, min(timeout, Double(UInt64.max) / 1_000_000_000))
-        return UInt64(seconds * 1_000_000_000)
-    }
-
-    private static func terminate(_ process: Process, processGroup: pid_t?) {
-        if let pgid = processGroup {
-            kill(-pgid, SIGTERM)
-        }
-        if process.isRunning {
-            process.terminate()
-        }
-
-        let deadline = Date().addingTimeInterval(2.0)
-        while process.isRunning, Date() < deadline {
-            usleep(100_000)
-        }
-
-        if process.isRunning {
-            if let pgid = processGroup {
-                kill(-pgid, SIGKILL)
-            }
-            kill(process.processIdentifier, SIGKILL)
-        }
-    }
-
-    private static func attachProcessGroup(_ process: Process) -> pid_t? {
-        let pid = process.processIdentifier
-        return setpgid(pid, pid) == 0 ? pid : nil
-    }
-
-    private static func combinedOutput(
-        stdout: ProcessPipeCapture,
-        stderr: ProcessPipeCapture,
-        timeout: TimeInterval) async -> String
-    {
-        let drainTimeout = Duration.seconds(max(0, timeout))
-        async let outData = stdout.finish(timeout: drainTimeout)
-        async let errData = stderr.finish(timeout: drainTimeout)
-        let out = await self.decode(outData)
-        let err = await self.decode(errData)
-
-        let merged: String = if !out.isEmpty, !err.isEmpty {
-            [out, err].joined(separator: "\n")
-        } else {
-            out + err
-        }
-        let trimmed = merged.trimmingCharacters(in: .whitespacesAndNewlines)
-        let limited = trimmed.prefix(4000)
-        return limited.isEmpty ? L("No output captured.") : String(limited)
-    }
-
-    private static func decode(_ data: Data) -> String {
-        ProcessPipeCapture.decodeUTF8(data)
-    }
-
-    /// Polls the still-running subprocess's pipes for a device-flow URL/code and reports it once,
-    /// so the UI can show it before the timeout kills a login that's waiting on browser approval.
-    private static func pollProgress(
-        stdout: ProcessPipeCapture,
-        stderr: ProcessPipeCapture,
-        interval: TimeInterval,
-        onProgress: @escaping @Sendable (String) -> Void) async
-    {
-        while !Task.isCancelled {
-            let combined = self.decode(stdout.currentSnapshot()) + self.decode(stderr.currentSnapshot())
-            let trimmed = combined.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.contains("http://") || trimmed.contains("https://") {
-                onProgress(trimmed)
-                return
-            }
-            try? await Task.sleep(nanoseconds: UInt64(max(0, interval) * 1_000_000_000))
-        }
+        return await CLILoginRunner.run(
+            executable: BinaryLocator.resolveKiroCLIBinary(env: env, loginPATH: loginPATH),
+            environment: env,
+            timeout: timeout,
+            outputDrainTimeout: outputDrainTimeout,
+            onProgress: onProgress)
     }
 }

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -738,7 +738,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         }
     }
 
-    func presentCodexLoginResult(_ result: CodexLoginRunner.Result) {
+    func presentCodexLoginResult(_ result: CLILoginRunner.Result) {
         guard let info = CodexLoginAlertPresentation.alertInfo(for: result) else { return }
         self.presentLoginAlert(title: info.title, message: info.message)
     }
@@ -780,9 +780,10 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         }
     }
 
-    func describe(_ outcome: CodexLoginRunner.Result.Outcome) -> String {
+    func describe(_ outcome: CLILoginRunner.Result.Outcome) -> String {
         switch outcome {
         case .success: "success"
+        case .cancelled: "cancelled"
         case .timedOut: "timedOut"
         case let .failed(status): "failed(status: \(status))"
         case .missingBinary: "missingBinary"

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -215,7 +215,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var _test_openMenuRebuildObserver: (@MainActor (NSMenu) -> Void)?
     var _test_providerSwitcherMenuRebuildDebounceNanoseconds: UInt64?
     var _test_codexAmbientLoginRunnerOverride:
-        (@MainActor (TimeInterval) async -> CodexLoginRunner.Result)?
+        (@MainActor (TimeInterval) async -> CLILoginRunner.Result)?
     #endif
     var manualRefreshViewportRestoreState = ManualRefreshViewportRestoreState()
     var blinkTask: Task<Void, Never>?

--- a/Sources/CodexBarCore/Host/Process/ProcessTermination.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessTermination.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+package final class ProcessTermination: @unchecked Sendable {
+    private let lock = NSLock()
+    private var status: Int32?
+    private var continuation: CheckedContinuation<Int32, Never>?
+
+    package init() {}
+
+    package func resolve(_ status: Int32) {
+        let continuation: CheckedContinuation<Int32, Never>?
+        self.lock.lock()
+        self.status = status
+        continuation = self.continuation
+        self.continuation = nil
+        self.lock.unlock()
+        continuation?.resume(returning: status)
+    }
+
+    package func wait() async -> Int32 {
+        await withCheckedContinuation { continuation in
+            let status: Int32?
+            self.lock.lock()
+            status = self.status
+            if status == nil {
+                self.continuation = continuation
+            }
+            self.lock.unlock()
+
+            if let status {
+                continuation.resume(returning: status)
+            }
+        }
+    }
+}

--- a/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
+++ b/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
@@ -80,38 +80,6 @@ public enum SubprocessRunner {
         return .nanoseconds(Int(nanoseconds))
     }
 
-    private final class ProcessTermination: @unchecked Sendable {
-        private let lock = NSLock()
-        private var status: Int32?
-        private var continuation: CheckedContinuation<Int32, Never>?
-
-        func resolve(_ status: Int32) {
-            let continuation: CheckedContinuation<Int32, Never>?
-            self.lock.lock()
-            self.status = status
-            continuation = self.continuation
-            self.continuation = nil
-            self.lock.unlock()
-            continuation?.resume(returning: status)
-        }
-
-        func wait() async -> Int32 {
-            await withCheckedContinuation { continuation in
-                let status: Int32?
-                self.lock.lock()
-                status = self.status
-                if status == nil {
-                    self.continuation = continuation
-                }
-                self.lock.unlock()
-
-                if let status {
-                    continuation.resume(returning: status)
-                }
-            }
-        }
-    }
-
     /// Terminates a process and its process group, escalating from SIGTERM to SIGKILL.
     /// Returns `true` if the process was actually killed, `false` if it had already exited.
     @discardableResult

--- a/Tests/CodexBarTests/CLILoginRunnerTests.swift
+++ b/Tests/CodexBarTests/CLILoginRunnerTests.swift
@@ -1,0 +1,153 @@
+import Darwin
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite(.serialized)
+struct CLILoginRunnerTests {
+    @Test(arguments: [false, true])
+    func `cancelling a provider login stops its process`(kiro: Bool) async throws {
+        let fixture = try Fixture(script: """
+        #!/bin/sh
+        printf '%s' "$$" > "$LOGIN_PID_FILE"
+        printf 'login-started\\n'
+        exec /bin/sleep 20
+        """, binaryName: kiro ? "kiro-cli" : "codex")
+        defer { fixture.remove() }
+        let task = Task {
+            if kiro {
+                return await KiroLoginRunner.run(
+                    timeout: 10, environment: fixture.environment, loginPATH: nil)
+            }
+            return await CodexLoginRunner.run(
+                homePath: fixture.root.path, timeout: 10, environment: fixture.environment, loginPATH: nil)
+        }
+        defer { task.cancel() }
+        let pid = try await fixture.waitForPID()
+        let start = Date()
+        task.cancel()
+        let result = await task.value
+        #expect(result.outcome == .cancelled)
+        #expect(Date().timeIntervalSince(start) < 2)
+        #expect(kill(pid, 0) == -1 && errno == ESRCH)
+        #expect(CodexLoginAlertPresentation.alertInfo(for: result) == nil)
+        #expect(KiroLoginAlertPresentation.alertInfo(for: result) == nil)
+    }
+
+    @Test
+    func `already cancelled login never launches the executable`() async throws {
+        let fixture = try Fixture(script: "#!/bin/sh\nprintf '%s' \"$$\" > \"$LOGIN_PID_FILE\"\n")
+        defer { fixture.remove() }
+        let result = await Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await fixture.run()
+        }.value
+        #expect(result.outcome == .cancelled)
+        #expect(!FileManager.default.fileExists(atPath: fixture.pidFile.path))
+    }
+
+    @Test(arguments: [0, 7])
+    func `completed login preserves status and both output streams`(exitCode: Int) async throws {
+        let fixture = try Fixture(script: """
+        #!/bin/sh
+        printf 'stdout-message'
+        printf 'stderr-message' >&2
+        exit \(exitCode)
+        """)
+        defer { fixture.remove() }
+        let result = await fixture.run()
+        #expect(result.outcome == (exitCode == 0 ? .success : .failed(status: Int32(exitCode))))
+        #expect(result.output == "stdout-message\nstderr-message")
+    }
+
+    @Test
+    func `Codex login retains its requested home and login argument`() async throws {
+        let fixture = try Fixture(
+            script: "#!/bin/sh\nprintf '%s\\n%s' \"$CODEX_HOME\" \"$1\"\n", binaryName: "codex")
+        defer { fixture.remove() }
+        let result = await CodexLoginRunner.run(
+            homePath: fixture.root.path,
+            environment: fixture.environment,
+            loginPATH: nil)
+        #expect(result.outcome == .success)
+        #expect(result.output == "\(fixture.root.path)\nlogin")
+    }
+
+    @Test(arguments: [Double.infinity, Double.greatestFiniteMagnitude])
+    func `large login timeouts do not trap`(timeout: Double) async throws {
+        let fixture = try Fixture(script: "#!/bin/sh\nprintf 'done'\n")
+        defer { fixture.remove() }
+        let result = await fixture.run(timeout: timeout, outputDrainTimeout: timeout)
+        #expect(result.outcome == .success)
+        #expect(result.output == "done")
+    }
+
+    @Test
+    func `timeout removes a child that ignores termination`() async throws {
+        let fixture = try Fixture(script: """
+        #!/bin/sh
+        /bin/sh -c 'trap "" TERM; while :; do /bin/sleep 1; done' &
+        printf '%s' "$!" > "$LOGIN_PID_FILE"
+        printf 'login-started\\n'
+        wait
+        """)
+        defer { fixture.remove() }
+        let task = Task { await fixture.run(timeout: 5) }
+        let childPID = try await fixture.waitForPID()
+        let result = await task.value
+        #expect(result.outcome == .timedOut)
+        #expect(result.output.contains("login-started"))
+        // A reparented child can briefly remain a zombie until launchd reaps it.
+        let deadline = Date().addingTimeInterval(2)
+        while kill(childPID, 0) == 0, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(kill(childPID, 0) == -1 && errno == ESRCH)
+    }
+
+    private struct Fixture: Sendable {
+        let root: URL
+        let executable: URL
+        let pidFile: URL
+
+        var environment: [String: String] {
+            ["PATH": self.root.path, "LOGIN_PID_FILE": self.pidFile.path]
+        }
+
+        init(script: String, binaryName: String = "login-fixture") throws {
+            self.root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("codexbar-cli-login-\(UUID().uuidString)", isDirectory: true)
+            self.executable = self.root.appendingPathComponent(binaryName)
+            self.pidFile = self.root.appendingPathComponent("login.pid")
+            try FileManager.default.createDirectory(at: self.root, withIntermediateDirectories: true)
+            try script.write(to: self.executable, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: self.executable.path)
+        }
+
+        func run(timeout: TimeInterval = 5, outputDrainTimeout: TimeInterval = 0.5) async -> CLILoginRunner.Result {
+            await CLILoginRunner.run(
+                executable: self.executable.path,
+                environment: self.environment,
+                timeout: timeout,
+                outputDrainTimeout: outputDrainTimeout)
+        }
+
+        func waitForPID() async throws -> pid_t {
+            let deadline = Date().addingTimeInterval(10)
+            while Date() < deadline {
+                if let text = try? String(contentsOf: self.pidFile, encoding: .utf8), let pid = pid_t(text) {
+                    return pid
+                }
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            throw CocoaError(.fileReadUnknown)
+        }
+
+        func remove() {
+            if let text = try? String(contentsOf: self.pidFile, encoding: .utf8), let pid = pid_t(text) {
+                kill(pid, SIGKILL)
+            }
+            try? FileManager.default.removeItem(at: self.root)
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodexAccountsSettingsSectionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountsSettingsSectionTests.swift
@@ -279,7 +279,7 @@ struct CodexAccountsSettingsSectionTests {
 
     @Test
     func `managed codex login failure message includes codex login output`() {
-        let error = ManagedCodexAccountServiceError.loginFailed(CodexLoginRunner.Result(
+        let error = ManagedCodexAccountServiceError.loginFailed(CLILoginRunner.Result(
             outcome: .failed(status: 2),
             output: "Browser selected the existing ChatGPT account"))
 
@@ -401,22 +401,22 @@ private struct TestManagedCodexHomeFactoryForSettingsSectionTests: ManagedCodexH
 }
 
 private struct StubManagedCodexLoginRunnerForSettingsSectionTests: ManagedCodexLoginRunning {
-    let result: CodexLoginRunner.Result
+    let result: CLILoginRunner.Result
 
-    func run(homePath _: String, timeout _: TimeInterval) async -> CodexLoginRunner.Result {
+    func run(homePath _: String, timeout _: TimeInterval) async -> CLILoginRunner.Result {
         self.result
     }
 
     static let success = StubManagedCodexLoginRunnerForSettingsSectionTests(
-        result: CodexLoginRunner.Result(outcome: .success, output: "ok"))
+        result: CLILoginRunner.Result(outcome: .success, output: "ok"))
 }
 
 private actor BlockingManagedCodexLoginRunnerForSettingsSectionTests: ManagedCodexLoginRunning {
-    private var waiters: [CheckedContinuation<CodexLoginRunner.Result, Never>] = []
+    private var waiters: [CheckedContinuation<CLILoginRunner.Result, Never>] = []
     private var startedWaiters: [CheckedContinuation<Void, Never>] = []
     private var didStart = false
 
-    func run(homePath _: String, timeout _: TimeInterval) async -> CodexLoginRunner.Result {
+    func run(homePath _: String, timeout _: TimeInterval) async -> CLILoginRunner.Result {
         self.didStart = true
         self.startedWaiters.forEach { $0.resume() }
         self.startedWaiters.removeAll()
@@ -433,7 +433,7 @@ private actor BlockingManagedCodexLoginRunnerForSettingsSectionTests: ManagedCod
     }
 
     func resume() {
-        let result = CodexLoginRunner.Result(outcome: .success, output: "ok")
+        let result = CLILoginRunner.Result(outcome: .success, output: "ok")
         self.waiters.forEach { $0.resume(returning: result) }
         self.waiters.removeAll()
     }

--- a/Tests/CodexBarTests/ManagedCodexAccountCoordinatorTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountCoordinatorTests.swift
@@ -44,7 +44,7 @@ struct ManagedCodexAccountCoordinatorTests {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let loginResult = CodexLoginRunner.Result(outcome: .timedOut, output: "timed out")
+        let loginResult = CLILoginRunner.Result(outcome: .timedOut, output: "timed out")
         let existingAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-222222222222"))
         let service = ManagedCodexAccountService(
             store: InMemoryManagedCodexAccountStoreForCoordinatorTests(
@@ -69,11 +69,11 @@ struct ManagedCodexAccountCoordinatorTests {
 }
 
 private actor BlockingManagedCodexLoginRunner: ManagedCodexLoginRunning {
-    private var waiters: [CheckedContinuation<CodexLoginRunner.Result, Never>] = []
+    private var waiters: [CheckedContinuation<CLILoginRunner.Result, Never>] = []
     private var startedWaiters: [CheckedContinuation<Void, Never>] = []
     private var didStart = false
 
-    func run(homePath _: String, timeout _: TimeInterval) async -> CodexLoginRunner.Result {
+    func run(homePath _: String, timeout _: TimeInterval) async -> CLILoginRunner.Result {
         self.didStart = true
         self.startedWaiters.forEach { $0.resume() }
         self.startedWaiters.removeAll()
@@ -90,16 +90,16 @@ private actor BlockingManagedCodexLoginRunner: ManagedCodexLoginRunning {
     }
 
     func resume() {
-        let result = CodexLoginRunner.Result(outcome: .success, output: "ok")
+        let result = CLILoginRunner.Result(outcome: .success, output: "ok")
         self.waiters.forEach { $0.resume(returning: result) }
         self.waiters.removeAll()
     }
 }
 
 private struct TimedOutManagedCodexLoginRunner: ManagedCodexLoginRunning {
-    let result: CodexLoginRunner.Result
+    let result: CLILoginRunner.Result
 
-    func run(homePath _: String, timeout _: TimeInterval) async -> CodexLoginRunner.Result {
+    func run(homePath _: String, timeout _: TimeInterval) async -> CLILoginRunner.Result {
         self.result
     }
 }

--- a/Tests/CodexBarTests/ManagedCodexAccountServiceTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountServiceTests.swift
@@ -649,7 +649,7 @@ struct ManagedCodexAccountServiceTests {
             store: store,
             homeFactory: UnsafeManagedCodexHomeFactory(root: root, homeURL: outsideHome),
             loginRunner: StubManagedCodexLoginRunner(
-                result: CodexLoginRunner.Result(outcome: .failed(status: 1), output: "nope")),
+                result: CLILoginRunner.Result(outcome: .failed(status: 1), output: "nope")),
             identityReader: StubManagedCodexIdentityReader.emails([]),
             workspaceResolver: StubManagedCodexWorkspaceResolver())
 
@@ -666,7 +666,7 @@ struct ManagedCodexAccountServiceTests {
         let root = CodexCredentialFixtures.root.appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let loginResult = CodexLoginRunner.Result(
+        let loginResult = CLILoginRunner.Result(
             outcome: .failed(status: 42),
             output: "OAuth callback used the wrong browser profile")
         let service = ManagedCodexAccountService(
@@ -913,25 +913,25 @@ private struct UnsafeManagedCodexHomeFactory: ManagedCodexHomeProducing {
 }
 
 private struct StubManagedCodexLoginRunner: ManagedCodexLoginRunning {
-    let result: CodexLoginRunner.Result
+    let result: CLILoginRunner.Result
 
-    func run(homePath: String, timeout: TimeInterval) async -> CodexLoginRunner.Result {
+    func run(homePath: String, timeout: TimeInterval) async -> CLILoginRunner.Result {
         self.result
     }
 
     static let success = StubManagedCodexLoginRunner(
-        result: CodexLoginRunner.Result(outcome: .success, output: "ok"))
+        result: CLILoginRunner.Result(outcome: .success, output: "ok"))
 }
 
 private struct WritingManagedCodexLoginRunner: ManagedCodexLoginRunning {
     let credentials: CodexOAuthCredentials
 
-    func run(homePath: String, timeout _: TimeInterval) async -> CodexLoginRunner.Result {
+    func run(homePath: String, timeout _: TimeInterval) async -> CLILoginRunner.Result {
         do {
             try CodexOAuthCredentialsStore.save(self.credentials, env: ["CODEX_HOME": homePath])
-            return CodexLoginRunner.Result(outcome: .success, output: "ok")
+            return CLILoginRunner.Result(outcome: .success, output: "ok")
         } catch {
-            return CodexLoginRunner.Result(outcome: .failed(status: 1), output: String(describing: error))
+            return CLILoginRunner.Result(outcome: .failed(status: 1), output: String(describing: error))
         }
     }
 }

--- a/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
@@ -1337,11 +1337,11 @@ private actor BlockingStatusMenuCodexFetchStrategy {
 }
 
 private actor BlockingManagedCodexLoginRunnerForStatusMenuTests: ManagedCodexLoginRunning {
-    private var waiters: [CheckedContinuation<CodexLoginRunner.Result, Never>] = []
+    private var waiters: [CheckedContinuation<CLILoginRunner.Result, Never>] = []
     private var startedWaiters: [CheckedContinuation<Void, Never>] = []
     private var didStart = false
 
-    func run(homePath _: String, timeout _: TimeInterval) async -> CodexLoginRunner.Result {
+    func run(homePath _: String, timeout _: TimeInterval) async -> CLILoginRunner.Result {
         await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
             self.didStart = true
@@ -1358,7 +1358,7 @@ private actor BlockingManagedCodexLoginRunnerForStatusMenuTests: ManagedCodexLog
     }
 
     func resume() {
-        let result = CodexLoginRunner.Result(outcome: .success, output: "ok")
+        let result = CLILoginRunner.Result(outcome: .success, output: "ok")
         self.waiters.forEach { $0.resume(returning: result) }
         self.waiters.removeAll()
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,14 @@ read_when:
 - Settings toggles feed `SettingsStore` → `UsageStore` refresh cadence + feature flags.
 - Runtime-only provider settings flow through typed, descriptor-registered sections in `ProviderSettingsSnapshot`.
 
+## CLI login lifecycle
+- `CodexLoginRunner` and `KiroLoginRunner` resolve their own executable and environment, including Codex home scoping.
+- `CLILoginRunner` owns browser-waiting login processes, bounded output capture, timeout/cancellation, and optional
+  device-flow progress. It returns one shared result type; provider presentations retain their own recovery messages.
+- The login runner and `SubprocessRunner` share `ProcessTermination` and process-tree termination. Cancelling a login
+  stops its child process, joins its progress callback task, and produces no failure alert. Timeouts retain captured
+  diagnostic output, and inherited pipes cannot keep the caller waiting indefinitely.
+
 ## Concurrency & platform
 - Swift 6 strict concurrency enabled; prefer Sendable state and explicit MainActor hops.
 - macOS 14+ targeting; avoid deprecated APIs when refactoring.


### PR DESCRIPTION
Codex and Kiro each maintained their own login-process lifecycle, and an unstructured task kept a login alive when its caller was cancelled. Both now use one `CLILoginRunner` that stops cancelled or timed-out process trees, retains bounded diagnostic output, and joins Kiro's progress polling before returning. Provider adapters still own executable lookup and environment setup, including Codex home isolation.

The runner reuses the existing bounded task join and process-tree termination helpers. `ProcessTermination` is shared with `SubprocessRunner`; internal result consumers migrate directly to the common result type. Cancelled login presentations remain silent. Very large timeout values no longer trap during conversion.

Validation:
- `make check`: passed, including zero SwiftLint violations across 2,137 files.
- Synthetic real-process tests cover both provider cancellation paths, pre-cancellation, exit status and output, Codex home/arguments, large timeouts, inherited pipes, and resistant child cleanup. The new suite is serialized to keep process-start contention out of its deadline assertions.
- Full `make test`: passed all 1,032 selections across 86 groups on the first pass, with zero retries or timeouts.
- Fresh Developer ID-signed CLI: config validation, live Codex OAuth usage, and live Kimi usage pass. Enabled/default matrix checks surface unavailable local Claude authentication; this is recorded rather than presented as a green provider check.
- Independent Codex review through P2: no actionable findings.
