### PR TITLE
fix: restore shared Codex spend in account menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Codex activity: read scoped daily totals without decoding unused event history, preserving account boundaries, coverage, and incomplete-scan checks (#3528, related to #3247). Thanks @brzvsk!
 
 ### Fixed
+- Codex accounts: restore shared local spend below multi-account cards in stacked and compact layouts, honoring the selected cost display mode and preserving account-scoped history isolation (#3540). Thanks @kays0x!
 - Website: keep Arabic and Persian hero copy clear of the illustration, preserve natural text direction, and avoid an oversized tablet popover during its reveal (#3514, fixes #3511). Thanks @devYRPauli!
 - Codex accounts: replace a misleading automatic CLI-retry promise with account-specific reauthentication guidance when native credentials need renewal (related to #3523). Thanks @zhulijin1991!
 - Menus: refresh cached status menus when macOS appearance changes, including previously opened submenus, so the first opening matches Light/Dark and accessibility appearances (#3526). Thanks @emanuelst!

--- a/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
+++ b/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 
 extension StatusItemController {
     func addStackedCodexMenuCards(
@@ -63,6 +64,53 @@ extension StatusItemController {
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
             menu.addItem(.separator())
         }
+    }
+
+    func addCodexAccountMenuCards(
+        _ display: CodexAccountMenuDisplay,
+        to menu: NSMenu,
+        captureMenu: NSMenu,
+        context: MenuCardContext)
+    {
+        if !self.addCompactCodexAccountMenuIfPlanned(
+            display: display, to: menu, captureMenu: captureMenu, context: context)
+        {
+            self.addStackedCodexMenuCards(display, to: menu, context: context)
+        }
+        self.addAccountAgnosticCostMenuSection(to: menu, context: context)
+    }
+
+    func addAccountAgnosticCostMenuSection(to menu: NSMenu, context: MenuCardContext) {
+        let provider = context.currentProvider
+        guard self.store.tokenCostIsAccountAgnostic(for: provider),
+              let model = self.menuCardModel(for: provider),
+              model.inlineUsageDashboard != nil || model.tokenUsage != nil
+        else { return }
+        if menu.items.last?.isSeparatorItem != true {
+            menu.addItem(.separator())
+        }
+        let scope = NSMenuItem(title: L("This Mac"), action: nil, keyEquivalent: "")
+        scope.isEnabled = false
+        scope.representedObject = "sharedCodexCostScope"
+        menu.addItem(scope)
+        if let dashboard = model.inlineUsageDashboard {
+            menu.addItem(self.makeMenuCardItem(
+                InlineUsageDashboardContent(model: dashboard)
+                    .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
+                    .padding(.vertical, 6)
+                    .frame(width: context.menuWidth),
+                id: "sharedCodexInlineCost",
+                width: context.menuWidth,
+                heightCacheScope: provider.rawValue,
+                heightCacheFingerprint: model.heightFingerprint(section: "usage")))
+        }
+        if model.tokenUsage != nil {
+            menu.addItem(self.makeCostMenuCardItem(
+                model: model,
+                submenu: self.makeCostHistorySubmenu(provider: provider, width: context.menuWidth),
+                width: context.menuWidth))
+        }
+        menu.addItem(.separator())
     }
 
     private func addCodexWorkspaceHeader(_ title: String, index: Int, to menu: NSMenu) {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -691,14 +691,8 @@ extension StatusItemController {
         }
 
         if let codexAccountDisplay = context.codexAccountDisplay, codexAccountDisplay.showAll {
-            if !self.addCompactCodexAccountMenuIfPlanned(
-                display: codexAccountDisplay,
-                to: menu,
-                captureMenu: captureMenu ?? menu,
-                context: context)
-            {
-                self.addStackedCodexMenuCards(codexAccountDisplay, to: menu, context: context)
-            }
+            self.addCodexAccountMenuCards(
+                codexAccountDisplay, to: menu, captureMenu: captureMenu ?? menu, context: context)
             self.addFleetAccountMenuCards(fleetProjection.additionalAccounts, to: menu, context: context)
             return false
         }

--- a/Sources/CodexBar/UsageStore+TokenCost.swift
+++ b/Sources/CodexBar/UsageStore+TokenCost.swift
@@ -591,4 +591,9 @@ extension UsageStore {
         }
         return false
     }
+
+    func tokenCostIsAccountAgnostic(for provider: UsageProvider) -> Bool {
+        // Provider-specific by design: only Codex's explicit ambient scope spans local accounts.
+        provider == .codex && self.tokenCostScope(for: provider).signature == "codex:ambient"
+    }
 }

--- a/Tests/CodexBarTests/CodexSharedCostNativeProofTests.swift
+++ b/Tests/CodexBarTests/CodexSharedCostNativeProofTests.swift
@@ -1,0 +1,157 @@
+import AppKit
+import XCTest
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+final class CodexSharedCostNativeProofTests: XCTestCase {
+    func test_sharedCostPresentation() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["CODEXBAR_SHARED_COST_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_SHARED_COST_PROOF_DIR for signed synthetic UI proof")
+        }
+        let output = URL(fileURLWithPath: path, isDirectory: true)
+        guard SettingsStore.isRunningTests,
+              environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment[CodexCredentialFileAccess.isolationEnvironmentKey] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1",
+              NSHomeDirectory().hasPrefix(output.deletingLastPathComponent().path + "/")
+        else { return XCTFail("Use a contained home and credential/session isolation") }
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let fixture = MenuCardCodexAmbientCostTests.makeFixture()
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let oldRendering = StatusItemController.menuCardRenderingEnabled
+        let oldRefresh = StatusItemController.menuRefreshEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = oldRendering
+            StatusItemController.setMenuRefreshEnabledForTesting(oldRefresh)
+        }
+        let controller = StatusItemController(
+            store: fixture.store,
+            settings: fixture.settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+        let app = NSApplication.shared
+        guard app.delegate == nil else { return XCTFail("Use a standalone test host") }
+        let previousApp = NSWorkspace.shared.frontmostApplication
+        let previousPolicy = app.activationPolicy()
+        let host = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1000, height: 850),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        host.title = "CodexBar — Synthetic Shared Cost"
+        host.isReleasedWhenClosed = false
+        let legacy = environment["CODEXBAR_SHARED_COST_PROOF_LEGACY"] == "1"
+        var count = 2
+        var style = CostSummaryDisplayStyle.both
+        let holder = SharedCostProofMenu()
+        let menu = holder.menu
+        var observed = Set<String>()
+        var historyOpened = false
+        var finished = false
+        func populate() {
+            menu.removeAllItems()
+            fixture.settings.costSummaryDisplayStyle = style
+            let display = MenuCardCodexAmbientCostTests.display(count: count)
+            let context = MenuCardCodexAmbientCostTests.context(display: display)
+            if legacy {
+                if !controller.addCompactCodexAccountMenuIfPlanned(
+                    display: display, to: menu, captureMenu: menu, context: context)
+                {
+                    controller.addStackedCodexMenuCards(display, to: menu, context: context)
+                }
+            } else {
+                controller.addCodexAccountMenuCards(display, to: menu, captureMenu: menu, context: context)
+            }
+        }
+        func button(_ title: String, index: Int, action: @escaping @MainActor (NSButton) -> Void) {
+            let button = SharedCostProofButton(frame: NSRect(
+                x: CGFloat(20 + index * 160),
+                y: 800,
+                width: 145,
+                height: 32))
+            button.title = title
+            button.callback = action
+            button.target = button
+            button.action = #selector(SharedCostProofButton.activate)
+            host.contentView?.addSubview(button)
+        }
+        button("Open menu", index: 0) { button in
+            populate()
+            observed.insert("\(count):\(style.rawValue)")
+            menu.popUp(positioning: nil, at: .zero, in: button)
+        }
+        button("Toggle layout", index: 1) { _ in count = count == 2 ? 5 : 2 }
+        button("Inline only", index: 2) { _ in style = .inlineSummary }
+        button("Submenu only", index: 3) { _ in style = .costSubmenu }
+        button("Both", index: 4) { _ in style = .both }
+        button("Finish proof", index: 5) { _ in finished = true }
+        let timer = Timer(timeInterval: 0.1, repeats: true) { _ in
+            MainActor.assumeIsolated {
+                let ids = holder.menu.items.compactMap { $0.representedObject as? String }
+                let costMenu = holder.menu.items.first { $0.representedObject as? String == "menuCardCost" }?.submenu
+                historyOpened = historyOpened || controller.openMenus.values.contains { $0 === costMenu }
+                let receipt: [String: Any] = [
+                    "pid": ProcessInfo.processInfo.processIdentifier, "window": host.windowNumber,
+                    "count": count, "style": style.rawValue, "legacy": legacy,
+                    "ids": ids, "observed": observed.sorted(), "historyOpened": historyOpened,
+                ]
+                do {
+                    try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys])
+                        .write(to: output.appendingPathComponent("state.json"), options: .atomic)
+                } catch { XCTFail("Could not write proof receipt") }
+            }
+        }
+        defer {
+            timer.invalidate()
+            menu.cancelTracking()
+            host.close()
+            _ = app.setActivationPolicy(previousPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApp?.activate()
+            }
+        }
+        _ = app.setActivationPolicy(.regular)
+        app.finishLaunching()
+        host.center()
+        host.makeKeyAndOrderFront(nil)
+        app.activate(ignoringOtherApps: true)
+        RunLoop.main.add(timer, forMode: .common)
+        let deadline = Date().addingTimeInterval(600)
+        while !finished, Date() < deadline {
+            if let event = app.nextEvent(
+                matching: .any, until: Date().addingTimeInterval(0.02), inMode: .default, dequeue: true)
+            { app.sendEvent(event) }
+            _ = RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertTrue(finished)
+        XCTAssertTrue(observed.contains("2:\(CostSummaryDisplayStyle.both.rawValue)"))
+        if !legacy {
+            XCTAssertTrue(observed.contains("5:\(CostSummaryDisplayStyle.both.rawValue)"))
+            XCTAssertTrue(observed.contains("5:\(CostSummaryDisplayStyle.inlineSummary.rawValue)"))
+            XCTAssertTrue(observed.contains("5:\(CostSummaryDisplayStyle.costSubmenu.rawValue)"))
+            XCTAssertTrue(historyOpened)
+        }
+    }
+}
+
+@MainActor
+private final class SharedCostProofButton: NSButton {
+    var callback: (@MainActor (NSButton) -> Void)?
+
+    @objc func activate() {
+        self.callback?(self)
+    }
+}
+
+@MainActor
+private final class SharedCostProofMenu {
+    let menu = NSMenu()
+}

--- a/Tests/CodexBarTests/MenuCardCodexAmbientCostTests.swift
+++ b/Tests/CodexBarTests/MenuCardCodexAmbientCostTests.swift
@@ -1,0 +1,208 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+/// Codex spend is scanned from an ambient `CODEX_HOME` shared by every account, so it belongs to
+/// the machine rather than to any one card. The multi-account menu therefore renders it once, from
+/// the live card model, instead of repeating the same total under every account.
+@MainActor
+struct MenuCardCodexAmbientCostTests {
+    struct Fixture {
+        let store: UsageStore
+        let settings: SettingsStore
+        let fetcher: UsageFetcher
+    }
+
+    static func makeFixture(costUsageEnabled: Bool = true, seedAmbientCost: Bool = true) -> Fixture {
+        let settings = testSettingsStore(suiteName: "MenuCardCodexAmbientCostTests")
+        settings._test_managedCodexAccountStoreURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ambient-cost-managed-\(UUID().uuidString).json")
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.costUsageEnabled = costUsageEnabled
+        let environment = ["HOME": FileManager.default.temporaryDirectory.path]
+        let fetcher = UsageFetcher(environment: environment)
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(homeDirectory: FileManager.default.temporaryDirectory.path, cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: environment)
+        store._test_widgetSnapshotSaveOverride = { _ in }
+        if seedAmbientCost {
+            store._setTokenSnapshotForTesting(
+                CostUsageTokenSnapshot(
+                    sessionTokens: 123,
+                    sessionCostUSD: 0.12,
+                    last30DaysTokens: 456,
+                    last30DaysCostUSD: 1.23,
+                    daily: [.init(
+                        date: String(ISO8601DateFormatter().string(from: Date()).prefix(10)),
+                        inputTokens: 100,
+                        outputTokens: 23,
+                        totalTokens: 123,
+                        costUSD: 0.12,
+                        modelsUsed: ["fictional-test-model"],
+                        modelBreakdowns: nil)],
+                    updatedAt: Date()),
+                provider: .codex)
+        }
+        return Fixture(store: store, settings: settings, fetcher: fetcher)
+    }
+
+    private static func accountCardModel(
+        _ controller: StatusItemController,
+        email: String) -> UsageMenuCardView.Model?
+    {
+        controller.menuCardModel(
+            for: .codex,
+            forceOverrideCard: true,
+            accountOverride: AccountInfo(email: email, plan: nil))
+    }
+
+    @Test
+    func `the shared cost section sources the ambient ledger from the live card`() throws {
+        let fixture = Self.makeFixture()
+
+        try withStatusItemControllerForTesting(
+            store: fixture.store,
+            settings: fixture.settings,
+            fetcher: fixture.fetcher)
+        { controller in
+            let model = try #require(controller.menuCardModel(for: .codex))
+            #expect(model.tokenUsage != nil)
+        }
+    }
+
+    @Test
+    func `codex account cards do not repeat the machine wide cost`() throws {
+        let fixture = Self.makeFixture()
+
+        try withStatusItemControllerForTesting(
+            store: fixture.store,
+            settings: fixture.settings,
+            fetcher: fixture.fetcher)
+        { controller in
+            let first = try #require(Self.accountCardModel(controller, email: "first@example.com"))
+            let second = try #require(Self.accountCardModel(controller, email: "second@example.com"))
+
+            // Both the inline usage dashboard and the cost block are driven by `tokenUsage`, so a
+            // per-card snapshot would render the same total twice per card and again per account.
+            #expect(first.tokenUsage == nil)
+            #expect(second.tokenUsage == nil)
+            #expect(first.inlineUsageDashboard == nil)
+            #expect(second.inlineUsageDashboard == nil)
+            #expect(first.email == "first@example.com")
+            #expect(second.email == "second@example.com")
+        }
+    }
+
+    @Test
+    func `the shared cost section is withheld when cost usage is disabled`() throws {
+        let fixture = Self.makeFixture(costUsageEnabled: false)
+
+        try withStatusItemControllerForTesting(
+            store: fixture.store,
+            settings: fixture.settings,
+            fetcher: fixture.fetcher)
+        { controller in
+            let model = try #require(controller.menuCardModel(for: .codex))
+            #expect(model.tokenUsage == nil)
+        }
+    }
+
+    @Test
+    func `only the ambient codex ledger counts as account agnostic`() {
+        let fixture = Self.makeFixture(seedAmbientCost: false)
+
+        // Ambient `~/.codex/sessions` scan: machine-wide, so it is rendered once for the menu.
+        #expect(fixture.store.tokenCostIsAccountAgnostic(for: .codex))
+        // Claude's cost is credential-scoped and belongs to a single account, so it is never
+        // promoted to a menu-wide section.
+        #expect(!fixture.store.tokenCostIsAccountAgnostic(for: .claude))
+    }
+
+    @Test(arguments: [2, 5], CostSummaryDisplayStyle.allCases)
+    func `both account layouts honor the shared cost display mode`(count: Int, style: CostSummaryDisplayStyle) throws {
+        let fixture = Self.makeFixture()
+        fixture.settings.costSummaryDisplayStyle = style
+        try withStatusItemControllerForTesting(
+            store: fixture.store,
+            settings: fixture.settings,
+            fetcher: fixture.fetcher)
+        { controller in
+            let display = Self.display(count: count)
+            let context = Self.context(display: display)
+            let menu = controller.makeMenu()
+            controller.addCodexAccountMenuCards(display, to: menu, captureMenu: menu, context: context)
+            let costRows = menu.items.filter { $0.representedObject as? String == "menuCardCost" }
+            let dashboards = menu.items.filter { $0.representedObject as? String == "sharedCodexInlineCost" }
+            #expect(costRows.count == (style.showsCostSubmenu ? 1 : 0))
+            #expect(dashboards.count == (style.showsInlineSummary ? 1 : 0))
+            if let cost = costRows.first {
+                #expect(cost.title == StatusItemController.costMenuTitle)
+                #expect(cost.submenu != nil)
+            }
+        }
+    }
+
+    @Test
+    func `managed account history is not promoted to shared spend`() {
+        let fixture = Self.makeFixture(seedAmbientCost: false)
+        fixture.settings.codexLocalSessionCostLedgerEnabled = false
+        fixture.settings.codexActiveSource = .managedAccount(id: UUID())
+        #expect(!fixture.store.tokenCostIsAccountAgnostic(for: .codex))
+        fixture.settings.codexLocalSessionCostLedgerEnabled = true
+        #expect(fixture.store.tokenCostIsAccountAgnostic(for: .codex))
+    }
+
+    static func display(count: Int) -> CodexAccountMenuDisplay {
+        let accounts = (1...count).map { index in
+            CodexVisibleAccount(
+                id: "synthetic-account-\(index)",
+                email: "account\(index)@example.com",
+                storedAccountID: nil,
+                selectionSource: .liveSystem,
+                isActive: index == 1,
+                isLive: true,
+                canReauthenticate: false,
+                canRemove: false)
+        }
+        let snapshots = accounts.map { account in
+            CodexAccountUsageSnapshot(
+                account: account,
+                snapshot: UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: 20,
+                        windowMinutes: 300,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: Date()),
+                error: nil,
+                sourceLabel: "synthetic")
+        }
+        return CodexAccountMenuDisplay(
+            accounts: accounts,
+            snapshots: snapshots,
+            activeVisibleAccountID: accounts.first?.id,
+            layout: .stacked)
+    }
+
+    static func context(display: CodexAccountMenuDisplay) -> StatusItemController.MenuCardContext {
+        .init(
+            currentProvider: .codex,
+            selectedProvider: .codex,
+            menuWidth: 310,
+            codexAccountDisplay: display,
+            tokenAccountDisplay: nil,
+            openAIContext: .init(
+                hasUsageBreakdown: false,
+                hasCreditsHistory: false,
+                hasCostHistory: false,
+                canShowBuyCredits: false,
+                hasOpenAIWebMenuItems: false))
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1013,7 +1013,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This publication projection maps stable Codex account source IDs back to their provider family."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/StatusItemController+CodexStackedMenu.swift",
-            line: 26,
+            line: 27,
             anchor: "for: .codex,",
             expectedProviderIDs: ["codex"],
             reason: "This provider-owned integration passes its fixed identity to a shared helper."),
@@ -1043,7 +1043,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "The memory-pressure debug fixture installs its synthetic entry in the Codex cache slot."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1129,
+            line: 1123,
             anchor: "controller.refreshOpenMenuIfStillVisible(menu, provider: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -2593,7 +2593,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/StatusItemController+Menu.swift",
-            line: 1159,
+            line: 1153,
             anchor: "return self.store.enabledFirstPartyProvidersForDisplay().first ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -200,6 +200,8 @@ is limited, using additional rows when needed.
   - By default, a selected managed account keeps its own `CODEX_HOME` session history.
   - **Local session cost estimates** is a Codex-only opt-in that instead scans this Mac's ambient `$CODEX_HOME`
     (or `~/.codex`) independently of quota, OAuth, web-dashboard, and administrator access.
+  - Multi-account menus show an ambient ledger once under **This Mac**, honoring inline, submenu, or combined display.
+    Managed-account and profile-home history is never promoted to this shared section.
   - Regular menu cost refreshes publish local session estimates even when global cost tracking is off. This does not
     enable other providers' cost scans; results still require the same provider configuration and history/account scope.
   - The local-only mode never makes a network request or uploads session content. It uses an existing local models.dev


### PR DESCRIPTION
Restores the shared ambient Codex ledger beneath multi-account cards. Both stacked and compact account layouts now reach one Codex-owned trailing section, labeled **This Mac**, without assigning the same spend to individual accounts. Only the existing `codex:ambient` scope qualifies; managed-account and profile-home history remains isolated.

The maintainer pass also fixes the proposal’s display-mode mismatch: inline-only uses the existing inline dashboard, submenu-only uses the existing compact Cost row, and Both shows each once. The generic compact renderer no longer needs a Codex-specific trailing callback. Account override-card isolation is unchanged.

Validation:
- The new layout/preference regressions produced 12 failing assertions against the proposal. 53 focused tests then passed, including override isolation and architecture checks.
- `make check`: zero violations across 2,173 Swift files. Independent P0–P2 review is clean.
- Full `make test`: 1,061 selections across 89 groups passed on the first attempt, with no retries or timeouts (787.6 seconds).
- Developer-ID-signed native proof exercised two-account stacked and five-account compact menus, all three display modes, and opening the Cost history submenu. The native test passed with no failures. Only synthetic accounts and spend data were used.
- Native proof source matches commit `9b44b2fe9a6ae85712fbbc7242b700997c11cbdc`. [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34524643609) passed all Linux, musl and macOS checks. Merged as `cebf9995f672d2c0c9ff3501b24721855b86b16c`.

Documentation and the Unreleased changelog explain the ambient scope and credit @kays0x.

<details>
<summary>Inspected synthetic native before/after proof</summary>

Legacy stacked rendering omits spend:

![Before: stacked accounts without shared spend](https://github.com/user-attachments/assets/f1146386-05ba-4e85-af62-ef86680baebe)

Stacked accounts with shared inline spend and Cost history:

![After: shared spend below stacked accounts](https://github.com/user-attachments/assets/a574b175-bfce-4792-b2cf-bcd40402d099)

Compact accounts with the Cost history submenu open:

![After: compact accounts and history](https://github.com/user-attachments/assets/a250158c-0b36-4298-a8e5-727535dbe751)

Submenu-only mode keeps the compact Cost row:

![After: submenu-only preference](https://github.com/user-attachments/assets/d15c7175-5716-4736-bdfd-819fcbd39739)

</details>
