### PR TITLE
Fix misleading Codex credential recovery guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Performance
 - Codex activity: read scoped daily totals without decoding unused event history, preserving account boundaries, coverage, and incomplete-scan checks (#3528, related to #3247). Thanks @brzvsk!
 
+### Fixed
+- Codex accounts: replace a misleading automatic CLI-retry promise with account-specific reauthentication guidance when native credentials need renewal (related to #3523). Thanks @zhulijin1991!
+
 ## 0.58.0 — 2026-09-09
 
 ### Highlights

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthCredentials.swift
@@ -81,8 +81,7 @@ public enum CodexOAuthCredentialsError: LocalizedError, Sendable {
         case .missingTokens:
             "Codex auth.json exists but contains no tokens."
         case .nativeRefreshRequired:
-            "Codex auth.json needs refresh. CodexBar will retry through the Codex CLI; "
-                + "run `codex login` if recovery fails."
+            "Codex auth.json needs refresh. Reauthenticate this account or run `codex login` in the same Codex home."
         case .readOnlySource:
             "This external Codex credential source is stale and read-only. "
                 + "Sign in again with its owning app or run `codex login` to create fresh native credentials."

--- a/Tests/CodexBarTests/CodexOAuthExpiryPipelineTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthExpiryPipelineTests.swift
@@ -109,6 +109,9 @@ struct CodexOAuthExpiryPipelineTests {
                     Issue.record("Managed scope must retain nativeRefreshRequired without CLI recovery")
                     continue
                 }
+                #expect(!error.localizedDescription.contains("will retry"))
+                #expect(error.localizedDescription.contains("Codex home"))
+                #expect(outcome.attempts.filter { $0.kind == .cli && $0.wasAvailable }.isEmpty)
             } else {
                 guard case let .failure(error) = outcome.result, error is CLISelected else {
                     Issue.record("Native refresh must be handed to the CLI")

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -68,6 +68,9 @@ Usage source picker:
   Automatic mode also suppresses unscoped CLI fallback whenever a managed workspace is selected. Explicit
   managed-account workspace selection is stored in CodexBar's private managed-account metadata; it never edits the
   source `auth.json` or publishes an `account_id` change back to another application's credential file.
+- If native credentials need renewal, use **Reauthenticate** for the affected account in Settings → Providers → Codex.
+  For CLI recovery, run `codex login` with that account's existing `CODEX_HOME` and select the intended workspace.
+  The refresh error describes this manual recovery without promising automatic CLI fallback for managed workspaces.
 - Stacked account refreshes retain each managed account's selected workspace through usage publication and menu
   matching, even when its auth file names a different default workspace. Changing the selected workspace while a
   refresh is running discards the old workspace's result.


### PR DESCRIPTION
The shared native-credential refresh error no longer promises that CodexBar will retry through the CLI. Managed workspace selection deliberately disables that unscoped fallback, so the previous promise was false in both Auto and OAuth modes. The error now points to reauthenticating the affected account or running `codex login` in the same Codex home.

This corrects the diagnostic portion of #3523. It preserves `nativeRefreshRequired`, all strategy selection, credential ownership, and the existing reauthentication flow. The broader automatic-renewal work remains separate in #3379; #3523 should stay open.

Proof:
- The existing production-pipeline fixture failed eight added wording assertions before the change, across expired/near-expiry managed credentials in Auto and OAuth modes.
- 80 focused tests passed afterward, including default-account CLI delegation, managed-scope suppression, zero transport requests for stale credentials, and unchanged auth-file bytes, modification time and inode.
- Formatting/lint and independent P0–P2 review are clean. The full local suite passed all 1,058 selections in 89 groups on the first pass, with no retries or timeouts. All exact-head CI checks passed, including both macOS shards and the Linux builds: https://github.com/steipete/CodexBar/actions/runs/34451275400.

Documentation identifies the existing account-specific Reauthenticate action and same-home CLI recovery. The 0.58.1 Unreleased entry credits @zhulijin1991 for the report. No live credentials were used.
