### PR TITLE
fix: wire Devin manual auth through the CLI on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Codex accounts: replace a misleading automatic CLI-retry promise with account-specific reauthentication guidance when native credentials need renewal (related to #3523). Thanks @zhulijin1991!
 - Menus: refresh cached status menus when macOS appearance changes, including previously opened submenus, so the first opening matches Light/Dark and accessibility appearances (#3526). Thanks @emanuelst!
 
+- Devin CLI: load manual bearer and organization settings from config and allow manual quota requests on Linux while keeping browser import macOS-only (#3541). Thanks @Waseemilyas!
+
 - Documentation: point Spark and Daily Routines visibility instructions to the current per-item controls and include Overview in their scope.
 
 ## 0.58.0 — 2026-09-09

--- a/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinProviderDescriptor.swift
@@ -16,7 +16,15 @@ public enum DevinProviderDescriptor {
     static func makeDescriptor() -> ProviderDescriptor {
         ProviderDescriptor(
             id: .devin,
-            settingsSection: .init(DevinProviderSettingsKey.self),
+            settingsSection: .init(
+                DevinProviderSettingsKey.self,
+                credentialSettings: { context in
+                    let settings = context.cookieSettings(for: .devin)
+                    return DevinProviderSettings(
+                        cookieSource: settings.cookieSource,
+                        manualBearerToken: settings.manualCookieHeader,
+                        organization: context.config?.sanitizedWorkspaceID)
+                }),
             config: ProviderConfigCapabilities(workspaceIDValidationOrder: 4),
             metadata: ProviderMetadata(
                 id: .devin,
@@ -74,7 +82,16 @@ public enum DevinProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [DevinWebFetchStrategy()] })),
             cli: ProviderCLIConfig(
                 name: "devin",
-                versionDetector: nil))
+                versionDetector: nil,
+                browserSupportExemption: { _, environment, settings in
+                    #if os(Linux)
+                    settings?.devin?.cookieSource == .manual &&
+                        DevinUsageFetcher.manualAuth(
+                            from: settings?.devin?.bearerToken(environment: environment ?? [:])) != nil
+                    #else
+                    false
+                    #endif
+                }))
     }
 }
 
@@ -87,7 +104,7 @@ struct DevinWebFetchStrategy: ProviderFetchStrategy {
         let source = settings?.cookieSource ?? .auto
         guard source != .off else { return false }
         if source == .manual {
-            return DevinUsageFetcher.manualAuth(from: Self.bearerTokenOverride(context: context)) != nil
+            return DevinUsageFetcher.manualAuth(from: settings?.bearerToken(environment: context.env)) != nil
         }
         #if os(macOS)
         return true
@@ -103,7 +120,8 @@ struct DevinWebFetchStrategy: ProviderFetchStrategy {
             ? { msg in CodexBarLog.logger(LogCategories.provider(.devin)).verbose(msg) }
             : nil
         let snapshot = try await fetcher.fetch(
-            bearerTokenOverride: settings?.cookieSource == .manual ? Self.bearerTokenOverride(context: context) : nil,
+            bearerTokenOverride: settings?.cookieSource == .manual ? settings?
+                .bearerToken(environment: context.env) : nil,
             organizationOverride: Self.organizationOverride(context: context),
             timeout: context.webTimeout,
             logger: logger)
@@ -114,12 +132,6 @@ struct DevinWebFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
         false
-    }
-
-    private static func bearerTokenOverride(context: ProviderFetchContext) -> String? {
-        context.env["DEVIN_BEARER_TOKEN"]
-            ?? context.env["DEVIN_AUTHORIZATION"]
-            ?? context.settings?.devin?.manualBearerToken
     }
 
     private static func organizationOverride(context: ProviderFetchContext) -> String? {

--- a/Sources/CodexBarCore/Providers/Devin/DevinProviderSettings.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinProviderSettings.swift
@@ -10,6 +10,12 @@ public struct DevinProviderSettings: Sendable {
         self.manualBearerToken = manualBearerToken
         self.organization = organization
     }
+
+    public func bearerToken(environment: [String: String]) -> String? {
+        environment["DEVIN_BEARER_TOKEN"]
+            ?? environment["DEVIN_AUTHORIZATION"]
+            ?? self.manualBearerToken
+    }
 }
 
 public enum DevinProviderSettingsKey: ProviderSettingsSectionKey {

--- a/TestsLinux/DevinCLISettingsTests.swift
+++ b/TestsLinux/DevinCLISettingsTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+@testable import CodexBarCLI
+@testable import CodexBarCore
+
+struct DevinCLISettingsTests {
+    private func settings(source: String? = "manual", token: String = "Bearer fixture-token") throws
+        -> ProviderSettingsSnapshot
+    {
+        var provider = ["id": "devin", "cookieHeader": token, "workspaceID": "org_fixture"]
+        provider["cookieSource"] = source
+        let config = try JSONDecoder().decode(
+            CodexBarConfig.self,
+            from: JSONSerialization.data(withJSONObject: ["version": 1, "providers": [provider]]))
+        let context = try TokenAccountCLIContext(
+            selection: .init(label: nil, index: nil, allAccounts: false),
+            config: config,
+            verbose: false,
+            baseEnvironment: [:])
+        return try #require(context.settingsSnapshot(for: .devin, account: nil))
+    }
+
+    @Test(arguments: ["manual", nil])
+    func `configured Devin bearer reaches the CLI request`(source: String?) async throws {
+        let snapshot = try self.settings(source: source)
+        let settings = try #require(snapshot.devin)
+        #expect(settings.cookieSource == .manual)
+        #expect(settings.manualBearerToken == "Bearer fixture-token")
+        #expect(settings.organization == "org_fixture")
+        #if os(Linux)
+        for mode: ProviderSourceMode in [.auto, .web] {
+            #expect(!CodexBarCLI.sourceModeRequiresWebSupport(mode, provider: .devin, settings: snapshot))
+        }
+        #endif
+
+        let transport = DevinRequestFixture()
+        let result = try await DevinUsageFetcher(browserDetection: BrowserDetection(homeDirectory: "/nonexistent"))
+            .fetch(
+                bearerTokenOverride: settings.bearerToken(environment: [:]),
+                organizationOverride: settings.organization,
+                transport: transport)
+        #expect(result.daily?.usedPercent == 12)
+        #expect(result.weekly?.usedPercent == 34)
+        let requests = await transport.requests
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.url?.absoluteString == "https://app.devin.ai/api/org_fixture/billing/quota/usage")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-token")
+    }
+
+    @Test(arguments: ["auto", "off"])
+    func `environment token does not opt into manual auth`(source: String) throws {
+        let snapshot = try self.settings(source: source)
+        #expect(snapshot.devin?.cookieSource.rawValue == source)
+        #if os(Linux)
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(
+            .web,
+            provider: .devin,
+            environment: ["DEVIN_BEARER_TOKEN": "environment-fixture"],
+            settings: snapshot))
+        #endif
+    }
+
+    @Test(arguments: ["environment-fixture", "", "  "])
+    func `manual gate and request token preserve environment precedence`(token: String) throws {
+        let snapshot = try self.settings()
+        let settings = try #require(snapshot.devin)
+        let environment = ["DEVIN_BEARER_TOKEN": token, "DEVIN_AUTHORIZATION": "fallback-fixture"]
+        #expect(settings.bearerToken(environment: environment) == token)
+        #expect(settings.bearerToken(environment: ["DEVIN_AUTHORIZATION": "fallback-fixture"]) == "fallback-fixture")
+        #if os(Linux)
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(
+            .web,
+            provider: .devin,
+            environment: environment,
+            settings: snapshot) == token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #endif
+    }
+
+    @Test
+    func `blank configured manual token stays unavailable`() throws {
+        let snapshot = try self.settings(token: "  ")
+        #expect(DevinUsageFetcher.manualAuth(from: snapshot.devin?.bearerToken(environment: [:])) == nil)
+        #if os(Linux)
+        #expect(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .devin, settings: snapshot))
+        #endif
+    }
+}
+
+private actor DevinRequestFixture: ProviderHTTPTransport {
+    var requests: [URLRequest] = []
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        self.requests.append(request)
+        let url = try #require(request.url)
+        return try (
+            Data(#"{"daily_percentage":12,"weekly_percentage":34}"#.utf8),
+            #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil)))
+    }
+}

--- a/docs/devin.md
+++ b/docs/devin.md
@@ -31,6 +31,28 @@ Environment overrides:
 - `DEVIN_BEARER_TOKEN` or `DEVIN_AUTHORIZATION`
 - `DEVIN_ORGANIZATION` or `DEVIN_ORG`
 
+## Linux CLI
+
+Automatic Chrome session import is macOS-only. On Linux, configure manual auth in
+`~/.config/codexbar/config.json` (or your existing legacy config):
+
+```json
+{
+  "version": 1,
+  "providers": [{
+    "id": "devin",
+    "cookieSource": "manual",
+    "cookieHeader": "Bearer YOUR_DEVIN_TOKEN",
+    "workspaceID": "org_YOUR_ORGANIZATION"
+  }]
+}
+```
+
+Run `codexbar usage --provider devin`. You can omit `cookieHeader` when supplying
+`DEVIN_BEARER_TOKEN` or `DEVIN_AUTHORIZATION`, but keep `cookieSource` set to `manual`.
+The organization environment overrides also apply. Environment tokens take precedence
+without enabling automatic auth; an empty override does not fall back to the configured token.
+
 ## Data Source
 
 CodexBar requests:


### PR DESCRIPTION
Fixes the Devin CLI config path as well as the Linux platform gate. A configured manual bearer token previously never reached the provider's typed settings, so exempting prebuilt settings in the gate alone did not make the CLI work.

Devin now reads manual auth and organization through the existing descriptor credential adapter. Availability, the Linux gate, and the request share token precedence. Only a usable token in manual mode permits Linux quota requests; automatic browser import remains macOS-only. An empty primary environment override continues to shadow fallback values.

The regression decodes real provider config, checks the resulting settings, and exercises the existing fetcher with a synthetic HTTP transport. It verifies the final organization URL, Authorization header, and daily/weekly result. Linux CI also checks both Auto/Web CLI source modes, explicit Auto/Off auth, and empty overrides using those config-derived settings.

Validation so far: the original proposal failed the config-to-settings regression; 26 existing Devin tests and four new tests (eight cases) pass locally. `make check` is clean and independent P0–P2 review found no actionable defects. Full `make test` passed all 1,060 selections across 89 groups on the first attempt, with no retries or timeouts (954.4 seconds). [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34527317199) passed all Linux x64, Linux ARM64, musl and macOS checks. The Linux x64 log confirms all eight new config/request cases executed successfully. Merged as `c9f2eca8da03b525f097e89f6b98a55fed96b9fd`.

Includes Linux setup documentation and an Unreleased changelog entry. Thanks @Waseemilyas for the original Linux-gate fix.
