### PR TITLE
docs(changelog): collect spend refresh and Claude cost improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## 0.56.9 — Unreleased
 
 ### Highlights
+- **Fresher spend charts and faster Claude startup:** refresh stale dashboards, resume interrupted Codex scans, and reuse compatible Claude cost reports across launches.
 - **Safer updates and more reliable usage:** refresh Sparkle's installer protections, preserve claude-swap measurement ages, and improve local history and account handling.
 
-### Performance
-- Codex local costs: reuse model pricing resolution across daily, project, and session report rows without changing token accounting, tariffs, or refresh cadence (#3476). Thanks @brzvsk!
-
 ### Fixed
+- Usage & Spend: refresh expired charts on pane return or app activation, keep cached data visible during loading, and refresh across midnight (#3107). Thanks @Yuxin-Qiao!
+- Codex local costs: retain unfinished file work when a warm refresh reaches its time limit, so compatible history windows resume without reseeding completed files; preserve exact validation and existing caches (related to #3411). Thanks @kesslerio!
 - Updates: adopt Sparkle 2.9.6 installer hardening, including archive-moving and package-signature validation fixes.
 - Claude: preserve claude-swap's source measurement timestamps so repeated reads of cached usage do not show as freshly updated; retain the existing fallback for missing or malformed optional timestamps (#3485, extracted from #3452). Thanks @QuantIntellect!
 - CLI login: share Codex and Kiro process handling, stop cancelled logins and lingering children, and preserve bounded timeout output and device-flow progress.
@@ -22,6 +22,13 @@
 - Claude: recover an expired default-profile cache from changed, fresh CLI credentials when existing read consent and policy permit, preserving explicit-file precedence and custom-profile isolation (related to #3390).
 - Claude local usage: discard stale cached rows when a transcript is atomically replaced, including across process restarts; retain incremental parsing for genuine appends and rebuild legacy cache entries without file identity once.
 - Antigravity local usage: tolerate bookkeeping steps without UUIDs while retaining duplicate bot-ID ambiguity checks, so valid history remains available without assigning uncertain dates (#3462). Thanks @urda!
+
+### Performance
+- Claude local costs: persist compatible reports across launches to avoid decoding unchanged transcript caches, and invalidate them when source, pricing, or report semantics change (#3284). Thanks @eggyrooch-blip!
+- Codex local costs: reuse model pricing resolution across daily, project, and session report rows without changing token accounting, tariffs, or refresh cadence (#3476). Thanks @brzvsk!
+
+### Added
+- CLI: add opt-in Claude `cost --breakdown` daily and model details with matching calendar/recorded periods and partial-attribution labels (#3244). Thanks @Yuxin-Qiao!
 
 ### Maintenance
 - Update Commander to 0.2.4, swift-log to 1.15.0, swift-asn1 to 1.7.2, and the pinned checkout action to 7.0.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Safer updates and more reliable usage:** refresh Sparkle's installer protections, preserve claude-swap measurement ages, and improve local history and account handling.
 
 ### Fixed
+- Antigravity: render each CLI quota bucket once, keep unknown or disabled usage unavailable in text and full/brief cards, and apply shared idle-family visibility (#3489). Thanks @urda!
 - Usage & Spend: refresh expired charts on pane return or app activation, keep cached data visible during loading, and refresh across midnight (#3107). Thanks @Yuxin-Qiao!
 - Codex local costs: retain unfinished file work when a warm refresh reaches its time limit, so compatible history windows resume without reseeding completed files; preserve exact validation and existing caches (related to #3411). Thanks @kesslerio!
 - Updates: adopt Sparkle 2.9.6 installer hardening, including archive-moving and package-signature validation fixes.


### PR DESCRIPTION
Collect the batch's user-visible notes in one independent changelog PR, preserving all existing Unreleased entries and Peter's concurrent Overview fix #3482. Lead with spend reliability, then performance and the bounded opt-in CLI addition. Released sections are unchanged.

Merge this after the five code PRs:

- #3107: refresh expired Usage & Spend charts and handle midnight rollover.
- #3284: reuse compatible Claude local-cost reports across launches.
- #3244: opt-in Claude CLI daily/model detail with accurate periods and partial attribution.
- #3490: preserve unfinished warm Codex scan work; #3411 remains open for the broader managed-account report.
- #3489: Antigravity CLI quota-bucket parity with unknown/disabled availability preserved.

Validation: local and final committed-branch autoreview clean through P2; checked that all five entries and #3482 are present and that released sections are byte-for-byte unchanged. Runtime proof and full suites are recorded on the code PRs. [Exact-head notes CI](https://github.com/steipete/CodexBar/actions/runs/34185810334) succeeded on `69c93cd032fbf5582f972bf26d6923986417c8a1`; all applicable checks are green.

This prepares notes only. The remaining queue still contains autonomous work, so there is no release/tag/publication in this batch. The existing pending version remains 0.56.9.
