### PR TITLE
fix(minimax): preserve transport errors for offline cache and retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Copilot: resolve Enterprise sign-in identities on the configured host, keep equal user IDs on different hosts distinct, and skip public GitHub budget enrichment for Enterprise accounts (#3341). Thanks @Fletcher-Alderton!
 - Local costs: avoid overflow traps in OpenCodex and combined cost reports, keeping unrepresentable token sums unavailable while retaining valid neighboring token classes.
 - Kiro: route existing overage enrichment to the CLI profile’s supported region instead of always using US East; reject invalid profile ARNs before sending credentials and retain CLI fallback (#3359). Thanks @zucram!
+- MiniMax: retain transport error codes so DNS, connection, and translated offline failures preserve cached usage and participate in normal connectivity retries.
 - Settings: observe rapid external config replacements and edits that restore earlier app-written contents, while keeping successful app writes out of the external-change sync path.
 - Local usage: honor the app’s Low Power Mode interval for automatic Codex catch-up passes in both usage and Spend Dashboard, while retaining manual acceleration and system thermal pauses.
 - z.ai: preserve required quota when optional model analytics exceed display bounds or overflow; retain valid Unicode labels with shared native validation and normalize token inputs once.

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -163,17 +163,18 @@ public struct MiniMaxUsageFetcher: Sendable {
                     remainsURL: remainsURL,
                     now: now,
                     transport: transport)
-            } catch let error as MiniMaxUsageError {
+            } catch {
+                guard error is MiniMaxUsageError || self.shouldTryNextEndpoint(after: error) else { throw error }
                 lastError = error
                 guard remainsURL == region.tokenPlanRemainsURL,
-                      self.shouldTryLegacyAPIEndpoint(after: error)
+                      self.shouldTryNextEndpoint(after: error, retryRejectedCredentials: true)
                 else {
                     if tokenPlanCredentialFailure {
                         throw MiniMaxUsageError.invalidCredentials
                     }
                     throw error
                 }
-                if case .invalidCredentials = error {
+                if case .invalidCredentials? = error as? MiniMaxUsageError {
                     tokenPlanCredentialFailure = true
                 }
                 Self.log.debug("MiniMax token-plan API failed, trying legacy coding-plan endpoint")
@@ -232,10 +233,14 @@ public struct MiniMaxUsageFetcher: Sendable {
         return normalizedMessage == "invalid api key" ? .invalidCredentials : error
     }
 
-    private static func shouldTryLegacyAPIEndpoint(after error: MiniMaxUsageError) -> Bool {
-        switch error {
+    private static func shouldTryNextEndpoint(after error: Error, retryRejectedCredentials: Bool = false) -> Bool {
+        guard let error = error as? MiniMaxUsageError else {
+            let error = error as NSError
+            return error.domain == NSURLErrorDomain && error.code != NSURLErrorCancelled
+        }
+        return switch error {
         case .invalidCredentials:
-            true
+            retryRejectedCredentials
         case let .apiError(message):
             message.contains("HTTP 404") || message.contains("HTTP 405")
         case .networkError, .parseFailed:
@@ -323,9 +328,9 @@ public struct MiniMaxUsageFetcher: Sendable {
                     context: context,
                     remainsContext: remainsContext,
                     now: now)
-            } catch let error as MiniMaxUsageError {
+            } catch {
                 lastError = error
-                guard self.shouldTryNextRemainsURL(after: error) else { throw error }
+                guard self.shouldTryNextEndpoint(after: error) else { throw error }
                 Self.log.debug("MiniMax remains API failed for \(baseRemainsURL.host ?? "unknown host"), trying next")
             }
         }
@@ -400,31 +405,15 @@ public struct MiniMaxUsageFetcher: Sendable {
         return try MiniMaxUsageParser.parse(html: html, now: now)
     }
 
-    private static func shouldTryNextRemainsURL(after error: MiniMaxUsageError) -> Bool {
-        switch error {
-        case .invalidCredentials:
-            false
-        case let .apiError(message):
-            message.contains("HTTP 404") || message.contains("HTTP 405")
-        case .networkError, .parseFailed:
-            true
-        }
-    }
-
     private static func normalizedTransportError(_ error: Error) -> Error {
-        if error is MiniMaxUsageError || error is CancellationError {
-            return error
-        }
-        if let urlError = error as? URLError {
-            if urlError.code == .cancelled {
-                return error
-            }
-            if urlError.code == .badServerResponse {
-                return MiniMaxUsageError.networkError("Invalid response")
-            }
-            return MiniMaxUsageError.networkError(urlError.localizedDescription)
-        }
-        return error
+        let original = error as NSError
+        guard original.domain == NSURLErrorDomain, original.code != NSURLErrorCancelled else { return error }
+        // Keep transport identity for cache/retry policy and MiniMax text for diagnostic classification.
+        var userInfo = original.userInfo
+        let description = original.code == NSURLErrorBadServerResponse ? "Invalid response" : original
+            .localizedDescription
+        userInfo[NSLocalizedDescriptionKey] = MiniMaxUsageError.networkError(description).localizedDescription
+        return NSError(domain: original.domain, code: original.code, userInfo: userInfo)
     }
 
     private static func shouldRethrowAfterHTMLFallback(_ error: Error) -> Bool {

--- a/Tests/CodexBarTests/MiniMaxTransportIdentityTests.swift
+++ b/Tests/CodexBarTests/MiniMaxTransportIdentityTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+struct MiniMaxTransportIdentityTests {
+    enum Route: CaseIterable, Sendable {
+        case api
+        case html
+        case remains
+    }
+
+    @Test(arguments: Route.allCases)
+    func `cancelled transports do not try another endpoint`(route: Route) async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            if route == .remains, let url = request.url, url.path.contains("coding-plan") {
+                let response = try #require(HTTPURLResponse(
+                    url: url, statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "text/html"]))
+                return (Data("<html>synthetic fixture</html>".utf8), response)
+            }
+            throw URLError(.cancelled)
+        }
+        do {
+            if route == .api {
+                _ = try await MiniMaxUsageFetcher.fetchUsage(
+                    apiToken: "sk-cp-test", region: .chinaMainland, session: transport)
+            } else {
+                _ = try await MiniMaxUsageFetcher.fetchUsage(
+                    cookieHeader: "HERTZ-SESSION=synthetic",
+                    region: .chinaMainland,
+                    environment: [:],
+                    includeBillingHistory: false,
+                    session: transport)
+            }
+            Issue.record("Expected cancellation")
+        } catch {
+            #expect((error as NSError).domain == NSURLErrorDomain)
+            #expect((error as NSError).code == NSURLErrorCancelled)
+        }
+        #expect(await transport.requests().count == (route == .remains ? 2 : 1))
+    }
+
+    @Test(arguments: [NSURLErrorCancelled, NSURLErrorCannotFindHost, 42])
+    func `official auth rejection only replaces recognized legacy transport errors`(code: Int) async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            if url.path == "/v1/token_plan/remains" {
+                let response = try #require(HTTPURLResponse(
+                    url: url,
+                    statusCode: 401,
+                    httpVersion: nil,
+                    headerFields: nil))
+                return (Data("{}".utf8), response)
+            }
+            throw NSError(domain: code == 42 ? "synthetic-error" : NSURLErrorDomain, code: code)
+        }
+        do {
+            _ = try await MiniMaxUsageFetcher.fetchUsage(
+                apiToken: "sk-cp-test", region: .chinaMainland, session: transport)
+            Issue.record("Expected endpoint failure")
+        } catch {
+            if code == NSURLErrorCannotFindHost {
+                #expect(error as? MiniMaxUsageError == .invalidCredentials)
+            } else {
+                #expect((error as NSError).code == code)
+                #expect((error as NSError).domain == (code == 42 ? "synthetic-error" : NSURLErrorDomain))
+            }
+        }
+        #expect(await transport.requests().count == 2)
+    }
+
+    @Test
+    func `invalid server responses retain their existing diagnostic description`() async throws {
+        let transport = ProviderHTTPTransportStub { _ in throw URLError(.badServerResponse) }
+        do {
+            _ = try await MiniMaxUsageFetcher.fetchUsage(
+                apiToken: "sk-cp-test", region: .chinaMainland, session: transport)
+            Issue.record("Expected invalid response")
+        } catch {
+            #expect((error as NSError).domain == NSURLErrorDomain)
+            #expect((error as NSError).code == NSURLErrorBadServerResponse)
+            #expect(error.localizedDescription == "MiniMax network error: Invalid response")
+            #expect(ProviderDiagnosticError(from: error, authConfigured: true).category == "network")
+        }
+    }
+
+    @Test(arguments: [
+        URLError.Code.cannotFindHost, .cannotConnectToHost, .notConnectedToInternet,
+        .timedOut, .dnsLookupFailed, .networkConnectionLost,
+    ], Route.allCases)
+    func `translated transport failures keep machine identity and cached usage policy`(
+        code: URLError.Code,
+        route: Route) async throws
+    {
+        let transport = ProviderHTTPTransportStub { request in
+            if route == .remains, let url = request.url, url.path.contains("coding-plan") {
+                let response = try #require(HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "text/html"]))
+                return (Data("<html>synthetic fixture</html>".utf8), response)
+            }
+            throw NSError(domain: NSURLErrorDomain, code: code.rawValue, userInfo: [
+                NSLocalizedDescriptionKey: "Verbindung fehlgeschlagen",
+                "synthetic-marker": "preserved",
+            ])
+        }
+        do {
+            if route == .api {
+                _ = try await MiniMaxUsageFetcher.fetchUsage(
+                    apiToken: "sk-cp-test",
+                    region: .chinaMainland,
+                    session: transport)
+            } else {
+                _ = try await MiniMaxUsageFetcher.fetchUsage(
+                    cookieHeader: "HERTZ-SESSION=synthetic",
+                    region: .chinaMainland,
+                    environment: [:],
+                    includeBillingHistory: false,
+                    session: transport)
+            }
+            Issue.record("Expected a synthetic transport failure")
+        } catch {
+            let failure = error as NSError
+            #expect(failure.domain == NSURLErrorDomain)
+            #expect(failure.code == code.rawValue)
+            #expect(failure.userInfo["synthetic-marker"] as? String == "preserved")
+            #expect(error.localizedDescription == "MiniMax network error: Verbindung fehlgeschlagen")
+            #expect(UsageStore.shouldPreservePriorSnapshot(after: error, hadPriorData: true))
+            #expect(!UsageStore.shouldPreservePriorSnapshot(after: error, hadPriorData: false))
+            #expect(UsageStore.isStartupConnectivityRetryableError(error))
+            #expect(UsageStore.refreshFailureHookStatus(error) == (code == .timedOut ? "timeout" : "offline"))
+            #expect(ProviderDiagnosticError(from: error, authConfigured: true).category == "network")
+            #expect(ProviderDiagnosticFetchAttempt.errorCategoryLabel(error.localizedDescription) == "network")
+        }
+        let requests = await transport.requests()
+        #expect(requests.count == (route == .api ? 2 : route == .html ? 1 : 3))
+    }
+}

--- a/docs/minimax.md
+++ b/docs/minimax.md
@@ -42,6 +42,10 @@ falls back across the provider's supported web requests when needed.
 - Security policy: endpoint overrides are only accepted when they use `https://`, omit userinfo, and do not contain encoded host delimiters. Custom HTTPS proxy/test domains continue to work for compatibility, but `http://` endpoints are rejected so cookies and authorization headers are not sent in cleartext.
 - Strict provider-host mode: set `MINIMAX_REQUIRE_PROVIDER_ENDPOINT_OVERRIDES=true` to additionally reject custom proxy/test domains and only accept MiniMax-owned hosts under `minimax.io` or `minimaxi.com`.
 
+Transport failures retain their URL error codes and MiniMax diagnostic descriptions, so offline, DNS, and connection
+failures preserve existing usage and qualify for the normal startup retry policy regardless of system language.
+Endpoint fallback, rejected-credential handling, and optional billing enrichment keep their existing behavior.
+
 ## Cookie capture (optional override)
 - Open the Coding Plan page and DevTools → Network.
 - Select the request to `/v1/api/openplatform/coding_plan/remains`.


### PR DESCRIPTION
MiniMax converted URL transport failures into text-only provider errors. That erased the URL domain and code, so localized offline, DNS, and connection errors could discard cached usage or miss startup retry handling.

Preserve the original URL error identity and metadata while keeping MiniMax's diagnostic description. Consolidate the duplicate endpoint retry policies; authentication rejection remains authoritative, and cancellation or unrelated errors escape fallback. Production code is net −11 lines. Includes provider documentation and an Unreleased changelog entry.

Related to #3500; this fixes the MiniMax transport classification path without claiming to explain every offline-widget report.

Validation: the regression cases failed before the fix with 108 assertions across 18 localized transport scenarios. All 138 focused tests in 17 suites passed, including cancellation, authentication, diagnostics, cache, startup retry, and hook controls. The full `make test` passed 1,038 selections in 87 groups on the first pass, with no retries or timeouts. `make check` and independent P0–P2 review passed. Tests use injected transports and synthetic errors; no real credentials or provider requests.
