### PR TITLE
Keep the hero copy on the left under RTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Codex activity: read scoped daily totals without decoding unused event history, preserving account boundaries, coverage, and incomplete-scan checks (#3528, related to #3247). Thanks @brzvsk!
 
 ### Fixed
+- Website: keep Arabic and Persian hero copy clear of the illustration, preserve natural text direction, and avoid an oversized tablet popover during its reveal (#3514, fixes #3511). Thanks @devYRPauli!
 - Menus: refresh cached status menus when macOS appearance changes, including previously opened submenus, so the first opening matches Light/Dark and accessibility appearances (#3526). Thanks @emanuelst!
 
 ## 0.58.0 — 2026-09-09

--- a/docs/site.css
+++ b/docs/site.css
@@ -621,7 +621,10 @@ html.bg-black { background-color: var(--page-bg) !important; }
   width: 100%;
   max-width: 42rem;
   padding-top: clamp(9rem, 21vh, 13rem);
-  text-align: left;
+  /* The mockup art is anchored to the physical right and cannot mirror, so the
+     copy keeps the left side under RTL instead of sliding onto the art. */
+  margin-right: auto;
+  text-align: start;
 }
 
 .hero-cta-row {
@@ -1675,7 +1678,6 @@ html.bg-black { background-color: var(--page-bg) !important; }
     top: var(--tablet-hud-panel-top);
     right: var(--tablet-hud-panel-margin-right);
     width: var(--tablet-hud-panel-width);
-    transform: translate(var(--hud-panel-nudge-x), var(--hud-panel-nudge-y)) scale(var(--tablet-popover-scale));
   }
 }
 
@@ -2329,7 +2331,7 @@ html.bg-black { background-color: var(--page-bg) !important; }
     max-width: none;
     margin-inline: 0;
     padding: 2.25rem 0 0;
-    text-align: left;
+    text-align: start;
   }
 
   .hero-copy .justify-center {


### PR DESCRIPTION
Fixes #3511.

Arabic and Persian hero copy stays physically left of the fixed artwork while text alignment follows its reading direction. Mobile keeps the existing stacked layout. The tablet popover also inherits the shared reveal scale: its previous tablet-only starting transform grew across the text before the more-specific animated rule settled it back down.

Real Chrome verification used the existing profile through the approved browser integration and a local server for the current checkout. The original desktop overlap was reproduced, and the site’s own language picker was exercised. Fifteen normal-layout cases cover Arabic/Persian at the 769/1023 tablet edges, 900px tablet, 1671/1280 desktop, and 768/375 mobile widths, with English controls. All final cases have zero text/illustration overlap and horizontal overflow; English placement is unchanged.

A frame-by-frame replay of the actual 769px reveal found six visible glyph-overlap frames with the original proposal; the additional transform cleanup reduced that to zero across 55 frames. Static fixed-transform measurements were supporting diagnostics, not substitutes for normal rendering.

`node --check docs/site.js`, `node Scripts/check-site-locales.mjs` (23 locales / 138 messages), `make check`, and independent P0–P2 review passed. The full repository suite passed all 1,058 selections in 89 groups on the first pass, with no retries or timeouts (951.1 seconds). Final-head CI passed: https://github.com/steipete/CodexBar/actions/runs/34454905234. After integrating main, the Swift source and tests are identical to the fully tested credential-guidance merge.

Includes a 0.58.1 Unreleased entry. Thanks @devYRPauli!

Before, normal Arabic rendering overlaps the panel:

![Arabic hero overlap before the fix](https://github.com/user-attachments/assets/7125486a-31c7-4b00-bd58-1f970c878cb1)

After, selected through the actual language picker with normal animation:

![Arabic hero clear of the artwork after the fix](https://github.com/user-attachments/assets/3ba8c29f-369f-440f-861f-77f5da60425d)
