### PR TITLE
docs: collect unreleased maintenance notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## 0.56.9 — Unreleased
 
+### Highlights
+- **Safer updates and more reliable usage:** refresh Sparkle's installer protections, preserve claude-swap measurement ages, and improve local history and account handling.
+
 ### Performance
 - Codex local costs: reuse model pricing resolution across daily, project, and session report rows without changing token accounting, tariffs, or refresh cadence (#3476). Thanks @brzvsk!
 
 ### Fixed
+- Updates: adopt Sparkle 2.9.6 installer hardening, including archive-moving and package-signature validation fixes.
+- Claude: preserve claude-swap's source measurement timestamps so repeated reads of cached usage do not show as freshly updated; retain the existing fallback for missing or malformed optional timestamps (#3485, extracted from #3452). Thanks @QuantIntellect!
 - CLI login: share Codex and Kiro process handling, stop cancelled logins and lingering children, and preserve bounded timeout output and device-flow progress.
 - Widgets: remove redundant outer padding from Usage, Switcher, History, and Metric views so WidgetKit alone controls their content margins (extracted from #3137). Thanks @iamenahs!
 - Copilot: resolve Enterprise sign-in identities on the configured host, keep equal user IDs on different hosts distinct, and skip public GitHub budget enrichment for Enterprise accounts (#3341). Thanks @Fletcher-Alderton!
@@ -16,6 +21,9 @@
 - Claude: recover an expired default-profile cache from changed, fresh CLI credentials when existing read consent and policy permit, preserving explicit-file precedence and custom-profile isolation (related to #3390).
 - Claude local usage: discard stale cached rows when a transcript is atomically replaced, including across process restarts; retain incremental parsing for genuine appends and rebuild legacy cache entries without file identity once.
 - Antigravity local usage: tolerate bookkeeping steps without UUIDs while retaining duplicate bot-ID ambiguity checks, so valid history remains available without assigning uncertain dates (#3462). Thanks @urda!
+
+### Maintenance
+- Update Commander to 0.2.4, swift-log to 1.15.0, swift-asn1 to 1.7.2, and the pinned checkout action to 7.0.1.
 
 ## 0.56.8 — 2026-09-07
 


### PR DESCRIPTION
Collect the user-visible timestamp fix from #3485 and compatible dependency updates from #3487 in one final Unreleased section, with contributor credit and a Highlights lead-in. Preserve the existing main entries, including the newly landed CLI login cancellation fix.

Land #3485, then #3487, then this notes PR. Keeping notes separate prevents unrelated additions to main’s changelog from conflicting with the dependency branch.

Validation: local documentation links and whitespace checks pass; independent P0–P2 review is clean. Released sections are unchanged. The underlying changes have complete local suites, built CLI/native app proof and independent reviews; #3485 and #3487 both have green exact-head CI. This notes-only PR passes its own exact-head CI, including both Linux builds and aggregate; macOS/musl use the documented skip.

This does not change the version, create a tag, or authorize publication. The broader issue/PR queue still needs another bounded pass before release preparation.
