### PR TITLE
docs(changelog): collect local cost accuracy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - **Safer updates and more reliable usage:** refresh Sparkle's installer protections, preserve claude-swap measurement ages, and improve local history and account handling.
 
 ### Fixed
+- Codex local costs: accept valid JSON whitespace in usage events, retain next-day appended usage, and rebuild previously empty cached scans.
+- Codex local costs: include reserve usage in fresh and cached GPT-5.6 Luna cost estimates; preserve the subscription estimate disclaimer (#3503, #3502). Thanks @BUKOWSKIREAL!
 - Usage parsing: reject out-of-range numeric counts in MiMo, Pi/OMP, OpenCodex, and Bedrock instead of trapping at rounded integer limits; preserve existing rounding and valid usage fields, and reparse OpenCodex caches created by the older parser (#3486).
 - Subprocesses: accept very large finite timeouts without overflowing nanosecond conversion.
 - AWS Bedrock: disclose monitoring charges in both authentication modes, link current Cost Explorer pricing, and explain the shared refresh controls and informational budget (#3496, related to #3387). Thanks @kyen99!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - **Safer updates and more reliable usage:** refresh Sparkle's installer protections, preserve claude-swap measurement ages, and improve local history and account handling.
 
 ### Fixed
-- Codex local costs: accept valid JSON whitespace in usage events, retain next-day appended usage, and rebuild previously empty cached scans.
-- Codex local costs: include reserve usage in fresh and cached GPT-5.6 Luna cost estimates; preserve the subscription estimate disclaimer (#3503, #3502). Thanks @BUKOWSKIREAL!
+- Codex local costs: accept valid JSON whitespace in usage events, retain next-day appended usage, and reparse older files once without deleting compatible stores (#3504).
+- Codex local costs: include reserve usage in fresh and cached GPT-5.6 Luna cost estimates while preserving compatible rows and scan progress (#3503, #3502). Thanks @BUKOWSKIREAL!
 - Usage parsing: reject out-of-range numeric counts in MiMo, Pi/OMP, OpenCodex, and Bedrock instead of trapping at rounded integer limits; preserve existing rounding and valid usage fields, and reparse OpenCodex caches created by the older parser (#3486).
 - Subprocesses: accept very large finite timeouts without overflowing nanosecond conversion.
 - AWS Bedrock: disclose monitoring charges in both authentication modes, link current Cost Explorer pricing, and explain the shared refresh controls and informational budget (#3496, related to #3387). Thanks @kyen99!


### PR DESCRIPTION
Collect exactly two local-cost release notes in the existing Unreleased section: reserve pricing from #3503 and valid-JSON whitespace parsing/cache migration from #3504. Preserve contributor credit and all prior changelog content.

#3503 is on main. Land this notes PR after #3504. Both main and the rebased #3504 merge cleanly with these notes; no release, tag, or version bump is included.

Verification at `28396b1c0c24219a75c00519fd8f03872cdad0f5`: only CHANGELOG.md changes, exactly two added lines, all previous content byte-for-byte unchanged, independent P2 review clean. Exact-head CI succeeded: https://github.com/steipete/CodexBar/actions/runs/34210095572. Runtime and full-suite evidence belong to the linked code PRs.
