### PR TITLE
docs: add CodexBar for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ CLI install:
 
 ## Looking for a Windows version?
 - [Win-CodexBar](https://github.com/Finesssee/Win-CodexBar)
+- [CodexBar for Windows](https://github.com/hinneslung/CodexBar-for-Windows) — Native Windows tray app powered by the original CodexBar CLI through WSL2; x64 and ARM64 installers.
 
 ## Linux desktop integration?
 - [codexbar-waybar](https://github.com/Marouan-chak/codexbar-waybar) — Waybar custom module + GTK4 popover for Hyprland / Sway / other Wayland compositors, built on top of the bundled Linux CLI.


### PR DESCRIPTION
Hi, thanks for building CodexBar! I would like to request listing [CodexBar for Windows](https://github.com/hinneslung/CodexBar-for-Windows) alongside Win-CodexBar.

It's a native Windows tray app that uses the unchanged CodexBar CLI through WSL2, with x64 and ARM64 installers. I maintain the Windows code and handle support in the fork.

This adds one README link, following the Linux integration listings in #991 and #2734. No application code changes.

Checks: `git diff --check` passed; confirmed the repository and published downloads are available. `make test` could not run because make is not installed on this Windows machine. A native Windows debug build stopped in unchanged upstream CQuickJS code (`clock_gettime` / `CLOCK_MONOTONIC` unavailable).
