### PR TITLE
fix: normalize rounded token counts safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.57.1 — Unreleased
 
 ### Fixed
-- Token counts: promote rounded `1000K` and `1000M` values to `1M` and `1B` (#3518).
+- Token counts: promote rounded `1000K` and `1000M` values to `1M` and `1B`, preserve ordinary precision, and handle the full signed integer range without crashing (#3519, fixes #3518). Thanks @harjothkhara!
 
 ## 0.57.0 — 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.57.1 — Unreleased
 
+### Fixed
+- Token counts: promote rounded `1000K` and `1000M` values to `1M` and `1B` (#3518).
+
 ## 0.57.0 — 2026-09-08
 
 ### Highlights

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -335,9 +335,10 @@ public enum UsageFormatter {
         let absValue = abs(value)
         let sign = value < 0 ? "-" : ""
 
+        // Promote at the point where whole lower units would round to 1000.
         let units: [(threshold: Int, divisor: Double, suffix: String)] = [
-            (1_000_000_000, 1_000_000_000, "B"),
-            (1_000_000, 1_000_000, "M"),
+            (999_500_000, 1_000_000_000, "B"),
+            (999_500, 1_000_000, "M"),
             (1000, 1000, "K"),
         ]
 

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -332,11 +332,11 @@ public enum UsageFormatter {
     }
 
     public static func tokenCountString(_ value: Int) -> String {
-        let absValue = abs(value)
+        let absValue = value.magnitude
         let sign = value < 0 ? "-" : ""
 
         // Promote at the point where whole lower units would round to 1000.
-        let units: [(threshold: Int, divisor: Double, suffix: String)] = [
+        let units: [(threshold: UInt, divisor: Double, suffix: String)] = [
             (999_500_000, 1_000_000_000, "B"),
             (999_500, 1_000_000, "M"),
             (1000, 1000, "K"),

--- a/Tests/CodexBarTests/CLICostTests.swift
+++ b/Tests/CodexBarTests/CLICostTests.swift
@@ -415,12 +415,20 @@ struct CLICostTests {
         #expect(!json.contains("\"sessions\""))
     }
 
-    @Test
-    func `renders cost text snapshot`() {
+    @Test(arguments: [
+        (1200, 9000, "1.2K", "9K"),
+        (999_999, 999_999_999, "1M", "1B"),
+    ])
+    func `renders cost text snapshot`(
+        sessionTokens: Int,
+        historyTokens: Int,
+        sessionText: String,
+        historyText: String)
+    {
         let snap = CostUsageTokenSnapshot(
-            sessionTokens: 999_999,
+            sessionTokens: sessionTokens,
             sessionCostUSD: 1.25,
-            last30DaysTokens: 999_999_999,
+            last30DaysTokens: historyTokens,
             last30DaysCostUSD: 9.99,
             historyDays: 90,
             daily: [],
@@ -431,8 +439,8 @@ struct CLICostTests {
             .replacingOccurrences(of: "$ ", with: "$")
 
         #expect(output.contains("Claude Cost (API-rate estimate)"))
-        #expect(output.contains("Today: $1.25 · 1M tokens"))
-        #expect(output.contains("Last 90 days: $9.99 · 1B tokens"))
+        #expect(output.contains("Today: $1.25 · \(sessionText) tokens"))
+        #expect(output.contains("Last 90 days: $9.99 · \(historyText) tokens"))
         #expect(output.contains("cache read/write tokens"))
         #expect(output.contains("Claude Code /status"))
     }

--- a/Tests/CodexBarTests/CLICostTests.swift
+++ b/Tests/CodexBarTests/CLICostTests.swift
@@ -418,9 +418,9 @@ struct CLICostTests {
     @Test
     func `renders cost text snapshot`() {
         let snap = CostUsageTokenSnapshot(
-            sessionTokens: 1200,
+            sessionTokens: 999_999,
             sessionCostUSD: 1.25,
-            last30DaysTokens: 9000,
+            last30DaysTokens: 999_999_999,
             last30DaysCostUSD: 9.99,
             historyDays: 90,
             daily: [],
@@ -431,8 +431,8 @@ struct CLICostTests {
             .replacingOccurrences(of: "$ ", with: "$")
 
         #expect(output.contains("Claude Cost (API-rate estimate)"))
-        #expect(output.contains("Today: $1.25 · 1.2K tokens"))
-        #expect(output.contains("Last 90 days: $9.99 · 9K tokens"))
+        #expect(output.contains("Today: $1.25 · 1M tokens"))
+        #expect(output.contains("Last 90 days: $9.99 · 1B tokens"))
         #expect(output.contains("cache read/write tokens"))
         #expect(output.contains("Claude Code /status"))
     }

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -398,6 +398,18 @@ struct UsageFormatterTests {
     }
 
     @Test
+    func `token count string promotes rounded unit boundaries`() {
+        #expect(UsageFormatter.tokenCountString(999_499) == "999K")
+        #expect(UsageFormatter.tokenCountString(999_500) == "1M")
+        #expect(UsageFormatter.tokenCountString(999_999) == "1M")
+        #expect(UsageFormatter.tokenCountString(999_499_999) == "999M")
+        #expect(UsageFormatter.tokenCountString(999_500_000) == "1B")
+        #expect(UsageFormatter.tokenCountString(999_999_999) == "1B")
+        #expect(UsageFormatter.tokenCountString(-999_999) == "-1M")
+        #expect(UsageFormatter.tokenCountString(-999_999_999) == "-1B")
+    }
+
+    @Test
     func `clean plan maps O auth to ollama`() {
         #expect(UsageFormatter.cleanPlanName("oauth") == "Ollama")
     }

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -405,8 +405,18 @@ struct UsageFormatterTests {
         #expect(UsageFormatter.tokenCountString(999_499_999) == "999M")
         #expect(UsageFormatter.tokenCountString(999_500_000) == "1B")
         #expect(UsageFormatter.tokenCountString(999_999_999) == "1B")
+        #expect(UsageFormatter.tokenCountString(-999_499) == "-999K")
+        #expect(UsageFormatter.tokenCountString(-999_500) == "-1M")
         #expect(UsageFormatter.tokenCountString(-999_999) == "-1M")
+        #expect(UsageFormatter.tokenCountString(-999_499_999) == "-999M")
+        #expect(UsageFormatter.tokenCountString(-999_500_000) == "-1B")
         #expect(UsageFormatter.tokenCountString(-999_999_999) == "-1B")
+    }
+
+    @Test
+    func `token count string handles integer limits`() {
+        #expect(UsageFormatter.tokenCountString(Int.max) == "9223372037B")
+        #expect(UsageFormatter.tokenCountString(Int.min) == "-9223372037B")
     }
 
     @Test


### PR DESCRIPTION
Token summaries could select `K` or `M` before rounding and then display `1000K` or `1000M`. Promote at the existing rounding boundaries so those values display as `1M` and `1B` across CLI and app summaries. Use unsigned magnitude to avoid an overflow for `Int.min`; token accounting and pricing are unchanged.

Retain the original CLI `1.2K`/`9K` cases alongside the new `1M`/`1B` cases, cover positive and negative boundary neighbors and both integer limits, and preserve contributor credit in the changelog.

Fixes #3518.

Validation on `3b42cc42a1a958423d7849a3e02b03df8e278074`:

- 81 focused formatter/CLI tests passed with Keychain and provider-file isolation enabled.
- `make check` passed, including zero SwiftLint violations across 2,150 files.
- Independent P0–P2 review found no actionable issues.
- [CI passed](https://github.com/steipete/CodexBar/actions/runs/34358007775): both macOS test shards, Linux x86_64/arm64 CLI builds, and musl.
- All 1,043 local test selections were verified across the original, isolated, and resumed runs. The initial `make test` stopped on a cost-store scale-suite timeout on a nearly full disk; the isolated retry passed all three scale tests in 80 seconds. A later grouped status-menu timeout recovered through the runner’s isolated retries. No assertions or timeout limits were relaxed.

Source-level before/after execution reproduced `999500 → 1000K` and `999500000 → 1000M` on main, then `1M` and `1B` on this candidate. The contributor also exercised the built CLI with isolated synthetic history; the retained CLI renderer regression covers those outputs directly.
