### PR TITLE
docs: correct provider usage visibility controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Codex activity: read scoped daily totals without decoding unused event history, preserving account boundaries, coverage, and incomplete-scan checks (#3528, related to #3247). Thanks @brzvsk!
 
 ### Fixed
+- Documentation: point Spark and Daily Routines visibility instructions to the current per-item controls and include Overview in their scope.
 - Menus: refresh cached status menus when macOS appearance changes, including previously opened submenus, so the first opening matches Light/Dark and accessibility appearances (#3526). Thanks @emanuelst!
 
 ## 0.58.0 — 2026-09-09

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -84,9 +84,9 @@ Admin API key setup:
   - `seven_day_routines` / `seven_day_cowork` → Daily Routines extra window.
   - Claude Design/Omelette keys are ignored because Claude Design shares the main Claude usage limit.
   - `extra_usage` → Extra usage cost (monthly spend/limit).
-- Preferences → Providers → Claude → Show Daily Routines usage hides only the Daily Routines row in menus and the
-  provider preview. The global optional credits and extra usage setting is its master switch. The Claude-specific
-  setting does not change fetching, history, notifications, widgets, model-scoped weekly limits, hooks, or CLI output.
+- Preferences → Providers → Claude → Visible usage items lets you hide the Daily Routines row in menus, the Settings
+  preview, and Overview. The global optional credits and extra usage setting remains its master switch. Hiding this
+  row does not change fetching, history, notifications, widgets, model-scoped weekly limits, hooks, or CLI output.
 - Preferences → Providers → Claude → Show model-specific weekly usage in widgets controls model-scoped weekly quota
   rows in desktop widgets. It is off by default; turning it on displays every known Claude window with a
   `claude-weekly-scoped-` identifier (for example, Fable). Turning it back off also drops scoped rows that a previous

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -53,8 +53,8 @@ Usage source picker:
 - `additional_rate_limits[]` (model-specific limits such as GPT-5.3-Codex-Spark) map to named
   `UsageSnapshot.extraRateWindows` entries. Spark uses stable `codex-spark` / `codex-spark-weekly` ids and
   `Codex Spark 5-hour` / `Codex Spark Weekly` titles. When the field is absent, the snapshot is unchanged.
-- Preferences → Providers → Codex → Show Codex Spark usage hides only the Spark rows in menus and the provider
-  preview. It does not change fetching, history, notifications, widgets, credits, or other extra limits.
+- Preferences → Providers → Codex → Visible usage items lets you hide individual Spark rows in menus, the Settings
+  preview, and Overview. It does not change fetching, history, notifications, widgets, credits, or other extra limits.
 
 ### Optional external OAuth sources (off by default)
 - **External Codex OAuth sources** is a provider setting that must be enabled explicitly before CodexBar reads


### PR DESCRIPTION
The Codex and Claude provider guides still directed users to the removed “Show Codex Spark usage” and “Show Daily Routines usage” controls. They now point to **Visible usage items**, describe individual Spark rows, and include Overview alongside menus and the Settings preview.

The existing fetching, notification, widget, and master-switch behavior remains documented. This only corrects instructions for controls already shipped in 0.58.0; no production behavior changes.

Validated against the current provider detail UI and visibility projection, with `git diff --check` and a clean independent P0–P2 review. Added an Unreleased changelog entry.

All final-head checks passed in [CI run 34454905836](https://github.com/steipete/CodexBar/actions/runs/34454905836). The production Swift tree matches the main version already verified by the full 1,058-selection suite.
