### PR TITLE
Add top-level plugin switcher tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.58.1 — Unreleased
 
+### Added
+- Plugins: opt into first-class provider switcher tabs with selected-plugin refresh, plugin-only menus, and continued access to appended plugin cards (#3516, fixes #2988). Thanks @harjothkhara!
+
 ### Performance
 - Codex activity: read scoped daily totals without decoding unused event history, preserving account boundaries, coverage, and incomplete-scan checks (#3528, related to #3247). Thanks @brzvsk!
 

--- a/Sources/CodexBar/MenuSwitchFlickerProbe.swift
+++ b/Sources/CodexBar/MenuSwitchFlickerProbe.swift
@@ -324,7 +324,9 @@ enum MenuSwitchFlickerProbe {
             let selection = self.controller.resolvedSwitcherSelection(
                 enabledProviders: enabledProviders,
                 includesOverview: includesOverview)
-            var segments: [ProviderSwitcherSelection] = enabledProviders.map { .provider($0.instanceID) }
+            var segments: [ProviderSwitcherSelection] = self.controller
+                .switcherProviderIDs(enabledFirstPartyProviders: enabledProviders)
+                .map { .provider($0) }
             if includesOverview {
                 segments.insert(.overview, at: 0)
             }

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -184,12 +184,13 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             originatingMenuInteractionGeneration: originatingMenuInteractionGeneration)
     }
 
-    private func startManualRefresh(
+    func startManualRefresh(
         for provider: ProviderInstanceID?,
         originatingMenuID: ObjectIdentifier?,
         originatingMenuInteractionGeneration: Int?)
     {
         let firstPartyProvider = provider?.firstPartyProvider
+        let tracksFirstPartyCards = provider == nil || firstPartyProvider != nil
         let scope: ManualRefreshScope = provider.map(ManualRefreshScope.provider) ?? .global
         let scopedRefreshInFlight = provider.map { self.store.refreshingProviders.contains($0) }
             ?? !self.store.refreshingProviders.isEmpty
@@ -206,7 +207,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
               !scopedRefreshInFlight
         else { return }
 
-        let frozenModels = self.frozenManualRefreshMenuCardModels()
+        let frozenModels = tracksFirstPartyCards ? self.frozenManualRefreshMenuCardModels() : [:]
         let viewportRestoreRequests = self.armManualRefreshViewportRestoreRequests(
             originatingMenuID: originatingMenuID,
             originatingMenuInteractionGeneration: originatingMenuInteractionGeneration)
@@ -215,7 +216,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             var completed = false
             defer {
                 self.manualRefreshTasks[scope] = nil
-                self.menuCardRefreshMonitor.endManualRefresh(for: firstPartyProvider)
+                if tracksFirstPartyCards {
+                    self.menuCardRefreshMonitor.endManualRefresh(for: firstPartyProvider)
+                }
                 self.updatePersistentRefreshItemsEnabled()
                 if completed {
                     self.scheduleCompletedManualRefreshViewportRestore(viewportRestoreRequests)
@@ -239,6 +242,12 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
                     for: provider,
                     refreshOpenMenusWhenComplete: true,
                     interaction: .userInitiated)
+            } else if let provider {
+                await self.withProviderInteraction(.userInitiated) {
+                    await self.store.refreshUserPlugin(provider)
+                    guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+                    self.refreshOpenMenusAfterUserPluginRefresh(provider)
+                }
             } else {
                 await self.performStoreRefresh(
                     enrichmentMode: .forcedBackground,
@@ -249,16 +258,21 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             completed = true
         }
         self.manualRefreshTasks[scope] = task
-        self.menuCardRefreshMonitor.beginManualRefresh(frozenModels: frozenModels, provider: firstPartyProvider)
+        if tracksFirstPartyCards {
+            self.menuCardRefreshMonitor.beginManualRefresh(frozenModels: frozenModels, provider: firstPartyProvider)
+        }
         self.updatePersistentRefreshItemsEnabled()
     }
 
-    private func manualRefreshProvider(for menu: NSMenu?) -> ProviderInstanceID? {
+    func manualRefreshProvider(for menu: NSMenu?) -> ProviderInstanceID? {
         guard let menu else { return nil }
         if self.shouldMergeIcons {
             guard self.mergedMenu == nil || menu === self.mergedMenu else { return nil }
-            guard !self.isMergedOverviewSelected(in: menu) else { return nil }
-            return self.resolvedMenuProvider()?.instanceID
+            let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
+            if let selection = self.resolvedMergedMenuSelection(enabledProviders: enabledProviders) {
+                return selection.instanceID
+            }
+            return self.resolvedMenuProvider(enabledProviders: enabledProviders)?.instanceID
         }
         return self.menuProviders[ObjectIdentifier(menu)]
     }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -113,10 +113,17 @@ extension StatusItemController {
 
         var provider: UsageProvider?
         if self.shouldMergeIcons {
-            // Provider-specific by design: Codex is the persisted menu identity fallback when selection is empty.
-            let resolvedProvider = self.resolvedMenuProvider()
-            self.lastMenuProvider = (resolvedProvider ?? .codex).instanceID
-            provider = resolvedProvider
+            let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
+            let selection = self.resolvedMergedMenuSelection(enabledProviders: enabledProviders)
+            if Self.isUserPluginSelection(selection), let pluginID = selection?.instanceID {
+                self.lastMenuProvider = pluginID
+                provider = nil
+            } else {
+                // Provider-specific by design: Codex is the persisted menu identity fallback when selection is empty.
+                let resolvedProvider = self.resolvedMenuProvider(enabledProviders: enabledProviders)
+                self.lastMenuProvider = (resolvedProvider ?? .codex).instanceID
+                provider = resolvedProvider
+            }
         } else {
             if let menuProvider = self.menuProviders[ObjectIdentifier(menu)] {
                 self.lastMenuProvider = menuProvider
@@ -247,35 +254,34 @@ extension StatusItemController {
         defer { self.scheduleMergedSwitcherSiblingWarmup(for: menu) }
 
         let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
+        let switcherProviderIDs = self.switcherProviderIDs(enabledFirstPartyProviders: enabledProviders)
         let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
-        let switcherSelection = self.shouldMergeIcons && enabledProviders.count > 1
-            ? self.resolvedSwitcherSelection(
-                enabledProviders: enabledProviders,
-                includesOverview: includesOverview)
-            : nil
+        let switcherSelection = self.resolvedMergedMenuSelection(enabledProviders: enabledProviders)
         let isOverviewSelected = switcherSelection == .overview
-        let selectedProvider = if isOverviewSelected {
-            self.resolvedMenuProvider(enabledProviders: enabledProviders)
-        } else {
-            switcherSelection?.provider ?? provider
+        let isPluginSelected = Self.isUserPluginSelection(switcherSelection)
+        let selectedProvider: UsageProvider? = switch switcherSelection {
+        case .overview: self.resolvedMenuProvider(enabledProviders: enabledProviders)
+        case let .provider(instanceID): instanceID.firstPartyProvider
+        case nil: provider
         }
         // Provider-specific by design: Codex remains the empty merged-menu selection fallback.
         let currentProvider = selectedProvider ?? enabledProviders.first ?? .codex
-        let rawCodexAccountDisplay = isOverviewSelected ? nil : self.codexAccountMenuDisplay(for: currentProvider)
-        let codexAccountDisplay = isOverviewSelected
+        let suppressAccountSwitchers = isOverviewSelected || isPluginSelected
+        let rawCodexAccountDisplay = suppressAccountSwitchers ? nil : self.codexAccountMenuDisplay(for: currentProvider)
+        let codexAccountDisplay = suppressAccountSwitchers
             ? nil
             : self.stableCodexAccountMenuDisplay(
                 rawCodexAccountDisplay,
                 menu: menu,
                 provider: currentProvider)
-        let tokenAccountDisplay = isOverviewSelected ? nil : self.tokenAccountMenuDisplay(for: currentProvider)
+        let tokenAccountDisplay = suppressAccountSwitchers ? nil : self.tokenAccountMenuDisplay(for: currentProvider)
         let showAllAccounts = (tokenAccountDisplay?.showAll ?? false) || (codexAccountDisplay?.showAll ?? false)
         let openAIContext = self.openAIWebContext(
             currentProvider: currentProvider,
             showAllAccounts: showAllAccounts)
         let descriptor = self.makeMenuDescriptor(
             provider: selectedProvider,
-            includeContextualActions: !isOverviewSelected)
+            includeContextualActions: !isOverviewSelected && !isPluginSelected)
         let menuWidth = self.menuCardWidth(
             for: enabledProviders,
             selectedProvider: selectedProvider,
@@ -283,7 +289,7 @@ extension StatusItemController {
 
         let hasTokenSwitcher = menu.items.contains { $0.view is TokenAccountSwitcherView }
         let hasCodexSwitcher = menu.items.contains { $0.view is CodexAccountSwitcherView }
-        let switcherProvidersMatch = enabledProviders.map(\.instanceID) == self.lastSwitcherProviders
+        let switcherProvidersMatch = switcherProviderIDs == self.lastSwitcherProviders
         let switcherUsageBarsShowUsedMatch = self.settings.usageBarsShowUsed == self.lastSwitcherUsageBarsShowUsed
         let switcherSelectionMatches = switcherSelection == self.lastMergedSwitcherSelection
         let switcherOverviewAvailabilityMatches = includesOverview == self.lastSwitcherIncludesOverview
@@ -302,7 +308,7 @@ extension StatusItemController {
             abs(view.frame.width - menuWidth) <= 0.5
         } ?? false
         let canSmartUpdate = self.shouldMergeIcons &&
-            enabledProviders.count > 1 &&
+            switcherProviderIDs.count > 1 &&
             !isOverviewSelected &&
             switcherProvidersMatch &&
             switcherUsageBarsShowUsedMatch &&
@@ -343,7 +349,7 @@ extension StatusItemController {
         }
 
         let canPreserveProviderSwitcher = self.shouldMergeIcons &&
-            enabledProviders.count > 1 &&
+            switcherProviderIDs.count > 1 &&
             switcherProvidersMatch &&
             switcherUsageBarsShowUsedMatch &&
             switcherOverviewAvailabilityMatches &&
@@ -437,14 +443,16 @@ extension StatusItemController {
                 selection: context.switcherSelection ?? .provider(context.currentProvider.instanceID),
                 width: context.menuWidth)
             // Track which providers the switcher was built with for smart update detection
-            if self.shouldMergeIcons, context.enabledProviders.count > 1 {
+            if self.shouldMergeIcons,
+               self.switcherProviderIDs(enabledFirstPartyProviders: context.enabledProviders).count > 1
+            {
                 self.rememberMergedSwitcherState(
                     context.enabledProviders,
                     context.switcherSelection,
                     context.includesOverview)
             }
             if self.shouldMergeIcons,
-               context.enabledProviders.count > 1,
+               self.switcherProviderIDs(enabledFirstPartyProviders: context.enabledProviders).count > 1,
                self.addCachedMergedSwitcherContent(
                    for: contentSelection,
                    to: menu,
@@ -516,7 +524,9 @@ extension StatusItemController {
         selection: ProviderSwitcherSelection,
         width: CGFloat)
     {
-        guard self.shouldMergeIcons, enabledProviders.count > 1 else { return }
+        guard self.shouldMergeIcons,
+              self.switcherProviderIDs(enabledFirstPartyProviders: enabledProviders).count > 1
+        else { return }
         let switcherItem = self.makeProviderSwitcherItem(
             providers: enabledProviders,
             includesOverview: includesOverview,
@@ -810,6 +820,15 @@ extension StatusItemController {
         switcherSelection: ProviderSwitcherSelection,
         captureMenu: NSMenu? = nil)
     {
+        if case let .provider(instanceID) = switcherSelection,
+           UserProviderPluginRegistry.plugin(for: instanceID) != nil
+        {
+            self.addUserPluginMenuCards(
+                to: menu,
+                width: context.menuWidth,
+                selectedPluginID: instanceID)
+            return
+        }
         if switcherSelection == .overview {
             let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
             if self.addOverviewRows(
@@ -983,12 +1002,16 @@ extension StatusItemController {
     {
         let view = ProviderSwitcherView(
             providers: providers,
+            pluginProviders: self.topLevelUserProviderPlugins(),
             selected: selected,
             includesOverview: includesOverview,
             width: width,
             showsIcons: self.settings.switcherShowsIcons,
             iconProvider: { [weak self] provider in
                 self?.switcherIcon(for: provider) ?? NSImage()
+            },
+            pluginIconProvider: { [weak self] plugin in
+                self?.userPluginSwitcherIcon(for: plugin) ?? NSImage()
             },
             weeklyRemainingProvider: { [weak self] provider in
                 self?.switcherWeeklyRemaining(for: provider)
@@ -1123,22 +1146,6 @@ extension StatusItemController {
         return enabled.first(where: { self.store.isProviderAvailable($0) }) ?? enabled.first
     }
 
-    func includesOverviewTab(enabledProviders: [UsageProvider]) -> Bool {
-        !self.settings.resolvedMergedOverviewProviders(
-            activeProviders: enabledProviders,
-            maxVisibleProviders: Self.maxOverviewProviders).isEmpty
-    }
-
-    func resolvedSwitcherSelection(
-        enabledProviders: [UsageProvider],
-        includesOverview: Bool) -> ProviderSwitcherSelection
-    {
-        if includesOverview, self.settings.mergedMenuLastSelectedWasOverview {
-            return .overview
-        }
-        return .provider((self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex).instanceID)
-    }
-
     func menuProvider(for menu: NSMenu) -> UsageProvider? {
         if self.shouldMergeIcons {
             return self.resolvedMenuProvider()
@@ -1264,12 +1271,20 @@ extension StatusItemController {
         let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
         guard !enabledProviders.isEmpty else { return [] }
         let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
+        let selection = self.resolvedSwitcherSelection(
+            enabledProviders: enabledProviders,
+            includesOverview: includesOverview)
+        let switcherProviderCount = self.switcherProviderIDs(enabledFirstPartyProviders: enabledProviders).count
+        if self.shouldMergeIcons,
+           switcherProviderCount > 1,
+           Self.isUserPluginSelection(selection)
+        {
+            return []
+        }
 
         if self.shouldMergeIcons,
-           enabledProviders.count > 1,
-           self.resolvedSwitcherSelection(
-               enabledProviders: enabledProviders,
-               includesOverview: includesOverview) == .overview
+           switcherProviderCount > 1,
+           selection == .overview
         {
             return self.settings.resolvedMergedOverviewProviders(
                 activeProviders: enabledProviders,

--- a/Sources/CodexBar/StatusItemController+MenuLocalization.swift
+++ b/Sources/CodexBar/StatusItemController+MenuLocalization.swift
@@ -2,11 +2,20 @@ import CodexBarCore
 
 extension StatusItemController {
     func menuLocalizationSignature() -> String {
-        [
+        let pluginSignature = self.topLevelUserProviderPlugins().map { plugin in
+            [
+                plugin.manifest.id.rawValue,
+                plugin.manifest.name,
+                plugin.manifest.icon.monogram,
+                plugin.manifest.icon.tint,
+            ].map { "\($0.utf8.count):\($0)" }.joined()
+        }.joined()
+        return [
             codexBarLocalizationSignature(),
             self.settings.hidePersonalInfo ? "hide-personal-info" : "show-personal-info",
             L("Overview"),
             L("Cost"),
+            pluginSignature,
         ].joined(separator: "|")
     }
 
@@ -14,7 +23,7 @@ extension StatusItemController {
         self.rememberMergedSwitcherState(
             providers,
             selection,
-            self.includesOverviewTab(for: providers))
+            self.includesOverviewTab(enabledProviders: providers))
     }
 
     func rememberMergedSwitcherState(
@@ -22,17 +31,11 @@ extension StatusItemController {
         _ selection: ProviderSwitcherSelection?,
         _ includesOverview: Bool)
     {
-        self.lastSwitcherProviders = providers.map(\.instanceID)
+        self.lastSwitcherProviders = self.switcherProviderIDs(enabledFirstPartyProviders: providers)
         self.lastSwitcherUsageBarsShowUsed = self.settings.usageBarsShowUsed
         self.lastMergedSwitcherSelection = selection
         self.lastMergedMenuContentSelection = selection
         self.lastSwitcherIncludesOverview = includesOverview
         self.lastMenuLocalizationSignature = self.menuLocalizationSignature()
-    }
-
-    private func includesOverviewTab(for providers: [UsageProvider]) -> Bool {
-        !self.settings.resolvedMergedOverviewProviders(
-            activeProviders: providers,
-            maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit).isEmpty
     }
 }

--- a/Sources/CodexBar/StatusItemController+MenuSwitcherWarmup.swift
+++ b/Sources/CodexBar/StatusItemController+MenuSwitcherWarmup.swift
@@ -41,12 +41,13 @@ extension StatusItemController {
     func warmMergedSwitcherSiblingContent(in menu: NSMenu) {
         guard menu.items.first?.view is ProviderSwitcherView else { return }
         let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
-        guard enabledProviders.count > 1 else { return }
+        let switcherProviderIDs = self.switcherProviderIDs(enabledFirstPartyProviders: enabledProviders)
+        guard switcherProviderIDs.count > 1 else { return }
         let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
         let currentSelection = self.resolvedSwitcherSelection(
             enabledProviders: enabledProviders,
             includesOverview: includesOverview)
-        var selections: [ProviderSwitcherSelection] = enabledProviders.map { .provider($0.instanceID) }
+        var selections: [ProviderSwitcherSelection] = switcherProviderIDs.map { .provider($0) }
         if includesOverview {
             selections.insert(.overview, at: 0)
         }
@@ -68,12 +69,17 @@ extension StatusItemController {
             ? self.resolvedMenuProvider(enabledProviders: enabledProviders)
             : selection.provider
         let currentProvider = selectedProvider ?? enabledProviders.first ?? .codex
-        let codexAccountDisplay = isOverviewSelected ? nil : self.codexAccountMenuDisplay(for: currentProvider)
-        let tokenAccountDisplay = isOverviewSelected ? nil : self.tokenAccountMenuDisplay(for: currentProvider)
+        let isPluginSelected = Self.isUserPluginSelection(selection)
+        let codexAccountDisplay = isOverviewSelected || isPluginSelected
+            ? nil
+            : self.codexAccountMenuDisplay(for: currentProvider)
+        let tokenAccountDisplay = isOverviewSelected || isPluginSelected
+            ? nil
+            : self.tokenAccountMenuDisplay(for: currentProvider)
         let showAllAccounts = (tokenAccountDisplay?.showAll ?? false) || (codexAccountDisplay?.showAll ?? false)
         let descriptor = self.makeMenuDescriptor(
             provider: selectedProvider,
-            includeContextualActions: !isOverviewSelected)
+            includeContextualActions: !isOverviewSelected && !isPluginSelected)
         let menuWidth = self.menuCardWidth(
             for: enabledProviders,
             selectedProvider: selectedProvider,

--- a/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
@@ -9,8 +9,10 @@ extension StatusItemController {
         selectedProvider: UsageProvider?,
         descriptor: MenuDescriptor) -> CGFloat
     {
-        let sectionSets: [(provider: UsageProvider?, sections: [MenuDescriptor.Section])] = if self.shouldMergeIcons,
-                                                                                               providers.count > 1
+        let usesMergedSwitcherWidth = self.shouldMergeIcons &&
+            self.switcherProviderIDs(enabledFirstPartyProviders: providers).count > 1
+        let sectionSets: [(provider: UsageProvider?, sections: [MenuDescriptor.Section])] = if usesMergedSwitcherWidth,
+                                                                                               !providers.isEmpty
         {
             providers.map { provider in
                 if provider == selectedProvider {

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -37,12 +37,12 @@ extension StatusItemController {
                 || !self.manualRefreshTasks.isEmpty
                 || !self.store.refreshingProviders.isEmpty
         }
-        if let provider = self.menuProvider(for: menu) {
+        if let provider = self.manualRefreshProvider(for: menu) {
             // A manual refresh of a different provider must not grey out this provider's row: only
             // reflect the global refresh, this provider's own manual refresh, and its store refresh.
             return self.store.isRefreshing
-                || self.manualRefreshTasks[.provider(provider.instanceID)] != nil
-                || self.store.refreshingProviders.contains(provider.instanceID)
+                || self.manualRefreshTasks[.provider(provider)] != nil
+                || self.store.refreshingProviders.contains(provider)
         }
         return self.store.isRefreshing
             || !self.manualRefreshTasks.isEmpty
@@ -52,9 +52,8 @@ extension StatusItemController {
     func isMergedOverviewSelected(in menu: NSMenu) -> Bool {
         guard self.shouldMergeIcons else { return false }
         if let mergedMenu = self.mergedMenu, menu !== mergedMenu { return false }
-        let providers = self.settings.resolvedMergedOverviewProviders(
-            activeProviders: self.store.enabledFirstPartyProvidersForDisplay(),
-            maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
-        return !providers.isEmpty && self.settings.mergedMenuLastSelectedWasOverview
+        let providers = self.store.enabledFirstPartyProvidersForDisplay()
+        return self.includesOverviewTab(enabledProviders: providers) &&
+            self.settings.mergedMenuLastSelectedWasOverview
     }
 }

--- a/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
@@ -41,33 +41,28 @@ extension StatusItemController {
     {
         guard self.shouldMergeIcons else { return }
         let enabledProviders = self.store.enabledFirstPartyProvidersForDisplay()
-        guard enabledProviders.count > 1 else { return }
+        let switcherProviderIDs = self.switcherProviderIDs(enabledFirstPartyProviders: enabledProviders)
+        guard switcherProviderIDs.count > 1 else { return }
 
-        let includesOverview = !self.settings.resolvedMergedOverviewProviders(
-            activeProviders: enabledProviders,
-            maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit).isEmpty
-        var selections = enabledProviders.map { ProviderSwitcherSelection.provider($0.instanceID) }
+        let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
+        var selections = switcherProviderIDs.map { ProviderSwitcherSelection.provider($0) }
         if includesOverview {
             selections.insert(.overview, at: 0)
         }
 
-        let current: ProviderSwitcherSelection = if includesOverview,
-                                                    self.settings.mergedMenuLastSelectedWasOverview
-        {
-            .overview
-        } else {
-            .provider((self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex).instanceID)
-        }
+        let current = self.resolvedSwitcherSelection(
+            enabledProviders: enabledProviders,
+            includesOverview: includesOverview)
         guard let currentIndex = selections.firstIndex(of: current) else { return }
 
         let delta = direction == .next ? 1 : -1
         let nextIndex = (currentIndex + delta + selections.count) % selections.count
         let selection = selections[nextIndex]
-        let menuProvider: UsageProvider = switch selection {
+        let menuProvider: UsageProvider? = switch selection {
         case .overview:
             self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex
         case let .provider(instanceID):
-            instanceID.firstPartyProvider ?? .codex
+            instanceID.firstPartyProvider
         }
         self.preservingMergedSwitcherContentCachesDuringInvalidation {
             switch selection {

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -47,11 +47,13 @@ final class ProviderSwitcherView: NSView {
 
     init(
         providers: [UsageProvider],
+        pluginProviders: [UserProviderPlugin] = [],
         selected: ProviderSwitcherSelection?,
         includesOverview: Bool,
         width: CGFloat,
         showsIcons: Bool,
         iconProvider: (UsageProvider) -> NSImage,
+        pluginIconProvider: (UserProviderPlugin) -> NSImage = { _ in NSImage() },
         weeklyRemainingProvider: @escaping (UsageProvider) -> Double?,
         onSelect: @escaping (ProviderSwitcherSelection) -> Void)
     {
@@ -67,6 +69,12 @@ final class ProviderSwitcherView: NSView {
                 image: icon,
                 title: fullTitle)
         }
+        segments.append(contentsOf: pluginProviders.map { plugin in
+            Segment(
+                selection: .provider(plugin.manifest.id),
+                image: Self.pluginSwitcherImage(plugin, iconProvider: pluginIconProvider),
+                title: plugin.manifest.name)
+        })
         if includesOverview {
             let overviewIcon = Self.overviewIcon()
             overviewIcon.isTemplate = true
@@ -1010,6 +1018,10 @@ extension ProviderSwitcherView {
 
     func _test_buttonFrames() -> [NSRect] {
         self.buttons.map(\.frame)
+    }
+
+    func _test_segmentTitles() -> [String] {
+        self.segments.map(\.title)
     }
 
     func _test_buttonFittingSizes() -> [NSSize] {

--- a/Sources/CodexBar/StatusItemController+UserPlugins.swift
+++ b/Sources/CodexBar/StatusItemController+UserPlugins.swift
@@ -4,10 +4,83 @@ import CodexBarCore
 import SwiftUI
 
 extension StatusItemController {
-    func addUserPluginMenuCards(to menu: NSMenu, width: CGFloat) {
-        let plugins = UserProviderPluginRegistry.all.filter { self.settings.isPluginEnabled($0.manifest.id) }
+    var shouldMergeIcons: Bool {
+        self.settings.mergeIcons && (
+            self.store.enabledProvidersForDisplay().count > 1 ||
+                !self.topLevelUserProviderPlugins().isEmpty)
+    }
+
+    static func isUserPluginSelection(_ selection: ProviderSwitcherSelection?) -> Bool {
+        selection?.instanceID.map { UserProviderPluginRegistry.plugin(for: $0) != nil } == true
+    }
+
+    func topLevelUserProviderPlugins() -> [UserProviderPlugin] {
+        UserProviderPluginRegistry.all.filter {
+            $0.manifest.topLevel && self.settings.isPluginEnabled($0.manifest.id)
+        }
+    }
+
+    func switcherProviderIDs(enabledFirstPartyProviders: [UsageProvider]) -> [ProviderInstanceID] {
+        enabledFirstPartyProviders.map(\.instanceID) + self.topLevelUserProviderPlugins().map(\.manifest.id)
+    }
+
+    static func resolvedSwitcherProviderID(
+        providerIDs: [ProviderInstanceID],
+        selectedProviderID: ProviderInstanceID?,
+        fallbackProviderID: ProviderInstanceID) -> ProviderInstanceID
+    {
+        if let selectedProviderID, providerIDs.contains(selectedProviderID) {
+            return selectedProviderID
+        }
+        return providerIDs.contains(fallbackProviderID) ? fallbackProviderID : providerIDs.first ?? fallbackProviderID
+    }
+
+    func includesOverviewTab(enabledProviders: [UsageProvider]) -> Bool {
+        enabledProviders.count > 1 &&
+            !self.settings.resolvedMergedOverviewProviders(
+                activeProviders: enabledProviders,
+                maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit).isEmpty
+    }
+
+    func resolvedSwitcherSelection(
+        enabledProviders: [UsageProvider],
+        includesOverview: Bool) -> ProviderSwitcherSelection
+    {
+        if includesOverview, self.settings.mergedMenuLastSelectedWasOverview {
+            return .overview
+        }
+        let providerIDs = self.switcherProviderIDs(enabledFirstPartyProviders: enabledProviders)
+        let fallbackProviderID = (self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex).instanceID
+        return .provider(Self.resolvedSwitcherProviderID(
+            providerIDs: providerIDs,
+            selectedProviderID: self.selectedMenuProvider,
+            fallbackProviderID: fallbackProviderID))
+    }
+
+    func resolvedMergedMenuSelection(enabledProviders: [UsageProvider]) -> ProviderSwitcherSelection? {
+        guard self.shouldMergeIcons,
+              !self.switcherProviderIDs(enabledFirstPartyProviders: enabledProviders).isEmpty
+        else { return nil }
+        return self.resolvedSwitcherSelection(
+            enabledProviders: enabledProviders,
+            includesOverview: self.includesOverviewTab(enabledProviders: enabledProviders))
+    }
+
+    func addUserPluginMenuCards(
+        to menu: NSMenu,
+        width: CGFloat,
+        selectedPluginID: ProviderInstanceID? = nil)
+    {
+        let hasTopLevelSwitcher = self.shouldMergeIcons &&
+            self.switcherProviderIDs(
+                enabledFirstPartyProviders: self.store.enabledFirstPartyProvidersForDisplay()).count > 1
+        let plugins = Self.userPluginsForMenu(
+            UserProviderPluginRegistry.all,
+            isEnabled: self.settings.isPluginEnabled,
+            topLevelSwitcherVisible: hasTopLevelSwitcher,
+            selectedPluginID: selectedPluginID)
         guard !plugins.isEmpty else { return }
-        if menu.items.last?.isSeparatorItem != true {
+        if !menu.items.isEmpty, menu.items.last?.isSeparatorItem != true {
             menu.addItem(.separator())
         }
         for (index, plugin) in plugins.enumerated() {
@@ -20,8 +93,11 @@ extension StatusItemController {
                 isRefreshing: self.store.refreshingProviders.contains(plugin.manifest.id),
                 showUsed: self.settings.usageBarsShowUsed,
                 width: width,
-                onRefresh: { [weak store = self.store] in
-                    Task { @MainActor in await store?.refreshUserPlugin(plugin.manifest.id) }
+                onRefresh: { [weak self] in
+                    self?.startManualRefresh(
+                        for: plugin.manifest.id,
+                        originatingMenuID: nil,
+                        originatingMenuInteractionGeneration: nil)
                 })
             menu.addItem(self.makeMenuCardItem(
                 view,
@@ -36,6 +112,61 @@ extension StatusItemController {
         }
         menu.addItem(.separator())
     }
+
+    func refreshOpenMenusAfterUserPluginRefresh(_ instanceID: ProviderInstanceID) {
+        self.invalidateMenus()
+        guard self.isMenuRefreshEnabled else { return }
+        let cardID = "pluginCard:\(instanceID.rawValue)"
+        // Plugin cards capture snapshots, so their visible payload needs the guarded rebuild path.
+        for menu in self.openMenus.values
+            where menu.items.contains(where: { $0.representedObject as? String == cardID })
+        {
+            self.scheduleOpenMenuRebuildIfStillVisible(menu, provider: self.menuProvider(for: menu))
+        }
+    }
+
+    static func userPluginsForMenu(
+        _ plugins: [UserProviderPlugin],
+        isEnabled: (ProviderInstanceID) -> Bool,
+        topLevelSwitcherVisible: Bool,
+        selectedPluginID: ProviderInstanceID?) -> [UserProviderPlugin]
+    {
+        let enabledPlugins = plugins.filter { isEnabled($0.manifest.id) }
+        if let selectedPluginID {
+            let selected = enabledPlugins.filter { $0.manifest.id == selectedPluginID }
+            let legacy = enabledPlugins.filter {
+                !$0.manifest.topLevel && $0.manifest.id != selectedPluginID
+            }
+            return selected + legacy
+        }
+        return enabledPlugins.filter { !topLevelSwitcherVisible || !$0.manifest.topLevel }
+    }
+
+    func userPluginSwitcherIcon(for plugin: UserProviderPlugin) -> NSImage {
+        let size = NSSize(width: 16, height: 16)
+        let image = NSImage(size: size, flipped: false) { rect in
+            let rawTint = plugin.manifest.icon.tint.dropFirst()
+            let tint = UInt32(rawTint, radix: 16) ?? 0x6B7280
+            NSColor(
+                deviceRed: CGFloat((tint >> 16) & 0xFF) / 255,
+                green: CGFloat((tint >> 8) & 0xFF) / 255,
+                blue: CGFloat(tint & 0xFF) / 255,
+                alpha: 1).setFill()
+            NSBezierPath(roundedRect: rect, xRadius: 4, yRadius: 4).fill()
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 8, weight: .bold),
+                .foregroundColor: NSColor.white,
+            ]
+            let monogram = plugin.manifest.icon.monogram as NSString
+            let textSize = monogram.size(withAttributes: attributes)
+            monogram.draw(
+                at: NSPoint(x: rect.midX - textSize.width / 2, y: rect.midY - textSize.height / 2),
+                withAttributes: attributes)
+            return true
+        }
+        image.isTemplate = false
+        return image
+    }
 }
 
 struct UserPluginQuotaPresentation: Equatable {
@@ -48,6 +179,17 @@ struct UserPluginQuotaPresentation: Equatable {
         return Self(
             percent: showUsed ? used : remaining,
             text: UsageFormatter.usageLine(remaining: remaining, used: used, showUsed: showUsed))
+    }
+}
+
+extension ProviderSwitcherView {
+    static func pluginSwitcherImage(
+        _ plugin: UserProviderPlugin,
+        iconProvider: (UserProviderPlugin) -> NSImage) -> NSImage
+    {
+        let image = iconProvider(plugin)
+        image.size = NSSize(width: 16, height: 16)
+        return image
     }
 }
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -915,10 +915,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             || self.fallbackProvider == provider
     }
 
-    var shouldMergeIcons: Bool {
-        self.settings.mergeIcons && self.store.enabledProvidersForDisplay().count > 1
-    }
-
     func switchAccountSubtitle(for target: UsageProvider) -> String? {
         guard self.loginTask != nil, let provider = self.activeLoginProvider, provider == target
         else { return nil }

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -334,7 +334,7 @@ final class UsageStore {
     @ObservationIgnored private let registry: ProviderRegistry
     @ObservationIgnored let settings: SettingsStore
     @ObservationIgnored let environmentBase: [String: String]
-    @ObservationIgnored let pluginApprovalStore = ProviderPluginApprovalStore()
+    @ObservationIgnored let pluginApprovalStore: ProviderPluginApprovalStore
     @ObservationIgnored let sessionQuotaNotifier: any SessionQuotaNotifying
     @ObservationIgnored let sessionQuotaLogger = CodexBarLog.logger(LogCategories.sessionQuota)
     // Provider-specific by design: OpenAI web and Augment runtime diagnostics have dedicated app-owned log streams.
@@ -495,6 +495,7 @@ final class UsageStore {
         sessionQuotaNotifier: any SessionQuotaNotifying = SessionQuotaNotifier(),
         startupBehavior: StartupBehavior = .automatic,
         environmentBase: [String: String] = ProcessInfo.processInfo.environment,
+        pluginApprovalStore: ProviderPluginApprovalStore = ProviderPluginApprovalStore(),
         widgetSnapshotURL: URL? = nil,
         widgetTimelineReloader: @escaping @MainActor () -> Void = UsageStore.reloadWidgetTimelines,
         planUtilizationHistoryLoadGateForTesting: PlanUtilizationHistoryLoadGate? = nil)
@@ -506,6 +507,7 @@ final class UsageStore {
         self.settings = settings
         self.registry = registry
         self.environmentBase = environmentBase
+        self.pluginApprovalStore = pluginApprovalStore
         self.widgetSnapshotURL = widgetSnapshotURL
         self.widgetTimelineReloader = widgetTimelineReloader
         self.historicalUsageHistoryStore = historicalUsageHistoryStore

--- a/Sources/CodexBarCore/Plugins/ProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginEngine.swift
@@ -86,6 +86,7 @@ protocol ProviderPluginValue {
     var isUndefined: Bool { get }
     var isString: Bool { get }
     var isNumber: Bool { get }
+    var isBoolean: Bool { get }
     var isDate: Bool { get }
 
     func property(_ name: String) -> (any ProviderPluginValue)?
@@ -93,6 +94,7 @@ protocol ProviderPluginValue {
     func stringValue() -> String
     func int32Value() -> Int32
     func doubleValue() -> Double
+    func boolValue() -> Bool
     func dateValue() -> Date?
 }
 
@@ -128,6 +130,11 @@ final class JSONProviderPluginValue: ProviderPluginValue {
         return CFGetTypeID(number) != CFBooleanGetTypeID()
     }
 
+    var isBoolean: Bool {
+        guard let number = self.value as? NSNumber else { return false }
+        return CFGetTypeID(number) == CFBooleanGetTypeID()
+    }
+
     var isDate: Bool {
         false
     }
@@ -157,6 +164,10 @@ final class JSONProviderPluginValue: ProviderPluginValue {
 
     func doubleValue() -> Double {
         (self.value as? NSNumber)?.doubleValue ?? .nan
+    }
+
+    func boolValue() -> Bool {
+        (self.value as? NSNumber)?.boolValue ?? false
     }
 
     func dateValue() -> Date? {
@@ -198,6 +209,10 @@ final class JavaScriptCorePluginValue: ProviderPluginValue {
         self.value.isNumber
     }
 
+    var isBoolean: Bool {
+        self.value.isBoolean
+    }
+
     var isDate: Bool {
         self.value.isDate
     }
@@ -220,6 +235,10 @@ final class JavaScriptCorePluginValue: ProviderPluginValue {
 
     func doubleValue() -> Double {
         self.value.toDouble()
+    }
+
+    func boolValue() -> Bool {
+        self.value.toBool()
     }
 
     func dateValue() -> Date? {

--- a/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
+++ b/Sources/CodexBarCore/Plugins/ProviderPluginManifest.swift
@@ -70,6 +70,7 @@ public struct ProviderPluginManifest: Sendable {
     public let id: ProviderInstanceID
     public let name: String
     public let icon: ProviderPluginIcon
+    public let topLevel: Bool
     public let endpoints: Set<ProviderPluginEndpoint>
     public let auth: ProviderPluginAuth?
     public let settings: [ProviderPluginSetting]
@@ -95,6 +96,14 @@ public struct ProviderPluginManifest: Sendable {
         self.id = id
         self.name = try Self.boundedString(definition, property: "name", maximumLength: 80)
         self.icon = try Self.parseIcon(definition.property("icon"), fallbackName: self.name)
+        if let topLevel = definition.property("topLevel"), !topLevel.isUndefined, !topLevel.isNull {
+            guard topLevel.isBoolean else {
+                throw ProviderPluginError.invalidManifest("'topLevel' must be a boolean when present")
+            }
+            self.topLevel = topLevel.boolValue()
+        } else {
+            self.topLevel = false
+        }
 
         let endpointValue = definition.property("endpoints")
         guard let endpointValue, endpointValue.isArray else {

--- a/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
+++ b/Sources/CodexBarCore/Plugins/QuickJSProviderPluginEngine.swift
@@ -108,6 +108,10 @@ private final class QuickJSPluginValue: ProviderPluginValue {
         cqjs_is_number(self.value)
     }
 
+    var isBoolean: Bool {
+        JS_IsBool(self.value)
+    }
+
     var isDate: Bool {
         JS_IsDate(self.value)
     }
@@ -136,6 +140,10 @@ private final class QuickJSPluginValue: ProviderPluginValue {
         var value = Double.nan
         _ = JS_ToFloat64(self.engine.context, &value, self.value)
         return value
+    }
+
+    func boolValue() -> Bool {
+        JS_ToBool(self.engine.context, self.value) == 1
     }
 
     func dateValue() -> Date? {

--- a/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
+++ b/Sources/CodexBarCore/Resources/Plugins/codexbar-plugin.d.ts
@@ -191,6 +191,8 @@ interface CodexBarProviderDefinition {
   id: string;
   name: string;
   icon?: { monogram?: string; tint?: string };
+  /** Shows this plugin as its own provider-switcher tab. */
+  topLevel?: boolean;
   endpoints: CodexBarEndpoint[];
   auth?: CodexBarAuth;
   settings: CodexBarSetting[];

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1043,7 +1043,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "The memory-pressure debug fixture installs its synthetic entry in the Codex cache slot."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1106,
+            line: 1129,
             anchor: "controller.refreshOpenMenuIfStillVisible(menu, provider: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -1339,19 +1339,19 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Claude widget quota ownership uses the selected Claude account's isolated snapshot key."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1079,
+            line: 1081,
             anchor: "provider: .deepseek,",
             expectedProviderIDs: ["deepseek"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1181,
+            line: 1183,
             anchor: "let sourceMode = self.sourceMode(for: .claude)",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1185,
+            line: 1187,
             anchor: "provider: .claude,",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -2497,7 +2497,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 387,
+            line: 401,
             anchor: "if provider == .qoder {",
             expectedProviderIDs: ["claude", "qoder"],
             expectedReferenceCount: 3,
@@ -2505,7 +2505,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 457,
+            line: 471,
             anchor: "?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledFirstPartyProviders().first)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 4,
@@ -2513,7 +2513,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 478,
+            line: 492,
             anchor: "?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledFirstPartyProviders().first)",
             expectedProviderIDs: ["claude", "codex"],
             expectedReferenceCount: 4,
@@ -2521,7 +2521,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 551,
+            line: 565,
             anchor: "?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2529,7 +2529,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 620,
+            line: 634,
             anchor: "self.lazyStatusItem(for: provider ?? .codex)",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2537,7 +2537,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Actions.swift",
-            line: 717,
+            line: 731,
             anchor: "return .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2584,16 +2584,16 @@ struct ProviderArchitectureGatekeeperTests {
             expectedReferenceFingerprint: ["codex@0"],
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
-            path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1139,
-            anchor: "return .provider((self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex).instanceID)",
+            path: "Sources/CodexBar/StatusItemController+UserPlugins.swift",
+            line: 53,
+            anchor: "let fallbackProviderID = (self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex).instanceID",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
             expectedReferenceFingerprint: ["codex@0"],
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1152,
+            line: 1159,
             anchor: "return self.store.enabledFirstPartyProvidersForDisplay().first ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2609,7 +2609,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+MenuSwitcherWarmup.swift",
-            line: 70,
+            line: 71,
             anchor: "let currentProvider = selectedProvider ?? enabledProviders.first ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -2649,15 +2649,15 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+ProviderNavigation.swift",
-            line: 59,
-            anchor: ".provider((self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex).instanceID)",
+            line: 63,
+            anchor: "self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex",
             expectedProviderIDs: ["codex"],
-            expectedReferenceCount: 4,
-            expectedReferenceFingerprint: ["codex@0", "codex@9", "codex@11", "codex@18"],
+            expectedReferenceCount: 2,
+            expectedReferenceFingerprint: ["codex@0", "codex@9"],
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+ProviderNavigation.swift",
-            line: 96,
+            line: 91,
             anchor: "return .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3382,7 +3382,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 619,
+            line: 621,
             anchor: "self.metadata(for: .codex).browserCookieOrder ?? Browser.defaultImportOrder",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3390,7 +3390,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 671,
+            line: 673,
             anchor: "self.providerSpecs[provider]?.style ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3398,7 +3398,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 704,
+            line: 706,
             anchor: "guard provider != .codex else { return true }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3406,7 +3406,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1053,
+            line: 1055,
             anchor: "let claudeDebugConfiguration: ClaudeDebugLogConfiguration? = if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3414,7 +3414,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1076,
+            line: 1078,
             anchor: "let deepSeekHasTokenAccount = self.settings.selectedTokenAccount(for: .deepseek) != nil",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3422,7 +3422,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1133,
+            line: 1135,
             anchor: "case .amp:",
             expectedProviderIDs: ["amp", "deepseek", "notion", "ollama", "warp"],
             expectedReferenceCount: 7,
@@ -3438,7 +3438,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1188,
+            line: 1190,
             anchor: "let claudeSettings = snapshot.claude ?? ProviderSettingsSnapshot.ClaudeProviderSettings(",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/UserPluginTabsNativeProofTests.swift
+++ b/Tests/CodexBarTests/UserPluginTabsNativeProofTests.swift
@@ -1,0 +1,197 @@
+import AppKit
+import Foundation
+import XCTest
+@testable import CodexBar
+@testable import CodexBarCore
+
+/// Opt-in interaction proof using production menus and synthetic, network-free plugins.
+@MainActor
+final class UserPluginTabsNativeProofTests: XCTestCase {
+    func test_pluginSelectionAndScopedRefresh() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["CODEXBAR_PLUGIN_TABS_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_PLUGIN_TABS_PROOF_DIR for signed native proof")
+        }
+        let output = URL(fileURLWithPath: path, isDirectory: true)
+        guard SettingsStore.isRunningTests,
+              environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment[CodexCredentialFileAccess.isolationEnvironmentKey] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1",
+              NSHomeDirectory().hasPrefix(output.deletingLastPathComponent().path + "/")
+        else { return XCTFail("Native proof requires a contained home and credential/session isolation") }
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let fixture = try CodexWorkspacesNavigationFixture(userDefaults: InMemoryUserDefaults())
+        defer { fixture.cleanup() }
+        let pluginsRoot = fixture.files.root.appendingPathComponent("plugins", isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginsRoot, withIntermediateDirectories: true)
+        let topLevel = environment["CODEXBAR_PLUGIN_TABS_PROOF_LEGACY"] != "1"
+        try Self.writePlugins(to: pluginsRoot, topLevel: topLevel)
+        let loader = UserProviderPluginLoader(
+            providersDirectory: pluginsRoot,
+            cacheDirectory: fixture.files.root.appendingPathComponent("plugin-cache"),
+            transport: PluginProofNoNetwork())
+        let plugins = UserProviderPluginRegistry.refresh(loader: loader).compactMap(\.plugin)
+        XCTAssertEqual(plugins.count, 3)
+        defer {
+            try? FileManager.default.removeItem(at: pluginsRoot)
+            UserProviderPluginRegistry.refresh(loader: loader)
+        }
+        fixture.settings.mergeIcons = true
+        fixture.settings.selectedMenuProvider = .codex
+        fixture.settings.mergedMenuLastSelectedWasOverview = false
+        for plugin in plugins {
+            fixture.settings.setPluginEnabled(plugin.manifest.id, enabled: true)
+            try fixture.store.pluginApprovalStore.record(plugin.approvalBinding(settings: [:]))
+            fixture.store.snapshots[plugin.manifest.id] = UsageSnapshot(
+                primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: Date())
+        }
+        fixture.store._setSnapshotForTesting(UsageSnapshot(
+            primary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: Date()), provider: .codex)
+        let oldRendering = StatusItemController.menuCardRenderingEnabled
+        let oldRefresh = StatusItemController.menuRefreshEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = oldRendering
+            StatusItemController.setMenuRefreshEnabledForTesting(oldRefresh)
+        }
+        let controller = fixture.makeController()
+        defer { controller.releaseStatusItemsForTesting() }
+        let app = NSApplication.shared
+        guard app.delegate == nil else { return XCTFail("Use a standalone test application") }
+        let previousApp = NSWorkspace.shared.frontmostApplication
+        let previousPolicy = app.activationPolicy()
+        let host = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 650, height: 800),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        host.title = "CodexBar — Synthetic Plugin Tabs"
+        host.isReleasedWhenClosed = false
+        func addButton(_ title: String, x: CGFloat, action: @escaping @MainActor (NSButton) -> Void) {
+            let button = PluginProofButton(frame: NSRect(x: x, y: 725, width: 185, height: 32))
+            button.title = title
+            button.callback = action
+            button.target = button
+            button.action = #selector(PluginProofButton.activate)
+            host.contentView?.addSubview(button)
+        }
+        addButton("Open usage menu", x: 20) { button in
+            controller.statusItem.menu?.popUp(
+                positioning: nil, at: NSPoint(x: 0, y: button.bounds.minY), in: button)
+        }
+        addButton("Plugins only", x: 230) { _ in
+            if let metadata = ProviderRegistry.shared.metadata[.codex] {
+                fixture.settings.setProviderEnabled(provider: .codex, metadata: metadata, enabled: false)
+                controller.refreshProviderSelectionDependentUI(refreshOpenMenus: true)
+            }
+        }
+        var finished = false
+        addButton("Finish proof", x: 440) { _ in finished = true }
+        var seenSelections = Set<String>()
+        var seenCards = Set<String>()
+        let timer = Timer(timeInterval: 0.1, repeats: true) { _ in
+            MainActor.assumeIsolated {
+                let menu = controller.statusItem.menu
+                let selection = controller.selectedMenuProvider?.rawValue ?? "none"
+                seenSelections.insert(selection)
+                let cards = menu?.items.compactMap { $0.representedObject as? String }
+                    .filter { $0.hasPrefix("pluginCard:") } ?? []
+                seenCards.formUnion(cards)
+                let receipt: [String: Any] = [
+                    "pid": ProcessInfo.processInfo.processIdentifier,
+                    "window": host.windowNumber,
+                    "topLevel": topLevel,
+                    "selection": selection,
+                    "seenSelections": seenSelections.sorted(),
+                    "cards": cards,
+                    "tabs": (menu?.items.first?.view as? ProviderSwitcherView)?._test_segmentTitles() ?? [],
+                    "used": Dictionary(uniqueKeysWithValues: plugins.map {
+                        ($0.manifest.id.rawValue, fixture.store.snapshots[$0.manifest.id]?.primary?.usedPercent ?? -1)
+                    }),
+                    "firstParty": fixture.store.enabledFirstPartyProvidersForDisplay().map(\.rawValue),
+                    "openMenus": controller.openMenus.count,
+                ]
+                do {
+                    try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys])
+                        .write(to: output.appendingPathComponent("state.json"), options: .atomic)
+                } catch { XCTFail("Could not write native proof receipt") }
+            }
+        }
+        defer {
+            timer.invalidate()
+            controller.statusItem.menu?.cancelTracking()
+            host.close()
+            _ = app.setActivationPolicy(previousPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApp?.activate()
+            }
+        }
+        _ = app.setActivationPolicy(.regular)
+        app.finishLaunching()
+        host.center()
+        host.makeKeyAndOrderFront(nil)
+        app.activate(ignoringOtherApps: true)
+        RunLoop.main.add(timer, forMode: .common)
+        let deadline = Date().addingTimeInterval(600)
+        while !finished, Date() < deadline {
+            if let event = app.nextEvent(
+                matching: .any, until: Date().addingTimeInterval(0.02), inMode: .default, dequeue: true)
+            { app.sendEvent(event) }
+            _ = RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertTrue(finished, "Native proof timed out")
+        XCTAssertTrue(seenCards.contains("pluginCard:legacy-meter"))
+        if topLevel {
+            XCTAssertTrue(seenSelections.contains("atlas-quota"))
+            XCTAssertTrue(seenSelections.contains("boreal-quota"))
+            let atlas = try XCTUnwrap(ProviderInstanceID(rawValue: "atlas-quota"))
+            let boreal = try XCTUnwrap(ProviderInstanceID(rawValue: "boreal-quota"))
+            XCTAssertEqual(fixture.store.snapshots[atlas]?.primary?.usedPercent, 24)
+            XCTAssertEqual(fixture.store.snapshots[boreal]?.primary?.usedPercent, 50)
+            XCTAssertTrue(fixture.store.enabledFirstPartyProvidersForDisplay().isEmpty)
+        }
+    }
+
+    private static func writePlugins(to pluginsRoot: URL, topLevel: Bool) throws {
+        for (id, name, monogram, tint, used, primaryTab) in [
+            ("atlas-quota", "Atlas Quota", "AQ", "#336699", 24, true),
+            ("boreal-quota", "Boreal Quota", "BQ", "#8054B3", 63, true),
+            ("legacy-meter", "Legacy Meter", "LM", "#398A64", 40, false),
+        ] {
+            let source = """
+            defineProvider({
+              id: "\(id)", name: "\(name)",
+              icon: {monogram: "\(monogram)", tint: "\(tint)"},
+              topLevel: \(topLevel && primaryTab),
+              endpoints: ["https://example.com"], settings: [],
+              fetchUsage() { return {primary: {usedPercent: \(used)}}; }
+            });
+            """
+            try Data(source.utf8).write(to: pluginsRoot.appendingPathComponent(id + ".js"))
+        }
+    }
+}
+
+@MainActor
+private final class PluginProofButton: NSButton {
+    var callback: (@MainActor (NSButton) -> Void)?
+
+    @objc func activate() {
+        self.callback?(self)
+    }
+}
+
+private struct PluginProofNoNetwork: ProviderHTTPTransport {
+    func data(for _: URLRequest) async throws -> (Data, URLResponse) {
+        XCTFail("Synthetic plugin proof must not make network requests")
+        throw URLError(.unsupportedURL)
+    }
+}

--- a/Tests/CodexBarTests/UserProviderPluginTests.swift
+++ b/Tests/CodexBarTests/UserProviderPluginTests.swift
@@ -1,4 +1,5 @@
 #if canImport(JavaScriptCore)
+import AppKit
 import Foundation
 import Testing
 @testable import CodexBar
@@ -24,6 +25,7 @@ struct UserProviderPluginTests {
         #expect(plugin.manifest.id.rawValue == "acme-meter")
         #expect(plugin.manifest.icon.monogram == "AM")
         #expect(plugin.manifest.icon.tint == "#336699")
+        #expect(plugin.manifest.topLevel == false)
 
         let binding = try plugin.approvalBinding(settings: [:])
         await #expect(throws: UserProviderPluginError.self) {
@@ -45,6 +47,318 @@ struct UserProviderPluginTests {
         #expect(transport.requestCount == 1)
         #expect(transport.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-secret")
         #expect(transport.lastRequest?.value(forHTTPHeaderField: "Accept-Encoding") == "identity")
+    }
+
+    @MainActor
+    @Test
+    func `top level plugin becomes a stable provider switcher segment`() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let source = """
+        defineProvider({
+          id: "proxy-meter",
+          name: "Proxy Meter",
+          icon: { monogram: "PM", tint: "#336699" },
+          topLevel: true,
+          endpoints: ["https://proxy.example"],
+          settings: [],
+          fetchUsage() { return { primary: { usedPercent: 12 } }; },
+        });
+        """
+        _ = try fixture.write(name: "proxy.js", source: source)
+        let plugin = try #require(UserProviderPluginRegistry.refresh(
+            loader: fixture.loader(transport: RecordingTransport(responseJSON: "{}"))).first?.plugin)
+        var selected: ProviderSwitcherSelection?
+        let view = ProviderSwitcherView(
+            providers: [.codex],
+            pluginProviders: [plugin],
+            selected: .provider(.codex),
+            includesOverview: false,
+            width: 240,
+            showsIcons: true,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            pluginIconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { _ in nil },
+            onSelect: { selected = $0 })
+
+        #expect(plugin.manifest.topLevel)
+        #expect(view._test_segmentTitles() == ["Codex", "Proxy Meter"])
+        #expect(view._test_simulateRuntimeClick(buttonTag: 1))
+        #expect(selected == .provider(plugin.manifest.id))
+
+        #expect(StatusItemController.userPluginsForMenu(
+            [plugin],
+            isEnabled: { _ in true },
+            topLevelSwitcherVisible: true,
+            selectedPluginID: nil).isEmpty)
+        #expect(StatusItemController.userPluginsForMenu(
+            [plugin],
+            isEnabled: { _ in true },
+            topLevelSwitcherVisible: true,
+            selectedPluginID: plugin.manifest.id).map(\.manifest.id) == [plugin.manifest.id])
+        #expect(StatusItemController.isUserPluginSelection(.provider(plugin.manifest.id)))
+        #expect(!StatusItemController.isUserPluginSelection(.provider(.codex)))
+        #expect(ProviderSwitcherSelection.provider(plugin.manifest.id).provider == nil)
+        #expect(ProviderSwitcherSelection.provider(.codex).provider == .codex)
+        #expect(StatusItemController.resolvedSwitcherProviderID(
+            providerIDs: [plugin.manifest.id],
+            selectedProviderID: nil,
+            fallbackProviderID: .codex) == plugin.manifest.id)
+
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        let previousMenuRefresh = StatusItemController.menuRefreshEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+            StatusItemController.setMenuRefreshEnabledForTesting(previousMenuRefresh)
+        }
+        let (controller, _, _) = Self.makePluginMenuController(
+            suiteName: "UserProviderPluginTests.topLevelMenuCards",
+            selectedPluginID: plugin.manifest.id,
+            enabledPluginIDs: [plugin.manifest.id],
+            approvalStore: fixture.approvals)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let emptyMenu = NSMenu()
+        controller.addUserPluginMenuCards(to: emptyMenu, width: 240, selectedPluginID: plugin.manifest.id)
+        #expect(emptyMenu.items.first?.isSeparatorItem == false)
+        #expect(emptyMenu.items.first?.representedObject as? String == "pluginCard:proxy-meter")
+
+        let menuAfterSeparator = NSMenu()
+        menuAfterSeparator.addItem(.separator())
+        controller.addUserPluginMenuCards(to: menuAfterSeparator, width: 240, selectedPluginID: plugin.manifest.id)
+        let emptyIDs = emptyMenu.items.map { $0.representedObject as? String }
+        let separatedIDs = menuAfterSeparator.items.dropFirst().map { $0.representedObject as? String }
+        #expect(emptyIDs == separatedIDs)
+    }
+
+    @MainActor
+    @Test
+    func `sole top level plugin renders independently without a switcher`() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            name: "solo.js",
+            source: Self.menuPlugin(id: "solo-meter", name: "Solo Meter", topLevel: true))
+        let plugin = try #require(UserProviderPluginRegistry.refresh(
+            loader: fixture.loader(transport: RecordingTransport(responseJSON: "{}"))).first?.plugin)
+        let (controller, store, settings) = Self.makePluginMenuController(
+            suiteName: "UserProviderPluginTests.soleTopLevel",
+            selectedPluginID: plugin.manifest.id,
+            enabledPluginIDs: [plugin.manifest.id],
+            approvalStore: fixture.approvals)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = try #require(controller.statusItem.menu)
+        controller.populateMenu(menu, provider: nil)
+
+        #expect(store.enabledFirstPartyProvidersForDisplay().isEmpty)
+        #expect(controller.shouldMergeIcons)
+        #expect(controller.statusItem.isVisible)
+        #expect(menu === controller.mergedMenu)
+        #expect(!(menu.items.first?.view is ProviderSwitcherView))
+        #expect(Self.pluginCardIDs(in: menu) == ["pluginCard:solo-meter"])
+        #expect(settings.selectedMenuProvider == plugin.manifest.id)
+        #expect(controller.manualRefreshProvider(for: menu) == plugin.manifest.id)
+    }
+
+    @MainActor
+    @Test
+    func `top level plugin tabs retain legacy plugin cards without built in providers`() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            name: "first.js",
+            source: Self.menuPlugin(id: "first-meter", name: "First Meter", topLevel: true))
+        _ = try fixture.write(
+            name: "second.js",
+            source: Self.menuPlugin(id: "second-meter", name: "Second Meter", topLevel: true))
+        _ = try fixture.write(
+            name: "legacy.js",
+            source: Self.menuPlugin(id: "legacy-meter", name: "Legacy Meter", topLevel: false))
+        let plugins = UserProviderPluginRegistry.refresh(
+            loader: fixture.loader(transport: RecordingTransport(responseJSON: "{}"))).compactMap(\.plugin)
+        let firstID = try #require(ProviderInstanceID(rawValue: "first-meter"))
+        let secondID = try #require(ProviderInstanceID(rawValue: "second-meter"))
+        let (controller, store, settings) = Self.makePluginMenuController(
+            suiteName: "UserProviderPluginTests.legacyCards",
+            selectedPluginID: firstID,
+            enabledPluginIDs: plugins.map(\.manifest.id),
+            approvalStore: fixture.approvals)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.populateMenu(menu, provider: nil)
+        #expect(store.enabledFirstPartyProvidersForDisplay().isEmpty)
+        #expect(menu.items.first?.view is ProviderSwitcherView)
+        #expect(Self.pluginCardIDs(in: menu) == ["pluginCard:first-meter", "pluginCard:legacy-meter"])
+
+        let wideDescriptor = MenuDescriptor(sections: [
+            MenuDescriptor.Section(entries: [
+                .action(String(repeating: "W", count: 60), .dashboard),
+            ]),
+        ])
+        let measuredWidth = controller.measuredStandardMenuWidth(
+            for: wideDescriptor.sections,
+            baseWidth: StatusItemController.menuCardBaseWidth)
+        #expect(measuredWidth > StatusItemController.menuCardBaseWidth)
+        #expect(controller.menuCardWidth(
+            for: [],
+            selectedProvider: nil,
+            descriptor: wideDescriptor) == measuredWidth)
+
+        settings.selectedMenuProvider = secondID
+        controller.populateMenu(menu, provider: nil)
+        #expect(Self.pluginCardIDs(in: menu) == ["pluginCard:second-meter", "pluginCard:legacy-meter"])
+    }
+
+    @MainActor
+    @Test
+    func `top level plugin cache signature distinguishes delimiter containing metadata`() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let source: (String, String) -> String = { name, monogram in
+            """
+            defineProvider({
+              id: "collision-meter",
+              name: "\(name)",
+              icon: { monogram: "\(monogram)", tint: "#336699" },
+              topLevel: true,
+              endpoints: ["https://collision.example"],
+              settings: [],
+              fetchUsage() { return { primary: { usedPercent: 12 } }; },
+            });
+            """
+        }
+        let url = try fixture.write(name: "collision.js", source: source("A:B", "C"))
+        let firstPlugin = try #require(UserProviderPluginRegistry.refresh(
+            loader: fixture.loader(transport: RecordingTransport(responseJSON: "{}"))).first?.plugin)
+        let (controller, _, _) = Self.makePluginMenuController(
+            suiteName: "UserProviderPluginTests.cacheSignature",
+            selectedPluginID: firstPlugin.manifest.id,
+            enabledPluginIDs: [firstPlugin.manifest.id],
+            approvalStore: fixture.approvals)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let firstSignature = controller.menuLocalizationSignature()
+        try Data(source("A", "B:C").utf8).write(to: url, options: .atomic)
+        _ = UserProviderPluginRegistry.refresh(
+            loader: fixture.loader(transport: RecordingTransport(responseJSON: "{}")))
+
+        #expect(controller.menuLocalizationSignature() != firstSignature)
+    }
+
+    @MainActor
+    @Test
+    func `opening a selected top level plugin does not schedule Codex dashboard refresh`() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            name: "selected.js",
+            source: Self.menuPlugin(id: "selected-meter", name: "Selected Meter", topLevel: true))
+        let plugin = try #require(UserProviderPluginRegistry.refresh(
+            loader: fixture.loader(transport: RecordingTransport(responseJSON: "{}"))).first?.plugin)
+        let (controller, _, settings) = Self.makePluginMenuController(
+            suiteName: "UserProviderPluginTests.menuOpenOwnership",
+            selectedPluginID: plugin.manifest.id,
+            enabledPluginIDs: [plugin.manifest.id],
+            approvalStore: fixture.approvals)
+        defer { controller.releaseStatusItemsForTesting() }
+        try settings.setProviderEnabled(
+            provider: .codex,
+            metadata: #require(ProviderRegistry.shared.metadata[.codex]),
+            enabled: true)
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+
+        #expect(controller.lastMenuProvider == plugin.manifest.id)
+        #expect(controller.deferredOpenAIDashboardRefreshReason == nil)
+    }
+
+    @MainActor
+    @Test
+    func `persistent refresh targets the selected user plugin`() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        _ = try fixture.write(
+            name: "first.js",
+            source: Self.menuPlugin(id: "first-meter", name: "First Meter", topLevel: true))
+        _ = try fixture.write(
+            name: "second.js",
+            source: Self.menuPlugin(id: "second-meter", name: "Second Meter", topLevel: true))
+        let plugins = UserProviderPluginRegistry.refresh(
+            loader: fixture.loader(transport: RecordingTransport(responseJSON: "{}"))).compactMap(\.plugin)
+        let selectedID = try #require(ProviderInstanceID(rawValue: "second-meter"))
+        let selectedPlugin = try #require(plugins.first { $0.manifest.id == selectedID })
+        try fixture.approvals.record(selectedPlugin.approvalBinding(settings: [:]))
+        let (controller, store, settings) = Self.makePluginMenuController(
+            suiteName: "UserProviderPluginTests.selectedRefresh",
+            selectedPluginID: selectedID,
+            enabledPluginIDs: plugins.map(\.manifest.id),
+            approvalStore: fixture.approvals)
+        defer {
+            controller.manualRefreshTasks.values.forEach { $0.cancel() }
+            controller.releaseStatusItemsForTesting()
+        }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = try #require(controller.statusItem.menu as? StatusItemMenu)
+        controller.menuWillOpen(menu)
+        #expect(controller.manualRefreshProvider(for: menu) == selectedID)
+        try settings.setProviderEnabled(
+            provider: .codex,
+            metadata: #require(ProviderRegistry.shared.metadata[.codex]),
+            enabled: true)
+        settings.mergedMenuLastSelectedWasOverview = true
+        #expect(!controller.isMergedOverviewSelected(in: menu))
+        store.refreshingProviders.insert(plugins[0].manifest.id)
+        #expect(!controller.isRefreshActionInFlight(for: menu))
+        store.refreshingProviders.remove(plugins[0].manifest.id)
+        controller.refreshMenuProviderNow(in: menu)
+
+        #expect(controller.manualRefreshTasks[.provider(selectedID)] != nil)
+        #expect(controller.manualRefreshTasks[.global] == nil)
+        #expect(controller.manualRefreshTasks[.provider(.codex)] == nil)
+        #expect(controller.isRefreshActionInFlight(for: menu))
+
+        await controller.manualRefreshTasks[.provider(selectedID)]?.value
+        #expect(store.snapshots[selectedID]?.primary?.usedPercent == 12)
+        let menuID = ObjectIdentifier(menu)
+        for _ in 0..<20 where controller.menuNeedsRefresh(menu) {
+            if let rebuild = controller.openMenuRebuildTasks[menuID] {
+                await rebuild.value
+            } else {
+                await Task.yield()
+            }
+        }
+        #expect(!controller.menuSession.isParentRebuildDeferred(menuID))
+        let menuIsFresh = !controller.menuNeedsRefresh(menu)
+        #expect(menuIsFresh)
+        #expect(controller.manualRefreshProvider(for: menu) == selectedID)
+    }
+
+    @Test
+    func `top level manifest field rejects non boolean values`() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let source = """
+        defineProvider({
+          id: "proxy-meter",
+          name: "Proxy Meter",
+          topLevel: "yes",
+          endpoints: ["https://proxy.example"],
+          settings: [],
+          fetchUsage() { return { primary: { usedPercent: 12 } }; },
+        });
+        """
+
+        #expect(throws: ProviderPluginError.self) {
+            try fixture.loader(transport: RecordingTransport(responseJSON: "{}"))
+                .load(fileURL: fixture.write(name: "invalid-top-level.js", source: source))
+        }
     }
 
     @Test
@@ -529,6 +843,65 @@ struct UserProviderPluginTests {
           },
         });
         """
+    }
+}
+
+extension UserProviderPluginTests {
+    private static func menuPlugin(id: String, name: String, topLevel: Bool) -> String {
+        """
+        defineProvider({
+          id: "\(id)",
+          name: "\(name)",
+          topLevel: \(topLevel),
+          endpoints: ["https://\(id).example"],
+          settings: [],
+          fetchUsage() { return { primary: { usedPercent: 12 } }; },
+        });
+        """
+    }
+
+    @MainActor
+    private static func makePluginMenuController(
+        suiteName: String,
+        selectedPluginID: ProviderInstanceID,
+        enabledPluginIDs: [ProviderInstanceID],
+        approvalStore: ProviderPluginApprovalStore)
+        -> (StatusItemController, UsageStore, SettingsStore)
+    {
+        let settings = testSettingsStore(
+            suiteName: suiteName,
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.providerDetectionCompleted = true
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = selectedPluginID
+        for provider in UsageProvider.allCases {
+            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: false)
+        }
+        for pluginID in enabledPluginIDs {
+            settings.setPluginEnabled(pluginID, enabled: true)
+        }
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            pluginApprovalStore: approvalStore)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: testStatusBar())
+        return (controller, store, settings)
+    }
+
+    @MainActor
+    private static func pluginCardIDs(in menu: NSMenu) -> [String] {
+        menu.items.compactMap { $0.representedObject as? String }.filter { $0.hasPrefix("pluginCard:") }
     }
 }
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -54,6 +54,7 @@ defineProvider({
 - `name`: trimmed display name, 1–80 UTF-8 bytes.
 - `icon` (optional): `{monogram, tint}`. `monogram` is 1–3 characters; `tint` is `#RRGGBB`. The fallback is the first
   letter of `name` with a neutral tint. File/SVG icons are not supported.
+- `topLevel` (optional): set to `true` to give an enabled plugin its own provider-switcher tab. The default is `false`.
 - `endpoints`: 1–16 declared network origins. A fixed endpoint is a normalized HTTPS origin such as
   `https://api.example.com` (no path, query, fragment, or user info). A settings-derived endpoint is
   `{setting: "BASE_URL", policy: "https"}`, `{setting: "BASE_URL", policy: "https-or-loopback-http"}`, or
@@ -247,3 +248,15 @@ surfaces (status feeds, token accounts, OAuth, browser automation, storage probe
 specific payloads). Rendering is limited to generic snapshots and declarative details. There are no remote catalogs,
 downloaded plugins/assets, custom SVGs, imports, arbitrary local I/O, or compatibility fallback from an unknown ID to a
 built-in provider.
+
+## Provider switcher tabs
+
+Set `topLevel: true` in the manifest to give an enabled plugin its own tab when **Merge Icons** is enabled. The tab uses
+the manifest name and icon. Selecting it shows that plugin’s usage followed by any enabled plugins using the original
+appended-card placement. With Merge Icons disabled, plugins retain appended-card placement.
+
+A single plugin works without a redundant switcher, and multiple plugin tabs work even with no built-in providers
+enabled. Refresh and Cmd-R refresh the selected plugin; each card’s refresh button targets that card. Completed
+refreshes update visible plugin cards, and repeated requests for the same plugin share its in-flight refresh.
+Overview continues to summarize built-in providers. This setting changes placement only: it grants no additional host
+capabilities and does not change network approval.


### PR DESCRIPTION
Adds opt-in `topLevel: true` plugin tabs using the manifest name and icon. Stable plugin identities drive mouse/keyboard selection, Refresh and Cmd-R. A single plugin works without a redundant switcher, multiple plugin tabs work without built-in providers, and legacy appended cards remain reachable. Merge Icons disabled retains appended-card placement.

This changes presentation only: existing sandbox capabilities, network approval, settings enablement and provider-data isolation remain in place. Overview still summarizes built-in providers.

Native verification exposed a stale-card bug in the proposal: Cmd-R fetched the new plugin snapshot, but the open card kept its old value because it shared the built-in path that defers parent rebuilds. Plugin cards capture snapshots rather than using the built-in live-value monitor. Completed plugin refreshes now request the existing guarded rebuild only for menus containing that plugin’s card, preserving native-highlight and hosted-submenu safeguards. Card refresh buttons share the manual-refresh scope and in-flight guard. The maintainer pass also removes duplicated selection logic and an Overview wrapper.

Verification:
- The rendered-menu regression failed two assertions before the repair; 146 tests across plugin, architecture, persistent-refresh and viewport suites pass afterward.
- `make check`: zero violations across 2,171 Swift files. Independent P0–P2 review is clean.
- Matching Developer-ID-signed synthetic native hosts exercised real menu clicks, Cmd-R and a card refresh button. Atlas changed from 50% used to 24% used, and its open card immediately showed 76% left. The sibling stayed unchanged. Refreshing Legacy changed only that card to 60% left.
- Native switching reached both plugin tabs; disabling the built-in provider preserved the selected plugin and both tabs, with Legacy still accessible. The completed native test passed with no failures. No live account data or provider requests were used.
- The native proof’s source patch matches commit `8c359f56c894b106caffdf1be40f27df42cdd4e7`.
- Final `make test` passed all 1,059 selections across 89 groups in 905.1 seconds. One group passed on automatic retry after two unchanged Kiro login fixtures failed their first attempt (missing captured output / timeout); 88 groups passed first try, with no group timeouts or isolated-selection retries.
- All [exact-head CI checks](https://github.com/steipete/CodexBar/actions/runs/34498055897) passed, including both macOS shards, Linux x64/arm64/musl, lint and security checks.

Existing appended-card placement, with the opt-in disabled:

![Existing appended plugin cards](https://github.com/user-attachments/assets/d6cb5650-02c5-4bb8-a532-08140238a076)

Top-level tabs, showing the updated value after Cmd-R:

![Plugin tab with refreshed usage](https://github.com/user-attachments/assets/9d93f875-50f9-4a29-b154-09b99f6e14d8)

Includes authoring documentation and an Unreleased changelog entry. Thanks @harjothkhara!

Fixes #2988.
