### PR TITLE
fix(bedrock): disclose monitoring charges in settings

### DIFF
--- a/Sources/CodexBar/Providers/Bedrock/BedrockProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Bedrock/BedrockProviderImplementation.swift
@@ -26,6 +26,41 @@ struct BedrockProviderImplementation: ProviderImplementation {
     }
 
     @MainActor
+    func settingsActions(context _: ProviderSettingsContext) -> [ProviderSettingsActionsDescriptor] {
+        [
+            ProviderSettingsActionsDescriptor(
+                id: "bedrock-monitoring-charges",
+                title: "Monitoring adds AWS charges",
+                subtitle: "AWS charges $0.01 per Cost Explorer request against the primary billing view. "
+                    + "A refresh can make multiple requests, and CloudWatch activity can add charges. "
+                    + "The displayed monthly budget does not cap AWS billing.",
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "bedrock-monitoring-pricing",
+                        title: "AWS Cost Explorer pricing",
+                        style: .link,
+                        isVisible: nil,
+                        perform: {
+                            guard let url = URL(string:
+                                "https://aws.amazon.com/aws-cost-management/aws-cost-explorer/pricing/")
+                            else { return }
+                            NSWorkspace.shared.open(url)
+                        }),
+                ],
+                isVisible: nil),
+            ProviderSettingsActionsDescriptor(
+                id: "bedrock-monitoring-frequency",
+                title: "Reduce monitoring requests",
+                subtitle: "In General → Refreshing, choose a longer interval or Manual and turn off "
+                    + "Refresh when the menu opens. These controls apply to all providers. "
+                    + "Manual still allows startup and explicit refreshes. "
+                    + "Disable AWS Bedrock to stop its app refreshes.",
+                actions: [],
+                isVisible: nil),
+        ]
+    }
+
+    @MainActor
     func settingsPickers(context: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor] {
         let binding = Binding(
             get: { context.settings.bedrockAuthMode },

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -8,6 +8,26 @@ import Testing
 @Suite(.serialized)
 struct ProviderSettingsDescriptorTests {
     @Test
+    func `bedrock discloses monitoring charges before credentials in either authentication mode`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-bedrock-charges")
+        let context = fixture.settingsContext(provider: .bedrock)
+        for mode in [BedrockAuthMode.keys, .profile] {
+            fixture.settings.bedrockAuthMode = mode.rawValue
+            let groups = BedrockProviderImplementation().settingsActions(context: context)
+            let charges = try #require(groups.first { $0.id == "bedrock-monitoring-charges" })
+            let frequency = try #require(groups.first { $0.id == "bedrock-monitoring-frequency" })
+            #expect(charges.isVisible?() ?? true)
+            #expect(frequency.isVisible?() ?? true)
+            #expect(charges.subtitle.contains("per Cost Explorer request"))
+            #expect(charges.subtitle.contains("multiple requests"))
+            #expect(charges.subtitle.contains("does not cap"))
+            #expect(charges.actions.count == 1)
+            #expect(frequency.subtitle.contains("all providers"))
+            #expect(frequency.subtitle.contains("startup and explicit refreshes"))
+        }
+    }
+
+    @Test
     func `provider settings refresh enables explicit browser retry`() async {
         var observedInteraction: ProviderInteraction?
         var browserRetryAllowed = false

--- a/docs/bedrock.md
+++ b/docs/bedrock.md
@@ -26,6 +26,8 @@ and **Refresh when the menu opens** can still fetch data. Turn off that option a
 Disable AWS Bedrock in Providers to stop its app refreshes; separate CLI invocations can still make billed requests.
 
 The optional monthly budget only changes the displayed progress. It does not cap AWS charges or stop polling.
+The AWS Bedrock provider's Connection settings show these monitoring charges, link to current Cost Explorer pricing,
+and explain how the shared refresh controls reduce requests in both access-key and AWS-profile modes.
 
 ## Authentication
 


### PR DESCRIPTION
Bedrock monitoring can add AWS charges, but setup previously showed no warning. Show the per-request Cost Explorer price, explain that refreshes can make multiple requests, and link to current AWS pricing. The Connection section also explains the shared refresh controls and that the displayed budget does not cap billing.

Refs #3387. This addresses the in-app disclosure; keep the issue open for the separate Bedrock-specific interval decision. Scheduling and credential handling are unchanged. Thanks @kyen99 for reporting the surprise charge and providing the pricing reference.

Validation: `make check` passed; `make test` passed all 1,035 selections in 87 groups with no failures or retries. Independent branch review is clean through P2. A Developer ID-signed app exercised the production settings pane in both authentication modes using synthetic defaults. The built CLI returned $12.50 from a loopback AWS fixture, with one Cost Explorer and one CloudWatch request. No real account or credential was used.

The before image uses the original main implementation; the after images use this PR's production code.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/376156c0-e6bb-4956-858e-c64c06b22b51" width="360" alt="Bedrock settings before disclosure, synthetic data"> | <img src="https://github.com/user-attachments/assets/c4d6a26f-ec9d-4d6f-8783-299accef2a4d" width="360" alt="Bedrock monitoring disclosure, synthetic data"> |

[Profile-mode proof](https://github.com/user-attachments/assets/0e6c5364-0672-4e91-8d9c-fa1e96fa8c23). Release notes are collected separately in #3499.
