### PR TITLE
ci: explain unsupported Python test runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.57.1 — Unreleased
 
+### Fixed
+- Token counts: promote rounded `1000K` and `1000M` values to `1M` and `1B`, preserve ordinary precision, and handle the full signed integer range without crashing (#3519, fixes #3518). Thanks @harjothkhara!
+
 ## 0.57.0 — 2026-09-08
 
 ### Highlights

--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -432,11 +432,29 @@ def stop_unreaped_child(process: subprocess.Popen) -> None:
     process.wait(timeout=2)
 
 
-def run_command(command: list[str], timeout: int | None = None) -> int:
+CONTAINMENT_CAPABILITIES = ("waitid", "P_PID", "WEXITED", "WNOHANG", "WNOWAIT")
+
+
+def containment_support_error(capabilities: object = os) -> str | None:
     if sys.platform != "darwin" and not sys.platform.startswith("linux"):
-        raise RuntimeError("Swift test process containment requires macOS or Linux")
-    if not all(hasattr(os, name) for name in ("waitid", "P_PID", "WEXITED", "WNOHANG", "WNOWAIT")):
-        raise RuntimeError("Swift test process containment requires waitid with WNOWAIT")
+        return f"Swift test process containment requires macOS or Linux, not {sys.platform}."
+    missing = [name for name in CONTAINMENT_CAPABILITIES if not hasattr(capabilities, name)]
+    if not missing:
+        return None
+    # A version number alone does not tell the reader which build of python3 to reach for.
+    version = ".".join(str(part) for part in sys.version_info[:3])
+    return (
+        "Swift test process containment requires waitid with WNOWAIT. "
+        f"{sys.executable} is Python {version} and does not provide: {', '.join(missing)}. "
+        "Run make test and make check with a python3 that provides them, "
+        "for example Homebrew python@3.14 placed first on PATH."
+    )
+
+
+def run_command(command: list[str], timeout: int | None = None) -> int:
+    error = containment_support_error()
+    if error is not None:
+        raise RuntimeError(error)
     print(f"+ {' '.join(command)}", flush=True)
     started = time.monotonic()
     ownership = None
@@ -699,6 +717,13 @@ def main() -> int:
     if args.group_size < 1:
         print("--group-size must be positive", file=sys.stderr)
         return 2
+    # Discovery builds the package, so report an unusable interpreter before that cost.
+    # --list-only never runs a test command and keeps working without containment.
+    if not args.list_only:
+        error = containment_support_error()
+        if error is not None:
+            print(error, file=sys.stderr)
+            return 2
 
     swift_command = [args.swift_command, *args.swift_command_arg]
     result = 0

--- a/Scripts/test_swift_test_process_cleanup.py
+++ b/Scripts/test_swift_test_process_cleanup.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import threading
 import time
+import types
 import unittest
 from unittest.mock import Mock, patch
 
@@ -1499,6 +1500,27 @@ int main(int argc, char **argv) {
                     except subprocess.TimeoutExpired:
                         process.kill()
                         process.wait(timeout=2)
+
+
+class ContainmentSupportTests(unittest.TestCase):
+    def test_partial_capabilities_name_only_the_missing_ones(self):
+        partial = types.SimpleNamespace(waitid=None, P_PID=0, WEXITED=0)
+        error = runner.containment_support_error(partial)
+        self.assertIsNotNone(error)
+        self.assertIn("WNOHANG", error)
+        self.assertIn("WNOWAIT", error)
+        self.assertNotIn("P_PID", error)
+        self.assertIn(sys.executable, error)
+
+    def test_complete_capabilities_report_no_error(self):
+        complete = types.SimpleNamespace(**{name: 0 for name in runner.CONTAINMENT_CAPABILITIES})
+        self.assertIsNone(runner.containment_support_error(complete))
+
+    def test_run_command_rejects_an_interpreter_without_waitid(self):
+        with patch.object(runner, "containment_support_error", return_value="no waitid here"):
+            with self.assertRaises(RuntimeError) as raised:
+                runner.run_command(["/bin/echo", "unreachable"])
+        self.assertEqual(str(raised.exception), "no waitid here")
 
 
 if __name__ == "__main__":

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -332,12 +332,13 @@ public enum UsageFormatter {
     }
 
     public static func tokenCountString(_ value: Int) -> String {
-        let absValue = abs(value)
+        let absValue = value.magnitude
         let sign = value < 0 ? "-" : ""
 
-        let units: [(threshold: Int, divisor: Double, suffix: String)] = [
-            (1_000_000_000, 1_000_000_000, "B"),
-            (1_000_000, 1_000_000, "M"),
+        // Promote at the point where whole lower units would round to 1000.
+        let units: [(threshold: UInt, divisor: Double, suffix: String)] = [
+            (999_500_000, 1_000_000_000, "B"),
+            (999_500, 1_000_000, "M"),
             (1000, 1000, "K"),
         ]
 

--- a/Tests/CodexBarTests/CLICostTests.swift
+++ b/Tests/CodexBarTests/CLICostTests.swift
@@ -415,12 +415,20 @@ struct CLICostTests {
         #expect(!json.contains("\"sessions\""))
     }
 
-    @Test
-    func `renders cost text snapshot`() {
+    @Test(arguments: [
+        (1200, 9000, "1.2K", "9K"),
+        (999_999, 999_999_999, "1M", "1B"),
+    ])
+    func `renders cost text snapshot`(
+        sessionTokens: Int,
+        historyTokens: Int,
+        sessionText: String,
+        historyText: String)
+    {
         let snap = CostUsageTokenSnapshot(
-            sessionTokens: 1200,
+            sessionTokens: sessionTokens,
             sessionCostUSD: 1.25,
-            last30DaysTokens: 9000,
+            last30DaysTokens: historyTokens,
             last30DaysCostUSD: 9.99,
             historyDays: 90,
             daily: [],
@@ -431,8 +439,8 @@ struct CLICostTests {
             .replacingOccurrences(of: "$ ", with: "$")
 
         #expect(output.contains("Claude Cost (API-rate estimate)"))
-        #expect(output.contains("Today: $1.25 · 1.2K tokens"))
-        #expect(output.contains("Last 90 days: $9.99 · 9K tokens"))
+        #expect(output.contains("Today: $1.25 · \(sessionText) tokens"))
+        #expect(output.contains("Last 90 days: $9.99 · \(historyText) tokens"))
         #expect(output.contains("cache read/write tokens"))
         #expect(output.contains("Claude Code /status"))
     }

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -398,6 +398,28 @@ struct UsageFormatterTests {
     }
 
     @Test
+    func `token count string promotes rounded unit boundaries`() {
+        #expect(UsageFormatter.tokenCountString(999_499) == "999K")
+        #expect(UsageFormatter.tokenCountString(999_500) == "1M")
+        #expect(UsageFormatter.tokenCountString(999_999) == "1M")
+        #expect(UsageFormatter.tokenCountString(999_499_999) == "999M")
+        #expect(UsageFormatter.tokenCountString(999_500_000) == "1B")
+        #expect(UsageFormatter.tokenCountString(999_999_999) == "1B")
+        #expect(UsageFormatter.tokenCountString(-999_499) == "-999K")
+        #expect(UsageFormatter.tokenCountString(-999_500) == "-1M")
+        #expect(UsageFormatter.tokenCountString(-999_999) == "-1M")
+        #expect(UsageFormatter.tokenCountString(-999_499_999) == "-999M")
+        #expect(UsageFormatter.tokenCountString(-999_500_000) == "-1B")
+        #expect(UsageFormatter.tokenCountString(-999_999_999) == "-1B")
+    }
+
+    @Test
+    func `token count string handles integer limits`() {
+        #expect(UsageFormatter.tokenCountString(Int.max) == "9223372037B")
+        #expect(UsageFormatter.tokenCountString(Int.min) == "-9223372037B")
+    }
+
+    @Test
     func `clean plan maps O auth to ollama`() {
         #expect(UsageFormatter.cleanPlanName("oauth") == "Ollama")
     }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -142,6 +142,10 @@ not establish the cause of a position that changes again after launch; that requ
 make test
 ```
 
+`make test` and `make check` require a `python3` that provides `os.waitid` with `WNOWAIT`. Some macOS Python
+builds, including Apple's `/usr/bin/python3`, do not provide it. Both commands then stop before the build and
+name the interpreter path, its version and the missing attributes.
+
 Suite commands retain the default 180-second deadline, including SwiftPM startup and discovery.
 The runner reports elapsed time and owned PIDs every 30 seconds even when test output is buffered.
 It tracks process birth identities and descendants, including helpers that create separate process


### PR DESCRIPTION
On macOS Python builds without `os.waitid`, the Swift test runner previously performed discovery and then failed with a traceback that did not identify the interpreter. Report the interpreter path, Python version, and missing containment capabilities before discovery instead. The process-containment requirement introduced in #3252 remains enforced; interpreter selection is unchanged.

`--list-only` still performs discovery without requiring containment. The maintainer pass adds entry-point regressions proving that unsupported execution reaches neither discovery nor a child process, while list-only still works. Development documentation now distinguishes the test runner's early exit from earlier `make check` steps and shows the correct Homebrew generic-command path.

Fixes #3515. Thanks @devYRPauli!

Validation on `cd36bc49585d18879e24a8699895c7635387c44c`:

- All six containment-support tests passed under both Apple Python 3.9.6 and Homebrew Python 3.14.7.
- The actual runner under Apple Python exited 2 with one useful diagnostic and zero Swift invocations; `--list-only` exited 0 with exactly one stub discovery invocation.
- `make check` passed: 101 process-containment tests with one expected platform skip, sharding/path checks, and zero SwiftLint violations across 2,150 files.
- `./Scripts/test.sh --limit-groups 1` passed through the supported-Python execution path: 12 real Swift test selections, no retries or timeouts.
- Independent P0–P2 review found no actionable issues.
- [Final-head CI passed](https://github.com/steipete/CodexBar/actions/runs/34362750103): both full macOS test shards, Linux x86_64/arm64 CLI builds, musl, and lint.
