### PR TITLE
fix(claude): honor segmented account menu layout

### DIFF
--- a/Sources/CodexBar/Providers/Claude/ClaudeSwapAccountMenuDisplay.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeSwapAccountMenuDisplay.swift
@@ -1,4 +1,5 @@
 import CodexBarCore
+import Foundation
 
 struct ClaudeSwapAccountMenuDisplay {
     let accounts: [ProviderAccountUsageSnapshot]

--- a/Sources/CodexBar/Providers/Claude/ClaudeSwapAccountMenuDisplay.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeSwapAccountMenuDisplay.swift
@@ -1,0 +1,29 @@
+import CodexBarCore
+
+struct ClaudeSwapAccountMenuDisplay {
+    let accounts: [ProviderAccountUsageSnapshot]
+    let layout: MultiAccountMenuLayout
+    let switchingAccountID: ProviderAccountIdentity?
+    let errorAccountID: ProviderAccountIdentity?
+    var inspectedAccountID: ProviderAccountIdentity?
+
+    var showsSwitcher: Bool {
+        self.layout == .segmented && self.accounts.count > 1
+    }
+
+    var displayedAccount: ProviderAccountUsageSnapshot? {
+        // Keep pending/failed activation details attached to the requested stable slot.
+        for id in [self.switchingAccountID, self.inspectedAccountID, self.errorAccountID].compactMap(\.self) {
+            if let account = self.accounts.first(where: { $0.id == id }) {
+                return account
+            }
+        }
+        return self.accounts.first(where: \.isActive)
+    }
+
+    static func label(for account: ProviderAccountUsageSnapshot, hidePersonalInfo: Bool) -> String {
+        hidePersonalInfo
+            ? String(format: L("Account %@"), account.id.opaqueID)
+            : account.displayLabel
+    }
+}

--- a/Sources/CodexBar/Providers/Claude/ClaudeSwapAccountSwitcherView.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeSwapAccountSwitcherView.swift
@@ -1,0 +1,136 @@
+import AppKit
+import CodexBarCore
+
+final class ClaudeSwapAccountSwitcherView: NSView {
+    private let accounts: [ProviderAccountUsageSnapshot]
+    private let onSelect: (ProviderAccountIdentity) -> Void
+    private var buttons: [NSButton] = []
+    private var pressedAccountID: ProviderAccountIdentity?
+    private var selectionPending: Bool
+    private let preferredSize: NSSize
+
+    init(
+        display: ClaudeSwapAccountMenuDisplay,
+        hidePersonalInfo: Bool,
+        width: CGFloat,
+        onSelect: @escaping (ProviderAccountIdentity) -> Void)
+    {
+        self.accounts = display.accounts
+        self.onSelect = onSelect
+        self.selectionPending = display.switchingAccountID != nil
+        let rows = display.accounts.count > 3 ? 2 : 1
+        self.preferredSize = NSSize(width: width, height: CGFloat(rows * 26 + (rows - 1) * 4))
+        super.init(frame: NSRect(origin: .zero, size: self.preferredSize))
+
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .width
+        stack.spacing = 4
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        let columns = max(1, (self.accounts.count + rows - 1) / rows)
+        for start in stride(from: 0, to: self.accounts.count, by: columns) {
+            let row = NSStackView()
+            row.orientation = .horizontal
+            row.distribution = .fillEqually
+            row.spacing = 4
+            for index in start..<min(start + columns, self.accounts.count) {
+                let account = self.accounts[index]
+                let label = ClaudeSwapAccountMenuDisplay.label(for: account, hidePersonalInfo: hidePersonalInfo)
+                let button = PaddedToggleButton(title: label, target: self, action: #selector(self.handleSelect))
+                button.tag = index
+                button.toolTip = label
+                button.isBordered = false
+                button.setButtonType(.toggle)
+                button.controlSize = .small
+                button.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+                button.cell?.lineBreakMode = label.contains("@") ? .byTruncatingMiddle : .byTruncatingTail
+                button.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+                button.wantsLayer = true
+                button.layer?.cornerRadius = 6
+                button.state = account.isActive ? .on : .off
+                button.layer?.backgroundColor = account.isActive ? NSColor.controlAccentColor.cgColor : nil
+                button.contentTintColor = account.isActive ? .white : .secondaryLabelColor
+                button.isEnabled = !self.selectionPending
+                row.addArrangedSubview(button)
+                self.buttons.append(button)
+            }
+            stack.addArrangedSubview(row)
+            row.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+            row.heightAnchor.constraint(equalToConstant: 26).isActive = true
+        }
+        self.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 6),
+            stack.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -6),
+            stack.topAnchor.constraint(equalTo: self.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var intrinsicContentSize: NSSize {
+        self.preferredSize
+    }
+
+    override var fittingSize: NSSize {
+        self.preferredSize
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let descendant = super.hitTest(point)
+        if descendant != nil, descendant !== self {
+            self.toolTip = (descendant as? NSButton)?.toolTip
+            return self
+        }
+        self.toolTip = nil
+        return descendant
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        self.pressedAccountID = self.accountID(at: self.convert(event.locationInWindow, from: nil))
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        defer { self.pressedAccountID = nil }
+        guard let id = self.pressedAccountID,
+              self.accountID(at: self.convert(event.locationInWindow, from: nil)) == id
+        else { return }
+        self.select(id)
+    }
+
+    private func accountID(at point: NSPoint) -> ProviderAccountIdentity? {
+        guard let button = self.buttons.first(where: { self.convert($0.bounds, from: $0).contains(point) })
+        else { return nil }
+        return self.accounts[button.tag].id
+    }
+
+    @objc private func handleSelect(_ sender: NSButton) {
+        guard self.accounts.indices.contains(sender.tag) else { return }
+        self.select(self.accounts[sender.tag].id)
+    }
+
+    private func select(_ id: ProviderAccountIdentity) {
+        guard !self.selectionPending, let account = self.accounts.first(where: { $0.id == id }) else { return }
+        if account.canActivate {
+            self.selectionPending = true
+            for button in self.buttons {
+                button.isEnabled = false
+            }
+        }
+        self.onSelect(id)
+    }
+
+    #if DEBUG
+    func _test_select(_ id: ProviderAccountIdentity) {
+        self.select(id)
+    }
+    #endif
+}

--- a/Sources/CodexBar/Providers/Claude/StatusItemController+ClaudeSwapMenu.swift
+++ b/Sources/CodexBar/Providers/Claude/StatusItemController+ClaudeSwapMenu.swift
@@ -41,11 +41,15 @@ extension StatusItemController {
                 heading.isEnabled = false
                 menu.addItem(heading)
             }
-            self.addStackedClaudeSwapMenuCards(
-                accounts: display.displayedAccount.map { [$0] } ?? [],
-                to: menu,
-                captureMenu: captureMenu,
-                context: context)
+            if let account = display.displayedAccount {
+                self.addStackedClaudeSwapMenuCards(
+                    accounts: [account],
+                    to: menu,
+                    captureMenu: captureMenu,
+                    context: context)
+            } else if self.addStorageMenuCardSection(to: menu, provider: .claude, width: context.menuWidth) {
+                menu.addItem(.separator())
+            }
             return
         }
         let plan = self.compactAccountPlan(for: .claude, accounts: accounts)

--- a/Sources/CodexBar/Providers/Claude/StatusItemController+ClaudeSwapMenu.swift
+++ b/Sources/CodexBar/Providers/Claude/StatusItemController+ClaudeSwapMenu.swift
@@ -69,6 +69,12 @@ extension StatusItemController {
             context: context)
     }
 
+    func resetClaudeSwapAccountInspection() {
+        guard self.claudeSwapInspectedAccountID != nil else { return }
+        self.claudeSwapInspectedAccountID = nil
+        self.invalidateMenus()
+    }
+
     func handleClaudeSwapAccountSelection(_ id: ProviderAccountIdentity, menu: NSMenu?) {
         guard self.store.claudeSwapTransientState.task == nil,
               let account = self.store.claudeSwapAccountSnapshots.first(where: { $0.id == id })

--- a/Sources/CodexBar/Providers/Claude/StatusItemController+ClaudeSwapMenu.swift
+++ b/Sources/CodexBar/Providers/Claude/StatusItemController+ClaudeSwapMenu.swift
@@ -8,6 +8,46 @@ extension StatusItemController {
         context: MenuCardContext)
     {
         let accounts = self.store.claudeSwapAccountSnapshots
+        let display = ClaudeSwapAccountMenuDisplay(
+            accounts: accounts,
+            layout: self.settings.multiAccountMenuLayout,
+            switchingAccountID: self.store.claudeSwapTransientState.switchingAccountID,
+            errorAccountID: self.store.claudeSwapTransientState.lastErrorAccountID,
+            inspectedAccountID: self.claudeSwapInspectedAccountID)
+        if display.showsSwitcher {
+            let item = NSMenuItem()
+            item.view = ClaudeSwapAccountSwitcherView(
+                display: display,
+                hidePersonalInfo: self.settings.hidePersonalInfo,
+                width: context.menuWidth,
+                onSelect: { [weak self, weak captureMenu] id in
+                    self?.handleClaudeSwapAccountSelection(id, menu: captureMenu)
+                })
+            item.isEnabled = false
+            menu.addItem(item)
+            menu.addItem(.separator())
+            if !accounts.contains(where: \.isActive) {
+                let notice = NSMenuItem(title: L("No active account"), action: nil, keyEquivalent: "")
+                notice.isEnabled = false
+                menu.addItem(notice)
+            }
+            if let account = display.displayedAccount, !account.isActive {
+                let label = ClaudeSwapAccountMenuDisplay.label(
+                    for: account, hidePersonalInfo: self.settings.hidePersonalInfo)
+                let heading = NSMenuItem(
+                    title: String(format: L("Details for %@"), label),
+                    action: nil,
+                    keyEquivalent: "")
+                heading.isEnabled = false
+                menu.addItem(heading)
+            }
+            self.addStackedClaudeSwapMenuCards(
+                accounts: display.displayedAccount.map { [$0] } ?? [],
+                to: menu,
+                captureMenu: captureMenu,
+                context: context)
+            return
+        }
         let plan = self.compactAccountPlan(for: .claude, accounts: accounts)
         guard plan.usesCompactLayout else {
             self.addStackedClaudeSwapMenuCards(accounts: accounts, to: menu, captureMenu: captureMenu, context: context)
@@ -27,6 +67,24 @@ extension StatusItemController {
             to: menu,
             captureMenu: captureMenu,
             context: context)
+    }
+
+    func handleClaudeSwapAccountSelection(_ id: ProviderAccountIdentity, menu: NSMenu?) {
+        guard self.store.claudeSwapTransientState.task == nil,
+              let account = self.store.claudeSwapAccountSnapshots.first(where: { $0.id == id })
+        else { return }
+        self.advanceMenuInteraction(for: menu)
+        if account.isActive || !account.canActivate {
+            // Inspect sentinel diagnostics without asking the adapter to activate that slot.
+            self.claudeSwapInspectedAccountID = id
+            self.invalidateMenus()
+        } else {
+            self.claudeSwapInspectedAccountID = nil
+            self.store.switchClaudeSwapAccount(id)
+        }
+        if let menu {
+            self.deferSwitcherMenuRebuildIfStillVisible(menu, provider: .claude)
+        }
     }
 
     private func addStackedClaudeSwapMenuCards(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -169,7 +169,7 @@ extension StatusItemController {
         }
         if self.openMenus.isEmpty {
             self.cancelMergedSwitcherSiblingWarmup()
-            self.claudeSwapInspectedAccountID = nil
+            self.resetClaudeSwapAccountInspection()
         }
         self.resetCompactAccountMenuExpansionStateIfIdle()
     }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -169,6 +169,7 @@ extension StatusItemController {
         }
         if self.openMenus.isEmpty {
             self.cancelMergedSwitcherSiblingWarmup()
+            self.claudeSwapInspectedAccountID = nil
         }
         self.resetCompactAccountMenuExpansionStateIfIdle()
     }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -289,6 +289,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var mergedSwitcherWarmupTimer: Timer?
     /// Compact multi-account layout: accounts the user expanded to full cards this menu session.
     var compactAccountExpandedIDs: Set<ProviderAccountIdentity> = []
+    var claudeSwapInspectedAccountID: ProviderAccountIdentity?
     /// Compact multi-account layout: providers whose collapsed healthy tail is revealed this menu session.
     var compactAccountExpandedHealthyTailProviders: Set<ProviderInstanceID> = []
     /// Keeps detached merged-menu tab content reusable while the same menu remains open.

--- a/Tests/CodexBarTests/ClaudeSwapAccountMenuDisplayTests.swift
+++ b/Tests/CodexBarTests/ClaudeSwapAccountMenuDisplayTests.swift
@@ -1,0 +1,93 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct ClaudeSwapAccountMenuDisplayTests {
+    private func account(_ slot: String, active: Bool = false, canActivate: Bool = true)
+        -> ProviderAccountUsageSnapshot
+    {
+        ProviderAccountUsageSnapshot(
+            id: ProviderAccountIdentity(source: "claude-swap", opaqueID: slot),
+            provider: .claude,
+            displayLabel: "person\(slot)@example.com",
+            isActive: active,
+            canActivate: canActivate && !active,
+            snapshot: nil,
+            error: nil,
+            sourceLabel: "claude-swap")
+    }
+
+    private func display(
+        _ accounts: [ProviderAccountUsageSnapshot],
+        layout: MultiAccountMenuLayout = .segmented,
+        switching: ProviderAccountIdentity? = nil,
+        error: ProviderAccountIdentity? = nil) -> ClaudeSwapAccountMenuDisplay
+    {
+        ClaudeSwapAccountMenuDisplay(
+            accounts: accounts, layout: layout, switchingAccountID: switching, errorAccountID: error)
+    }
+
+    @Test
+    func `segmented preference selects the active stable slot after adapter reordering`() {
+        let first = self.account("7")
+        let active = self.account("2", active: true)
+        for accounts in [[first, active], [active, first]] {
+            let display = self.display(accounts)
+            #expect(display.showsSwitcher)
+            #expect(display.displayedAccount?.id == active.id)
+        }
+        #expect(!self.display([active]).showsSwitcher)
+        #expect(!self.display([first, active], layout: .stacked).showsSwitcher)
+        #expect(self.display([first, self.account("9")]).displayedAccount == nil)
+        #expect(self.display([self.account("9"), first]).displayedAccount == nil)
+    }
+
+    @Test
+    func `pending and failed activation retain the requested account details`() {
+        let active = self.account("2", active: true)
+        let target = self.account("7")
+        let removed = self.account("9")
+        #expect(self.display([active, target], switching: target.id).displayedAccount?.id == target.id)
+        #expect(self.display([active, target], error: target.id).displayedAccount?.id == target.id)
+        #expect(self.display([active, target], error: removed.id).displayedAccount?.id == active.id)
+        #expect(self.display([]).displayedAccount == nil)
+        var inspected = self.display([active, target], error: target.id)
+        inspected.inspectedAccountID = active.id
+        #expect(inspected.displayedAccount?.id == active.id)
+    }
+
+    @Test
+    func `redaction uses stable slot ordinals instead of labels or list positions`() {
+        let account = self.account("7")
+        #expect(ClaudeSwapAccountMenuDisplay.label(for: account, hidePersonalInfo: true) == "Account 7")
+        #expect(ClaudeSwapAccountMenuDisplay.label(for: account, hidePersonalInfo: false) == account.displayLabel)
+    }
+
+    @Test
+    func `switcher permits inspection and serializes repeated activation selection`() {
+        let active = self.account("2", active: true)
+        let unavailable = self.account("3", canActivate: false)
+        let target = self.account("7")
+        var selected: [ProviderAccountIdentity] = []
+        let view = ClaudeSwapAccountSwitcherView(
+            display: self.display([target, unavailable, active]),
+            hidePersonalInfo: true,
+            width: 320,
+            onSelect: { selected.append($0) })
+        view._test_select(unavailable.id)
+        view._test_select(active.id)
+        #expect(selected == [unavailable.id, active.id])
+        view._test_select(target.id)
+        view._test_select(target.id)
+        #expect(selected == [unavailable.id, active.id, target.id])
+        #expect(view.fittingSize.height == 26)
+        let wrapped = ClaudeSwapAccountSwitcherView(
+            display: self.display([active, target, unavailable, self.account("8")]),
+            hidePersonalInfo: true,
+            width: 320,
+            onSelect: { _ in })
+        #expect(wrapped.fittingSize.height == 56)
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1043,7 +1043,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "The memory-pressure debug fixture installs its synthetic entry in the Codex cache slot."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1102,
+            line: 1103,
             anchor: "controller.refreshOpenMenuIfStillVisible(menu, provider: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -2598,7 +2598,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1135,
+            line: 1136,
             anchor: "return .provider((self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex).instanceID)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2606,7 +2606,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1148,
+            line: 1149,
             anchor: "return self.store.enabledFirstPartyProvidersForDisplay().first ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2686,7 +2686,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController.swift",
-            line: 367,
+            line: 368,
             anchor: "if provider == .codex {",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/StatusMenuClaudeSwapCompactTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClaudeSwapCompactTests.swift
@@ -158,6 +158,18 @@ final class StatusMenuClaudeSwapCompactTests: XCTestCase {
         }
     }
 
+    func test_segmentedNoActiveAccountDoesNotDisplayAmbientUsage() {
+        let inactive = self.account(slot: 7, email: "inactive@example.com", sessionUsed: 10, weeklyUsed: 20)
+        let other = self.account(slot: 9, email: "other@example.com", sessionUsed: 30, weeklyUsed: 40)
+        let (controller, store) = self.makeController(accounts: [inactive, other], layout: .segmented)
+        defer { controller.releaseStatusItemsForTesting() }
+        store.snapshots[.claude] = self.sixAccounts()[0].snapshot
+        let menu = controller.makeMenu(for: .claude)
+        controller.menuWillOpen(menu)
+        XCTAssertTrue(menu.items.contains { $0.title == "No active account" })
+        XCTAssertFalse(self.representedIDs(in: menu).contains { $0.hasPrefix("menuCard") })
+    }
+
     func test_segmentedInspectionPreservesNoActiveAccountNotice() {
         let sentinel = self.account(
             slot: 9, email: "expired@example.com", sessionUsed: 0, weeklyUsed: 0, canActivate: false)

--- a/Tests/CodexBarTests/StatusMenuClaudeSwapCompactTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClaudeSwapCompactTests.swift
@@ -126,6 +126,38 @@ final class StatusMenuClaudeSwapCompactTests: XCTestCase {
         XCTAssertNil(controller.claudeSwapInspectedAccountID)
     }
 
+    func test_segmentedFreshPersistentMenuDropsInspectionOnReopenWithoutRefresh() {
+        for merged in [false, true] {
+            let sentinel = self.account(
+                slot: 9, email: "expired@example.com", sessionUsed: 0, weeklyUsed: 0, canActivate: false)
+            let (controller, store) = self.makeController(
+                accounts: [self.sixAccounts()[0], sentinel], layout: .segmented)
+            defer { controller.releaseStatusItemsForTesting() }
+            controller.settings.mergeIcons = merged
+            let menu = controller.makeMenu(for: .claude)
+            if merged {
+                controller.mergedMenu = menu
+            } else {
+                controller.providerMenus[.claude] = menu
+            }
+            controller.menuWillOpen(menu)
+            controller.handleClaudeSwapAccountSelection(sentinel.id, menu: nil)
+            controller.populateMenu(menu, provider: .claude)
+            controller.markMenuFresh(menu)
+            XCTAssertTrue(menu.items.contains { $0.title.hasPrefix("Details for") })
+            XCTAssertFalse(controller.menuNeedsRefresh(menu))
+            let revision = store.claudeSwapRevision
+
+            controller.menuDidClose(menu)
+            controller.refreshMenuForOpenIfNeeded(menu, provider: .claude)
+
+            XCTAssertNil(controller.claudeSwapInspectedAccountID)
+            XCTAssertFalse(menu.items.contains { $0.title.hasPrefix("Details for") })
+            XCTAssertFalse(controller.menuNeedsRefresh(menu))
+            XCTAssertEqual(store.claudeSwapRevision, revision)
+        }
+    }
+
     func test_segmentedInspectionPreservesNoActiveAccountNotice() {
         let sentinel = self.account(
             slot: 9, email: "expired@example.com", sessionUsed: 0, weeklyUsed: 0, canActivate: false)

--- a/Tests/CodexBarTests/StatusMenuClaudeSwapCompactTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClaudeSwapCompactTests.swift
@@ -10,7 +10,8 @@ import XCTest
 @MainActor
 final class StatusMenuClaudeSwapCompactTests: XCTestCase {
     private func makeController(
-        accounts: [ProviderAccountUsageSnapshot]) -> (controller: StatusItemController, store: UsageStore)
+        accounts: [ProviderAccountUsageSnapshot],
+        layout: MultiAccountMenuLayout = .stacked) -> (controller: StatusItemController, store: UsageStore)
     {
         StatusItemController.menuCardRenderingEnabled = false
         StatusItemController.setMenuRefreshEnabledForTesting(false)
@@ -21,6 +22,7 @@ final class StatusMenuClaudeSwapCompactTests: XCTestCase {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
+        settings.multiAccountMenuLayout = layout
         let registry = ProviderRegistry.shared
         for provider in UsageProvider.allCases {
             guard let metadata = registry.metadata[provider] else { continue }
@@ -45,14 +47,15 @@ final class StatusMenuClaudeSwapCompactTests: XCTestCase {
         email: String,
         isActive: Bool = false,
         sessionUsed: Double,
-        weeklyUsed: Double) -> ProviderAccountUsageSnapshot
+        weeklyUsed: Double,
+        canActivate: Bool = true) -> ProviderAccountUsageSnapshot
     {
         ProviderAccountUsageSnapshot(
             id: ProviderAccountIdentity(source: "claude-swap", opaqueID: String(slot)),
             provider: .claude,
             displayLabel: email,
             isActive: isActive,
-            canActivate: !isActive,
+            canActivate: !isActive && canActivate,
             snapshot: UsageSnapshot(
                 primary: RateWindow(
                     usedPercent: sessionUsed,
@@ -87,6 +90,54 @@ final class StatusMenuClaudeSwapCompactTests: XCTestCase {
 
     private func representedIDs(in menu: NSMenu) -> [String] {
         menu.items.compactMap { $0.representedObject as? String }
+    }
+
+    func test_segmentedRefreshKeepsOneSwitcherAndOneCard() {
+        let accounts = Array(self.sixAccounts().prefix(2))
+        let (controller, store) = self.makeController(accounts: accounts, layout: .segmented)
+        defer { controller.releaseStatusItemsForTesting() }
+        let menu = controller.makeMenu(for: .claude)
+        controller.menuWillOpen(menu)
+        for _ in 0..<2 {
+            XCTAssertEqual(menu.items.count(where: { $0.view is ClaudeSwapAccountSwitcherView }), 1)
+            XCTAssertEqual(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") }, ["menuCard-0"])
+            store.claudeSwapAccountSnapshots.reverse()
+            controller.populateMenu(menu, provider: .claude)
+        }
+    }
+
+    func test_segmentedSentinelInspectionNeverStartsActivationAndResetsOnClose() {
+        let sentinel = self.account(
+            slot: 9, email: "expired@example.com", sessionUsed: 0, weeklyUsed: 0, canActivate: false)
+        let (controller, store) = self.makeController(
+            accounts: [self.sixAccounts()[0], sentinel], layout: .segmented)
+        defer { controller.releaseStatusItemsForTesting() }
+        let menu = controller.makeMenu(for: .claude)
+        controller.menuWillOpen(menu)
+        controller.handleClaudeSwapAccountSelection(sentinel.id, menu: nil)
+        XCTAssertEqual(controller.claudeSwapInspectedAccountID, sentinel.id)
+        XCTAssertNil(store.claudeSwapTransientState.task)
+        XCTAssertNil(store.claudeSwapTransientState.switchingAccountID)
+        controller.settings.hidePersonalInfo = true
+        controller.populateMenu(menu, provider: .claude)
+        XCTAssertTrue(menu.items.contains { $0.title == "Details for Account 9" })
+        XCTAssertFalse(menu.items.contains { $0.title.contains("expired@example.com") })
+        controller.menuDidClose(menu)
+        XCTAssertNil(controller.claudeSwapInspectedAccountID)
+    }
+
+    func test_segmentedInspectionPreservesNoActiveAccountNotice() {
+        let sentinel = self.account(
+            slot: 9, email: "expired@example.com", sessionUsed: 0, weeklyUsed: 0, canActivate: false)
+        let inactive = self.account(slot: 7, email: "inactive@example.com", sessionUsed: 10, weeklyUsed: 20)
+        let (controller, _) = self.makeController(accounts: [inactive, sentinel], layout: .segmented)
+        defer { controller.releaseStatusItemsForTesting() }
+        let menu = controller.makeMenu(for: .claude)
+        controller.menuWillOpen(menu)
+        controller.handleClaudeSwapAccountSelection(sentinel.id, menu: nil)
+        controller.populateMenu(menu, provider: .claude)
+        XCTAssertTrue(menu.items.contains { $0.title == "No active account" })
+        XCTAssertEqual(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") }, ["menuCard-0"])
     }
 
     func test_manyAccountsRenderCompactLayoutRows() {

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -159,9 +159,14 @@ The accepted multi-account design in
   weekly windows from `usage.scoped`. Identity stays `claude-swap:<slot>`; organization name and alias are never
   used as identity. When two or more slots share an email, cards append ` · organizationName` or ` · Account N`;
   a user-chosen cswap alias replaces that label. Unique emails stay email-only.
-- Display: when claude-swap reports more than one account, the Claude menu and `codexbar cards` show one card per
-  account (active account first, then numeric slot) instead of ambient/token-account Claude cards. With four or more
-  accounts the app menu switches to a compact layout (`AccountMenuLayoutPlanner`): the active account keeps its full
+- Display: when claude-swap reports more than one account, its accounts replace ambient/token-account Claude cards.
+  The app honors **Menu → Multi-account layout**: Segmented shows account buttons and one active account card;
+  pending or failed switches show the requested account's details while the active marker stays source-owned.
+  Expired or otherwise unavailable accounts remain inspectable without activation; selecting the active account
+  returns to its card. If the adapter reports no active account, the menu says so instead of selecting the first row.
+  Buttons wrap into two rows above three accounts. Hide Personal Info uses stable `Account N` slot labels.
+  Stacked shows one card per account (active account first, then numeric slot). With four or more
+  accounts the stacked menu switches to a compact layout (`AccountMenuLayoutPlanner`): the active account keeps its full
   card, inactive accounts become one-line rows sorted by remaining headroom (most constrained first, red/amber below
   50%/10% left, a star on the healthiest activatable account), and healthy rows fold behind a "N more accounts ready"
   summary row. Clicking a compact row expands that account's full card for the current menu session; the summary row


### PR DESCRIPTION
Claude-swap ignored Menu → Multi-account layout and always rendered stacked/compact cards. Honor Segmented with stable account buttons and one source-owned detail card, reusing the existing serialized activation path.

Keep the active marker tied to adapter output. Unavailable accounts remain inspectable without activation; pending and failed switches retain the requested account’s usage and diagnostics. Use stable slot labels with Hide Personal Info. Closing inspection invalidates the cached menu so a fresh persistent menu returns to the active card on reopen without another fetch. With no active or explicitly selected account, show the no-active notice without falling back to ambient usage. Stacked/compact menus and CLI cards keep their existing behavior.

Fixes #3382. Thanks @thatlev for the report and acceptance criteria. Release notes are in #3499, to land after the code PRs.

Validation: make check passed; make test passed all 1,036 selections in 87 groups on the final head with no retries, failures, or timeouts. The persistent-menu regression failed before repair for both provider and merged menus, then passed. The architecture guard remains unchanged apart from four exact-line offsets. Independent branch review is clean through P2.

Developer ID-signed native proof exercised successful/failed switching, retained usage, privacy labels, sentinel inspection, merged menus, four-account wrapping, and no-active behavior. Reusing the same menu across inspection and reopen restored the active card with no change to provider revision or adapter invocation count. The built CLI continued to render every synthetic account, including the expired slot. All proof uses synthetic data and a fake cswap executable.

| Existing stacked rendering (preserved) | Segmented rendering |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5b59ec8f-6250-4e27-b3d9-fbe277bbf158" width="310" alt="Existing stacked Claude cards with synthetic accounts"> | <img src="https://github.com/user-attachments/assets/2215eef4-b3b7-42ef-9f52-36b46f8a7b0a" width="310" alt="Segmented Claude cards with the same synthetic accounts"> |

| Inspect an unavailable account | Reopen the same menu, without a fetch |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/afdadfd9-fd74-4e9b-9599-922e45206f16" width="310" alt="Inspecting a synthetic expired account"> | <img src="https://github.com/user-attachments/assets/311f8514-0c6c-4859-b2fa-dae0ac2f8e09" width="310" alt="Persistent menu restored to the active account"> |

[No active account: no ambient quota card](https://github.com/user-attachments/assets/bf0c06bb-8af6-472d-b850-f9624588d56d).
