### PR TITLE
fix(claude): preserve claude-swap measurement timestamps

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountList.swift
@@ -7,7 +7,7 @@ import Foundation
 /// are decoded: slot number, display email, display-only `organizationName`,
 /// optional display-only `alias`, active state, usage status, and the
 /// 5-hour/7-day windows and optional model-scoped weekly windows (percent +
-/// reset timestamp). Everything else in the payload is ignored; unknown schema
+/// reset timestamp), and optional usage measurement time. Everything else in the payload is ignored; unknown schema
 /// versions and partial top-level shapes are rejected.
 public struct ClaudeSwapAccountList: Equatable, Sendable {
     public let activeAccountNumber: Int?
@@ -34,6 +34,8 @@ public struct ClaudeSwapAccountRow: Equatable, Sendable {
     public let fiveHour: ClaudeSwapUsageWindow?
     public let sevenDay: ClaudeSwapUsageWindow?
     public let scoped: [ClaudeSwapScopedUsageWindow]
+    /// The adapter's measurement time, which can precede this list refresh.
+    public let usageFetchedAt: Date?
 
     public init(
         number: Int,
@@ -44,7 +46,8 @@ public struct ClaudeSwapAccountRow: Equatable, Sendable {
         usageStatus: ClaudeSwapUsageStatus,
         fiveHour: ClaudeSwapUsageWindow?,
         sevenDay: ClaudeSwapUsageWindow?,
-        scoped: [ClaudeSwapScopedUsageWindow] = [])
+        scoped: [ClaudeSwapScopedUsageWindow] = [],
+        usageFetchedAt: Date? = nil)
     {
         self.number = number
         self.email = email
@@ -55,6 +58,7 @@ public struct ClaudeSwapAccountRow: Equatable, Sendable {
         self.fiveHour = fiveHour
         self.sevenDay = sevenDay
         self.scoped = scoped
+        self.usageFetchedAt = usageFetchedAt
     }
 }
 
@@ -211,7 +215,8 @@ public enum ClaudeSwapListParser {
             usageStatus: ClaudeSwapUsageStatus(rawValue: rawStatus),
             fiveHour: self.parseWindow(usage?["fiveHour"], slot: number, name: "fiveHour"),
             sevenDay: self.parseWindow(usage?["sevenDay"], slot: number, name: "sevenDay"),
-            scoped: self.parseScopedWindows(usage?["scoped"]))
+            scoped: self.parseScopedWindows(usage?["scoped"]),
+            usageFetchedAt: (row["usageFetchedAt"] as? String).flatMap(self.parseTimestamp))
     }
 
     private static func parseWindow(_ raw: Any?, slot: Int, name: String) throws -> ClaudeSwapUsageWindow? {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeSwap/ClaudeSwapAccountProjection.swift
@@ -215,7 +215,7 @@ public enum ClaudeSwapAccountProjection {
             primary: primary,
             secondary: secondary,
             extraRateWindows: scoped.isEmpty ? nil : scoped,
-            updatedAt: now,
+            updatedAt: row.usageFetchedAt ?? now,
             identity: self.identitySnapshot(for: row))
     }
 

--- a/Tests/CodexBarTests/ClaudeSwapMeasurementTimeTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapMeasurementTimeTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeSwapMeasurementTimeTests {
+    private let now = Date(timeIntervalSince1970: 1_788_777_000)
+
+    @Test
+    func `cached measurements keep the source time across refreshes`() throws {
+        let list = try self.list(fetchedAt: "2026-09-07T08:54:23.123456+00:00")
+        let expected = try #require(ISO8601DateFormatter().date(from: "2026-09-07T08:54:23Z"))
+        let first = try #require(ClaudeSwapAccountProjection.accountSnapshots(from: list, now: self.now).first)
+        let later = try #require(ClaudeSwapAccountProjection.accountSnapshots(
+            from: list,
+            previousAccounts: [first],
+            now: self.now.addingTimeInterval(300)).first)
+
+        for account in [first, later] {
+            let snapshot = try #require(account.snapshot)
+            #expect(abs(snapshot.updatedAt.timeIntervalSince(expected) - 0.123456) < 0.001)
+            #expect(snapshot.primary?.usedPercent == 100)
+            #expect(account.id.opaqueID == "1")
+        }
+
+        let unavailable = try self.list(fetchedAt: nil, usageStatus: "unavailable", hasUsage: false)
+        let retained = try #require(ClaudeSwapAccountProjection.accountSnapshots(
+            from: unavailable,
+            previousAccounts: [later],
+            now: self.now.addingTimeInterval(600)).first)
+        #expect(retained.snapshot?.updatedAt == first.snapshot?.updatedAt)
+    }
+
+    @Test
+    func `missing or malformed optional timestamps preserve valid usage`() throws {
+        for fetchedAt in [nil, "not-a-timestamp", 42, true] as [Any?] {
+            let list = try self.list(fetchedAt: fetchedAt)
+            let account = try #require(ClaudeSwapAccountProjection.accountSnapshots(from: list, now: self.now).first)
+            #expect(account.snapshot?.updatedAt == self.now)
+            #expect(account.snapshot?.primary?.usedPercent == 100)
+            #expect(account.error == nil)
+        }
+    }
+
+    private func list(
+        fetchedAt: Any?,
+        usageStatus: String = "ok",
+        hasUsage: Bool = true) throws -> ClaudeSwapAccountList
+    {
+        var row: [String: Any] = [
+            "number": 1,
+            "active": true,
+            "email": "fixture@example.invalid",
+            "usageStatus": usageStatus,
+        ]
+        row["usageFetchedAt"] = fetchedAt
+        if hasUsage {
+            row["usage"] = ["fiveHour": ["pct": 100, "resetsAt": "2026-09-08T12:00:00Z"]]
+        }
+        return try ClaudeSwapListParser.parse(JSONSerialization.data(withJSONObject: [
+            "schemaVersion": 1,
+            "activeAccountNumber": 1,
+            "accounts": [row],
+        ]))
+    }
+}

--- a/docs/claude-multi-account-and-status-items.md
+++ b/docs/claude-multi-account-and-status-items.md
@@ -78,6 +78,8 @@ envelope. CodexBar does not need
   and percentages, reset timestamps, display-only `organizationName` (always present, may be empty), and optional
   display-only `alias` when non-empty. Ignore malformed or unknown scoped rows without discarding valid account-wide
   windows. Unknown extra JSON fields remain ignored. Empty `organizationName` is not an error; `alias` is not required.
+- Use optional `usageFetchedAt` for the measurement's last-updated time, so polling the adapter's cache does not make
+  old usage appear freshly measured. Missing or malformed timestamps retain the refresh-time fallback and valid windows.
 - Treat email, organization name, and alias as display-only. Never log or persist them. Respect Hide Personal Info.
   When two or more slots share an email, disambiguate with `email · organizationName` or `email · Account N`; a
   user-chosen alias wins. Unique emails stay email-only.


### PR DESCRIPTION
Repeated claude-swap refreshes displayed cached measurements as freshly updated because the parser discarded `usageFetchedAt` and the projection always used the current clock. Preserve the optional source timestamp using the existing parser; older adapters and malformed optional timestamps keep their existing fallback without dropping valid usage windows.

Extracted from #3452, with credit to @QuantIntellect. Its remaining last-known usage display and source-chosen account switching stay separate. This changes no adapter arguments, credential access, cache schema, or account activation behavior.

Validation: the regression fails on the baseline and passes after the fix, including fractional timestamps, repeated refreshes, exhausted-window retention, and malformed optional fields. Focused ClaudeSwap suites pass. `make check` passes using macOS system Bash (Homebrew Bash stalled in the existing signing fixture's here-document). Independent P0–P2 review is clean. The full suite passed all 1,032 selections across 86 groups on the first attempt, with no retries or timeouts. Exact-head CI passes all jobs, including both macOS shards, all three Linux builds, lint and the aggregate gate.

Live proof: the actual built CLI `dashboard --identity redacted` with an isolated synthetic adapter reproduced both baseline account timestamps being replaced by the poll time. The candidate preserves each distinct source measurement timestamp and the same quota values. The Developer ID–signed app also launched in an isolated synthetic profile and opened its real Settings menu through native automation. No real provider credentials, browser sessions, or personal history were used.

The changelog entry will be carried in #3488 to keep sibling branches independent.
