### PR TITLE
fix(kimi): recover monthly Total usage from Desktop Local Storage

### DIFF
--- a/Sources/CodexBarCore/Providers/Kimi/KimiDesktopAuthToken.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiDesktopAuthToken.swift
@@ -5,11 +5,18 @@ import SQLite3
 #elseif canImport(CSQLite3)
 import CSQLite3
 #endif
+#if os(macOS)
+import SweetCookieKit
+#endif
 
 #if canImport(SQLite3) || canImport(CSQLite3)
-/// Read-only access to the official Kimi Desktop Chromium cookie store.
+/// Read-only access to the official Kimi Desktop Chromium session store.
 public enum KimiDesktopAuthToken: Sendable {
     private static let log = CodexBarLog.logger(LogCategories.provider(.kimi, scope: "cookie"))
+    private static let localStorageOrigins = [
+        "https://www.kimi.com",
+        "https://kimi.com",
+    ]
 
     public static func cookiesDatabaseURL(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL
@@ -21,10 +28,41 @@ public enum KimiDesktopAuthToken: Sendable {
             .appendingPathComponent("Cookies", isDirectory: false)
     }
 
+    public static func localStorageDirectoryURL(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL
+    {
+        homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("kimi-desktop", isDirectory: true)
+            .appendingPathComponent("Local Storage", isDirectory: true)
+            .appendingPathComponent("leveldb", isDirectory: true)
+    }
+
     public static func load(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> String?
     {
-        self.load(databaseURL: self.cookiesDatabaseURL(homeDirectory: homeDirectory))
+        if let cookie = self.load(databaseURL: self.cookiesDatabaseURL(homeDirectory: homeDirectory)) {
+            return cookie
+        }
+        return self.loadLocalStorageAccessToken(homeDirectory: homeDirectory)
+    }
+
+    /// Prefer a live `typ=access` JWT. Current Kimi Desktop builds store that session in Local
+    /// Storage and no longer write a `kimi-auth` cookie.
+    static func selectAccessToken(from candidates: [String], now: Date = Date()) -> String? {
+        var best: (token: String, expiry: TimeInterval)?
+        for candidate in Set(candidates) {
+            guard let claims = self.jwtClaims(candidate),
+                  self.isKimiWebAccessToken(claims),
+                  let expiry = self.jwtExpiry(claims),
+                  expiry > now.timeIntervalSince1970
+            else { continue }
+            if best == nil || expiry > best!.expiry {
+                best = (candidate, expiry)
+            }
+        }
+        return best?.token
     }
 
     static func load(databaseURL: URL) -> String? {
@@ -94,15 +132,75 @@ public enum KimiDesktopAuthToken: Sendable {
 
     /// Cookie expiry and JWT expiry can differ. An old desktop JWT must not shadow a live browser session.
     static func isExpired(_ token: String, now: Date = Date()) -> Bool {
+        guard let claims = self.jwtClaims(token), let expiry = self.jwtExpiry(claims) else { return false }
+        return expiry <= now.timeIntervalSince1970
+    }
+
+    private static func loadLocalStorageAccessToken(homeDirectory: URL) -> String? {
+        #if os(macOS)
+        let levelDBURL = self.localStorageDirectoryURL(homeDirectory: homeDirectory)
+        guard FileManager.default.fileExists(atPath: levelDBURL.path) else { return nil }
+
+        var candidates: [String] = []
+        for origin in self.localStorageOrigins {
+            let entries = SweetCookieKit.ChromiumLocalStorageReader.readEntries(
+                for: origin,
+                in: levelDBURL,
+                logger: nil)
+            for entry in entries {
+                candidates.append(contentsOf: self.jwtCandidates(in: entry.value))
+            }
+        }
+        if candidates.isEmpty {
+            candidates = SweetCookieKit.ChromiumLocalStorageReader.readTokenCandidates(
+                in: levelDBURL,
+                minimumLength: 80,
+                logger: nil)
+        }
+        return self.selectAccessToken(from: candidates)
+        #else
+        _ = homeDirectory
+        return nil
+        #endif
+    }
+
+    static func jwtCandidates(in text: String) -> [String] {
+        guard text.contains("eyJ") else { return [] }
+        let pattern = #"eyJ[A-Za-z0-9_\-]{20,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.matches(in: text, range: range).compactMap { match in
+            guard let tokenRange = Range(match.range, in: text) else { return nil }
+            return String(text[tokenRange])
+        }
+    }
+
+    private static func jwtClaims(_ token: String) -> [String: Any]? {
         let parts = token.split(separator: ".")
-        guard parts.count == 3 else { return false }
+        guard parts.count == 3 else { return nil }
         var payload = String(parts[1]).replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
         payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
-        guard let data = Data(base64Encoded: payload),
-              let claims = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let expiry = claims["exp"] as? Double else { return false }
-        return expiry <= now.timeIntervalSince1970
+        guard let data = Data(base64Encoded: payload) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    private static func jwtExpiry(_ claims: [String: Any]) -> TimeInterval? {
+        if let expiry = claims["exp"] as? Double { return expiry }
+        if let expiry = claims["exp"] as? Int { return TimeInterval(expiry) }
+        return nil
+    }
+
+    private static func isKimiWebAccessToken(_ claims: [String: Any]) -> Bool {
+        let typ = (claims["typ"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard typ == "access" else { return false }
+        if let audience = claims["aud"] as? String {
+            return audience.contains("kimi.com")
+        }
+        if let audience = claims["aud"] as? [String] {
+            return audience.contains(where: { $0.contains("kimi.com") })
+        }
+        return false
     }
 
     private static func walSidecarsAreMissing(databaseURL: URL) -> Bool {
@@ -133,8 +231,27 @@ public enum KimiDesktopAuthToken: Sendable {
             .appendingPathComponent("Cookies", isDirectory: false)
     }
 
+    public static func localStorageDirectoryURL(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL
+    {
+        homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("kimi-desktop", isDirectory: true)
+            .appendingPathComponent("Local Storage", isDirectory: true)
+            .appendingPathComponent("leveldb", isDirectory: true)
+    }
+
     public static func load(homeDirectory _: URL = FileManager.default.homeDirectoryForCurrentUser) -> String? {
         nil
+    }
+
+    static func selectAccessToken(from _: [String], now _: Date = Date()) -> String? {
+        nil
+    }
+
+    static func jwtCandidates(in _: String) -> [String] {
+        []
     }
 }
 #endif

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -114,8 +114,15 @@ public enum KimiProviderDescriptor {
         context: ProviderMenuBarWindowContext) -> ProviderMenuBarWindowResolution
     {
         guard context.metric == .automatic else { return .unhandled }
+        // Membership Total usage lives in extraRateWindows. When that pool is empty, the 5-hour
+        // and 7-day Code windows can still look unused and must not hide the exhausted month.
+        let extras = (context.snapshot.extraRateWindows ?? [])
+            .filter(\.usageKnown)
+            .map(\.window)
+        let exhaustedExtra = extras.first { $0.remainingPercent <= 0 }
         return .resolved(
-            ProviderUsagePresentation.exhausted(context.snapshot.primary, context.snapshot.secondary)
+            exhaustedExtra
+                ?? ProviderUsagePresentation.exhausted(context.snapshot.primary, context.snapshot.secondary)
                 ?? context.snapshot.secondary
                 ?? context.snapshot.primary)
     }

--- a/Tests/CodexBarTests/KimiDesktopAuthTokenTests.swift
+++ b/Tests/CodexBarTests/KimiDesktopAuthTokenTests.swift
@@ -78,6 +78,19 @@ struct KimiDesktopAuthTokenTests {
     }
 
     @Test
+    func `selects a live desktop access JWT and ignores refresh tokens`() throws {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let refresh = try Self.makeJWT(typ: "refresh", audience: ["kimi.com"], expiry: 5_000)
+        let stale = try Self.makeJWT(typ: "access", audience: ["kimi.com"], expiry: 900)
+        let access = try Self.makeJWT(typ: "access", audience: ["kimi.com"], expiry: 2_000)
+        let other = try Self.makeJWT(typ: "access", audience: ["example.com"], expiry: 4_000)
+        #expect(KimiDesktopAuthToken.selectAccessToken(
+            from: [refresh, stale, other, access],
+            now: now) == access)
+        #expect(KimiDesktopAuthToken.jwtCandidates(in: #"{"access_token":"\#(access)"}"#) == [access])
+    }
+
+    @Test
     func `ignores tokens from unrelated hosts`() throws {
         let environment = try Self.makeEnvironment()
         defer { try? FileManager.default.removeItem(at: environment.root) }
@@ -177,6 +190,23 @@ struct KimiDesktopAuthTokenTests {
 
     private static func exec(db: OpaquePointer?, sql: String) throws {
         guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else { throw SQLiteTestError.exec }
+    }
+
+    private static func makeJWT(typ: String, audience: [String], expiry: TimeInterval) throws -> String {
+        let header = try Self.base64URL(JSONSerialization.data(withJSONObject: ["alg": "none", "typ": "JWT"]))
+        let payload = try Self.base64URL(JSONSerialization.data(withJSONObject: [
+            "typ": typ,
+            "aud": audience,
+            "exp": expiry,
+        ]))
+        return "\(header).\(payload).signature"
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "="))
     }
 
     private enum SQLiteTestError: Error {

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -1123,6 +1123,30 @@ struct KimiUsageSnapshotConversionTests {
         #expect(monthly.window.usedPercent == 100)
         #expect(monthly.window.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
         #expect(monthly.window.resetsAt == Self.date("2026-07-23T00:00:00Z"))
+
+        let unusedWeekly = try #require(usageSnapshot.primary)
+        let unusedRateLimit = RateWindow(
+            usedPercent: 0,
+            windowMinutes: KimiProviderDescriptor.sessionWindowMinutes,
+            resetsAt: now.addingTimeInterval(3 * 60 * 60),
+            resetDescription: "Rate: 0/100 per 5 hours")
+        let automatic = KimiProviderDescriptor.descriptor.presentation.menuBarWindow(
+            context: ProviderMenuBarWindowContext(
+                metric: .automatic,
+                snapshot: UsageSnapshot(
+                    primary: unusedWeekly,
+                    secondary: unusedRateLimit,
+                    extraRateWindows: [monthly],
+                    updatedAt: now),
+                supportsAverage: false,
+                prioritizesExhaustedQuotas: false,
+                now: now))
+        guard case let .resolved(window) = automatic else {
+            Issue.record("Kimi automatic menu-bar window should resolve")
+            return
+        }
+        #expect(window?.usedPercent == 100)
+        #expect(window?.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
     }
 
     @Test

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -18,6 +18,7 @@ Code subscription credentials.
 
 - Displays weekly request quota (from membership tier)
 - Shows current 5-hour rate limit usage
+- Shows the shared monthly membership pool (`Total usage`) when a web session is available, and prefers that lane in the menu bar when it is exhausted
 - Displays membership from the API/CLI usage response, with the active web subscription title as a fallback
 - Detects the installed Kimi CLI version, including standalone installs outside the GUI app PATH
 - Enriches Code API/CLI usage with the monthly membership pool when a web session is available
@@ -69,7 +70,9 @@ reuse; use an explicit API key for endpoint-override testing.
 3. Enable the Kimi provider toggle
 4. CodexBar will automatically find your session
 
-Automatic mode prefers a usable Kimi Desktop cookie. Expired desktop JWTs are skipped; if the server
+Automatic mode prefers a usable Kimi Desktop session. Current Kimi Desktop builds keep the web access
+JWT in Local Storage and often have no `kimi-auth` cookie; CodexBar reads that store read-only after
+the Cookies database. Expired desktop JWTs are skipped; if the server
 rejects a desktop session, the Web source continues through browser profiles instead of stopping.
 Explicit manual tokens remain authoritative. API-key and CLI quota responses include the membership level, so displaying the tier does not require
 browser access. A web session can supply a subscription title when the usage response omits membership;
@@ -112,7 +115,7 @@ When multiple sources are available, CodexBar uses this order:
 2. Fresh Kimi Code CLI access token (`~/.kimi-code/credentials/kimi-code.json`)
 3. Manual cookie/token (from Settings UI) when web fallback is used
 4. Cookie environment variable (`KIMI_AUTH_TOKEN`)
-5. Kimi Desktop `kimi-auth` cookie
+5. Kimi Desktop `kimi-auth` cookie, then the Desktop Local Storage access JWT
 6. Browser cookies (Arc → Chrome → Safari → Edge → Brave → Chromium)
 
 For Code API and CLI results, sources 3–6 are best-effort enrichment only: the required Code usage remains


### PR DESCRIPTION
## Summary
- Current Kimi Desktop keeps the web access JWT in Local Storage and often no longer writes a `kimi-auth` cookie, so Auto never calls `GetSubscriptionStats`.
- Code API 7-day / 5-hour windows can reset to unused while the shared monthly membership pool is already empty.
- Read the Desktop Local Storage access JWT automatically (skip refresh / expired tokens), and prefer an exhausted extra window (`Total usage`) in automatic menu-bar mode.

Fixes #3536

## Test plan
- [ ] Stay signed into current Kimi Desktop with no `kimi-auth` cookie; Cookie source Automatic; API key configured
- [ ] Confirm CodexBar recovers a live Desktop access JWT and enriches monthly `Total usage` from `GetSubscriptionStats`
- [ ] Exhaust the monthly pool and confirm automatic menu bar shows 100% `Total usage` instead of unused 5-hour / 7-day windows
- [ ] Confirm an existing Cookies `kimi-auth` still wins over Local Storage, and refresh / expired JWTs are ignored
- [ ] `swift test --filter KimiDesktopAuthTokenTests` and `swift test --filter KimiProviderTests`

Made with [Cursor](https://cursor.com)