### PR TITLE
fix(antigravity): read sidecar-less WAL conversations with an immutable fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Codex accounts: honor Hide Personal Info in switcher labels and tooltips, redact embedded workspace emails, and preserve distinct account numbers in narrow menus (#3551). Thanks @zenibako!
 - Codex accounts: reauthenticate the credential source used by the visible row, fixing repeated re-auth on saved accounts that also represent the System login, and reject stale account actions (#3558). Thanks @Nek-12!
 - Codex spend: keep waiting history files ahead of repeated migration revisits so large histories can finish bounded catch-up, preserving stored rows and checkpoints (#3548, related to #3411). Thanks @SergeiNikolenko!
+- Grok: skip discarded local-history scans and version probes after terminal CLI billing failures, allowing fallback to start sooner (extracted from #3236). Thanks @Yuxin-Qiao!
 
 ## 0.59.0 — 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.59.1 — Unreleased
 
 ### Fixed
+- Menu bar: align window and display coordinates so monitors above or below the primary display do not cause missed or false startup recovery.
 - Devin: honor hidden daily quotas even when the response includes daily usage, preserving weekly limits and extra balance (#3542). Thanks @dzienisz!
 - Codex accounts: honor Hide Personal Info in switcher labels and tooltips, redact embedded workspace emails, and preserve distinct account numbers in narrow menus (#3551). Thanks @zenibako!
 - Codex accounts: reauthenticate the credential source used by the visible row, fixing repeated re-auth on saved accounts that also represent the System login, and reject stale account actions (#3558). Thanks @Nek-12!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Devin: honor hidden daily quotas even when the response includes daily usage, preserving weekly limits and extra balance (#3542). Thanks @dzienisz!
 - Codex accounts: honor Hide Personal Info in switcher labels and tooltips, redact embedded workspace emails, and preserve distinct account numbers in narrow menus (#3551). Thanks @zenibako!
+- Codex accounts: reauthenticate the credential source used by the visible row, fixing repeated re-auth on saved accounts that also represent the System login, and reject stale account actions (#3558). Thanks @Nek-12!
 - Codex spend: keep waiting history files ahead of repeated migration revisits so large histories can finish bounded catch-up, preserving stored rows and checkpoints (#3548, related to #3411). Thanks @SergeiNikolenko!
 
 ## 0.59.0 — 2026-09-10

--- a/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
+++ b/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
@@ -15,13 +15,15 @@ struct MenuBarStatusItemWindowSnapshot: Equatable, CustomStringConvertible {
     }
 
     var isTahoeBlockedProxy: Bool {
-        self.ownerName == "Control Center"
+        // A primary-origin proxy can overlap an upper display below that display's menu bar.
+        let isPrimaryOriginProxy = self.bounds.maxY == 0 && self.displayBounds?.minY != self.bounds.minY
+        return self.ownerName == "Control Center"
             && self.isOnscreen
             && abs(self.bounds.minX) <= 1
             && self.bounds.maxY <= 0
             && self.bounds.width > 0
             && self.bounds.height > 0
-            && !self.isWithinDisplayBounds
+            && (!self.isWithinDisplayBounds || isPrimaryOriginProxy)
     }
 
     var description: String {
@@ -39,16 +41,21 @@ enum MenuBarStatusItemWindowProbe {
         self.snapshots(
             matching: names,
             windowInfo: self.windowInfo(),
-            displayBounds: NSScreen.screens.map(\.frame))
+            screenFrames: NSScreen.screens.map(\.frame))
     }
 
     static func snapshots(
         matching names: Set<String>,
         windowInfo: [[String: Any]],
-        displayBounds: [CGRect])
+        screenFrames: [CGRect])
         -> [MenuBarStatusItemWindowSnapshot]
     {
         guard !names.isEmpty else { return [] }
+        // Cocoa screen frames and Quartz window bounds have opposite vertical origins.
+        let primaryHeight = screenFrames.first?.height ?? 0
+        let displayBounds = screenFrames.map {
+            CGRect(x: $0.minX, y: primaryHeight - $0.maxY, width: $0.width, height: $0.height)
+        }
         return windowInfo.compactMap { record in
             self.snapshot(record: record, matching: names, displayBounds: displayBounds)
         }
@@ -85,26 +92,8 @@ enum MenuBarStatusItemWindowProbe {
 
     private static func bounds(_ value: Any?) -> CGRect? {
         guard let dictionary = value as? [String: Any],
-              let x = self.double(dictionary["X"]),
-              let y = self.double(dictionary["Y"]),
-              let width = self.double(dictionary["Width"]),
-              let height = self.double(dictionary["Height"])
+              ["X", "Y", "Width", "Height"].allSatisfy({ dictionary[$0] is NSNumber })
         else { return nil }
-        return CGRect(x: x, y: y, width: width, height: height)
-    }
-
-    private static func double(_ value: Any?) -> Double? {
-        switch value {
-        case let number as NSNumber:
-            number.doubleValue
-        case let double as Double:
-            double
-        case let int as Int:
-            Double(int)
-        case let cgFloat as CGFloat:
-            Double(cgFloat)
-        default:
-            nil
-        }
+        return CGRect(dictionaryRepresentation: dictionary as CFDictionary)
     }
 }

--- a/Sources/CodexBar/PreferencesCodexAccountsSection.swift
+++ b/Sources/CodexBar/PreferencesCodexAccountsSection.swift
@@ -55,11 +55,12 @@ struct CodexAccountsSectionState: Equatable {
     }
 
     var canAddAccount: Bool {
-        !self.hasUnreadableManagedAccountStore &&
-            !self.isAuthenticatingManagedAccount &&
-            !self.isRemovingManagedAccount &&
-            !self.isAuthenticatingLiveAccount &&
-            !self.isPromotingSystemAccount
+        !self.hasUnreadableManagedAccountStore && !self.hasAccountOperationInFlight
+    }
+
+    private var hasAccountOperationInFlight: Bool {
+        self.isAuthenticatingManagedAccount || self.isRemovingManagedAccount ||
+            self.isAuthenticatingLiveAccount || self.isPromotingSystemAccount
     }
 
     var addAccountTitle: String {
@@ -74,11 +75,7 @@ struct CodexAccountsSectionState: Equatable {
     }
 
     var isSystemSelectionDisabled: Bool {
-        self.hasUnreadableManagedAccountStore ||
-            self.isAuthenticatingManagedAccount ||
-            self.isRemovingManagedAccount ||
-            self.isAuthenticatingLiveAccount ||
-            self.isPromotingSystemAccount
+        !self.canAddAccount
     }
 
     func canPromoteToSystem(_ account: CodexVisibleAccount) -> Bool {
@@ -88,34 +85,29 @@ struct CodexAccountsSectionState: Equatable {
     }
 
     func canReauthenticate(_ account: CodexVisibleAccount) -> Bool {
-        guard account.canReauthenticate else { return false }
-        guard self.isAuthenticatingManagedAccount == false else { return false }
-        guard self.isRemovingManagedAccount == false else { return false }
-        guard self.isAuthenticatingLiveAccount == false else { return false }
-        guard self.isPromotingSystemAccount == false else { return false }
-        if account.storedAccountID != nil {
-            return self.hasUnreadableManagedAccountStore == false
+        guard account.canReauthenticate, !self.hasAccountOperationInFlight else { return false }
+        switch account.selectionSource {
+        case .managedAccount:
+            return !self.hasUnreadableManagedAccountStore
+        case .liveSystem:
+            return true
+        case .profileHome:
+            return false
         }
-        return true
     }
 
     func canRemove(_ account: CodexVisibleAccount) -> Bool {
-        guard account.canRemove else { return false }
-        guard self.isAuthenticatingManagedAccount == false else { return false }
-        guard self.isRemovingManagedAccount == false else { return false }
-        guard self.isAuthenticatingLiveAccount == false else { return false }
-        guard self.isPromotingSystemAccount == false else { return false }
-        return self.hasUnreadableManagedAccountStore == false
+        account.canRemove && self.canAddAccount
     }
 
     func reauthenticateTitle(for account: CodexVisibleAccount) -> String {
-        if let accountID = account.storedAccountID,
+        if case let .managedAccount(accountID) = account.selectionSource,
            self.isAuthenticatingManagedAccount,
            self.authenticatingManagedAccountID == accountID
         {
             return L("Re-authenticating…")
         }
-        if account.storedAccountID == nil, self.isAuthenticatingLiveAccount {
+        if account.selectionSource == .liveSystem, self.isAuthenticatingLiveAccount {
             return L("Re-authenticating…")
         }
         return L("Re-auth")

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -290,10 +290,15 @@ struct ProvidersPane: View {
 
     func reauthenticateCodexAccount(_ account: CodexVisibleAccount) async {
         self.codexAccountsNotice = nil
-        if let accountID = account.storedAccountID {
-            guard let state = self.codexAccountsSectionState(for: .codex), state.canReauthenticate(account) else {
-                return
-            }
+        self.settings.invalidateCodexAccountReconciliationSnapshotCache()
+        guard let state = self.codexAccountsSectionState(for: .codex),
+              let current = state.visibleAccounts.first(where: { $0.id == account.id }),
+              current.selectionSource == account.selectionSource,
+              current.storedAccountID == account.storedAccountID,
+              current.workspaceAccountID == account.workspaceAccountID,
+              state.canReauthenticate(current)
+        else { return }
+        if case let .managedAccount(accountID) = current.selectionSource {
             do {
                 _ = try await self.managedCodexAccountCoordinator
                     .authenticateManagedAccount(existingAccountID: accountID)
@@ -304,9 +309,7 @@ struct ProvidersPane: View {
             return
         }
 
-        guard let state = self.codexAccountsSectionState(for: .codex), state.canReauthenticate(account) else {
-            return
-        }
+        guard current.selectionSource == .liveSystem else { return }
 
         self.isAuthenticatingLiveCodexAccount = true
         self.codexAccountPromotionCoordinator.setLiveReauthenticationInProgress(true)

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSQLite.swift
@@ -51,18 +51,111 @@ extension AntigravityLocalReader {
     }
     #endif
 
+    private enum OpenMode {
+        /// Ordinary read-only access with WAL read-mark coordination through the sidecars.
+        case readOnly
+        /// Lock-free access to the main database file alone. Never creates or touches sidecars.
+        case immutable
+    }
+
+    private struct DatabaseAttempt {
+        let source: SourceResult
+        /// SQLite declined the database itself (SQLITE_CANTOPEN) before any row was read.
+        let cannotOpen: Bool
+
+        init(_ source: SourceResult, cannotOpen: Bool = false) {
+            self.source = source
+            self.cannotOpen = cannotOpen
+        }
+    }
+
     private static func readDatabase(_ url: URL, budget: Budget) throws -> SourceResult {
-        #if canImport(SQLite3) || canImport(CSQLite3)
+        let attempt = try self.readDatabase(url, budget: budget, mode: .readOnly)
+        // Some SQLite builds (Apple's system library among them) decline read-only access to a WAL database
+        // whose -wal and -shm sidecars are absent, because a read-only connection may not create them.
+        // A cleanly closed conversation is exactly that file. An absent -wal also means no WAL connection
+        // holds the database, so the main file alone carries the checkpointed state.
+        guard attempt.cannotOpen, let before = self.idleDatabaseState(url) else { return attempt.source }
+        budget.statistics.immutableFallbacks += 1
+        var source = try self.readDatabase(url, budget: budget, mode: .immutable).source
+        // An immutable connection neither locks nor detects changes. A writer that appeared during the read
+        // could have checkpointed pages into the main file, so the result is trusted only when the file and
+        // its sidecar state are unchanged afterwards. Anything else stays incomplete, as before.
+        guard self.idleDatabaseState(url) == before else {
+            source.isComplete = false
+            return source
+        }
+        return source
+    }
+
+    /// Identity of an idle WAL database: no `-wal` sidecar, plus the main file's size, modification time,
+    /// file system number, and 100-byte header. Nil when a `-wal` sidecar exists or the file cannot be examined.
+    private struct IdleDatabaseState: Equatable {
+        let size: UInt64
+        let modified: Date
+        let fileNumber: UInt64
+        let header: Data
+    }
+
+    private static func idleDatabaseState(_ url: URL) -> IdleDatabaseState? {
+        // SQLite places sidecars next to the resolved database file, not next to a symlink.
+        let resolved = url.resolvingSymlinksInPath()
+        guard !FileManager.default.fileExists(atPath: resolved.path + "-wal"),
+              let attributes = try? FileManager.default.attributesOfItem(atPath: resolved.path),
+              let size = (attributes[.size] as? NSNumber)?.uint64Value,
+              let modified = attributes[.modificationDate] as? Date,
+              let fileNumber = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value,
+              let handle = try? FileHandle(forReadingFrom: resolved)
+        else { return nil }
+        defer { try? handle.close() }
+        guard let header = try? handle.read(upToCount: 100) else { return nil }
+        return IdleDatabaseState(size: size, modified: modified, fileNumber: fileNumber, header: header)
+    }
+
+    /// The `immutable=1` query parameter is only reachable through a URI filename.
+    private static func immutableURI(for url: URL) -> String? {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "%?#")
+        guard let path = url.path.addingPercentEncoding(withAllowedCharacters: allowed) else { return nil }
+        return "file:\(path)?immutable=1"
+    }
+
+    #if canImport(SQLite3) || canImport(CSQLite3)
+    /// Opens the database for the given mode. A failed open leaves no handle behind.
+    private static func openDatabase(
+        _ url: URL,
+        mode: OpenMode,
+        budget: Budget) -> (status: Int32, database: OpaquePointer?)
+    {
         var database: OpaquePointer?
-        let opened = sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READONLY, nil)
+        let status: Int32 = switch mode {
+        case .readOnly:
+            sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READONLY, nil)
+        case .immutable:
+            if let uri = self.immutableURI(for: url) {
+                sqlite3_open_v2(uri, &database, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nil)
+            } else {
+                SQLITE_CANTOPEN
+            }
+        }
         if database != nil {
             budget.statistics.sqliteHandlesOpened += 1
         }
-        guard opened == SQLITE_OK, let database else {
+        guard status == SQLITE_OK, let database else {
             if let database, sqlite3_close(database) == SQLITE_OK {
                 budget.statistics.sqliteHandlesClosed += 1
             }
-            return SourceResult(isComplete: false)
+            return (status, nil)
+        }
+        return (status, database)
+    }
+    #endif
+
+    private static func readDatabase(_ url: URL, budget: Budget, mode: OpenMode) throws -> DatabaseAttempt {
+        #if canImport(SQLite3) || canImport(CSQLite3)
+        let opened = self.openDatabase(url, mode: mode, budget: budget)
+        guard let database = opened.database else {
+            return DatabaseAttempt(SourceResult(isComplete: false), cannotOpen: opened.status == SQLITE_CANTOPEN)
         }
         defer {
             if sqlite3_close(database) == SQLITE_OK {
@@ -87,7 +180,7 @@ extension AntigravityLocalReader {
             nil,
             nil,
             nil)
-        guard registered == SQLITE_OK else { return SourceResult(isComplete: false) }
+        guard registered == SQLITE_OK else { return DatabaseAttempt(SourceResult(isComplete: false)) }
         sqlite3_progress_handler(
             database,
             1000,
@@ -103,17 +196,24 @@ extension AntigravityLocalReader {
             }
         }
         // Ordinary read-only SQLite permits WAL read-mark coordination; it does not promise unchanged SHM bytes.
-        guard sqlite3_exec(database, "BEGIN DEFERRED", nil, nil, nil) == SQLITE_OK else {
+        let began = sqlite3_exec(database, "BEGIN DEFERRED", nil, nil, nil)
+        guard began == SQLITE_OK else {
             if let failure = progress.failure {
                 throw failure
             }
-            return SourceResult(isComplete: false)
+            return DatabaseAttempt(SourceResult(isComplete: false), cannotOpen: began == SQLITE_CANTOPEN)
         }
         let supported = try self.hasSupportedSQLiteTable(database, budget: budget)
         if let failure = progress.failure {
             throw failure
         }
-        guard supported else { return SourceResult(isComplete: false) }
+        // The deferred transaction first touches the file at the schema read, so a declined WAL open
+        // surfaces here as a failed prepare and leaves SQLITE_CANTOPEN as the connection's last error.
+        guard supported else {
+            return DatabaseAttempt(
+                SourceResult(isComplete: false),
+                cannotOpen: sqlite3_errcode(database) == SQLITE_CANTOPEN)
+        }
         sqlite3_limit(database, SQLITE_LIMIT_LENGTH, Int32(maximumValueBytes))
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -129,14 +229,16 @@ extension AntigravityLocalReader {
         if let failure = progress.failure {
             throw failure
         }
-        guard prepared == SQLITE_OK, let activeStatement = statement else { return SourceResult(isComplete: false) }
+        guard prepared == SQLITE_OK, let activeStatement = statement else {
+            return DatabaseAttempt(SourceResult(isComplete: false), cannotOpen: prepared == SQLITE_CANTOPEN)
+        }
         sqlite3_bind_int64(activeStatement, 1, Int64(min(budget.limits.rowsPerDatabase, 10000) + 1))
         let session = url.deletingPathExtension().lastPathComponent
         var rows = try self.readRows(activeStatement, session: session, progress: progress)
         if !rows.pendingTimestampRows.isEmpty {
             // Positional recovery is safe only when every generation row participated in the occurrence list.
             // A malformed row can still carry a reused step UUID, so partial primary scans must not realign later rows.
-            guard rows.source.isComplete else { return rows.source }
+            guard rows.source.isComplete else { return DatabaseAttempt(rows.source) }
             // Release the gen_metadata cursor before the optional steps pass reuses the same snapshot.
             sqlite3_finalize(activeStatement)
             statement = nil
@@ -157,7 +259,7 @@ extension AntigravityLocalReader {
                       self.embeddedTimestampsAgree(neededStepOccurrences, with: stepScan, botIDUses: rows.botIDUses)
                 else {
                     rows.source.isComplete = false
-                    return rows.source
+                    return DatabaseAttempt(rows.source)
                 }
                 let recoveredCount = self.appendRecoveredEvents(
                     to: &rows,
@@ -170,9 +272,9 @@ extension AntigravityLocalReader {
                 rows.source.isComplete = false
             }
         }
-        return rows.source
+        return DatabaseAttempt(rows.source)
         #else
-        return SourceResult(isComplete: false)
+        return DatabaseAttempt(SourceResult(isComplete: false))
         #endif
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalScan.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalScan.swift
@@ -53,6 +53,8 @@ extension AntigravityLocalReader {
         var schemaBytes = 0
         var sqliteHandlesOpened = 0
         var sqliteHandlesClosed = 0
+        /// Sidecar-less WAL databases that the ordinary read-only open declined and an immutable open read.
+        var immutableFallbacks = 0
     }
 
     enum ScanFailure: Error {

--- a/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
@@ -79,6 +79,14 @@ public struct GrokStatusProbe: Sendable {
     public static let usageUnavailableMessage =
         "Grok usage is unavailable because its billing sources did not report a usage percentage."
 
+    var localSummary: @Sendable ([String: String]) async throws -> GrokLocalSessionSummary? = {
+        try await GrokLocalSessionScanner.summarizeOffMainThread(env: $0)
+    }
+
+    var settingsTransport: any ProviderHTTPTransport = ProviderHTTPClient.shared
+    var identityOnlyFallback: @Sendable (GrokCredentials?, Bool, Error?) -> Bool =
+        GrokStatusProbe.shouldUseIdentityOnlyFallback
+
     public init() {}
 
     public static func detectVersion(env: [String: String] = ProcessInfo.processInfo.environment)
@@ -122,44 +130,32 @@ public struct GrokStatusProbe: Sendable {
             rpcError = error
         }
 
-        // Local fallback summary always succeeds (empty if no sessions yet).
-        let localSummary = try await GrokLocalSessionScanner.summarizeOffMainThread(env: env)
-        let cliVersion = Self.detectVersion(env: env)
-
-        // `localSummary` is *not* currently projected into a visible RateWindow or
-        // identity field, so a stale `~/.grok/sessions/` directory must not
-        // suppress the auth-required hint. CLI-only fetches need a billing
-        // response; the provider pipeline owns the separate web fallback.
-        if billing == nil,
-           let credentials,
-           Self.shouldUseIdentityOnlyFallback(
-               credentials: credentials,
-               billingAttempted: billingAttempted,
-               error: rpcError)
-        {
-            let subscriptionTier = try await Self.loadSettingsTier(credentials: credentials)
-            return Self.identityOnlySnapshot(
-                credentials: credentials,
-                localSummary: localSummary,
-                cliVersion: cliVersion,
-                subscriptionTier: subscriptionTier)
-        }
-
-        if billing == nil {
+        let isIdentityOnly = billing == nil && self.identityOnlyFallback(credentials, billingAttempted, rpcError)
+        // Terminal CLI failures must reach the provider's web fallback without scanning discarded history.
+        guard billing != nil || isIdentityOnly else {
             throw rpcError ?? GrokRPCError.notAuthenticated
         }
 
-        let subscriptionTier = try await Self.loadSettingsTier(credentials: credentials)
+        let localSummary = try await self.localSummary(env)
+        let cliVersion = Self.detectVersion(env: env)
+        // Preserve the original eligibility checkpoint after potentially slow local work.
+        if isIdentityOnly, !self.identityOnlyFallback(credentials, billingAttempted, rpcError) {
+            throw rpcError ?? GrokRPCError.notAuthenticated
+        }
+        let subscriptionTier = try await Self.loadSettingsTier(
+            credentials: credentials,
+            session: self.settingsTransport)
         return GrokUsageSnapshot(
             billing: billing,
             webBilling: nil,
-            credentials: Self.credentialsForSnapshot(
+            credentials: isIdentityOnly ? credentials : Self.credentialsForSnapshot(
                 credentials: credentials,
                 billing: billing,
                 webBilling: nil),
             localSummary: localSummary,
             cliVersion: cliVersion,
             updatedAt: Date(),
+            diagnostic: isIdentityOnly ? Self.teamUsageUnavailableMessage : nil,
             subscriptionTier: subscriptionTier)
     }
 

--- a/Tests/CodexBarTests/AntigravityLocalWALTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalWALTests.swift
@@ -183,10 +183,19 @@ struct AntigravityLocalWALTests {
         #expect(!FileManager.default.fileExists(atPath: url.path + "-wal"))
         #expect(!FileManager.default.fileExists(atPath: url.path + "-shm"))
         let report = try fixture.report()
-        #expect(report.coverage == (control == SQLITE_ROW ? .complete : .partial))
+        // Some SQLite builds decline read-only WAL access without sidecars. A cleanly closed conversation
+        // is exactly that file, so the reader falls back to an immutable read of the main file instead of
+        // withholding the whole history. The control shows which path this platform's SQLite took.
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27"])
+        #expect(report.statistics.immutableFallbacks == (control == SQLITE_ROW ? 0 : 1))
         #expect(report.statistics.sqliteHandlesOpened == report.statistics.sqliteHandlesClosed)
         #expect(try Data(contentsOf: url) == before)
-        // Some SQLite builds decline read-only WAL access without sidecars; that must stay unavailable.
+        if control == SQLITE_CANTOPEN {
+            // The fallback never creates sidecars either. An ordinary read-only open on other SQLite builds may.
+            #expect(!FileManager.default.fileExists(atPath: url.path + "-wal"))
+            #expect(!FileManager.default.fileExists(atPath: url.path + "-shm"))
+        }
         // This control uses the platform SQLite contract independently of the production reader.
         let reopened = try Fixture.open(url)
         var reopenedClosed = false
@@ -208,6 +217,126 @@ struct AntigravityLocalWALTests {
             #expect(budget.statistics.sqliteHandlesOpened == budget.statistics.sqliteHandlesClosed)
         }
         #expect(!FileManager.default.fileExists(atPath: missing.path))
+    }
+
+    @Test
+    func `immutable fallback reads a sidecar-less WAL database through an escaped URI path`() throws {
+        let fixture = try Fixture()
+        defer { withExtendedLifetime(fixture) {} }
+        // Every character here would change the meaning of an unescaped SQLite URI.
+        let session = "odd %25 ?q #f"
+        let url = try fixture.database(session, blobs: [Fixture.blob()])
+        try Self.prepareWAL(url)
+        #expect(!FileManager.default.fileExists(atPath: url.path + "-wal"))
+        // The raw SQLite control never opens the production target or prepares its sidecars.
+        let controlFixture = try Fixture()
+        defer { withExtendedLifetime(controlFixture) {} }
+        let controlURL = try controlFixture.database(session, blobs: [Fixture.blob()])
+        try Self.prepareWAL(controlURL)
+        let control = Self.readOnlyQueryStatus(controlURL)
+        let report = try fixture.report()
+        #expect(report.coverage == .complete)
+        #expect(report.report.data.map(\.date) == ["2026-08-27"])
+        #expect(report.statistics.immutableFallbacks == (control == SQLITE_ROW ? 0 : 1))
+        #expect(report.statistics.sqliteHandlesOpened == report.statistics.sqliteHandlesClosed)
+        if control == SQLITE_CANTOPEN {
+            #expect(!FileManager.default.fileExists(atPath: url.path + "-wal"))
+            #expect(!FileManager.default.fileExists(atPath: url.path + "-shm"))
+        }
+    }
+
+    @Test
+    func `a present WAL sidecar keeps a declined read-only open unavailable`() throws {
+        let fixture = try Fixture()
+        defer { withExtendedLifetime(fixture) {} }
+        let url = try fixture.database(blobs: [Fixture.blob()])
+        try Self.prepareWAL(url)
+        // A -wal sidecar means a WAL connection may hold the database. The reader must not read around
+        // it with an immutable open. An unreadable -wal makes the ordinary open decline on most builds;
+        // a root CI user still reads it, and the control reports which outcome this platform produced.
+        try Self.addUnreadableWAL(url)
+        let before = try Data(contentsOf: url)
+        // The raw SQLite control never opens the production target or prepares its sidecars.
+        let controlFixture = try Fixture()
+        defer { withExtendedLifetime(controlFixture) {} }
+        let controlURL = try controlFixture.database(blobs: [Fixture.blob()])
+        try Self.prepareWAL(controlURL)
+        try Self.addUnreadableWAL(controlURL)
+        let control = Self.readOnlyQueryStatus(controlURL)
+        let report = try fixture.report()
+        #expect(report.statistics.immutableFallbacks == 0)
+        #expect(report.coverage == (control == SQLITE_ROW ? .complete : .partial))
+        #expect(report.statistics.sqliteHandlesOpened == report.statistics.sqliteHandlesClosed)
+        #expect(try Data(contentsOf: url) == before)
+    }
+
+    @Test
+    func `a writer that checkpoints during the immutable fallback keeps the result incomplete`() throws {
+        let fixture = try Fixture()
+        defer { withExtendedLifetime(fixture) {} }
+        let url = try fixture.database(blobs: [Fixture.blob()])
+        try Self.prepareWAL(url)
+        #expect(!FileManager.default.fileExists(atPath: url.path + "-wal"))
+        // The raw SQLite control never opens the production target or prepares its sidecars.
+        let controlFixture = try Fixture()
+        defer { withExtendedLifetime(controlFixture) {} }
+        let controlURL = try controlFixture.database(blobs: [Fixture.blob()])
+        try Self.prepareWAL(controlURL)
+        let control = Self.readOnlyQueryStatus(controlURL)
+        // While the reader is inside the database, a writer reopens it, commits a row, checkpoints into the
+        // main file, and closes cleanly so the sidecars vanish again before the reader looks a second time.
+        var written = false
+        var budget: AntigravityLocalReader.Budget?
+        budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {
+            guard !written, budget?.statistics.rows == 1 else { return }
+            written = true
+            let writer = try Fixture.open(url)
+            defer { sqlite3_close(writer) }
+            try Fixture.insert(writer, row: 1, blob: Fixture.blob(response: "later"))
+            _ = try Self.checkpoint(writer)
+        })
+        let source = try AntigravityLocalReader.readDatabases([url], budget: #require(budget))
+        let statistics = try #require(budget).statistics
+        budget = nil
+        #expect(written)
+        #expect(statistics.sqliteHandlesOpened == statistics.sqliteHandlesClosed)
+        if control == SQLITE_CANTOPEN {
+            // The immutable read cannot prove one snapshot once the file changed underneath it.
+            #expect(statistics.immutableFallbacks == 1)
+            #expect(!source.isComplete)
+            // The writer has closed, so the next scan sees one stable file with both rows.
+            let next = try fixture.report()
+            #expect(next.coverage == .complete)
+            #expect(next.report.summary?.totalTokens == 396)
+        } else {
+            // The ordinary read-only snapshot excludes the coordinated later write, as on any WAL database.
+            #expect(statistics.immutableFallbacks == 0)
+            #expect(source.isComplete)
+            #expect(source.events.count == 1)
+        }
+    }
+
+    @Test
+    func `an unchanged database keeps the immutable fallback result complete`() throws {
+        let fixture = try Fixture()
+        defer { withExtendedLifetime(fixture) {} }
+        let url = try fixture.database(blobs: [Fixture.blob(), Fixture.blob(response: "second")])
+        try Self.prepareWAL(url)
+        let before = try Data(contentsOf: url)
+        let budget = AntigravityLocalReader.Budget(limits: .init(), cancellation: {})
+        let source = try AntigravityLocalReader.readDatabases([url], budget: budget)
+        #expect(source.isComplete)
+        #expect(source.events.count == 2)
+        #expect(budget.statistics.sqliteHandlesOpened == budget.statistics.sqliteHandlesClosed)
+        #expect(try Data(contentsOf: url) == before)
+    }
+
+    private static func addUnreadableWAL(_ url: URL) throws {
+        let wal = url.path + "-wal"
+        guard FileManager.default.createFile(atPath: wal, contents: Data()) else {
+            throw AntigravityLocalReader.ScanFailure.invalid
+        }
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: wal)
     }
 
     private static func prepareWAL(_ url: URL) throws {

--- a/Tests/CodexBarTests/CodexReauthenticationNativeProofTests.swift
+++ b/Tests/CodexBarTests/CodexReauthenticationNativeProofTests.swift
@@ -1,0 +1,109 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+final class CodexReauthenticationNativeProofTests: XCTestCase {
+    func test_systemReauthenticationProgress() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["CODEXBAR_REAUTH_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_REAUTH_PROOF_DIR for signed synthetic UI proof")
+        }
+        let output = URL(fileURLWithPath: path, isDirectory: true)
+        guard SettingsStore.isRunningTests,
+              environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment[CodexCredentialFileAccess.isolationEnvironmentKey] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1",
+              NSHomeDirectory().hasPrefix(output.deletingLastPathComponent().path + "/")
+        else { return XCTFail("Use a contained home and credential/session isolation") }
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let baseline = environment["CODEXBAR_REAUTH_PROOF_BASELINE"] == "1"
+        let account = CodexVisibleAccount(
+            id: "account@example.com",
+            email: "account@example.com",
+            workspaceLabel: "Example Workspace",
+            storedAccountID: UUID(),
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: true,
+            canRemove: true)
+        let state = CodexAccountsSectionState(
+            visibleAccounts: [account],
+            activeVisibleAccountID: account.id,
+            liveVisibleAccountID: account.id,
+            hasUnreadableManagedAccountStore: false,
+            isAuthenticatingManagedAccount: false,
+            authenticatingManagedAccountID: nil,
+            isRemovingManagedAccount: false,
+            isAuthenticatingLiveAccount: true,
+            isPromotingSystemAccount: false,
+            notice: nil)
+        XCTAssertEqual(state.reauthenticateTitle(for: account), baseline ? "Re-auth" : "Re-authenticating…")
+        XCTAssertFalse(state.canReauthenticate(account))
+        let app = NSApplication.shared
+        guard app.delegate == nil else { return XCTFail("Use a standalone test host") }
+        let previousApp = NSWorkspace.shared.frontmostApplication
+        let previousPolicy = app.activationPolicy()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 660, height: 380),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        window.title = "CodexBar — Synthetic Re-authentication"
+        window.isReleasedWhenClosed = false
+        defer {
+            window.close()
+            _ = app.setActivationPolicy(previousPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApp?.activate()
+            }
+        }
+        _ = app.setActivationPolicy(.regular)
+        app.finishLaunching()
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        app.activate(ignoringOtherApps: true)
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            window.appearance = NSAppearance(named: appearance)
+            window.contentView = NSHostingView(rootView:
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(baseline ? "Before: System re-auth progress is missing" :
+                        "After: System re-auth progress is shown")
+                        .font(.title2.bold())
+                    Text("Synthetic saved + System account · System sign-in is in progress")
+                        .font(.caption)
+                    Form {
+                        CodexAccountsSectionView(
+                            state: state,
+                            setActiveVisibleAccount: { _ in XCTFail("Unexpected selection") },
+                            reauthenticateAccount: { _ in XCTFail("Unexpected login") },
+                            removeAccount: { _ in XCTFail("Unexpected removal") },
+                            requestSystemVisibleAccount: { _ in XCTFail("Unexpected promotion") },
+                            addAccount: { XCTFail("Unexpected account creation") })
+                    }
+                    .formStyle(.grouped)
+                }.padding(24)
+                    .environment(\.locale, Locale(identifier: "en"))
+                    .preferredColorScheme(appearance == .aqua ? .light : .dark))
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 1))
+            let capture = Process()
+            capture.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+            capture.arguments = [
+                "-x", "-o", "-l", String(window.windowNumber),
+                output.appendingPathComponent("reauth-\(appearance.rawValue).png").path,
+            ]
+            try capture.run()
+            capture.waitUntilExit()
+            XCTAssertEqual(capture.terminationStatus, 0)
+        }
+        try JSONSerialization.data(withJSONObject: [
+            "baseline": baseline, "title": state.reauthenticateTitle(for: account),
+            "canReauthenticate": state.canReauthenticate(account),
+        ], options: [.sortedKeys, .prettyPrinted])
+            .write(to: output.appendingPathComponent("state.json"), options: .atomic)
+    }
+}

--- a/Tests/CodexBarTests/CodexReauthenticationRoutingTests.swift
+++ b/Tests/CodexBarTests/CodexReauthenticationRoutingTests.swift
@@ -1,0 +1,221 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(CodexCredentialFixtures())
+struct CodexReauthenticationRoutingTests {
+    enum Kind: Sendable, Equatable {
+        case merged, managed, live
+    }
+
+    @Test(arguments: [Kind.merged, .managed, .live])
+    func `reauthentication follows the visible credential owner`(_ kind: Kind) async throws {
+        let fixture = try self.fixture(kind: kind)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        if kind == .merged {
+            #expect(row.storedAccountID != nil)
+            #expect(row.selectionSource == .liveSystem)
+        }
+
+        await fixture.pane._test_reauthenticateCodexAccount(row)
+
+        #expect(await fixture.runner.calls == [kind == .managed ? "managed" : "system"])
+        #expect(fixture.refreshes.value == (kind == .managed ? 0 : 1))
+        #expect(try fixture.managedStore.loadAccounts().accounts.map(\.managedHomePath) ==
+            fixture.snapshot.value.storedAccounts.map(\.managedHomePath))
+    }
+
+    @Test
+    func `queued reauthentication rejects a row whose credential owner changed`() async throws {
+        let fixture = try self.fixture(kind: .merged)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        let stored = try #require(fixture.snapshot.value.storedAccounts.first)
+        fixture.snapshot.setValue(Self.snapshot(
+            stored: stored,
+            live: nil,
+            activeSource: .managedAccount(id: stored.id)))
+        fixture.settings.invalidateCodexAccountReconciliationSnapshotCache()
+        let current = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        #expect(current.id == row.id)
+        #expect(current.selectionSource != row.selectionSource)
+
+        await fixture.pane._test_reauthenticateCodexAccount(row)
+
+        #expect(await fixture.runner.calls.isEmpty)
+        #expect(fixture.refreshes.value == 0)
+    }
+
+    @Test
+    func `queued reauthentication rejects a removed row`() async throws {
+        let fixture = try self.fixture(kind: .merged)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        fixture.snapshot.setValue(Self.snapshot(stored: nil, live: nil, activeSource: .liveSystem))
+        fixture.settings.invalidateCodexAccountReconciliationSnapshotCache()
+
+        await fixture.pane._test_reauthenticateCodexAccount(row)
+
+        #expect(await fixture.runner.calls.isEmpty)
+        #expect(fixture.refreshes.value == 0)
+    }
+
+    @Test
+    func `queued system reauthentication rejects a different workspace with the same row id`() async throws {
+        let fixture = try self.fixture(kind: .live)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        let live = ObservedSystemCodexAccount(
+            email: row.email,
+            workspaceAccountID: "workspace-other",
+            codexHomePath: CodexCredentialFixtures.root.appendingPathComponent("system").path,
+            observedAt: Date(),
+            identity: .providerAccount(id: "workspace-other"))
+        fixture.snapshot.setValue(Self.snapshot(stored: nil, live: live, activeSource: .liveSystem))
+        fixture.settings.invalidateCodexAccountReconciliationSnapshotCache()
+        let current = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        #expect(current.id == row.id)
+        #expect(current.selectionSource == row.selectionSource)
+        #expect(current.workspaceAccountID != row.workspaceAccountID)
+
+        await fixture.pane._test_reauthenticateCodexAccount(row)
+
+        #expect(await fixture.runner.calls.isEmpty)
+        #expect(fixture.refreshes.value == 0)
+    }
+
+    @Test
+    func `merged system row uses live progress and does not require the managed store`() throws {
+        let fixture = try self.fixture(kind: .merged)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        func state(unreadable: Bool, authenticatingLive: Bool) -> CodexAccountsSectionState {
+            CodexAccountsSectionState(
+                visibleAccounts: [row],
+                activeVisibleAccountID: row.id,
+                liveVisibleAccountID: row.id,
+                hasUnreadableManagedAccountStore: unreadable,
+                isAuthenticatingManagedAccount: false,
+                authenticatingManagedAccountID: nil,
+                isRemovingManagedAccount: false,
+                isAuthenticatingLiveAccount: authenticatingLive,
+                isPromotingSystemAccount: false,
+                notice: nil)
+        }
+        #expect(state(unreadable: false, authenticatingLive: true).reauthenticateTitle(for: row) ==
+            "Re-authenticating…")
+        #expect(!state(unreadable: false, authenticatingLive: true).canReauthenticate(row))
+        #expect(state(unreadable: true, authenticatingLive: false).canReauthenticate(row))
+    }
+
+    private func fixture(kind: Kind) throws -> Fixture {
+        let root = CodexCredentialFixtures.root
+        let environment = ["HOME": root.path, "CODEX_HOME": root.appendingPathComponent("system").path]
+        let config = CodexBarConfigStore(fileURL: root.appendingPathComponent("config.json"))
+        let settings = ProviderUsageItemVisibilityTests.settings(
+            defaults: InMemoryUserDefaults(values: ["codexbar.legacySecretsMigrationCompleted": true]),
+            configStore: config)
+        settings._test_codexReconciliationEnvironment = environment
+        settings.openAIWebAccessEnabled = false
+        settings.codexCookieSource = .off
+        settings.costUsageEnabled = false
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        let stored = kind == .live ? nil : ManagedCodexAccount(
+            id: UUID(),
+            email: "account@example.com",
+            providerAccountID: "workspace-example",
+            managedHomePath: root.appendingPathComponent("managed/original").path,
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let live = kind == .managed ? nil : ObservedSystemCodexAccount(
+            email: "account@example.com",
+            codexHomePath: environment["CODEX_HOME"]!,
+            observedAt: Date(),
+            identity: .providerAccount(id: "workspace-example"))
+        let activeSource: CodexActiveSource = kind == .managed ? .managedAccount(id: stored!.id) : .liveSystem
+        let snapshot = LockIsolated(Self.snapshot(stored: stored, live: live, activeSource: activeSource))
+        settings._test_codexAccountSnapshotLoader = { _ in snapshot.value }
+        settings.codexActiveSource = activeSource
+        let managedStore = FileManagedCodexAccountStore(fileURL: root.appendingPathComponent("accounts.json"))
+        try managedStore.storeAccounts(.init(
+            version: FileManagedCodexAccountStore.currentVersion, accounts: stored.map { [$0] } ?? []))
+        let runner = ReauthenticationRecordingRunner()
+        let coordinator = ManagedCodexAccountCoordinator(service: ManagedCodexAccountService(
+            store: managedStore,
+            homeFactory: ManagedCodexHomeFactory(root: root.appendingPathComponent("managed")),
+            loginRunner: runner,
+            identityReader: UnusedReauthenticationIdentityReader()))
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: environment),
+            browserDetection: BrowserDetection(homeDirectory: root.path, cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: environment)
+        let refreshes = LockIsolated(0)
+        store._test_providerRefreshOverride = { _ in refreshes.setValue(refreshes.value + 1) }
+        store._test_codexCreditsLoaderOverride = { throw UsageError.noRateLimitsFound }
+        store._test_widgetSnapshotSaveOverride = { _ in }
+        let pane = ProvidersPane(
+            settings: settings,
+            store: store,
+            managedCodexAccountCoordinator: coordinator,
+            codexAmbientLoginRunner: runner)
+        return Fixture(
+            settings: settings,
+            store: store,
+            pane: pane,
+            runner: runner,
+            snapshot: snapshot,
+            managedStore: managedStore,
+            refreshes: refreshes)
+    }
+
+    private static func snapshot(
+        stored: ManagedCodexAccount?, live: ObservedSystemCodexAccount?, activeSource: CodexActiveSource)
+        -> CodexAccountReconciliationSnapshot
+    {
+        CodexAccountReconciliationSnapshot(
+            storedAccounts: stored.map { [$0] } ?? [],
+            activeStoredAccount: stored,
+            liveSystemAccount: live,
+            matchingStoredAccountForLiveSystemAccount: live == nil ? nil : stored,
+            activeSource: activeSource,
+            hasUnreadableAddedAccountStore: false,
+            storedAccountRuntimeIdentities: stored.map { [$0.id: .providerAccount(id: "workspace-example")] } ?? [:])
+    }
+
+    private struct Fixture {
+        let settings: SettingsStore
+        let store: UsageStore
+        let pane: ProvidersPane
+        let runner: ReauthenticationRecordingRunner
+        let snapshot: LockIsolated<CodexAccountReconciliationSnapshot>
+        let managedStore: FileManagedCodexAccountStore
+        let refreshes: LockIsolated<Int>
+    }
+}
+
+private actor ReauthenticationRecordingRunner: CodexAmbientLoginRunning, ManagedCodexLoginRunning {
+    private(set) var calls: [String] = []
+
+    func run(timeout _: TimeInterval) async -> CLILoginRunner.Result {
+        self.calls.append("system")
+        return .init(outcome: .success, output: "synthetic system login")
+    }
+
+    func run(homePath _: String, timeout _: TimeInterval) async -> CLILoginRunner.Result {
+        self.calls.append("managed")
+        return .init(outcome: .cancelled, output: "synthetic managed login cancelled")
+    }
+}
+
+private struct UnusedReauthenticationIdentityReader: ManagedCodexIdentityReading {
+    func loadAccountIdentity(homePath _: String) throws -> CodexAuthBackedAccount {
+        throw ManagedCodexAccountServiceError.missingEmail
+    }
+}

--- a/Tests/CodexBarTests/GrokFailedBillingWorkTests.swift
+++ b/Tests/CodexBarTests/GrokFailedBillingWorkTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct GrokFailedBillingWorkTests {
+    enum Scenario: String, CaseIterable, Sendable {
+        case personalUnavailable, teamUnauthorized, initializationFailure, expiredTeam, teamFallback, billingSuccess
+        case expiresDuringScan, expiresDuringVersion, acceptedIdentity
+
+        var acceptsSnapshot: Bool {
+            self == .teamFallback || self == .billingSuccess || self == .acceptedIdentity
+        }
+
+        var scansBeforeResult: Bool {
+            self.acceptsSnapshot || self == .expiresDuringScan || self == .expiresDuringVersion
+        }
+
+        var errorMessage: String {
+            switch self {
+            case .teamUnauthorized: "Unauthorized"
+            case .initializationFailure: "Initialize failed"
+            default: "Method not found"
+            }
+        }
+    }
+
+    @Test(arguments: Scenario.allCases)
+    func `terminal billing failures skip local history and settings work`(_ scenario: Scenario) async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("grok-work-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        if scenario != .personalUnavailable, scenario != .billingSuccess {
+            let auth = try JSONSerialization.data(withJSONObject: [
+                "https://auth.x.ai::fake-client": [
+                    "key": "synthetic-token", "refresh_token": "synthetic-refresh",
+                    "email": "team@example.com", "team_id": "example-team", "user_id": "example-user",
+                    "auth_mode": "oidc", "principal_type": "Team",
+                    "expires_at": [.expiredTeam, .acceptedIdentity].contains(scenario)
+                        ? "2000-01-01T00:00:00Z" : "2099-01-01T00:00:00Z",
+                ],
+            ])
+            try auth.write(to: root.appendingPathComponent("auth.json"))
+        }
+        let binary = root.appendingPathComponent("grok-fixture")
+        func reply(id: Int, result: [String: Any], error: String?) throws -> String {
+            var value: [String: Any] = ["jsonrpc": "2.0", "id": id]
+            if let error {
+                value["error"] = ["code": -32601, "message": error]
+            } else {
+                value["result"] = result
+            }
+            let data = try JSONSerialization.data(withJSONObject: value)
+            return try #require(String(bytes: data, encoding: .utf8))
+        }
+        let initialize = try reply(
+            id: 1, result: [:], error: scenario == .initializationFailure ? scenario.errorMessage : nil)
+        let billing = try reply(
+            id: 2,
+            result: ["monthlyLimit": ["val": 100], "usage": ["totalUsed": ["val": 25]]],
+            error: scenario == .billingSuccess ? nil : scenario.errorMessage)
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "--version" ]; then
+            if [ "$GROK_TEST_MARK_EXPIRY" = "1" ]; then : > "$GROK_HOME/expiry-marker"; fi
+            printf '%s\\n' 'grok synthetic-version'
+            exit 0
+        fi
+        IFS= read -r initialize_request
+        printf '%s\\n' '\(initialize)'
+        IFS= read -r billing_request || exit 0
+        printf '%s\\n' '\(billing)'
+        """
+        try script.write(to: binary, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+        let environment = [
+            "HOME": root.path,
+            "GROK_HOME": root.path,
+            "GROK_CLI_PATH": binary.path,
+            "PATH": "/usr/bin:/bin",
+            "GROK_TEST_MARK_EXPIRY": scenario == .expiresDuringVersion ? "1" : "0",
+        ]
+        let calls = GrokFetchWorkRecorder()
+        let summary = GrokLocalSessionSummary(
+            sessionCount: 2,
+            totalTokens: 42,
+            lastSessionAt: nil,
+            primaryModel: "example-model",
+            models: ["example-model"],
+            daily: [.init(date: "2026-09-11", totalTokens: 42, sessionCount: 2, models: [])])
+        let expiryMarker = root.appendingPathComponent("expiry-marker")
+        var probe = GrokStatusProbe()
+        if scenario == .expiresDuringScan || scenario == .expiresDuringVersion {
+            probe.identityOnlyFallback = { credentials, attempted, error in
+                GrokStatusProbe.shouldUseIdentityOnlyFallback(
+                    credentials: credentials, billingAttempted: attempted, error: error)
+                    && !FileManager.default.fileExists(atPath: expiryMarker.path)
+            }
+        } else if scenario == .acceptedIdentity {
+            // Model a prior accepted decision without racing a wall clock; the default expired case stays rejected.
+            probe.identityOnlyFallback = { _, _, _ in true }
+        }
+        probe.localSummary = { receivedEnvironment in
+            #expect(receivedEnvironment == environment)
+            await calls.scanned()
+            if scenario == .expiresDuringScan { try Data().write(to: expiryMarker) }
+            return summary
+        }
+        probe.settingsTransport = ProviderHTTPTransportHandler { request in
+            #expect(request.url == GrokCLISettingsFetcher.defaultEndpoint)
+            await calls.loadedSettings()
+            let response = try #require(HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil))
+            return (Data("{\"subscription_tier_display\":\"Grok Team\"}".utf8), response)
+        }
+
+        do {
+            let snapshot = try await probe.fetch(env: environment)
+            #expect(scenario.acceptsSnapshot)
+            #expect(snapshot.localSummary?.totalTokens == 42)
+            #expect(snapshot.localSummary?.daily == summary.daily)
+            #expect(snapshot.cliVersion == "synthetic-version")
+            if scenario != .billingSuccess {
+                #expect(snapshot.billing == nil)
+                #expect(snapshot.credentials?.email == "team@example.com")
+                #expect(snapshot.diagnostic == GrokStatusProbe.teamUsageUnavailableMessage)
+            } else {
+                #expect(snapshot.billing?.monthlyUsedPercent == 25)
+                #expect(snapshot.diagnostic == nil)
+            }
+        } catch let error as GrokRPCError {
+            #expect(!scenario.acceptsSnapshot)
+            guard case let .requestFailed(message) = error else {
+                Issue.record("Unexpected RPC error: \(error)")
+                return
+            }
+            #expect(message == scenario.errorMessage)
+        }
+        #expect(await calls.scans == (scenario.scansBeforeResult ? 1 : 0))
+        #expect(await calls.settings == (scenario == .teamFallback ? 1 : 0))
+    }
+}
+
+private actor GrokFetchWorkRecorder {
+    private(set) var scans = 0
+    private(set) var settings = 0
+    func scanned() {
+        self.scans += 1
+    }
+
+    func loadedSettings() {
+        self.settings += 1
+    }
+}

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -4,6 +4,76 @@ import Testing
 @testable import CodexBar
 
 struct MenuBarVisibilityWatcherTests {
+    @Test(arguments: [
+        (CGRect(x: 0, y: -900, width: 1440, height: 900), CGRect(x: 0, y: -22, width: 76, height: 22), true, false),
+        (CGRect(x: 0, y: 1080, width: 1440, height: 900), CGRect(x: 0, y: -900, width: 76, height: 22), false, true),
+        (CGRect(x: 0, y: 1080, width: 1440, height: 900), CGRect(x: 0, y: -22, width: 76, height: 22), true, true),
+        (CGRect(x: 0, y: 1080, width: 1440, height: 900), CGRect(x: 0, y: -450, width: 76, height: 22), false, true),
+        (CGRect(x: 0, y: 1080, width: 1440, height: 22), CGRect(x: 0, y: -22, width: 76, height: 22), false, true),
+        (CGRect(x: 0, y: -900, width: 1440, height: 900), CGRect(x: 0, y: 1080, width: 76, height: 22), false, true),
+        (CGRect(x: -1440, y: 180, width: 1440, height: 900), CGRect(x: -100, y: 0, width: 76, height: 22), false, true),
+    ])
+    func `window probe aligns secondary screen coordinates before recovery decisions`(
+        _ screenFrame: CGRect, _ windowBounds: CGRect, _ blocked: Bool, _ contained: Bool) throws
+    {
+        let windows = MenuBarStatusItemWindowProbe.snapshots(
+            matching: ["codexbar-merged"],
+            windowInfo: [[
+                kCGWindowName as String: "codexbar-merged",
+                kCGWindowOwnerName as String: "Control Center",
+                kCGWindowIsOnscreen as String: true,
+                kCGWindowBounds as String: windowBounds.dictionaryRepresentation,
+            ]],
+            screenFrames: [CGRect(x: 0, y: 0, width: 1920, height: 1080), screenFrame])
+        let window = try #require(windows.first)
+        #expect(window.isWithinDisplayBounds == contained)
+        #expect(window.isTahoeBlockedProxy == blocked)
+        let detached = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 76)
+        let launched = Date(timeIntervalSince1970: 1000)
+        #expect(MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launched,
+            now: launched.addingTimeInterval(2),
+            snapshots: [detached],
+            windowSnapshots: windows,
+            detectTahoeBlockedStatusItem: true) == blocked)
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launched,
+            now: launched.addingTimeInterval(2),
+            snapshots: [detached],
+            windowSnapshots: windows,
+            detectTahoeBlockedStatusItem: false))
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launched,
+            now: launched.addingTimeInterval(30),
+            snapshots: [detached],
+            windowSnapshots: windows,
+            detectTahoeBlockedStatusItem: true))
+    }
+
+    @Test
+    func `window probe rejects malformed rectangles and unmatched names`() {
+        let malformed: [[String: Any]] = [
+            [:],
+            ["X": 0, "Y": 0, "Width": 76],
+            ["X": "invalid", "Y": 0, "Width": 76, "Height": 22],
+        ]
+        var records = malformed.map {
+            [kCGWindowName as String: "codexbar-merged", kCGWindowBounds as String: $0] as [String: Any]
+        }
+        records.append([
+            kCGWindowName as String: "other-item",
+            kCGWindowBounds as String: CGRect(x: 0, y: 0, width: 76, height: 22).dictionaryRepresentation,
+        ])
+        #expect(MenuBarStatusItemWindowProbe.snapshots(
+            matching: ["codexbar-merged"], windowInfo: records, screenFrames: []).isEmpty)
+    }
+
     @Test
     func `does not flag intentionally hidden status item`() {
         let snapshot = StatusItemVisibilitySnapshot(
@@ -79,7 +149,7 @@ struct MenuBarVisibilityWatcherTests {
                     "Height": 24,
                 ],
             ]],
-            displayBounds: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
+            screenFrames: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
 
         #expect(snapshots.count == 1)
         #expect(snapshots.first?.name == "codexbar-merged")
@@ -103,7 +173,7 @@ struct MenuBarVisibilityWatcherTests {
                     "Height": 24,
                 ],
             ]],
-            displayBounds: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
+            screenFrames: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
 
         #expect(snapshots.count == 1)
         #expect(snapshots.first?.isOnscreen == true)

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -639,10 +639,13 @@ struct OpenCodeGoUsageFetcherErrorTests {
                 contentType: "text/html")
         }
 
+        // The billing fallback needs two hops. Without the completeness wait, the app's 250 ms optional-balance
+        // grace can cancel the balance task before the billing request is sent on a loaded CI runner.
         let snapshot = try await OpenCodeGoUsageFetcher.fetchUsage(
             cookieHeader: "auth=test",
             timeout: 2,
             workspaceIDOverride: "wrk_TEST123",
+            waitForZenBalance: true,
             session: self.makeSession())
 
         #expect(snapshot.zenBalanceUSD == 98.76)

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2281,15 +2281,7 @@ struct ProviderArchitectureGatekeeperTests {
         AllowedProviderConstruct(
             path: "Sources/CodexBar/PreferencesProvidersPane.swift",
             line: 294,
-            anchor: "guard let state = self.codexAccountsSectionState(for: .codex), state.canReauthenticate(account) else {",
-            expectedProviderIDs: ["codex"],
-            expectedReferenceCount: 1,
-            expectedReferenceFingerprint: ["codex@0"],
-            reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
-        AllowedProviderConstruct(
-            path: "Sources/CodexBar/PreferencesProvidersPane.swift",
-            line: 307,
-            anchor: "guard let state = self.codexAccountsSectionState(for: .codex), state.canReauthenticate(account) else {",
+            anchor: "guard let state = self.codexAccountsSectionState(for: .codex),",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
             expectedReferenceFingerprint: ["codex@0"],

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -277,7 +277,12 @@ The cost endpoint and dashboard also include it when Antigravity is selected. To
 costs, and these entry points do not expand the supported timestamp layouts described below.
 
 SQLite is authoritative when present. An unreadable root, malformed database, unsupported event layout, or exhausted
-budget never authorizes replacement by a smaller/stale JSONL cache. Complete empty databases and complete histories
+budget never authorizes replacement by a smaller/stale JSONL cache. Some SQLite builds, including the macOS system
+library, decline a read-only open of a WAL database whose `-wal` and `-shm` sidecars are absent, which is what a
+cleanly closed conversation leaves behind. When that happens and no `-wal` sidecar exists, the reader retries that
+one database with an `immutable=1` open of the main file; it never creates sidecars. The retry counts only when
+the file and its sidecar state are unchanged afterwards. A database with a `-wal` sidecar present stays
+unavailable, because a WAL connection may still hold it. Complete empty databases and complete histories
 outside the selected window establish empty history; absent sources and partial scans do not. Partial reports remain
 diagnostic only: the fetcher withholds their rows. Regular refresh applies its existing failure/retention policy,
 and neither regular refresh nor the dashboard publishes unavailable results as confirmed zero. Failed dashboard
@@ -345,12 +350,16 @@ payload lengths still count as attempted work. Before copying, the selected BLOB
 length. There is no view or sorting step that can buffer payloads ahead of accounting;
 the reader buffers only validated typed events.
 
-Database access uses ordinary `SQLITE_OPEN_READONLY`, never `immutable=1` or an unsafe file copy. This does not mutate
+Database access uses ordinary `SQLITE_OPEN_READONLY` and never an unsafe file copy. This does not mutate
 database records, but SQLite's normal WAL access may create sidecars and coordinate through SHM read marks.
-It is not a guarantee of literal SHM-byte preservation. A platform SQLite build that cannot open a WAL database
-without sidecars reports unavailable rather than bypassing normal coordination. Temporary fixture tests compare DB/WAL contents without
-writer activity, coordinate subsequent writer activity against one read snapshot, and verify reader cleanup after
-cancellation. The fixtures are synthetic and source-linked, not private captures or proof of live installation/UI behavior.
+It is not a guarantee of literal SHM-byte preservation. The one exception is the `immutable=1` retry described
+above for a sidecar-less WAL database that the platform SQLite declines. That connection neither locks nor detects
+changes, so the reader records the file's size, modification time, file system number, and header before the
+retry and accepts the result only when they and the sidecar state are unchanged afterwards. A writer that appears
+and checkpoints during the retry leaves the database incomplete. Temporary fixture tests compare DB/WAL contents
+without writer activity, coordinate subsequent writer activity against one read snapshot, cover a writer that
+checkpoints during the immutable retry, and verify reader cleanup after cancellation. The fixtures are synthetic
+and source-linked, not private captures or proof of live installation/UI behavior.
 
 ## Constraints
 - Internal protocol; fields may change.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -68,6 +68,7 @@ Usage source picker:
   Automatic mode also suppresses unscoped CLI fallback whenever a managed workspace is selected. Explicit
   managed-account workspace selection is stored in CodexBar's private managed-account metadata; it never edits the
   source `auth.json` or publishes an `account_id` change back to another application's credential file.
+- **Reauthenticate** follows the credential source shown by the account row: System rows use the existing system Codex login flow even when the same account is also saved; managed rows renew their private managed home. Credentials are not copied between those homes. A queued action is discarded if the row's source or workspace changes.
 - If native credentials need renewal, use **Reauthenticate** for the affected account in Settings → Providers → Codex.
   For CLI recovery, run `codex login` with that account's existing `CODEX_HOME` and select the intended workspace.
   The refresh error describes this manual recovery without promising automatic CLI fallback for managed workspaces.

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -39,6 +39,7 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
      fallback, while a team principal degrades to identity-only with an explicit
      unsupported-team-usage diagnostic. When xAI exposes billing on the agent
      protocol, no code change is required.
+   - A terminal CLI billing failure returns before scanning local session history or probing the CLI version, so the provider fallback does not wait for data that would be discarded. Successful billing and the established identity-only team fallback retain local history and plan enrichment.
    - After a successful RPC billing result (or the identity-only team fallback),
      CodexBar still GETs `/v1/settings` for `subscription_tier_display` so the
      billed plan is not lost just because the CLI route succeeded first. The


### PR DESCRIPTION
## Summary

One cleanly closed Antigravity conversation makes the whole Antigravity spend history unavailable on macOS. The Usage & Spend pane then lists no Antigravity source and shows "Refresh failures: 1", and `codexbar cost --provider antigravity` returns an empty report with `historyCoverageIsEstablished: false`.

The cause is a SQLite platform behavior. When SQLite closes the last connection to a WAL database cleanly, it deletes the `-wal` and `-shm` sidecars. Apple's system SQLite (3.51.0 on macOS 26) then declines a read-only open of that file with `SQLITE_CANTOPEN`, because a read-only connection may not create the sidecars. The reader marks that database incomplete, the report becomes partial, and the fetcher withholds every row by design.

This PR adds a narrow fallback in `AntigravityLocalReader.readDatabase`:

- When the ordinary read-only attempt fails with `SQLITE_CANTOPEN` before any row is read, and no `-wal` sidecar exists next to the database, the reader retries that one database with `file:<path>?immutable=1` and `SQLITE_OPEN_READONLY | SQLITE_OPEN_URI`.
- An absent `-wal` means no WAL connection holds the database, so the main file alone carries the checkpointed state. A database with a `-wal` sidecar present stays unavailable, as before.
- The immutable open never creates or touches sidecars. The path is percent-encoded so `%`, `?`, and `#` cannot change the URI.
- An immutable connection neither locks nor detects changes. The reader therefore records the file's size, modification time, file system number, and 100-byte header before the retry, and accepts the result only when they and the sidecar state are unchanged afterwards. A writer that appears and checkpoints during the retry leaves that database incomplete, which keeps the report partial and withheld, as before.
- `Statistics.immutableFallbacks` counts the retries.

The `#3212` WAL test carried the comment "Some SQLite builds decline read-only WAL access without sidecars; that must stay unavailable." This PR argues against that ruling with field data: every new conversation lacks sidecars until some later bulk event recreates them, so the current policy blanks Antigravity spend for most macOS users most of the time.

## Evidence

On the reporting machine, 214 conversation databases exist. 213 have sidecars and open read-only. One has a WAL header (`writer version 2, read version 2`) and no sidecars, and it fails:

```
$ sqlite3 -readonly 31125604-ffff-41db-b409-11d11a858825.db 'select 1'
Error: in prepare, unable to open database file (14)
```

A one-off Swift probe that links the system SQLite3 library reproduces `rc=14` at prepare after a successful open and `BEGIN DEFERRED`. Python's bundled SQLite 3.53.4 opens the same file and creates the sidecars. Sidecar birth times on the 213 databases cluster on five moments (184 of them on one day), not on each conversation's creation, so new conversations regularly lack sidecars.

With this change, the same CLI command on the same machine returns 38 daily rows from 2026-06-20 through 2026-09-06 with `historyCoverageIsEstablished: true`, and the file still has no sidecars afterwards.

## Trade-off

An immutable connection skips locking and change detection, so the read alone cannot prove one snapshot. The stability bracket above turns that into a fail-closed check: any change to the main file or the appearance of a `-wal` sidecar during the retry marks the database incomplete. The next scan reads the stable file. A temp copy would carry the same window and cost I/O on every refresh.

## Tests

All three cases keep the existing raw-SQLite control pattern: a separate control fixture reports which outcome the platform's SQLite produced, and the expectations follow that outcome. On Apple's SQLite the control returns `SQLITE_CANTOPEN` and the fallback path runs; on a SQLite that creates the sidecars itself, the ordinary path runs and no fallback is counted.

- `AntigravityLocalWALTests`: the existing sidecar-less case now expects `.complete` coverage and the fixture row on every platform, `immutableFallbacks` equal to 1 only when the control declined, and no sidecars afterwards in that case.
- New: a sidecar-less database whose file name contains `%`, `?`, and `#` reads completely through the escaped URI.
- New: a database with an unreadable empty `-wal` sidecar never takes the fallback. Apple's SQLite declines that open, so the guard is exercised on macOS and the report stays partial. A root CI user can still read the file, and the control accepts that outcome.
- New: a writer that reopens the database, commits a row, checkpoints, and closes while the reader is inside the immutable retry. On Apple's SQLite the fallback runs and the result is incomplete; the next scan is complete with both rows. On a SQLite that takes the ordinary path, the read-only snapshot excludes the later write as in the existing coordinated-writer test.
- New: an unchanged two-row sidecar-less database reads completely through the bracket.

## Commands run

```
swift test --filter AntigravityLocalWALTests
make check
make test
.build/debug/CodexBarCLI cost --provider antigravity --format json --days 365
```

## Docs

`docs/antigravity.md` describes the fallback and its guard under "Local token history". No CHANGELOG entry, per repository convention.
