### PR TITLE
fix: surface exhausted Kimi monthly usage automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - Website: keep Arabic and Persian hero copy clear of the illustration, preserve natural text direction, and avoid an oversized tablet popover during its reveal (#3514, fixes #3511). Thanks @devYRPauli!
 - Codex accounts: replace a misleading automatic CLI-retry promise with account-specific reauthentication guidance when native credentials need renewal (related to #3523). Thanks @zhulijin1991!
+- Kimi: show an exhausted monthly membership pool in automatic menu-bar usage even when Code quota windows have reset (related to #3536, #3537). Thanks @OttoPrua!
 - Menus: refresh cached status menus when macOS appearance changes, including previously opened submenus, so the first opening matches Light/Dark and accessibility appearances (#3526). Thanks @emanuelst!
 
 - Documentation: point Spark and Daily Routines visibility instructions to the current per-item controls and include Overview in their scope.

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -114,8 +114,9 @@ public enum KimiProviderDescriptor {
         context: ProviderMenuBarWindowContext) -> ProviderMenuBarWindowResolution
     {
         guard context.metric == .automatic else { return .unhandled }
+        let monthly = context.snapshot.extraRateWindows?.first { $0.id == "kimi-monthly" && $0.usageKnown }?.window
         return .resolved(
-            ProviderUsagePresentation.exhausted(context.snapshot.primary, context.snapshot.secondary)
+            ProviderUsagePresentation.exhausted(monthly, context.snapshot.primary, context.snapshot.secondary)
                 ?? context.snapshot.secondary
                 ?? context.snapshot.primary)
     }

--- a/Tests/CodexBarTests/KimiMenuBarWindowTests.swift
+++ b/Tests/CodexBarTests/KimiMenuBarWindowTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct KimiMenuBarWindowTests {
+    @Test
+    func `exhausted membership takes precedence over reset Code windows`() throws {
+        let monthly = Self.monthly(used: 100)
+        let weekly = Self.window(used: 0, minutes: 10080)
+        let session = Self.window(used: 0, minutes: 300)
+        #expect(try Self.resolve(primary: weekly, secondary: session, extra: monthly) == monthly.window)
+    }
+
+    @Test(arguments: [
+        nil,
+        Self.monthly(used: 99),
+        Self.monthly(used: 100, known: false),
+        NamedRateWindow(id: "unrelated", title: "Other", window: Self.window(used: 100, minutes: nil)),
+    ])
+    func `only known exhausted monthly usage overrides the session`(extra: NamedRateWindow?) throws {
+        let session = Self.window(used: 25, minutes: 300)
+        #expect(try Self.resolve(
+            primary: Self.window(used: 50, minutes: 10080),
+            secondary: session,
+            extra: extra) == session)
+    }
+
+    @Test(arguments: [false, true])
+    func `Code exhaustion still takes precedence over partial membership`(weeklyExhausted: Bool) throws {
+        let weekly = Self.window(used: weeklyExhausted ? 100 : 0, minutes: 10080)
+        let session = Self.window(used: weeklyExhausted ? 0 : 100, minutes: 300)
+        #expect(try Self.resolve(primary: weekly, secondary: session, extra: Self.monthly(used: 50)) ==
+            (weeklyExhausted ? weekly : session))
+    }
+
+    @Test(arguments: [
+        ProviderMenuBarMetric.primary,
+        .secondary,
+        .primaryAndSecondary,
+        .tertiary,
+        .extraUsage,
+        .average,
+        .monthlyPlan,
+    ])
+    func `explicit metrics keep their standard resolution`(metric: ProviderMenuBarMetric) {
+        let resolution = Self.resolution(
+            metric: metric,
+            primary: Self.window(used: 0, minutes: 10080),
+            secondary: Self.window(used: 0, minutes: 300),
+            extra: Self.monthly(used: 100))
+        guard case .unhandled = resolution else {
+            Issue.record("Kimi must leave explicit metric selection to the standard resolver")
+            return
+        }
+    }
+
+    @Test
+    func `status indicator resolves monthly automatically and preserves explicit Code windows`() {
+        let weekly = Self.window(used: 20, minutes: 10080)
+        let session = Self.window(used: 0, minutes: 300)
+        let monthly = Self.monthly(used: 100)
+        let snapshot = UsageSnapshot(
+            primary: weekly, secondary: session, extraRateWindows: [monthly], updatedAt: Date())
+        for (preference, expected) in [
+            (MenuBarMetricPreference.automatic, monthly.window), (.primary, weekly), (.secondary, session),
+        ] {
+            #expect(MenuBarMetricWindowResolver.rateWindow(
+                preference: preference, provider: .kimi, snapshot: snapshot, supportsAverage: false) == expected)
+        }
+    }
+
+    private static func resolve(
+        primary: RateWindow?, secondary: RateWindow?, extra: NamedRateWindow?) throws -> RateWindow?
+    {
+        guard case let .resolved(window) = resolution(
+            metric: .automatic, primary: primary, secondary: secondary, extra: extra)
+        else {
+            Issue.record("Kimi automatic metric should resolve")
+            return nil
+        }
+        return window
+    }
+
+    private static func resolution(
+        metric: ProviderMenuBarMetric, primary: RateWindow?, secondary: RateWindow?, extra: NamedRateWindow?)
+        -> ProviderMenuBarWindowResolution
+    {
+        let now = Date(timeIntervalSince1970: 1_788_000_000)
+        return KimiProviderDescriptor.descriptor.presentation.menuBarWindow(context: .init(
+            metric: metric,
+            snapshot: UsageSnapshot(
+                primary: primary, secondary: secondary, extraRateWindows: extra.map { [$0] }, updatedAt: now),
+            supportsAverage: false,
+            prioritizesExhaustedQuotas: false,
+            now: now))
+    }
+
+    private static func monthly(used: Double, known: Bool = true) -> NamedRateWindow {
+        NamedRateWindow(
+            id: "kimi-monthly",
+            title: "Total usage",
+            window: self.window(used: used, minutes: ProviderPaceCapability.monthlyWindowSentinelMinutes),
+            usageKnown: known)
+    }
+
+    private static func window(used: Double, minutes: Int?) -> RateWindow {
+        RateWindow(usedPercent: used, windowMinutes: minutes, resetsAt: nil, resetDescription: nil)
+    }
+}

--- a/Tests/CodexBarTests/KimiMonthlyNativeProofTests.swift
+++ b/Tests/CodexBarTests/KimiMonthlyNativeProofTests.swift
@@ -1,0 +1,155 @@
+import AppKit
+import XCTest
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+final class KimiMonthlyNativeProofTests: XCTestCase {
+    func test_monthlyStatusIndicator() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["CODEXBAR_KIMI_MONTHLY_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_KIMI_MONTHLY_PROOF_DIR for signed synthetic UI proof")
+        }
+        let output = URL(fileURLWithPath: path, isDirectory: true)
+        guard SettingsStore.isRunningTests,
+              environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment[CodexCredentialFileAccess.isolationEnvironmentKey] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1",
+              NSHomeDirectory().hasPrefix(output.deletingLastPathComponent().path + "/")
+        else { return XCTFail("Use a contained home and credential/session isolation") }
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let now = Date(timeIntervalSince1970: 1_788_000_000)
+        let weekly = RateWindow(usedPercent: 0, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)
+        let session = RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+        let monthly = RateWindow(
+            usedPercent: 100,
+            windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
+            resetsAt: nil,
+            resetDescription: nil)
+        let snapshot = UsageSnapshot(
+            primary: weekly,
+            secondary: session,
+            extraRateWindows: [NamedRateWindow(id: "kimi-monthly", title: "Total usage", window: monthly)],
+            updatedAt: now)
+        let automatic = try XCTUnwrap(MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic, provider: .kimi, snapshot: snapshot, supportsAverage: false, now: now))
+        // This flag changes expectations only; capture the baseline using the actual old descriptor binary.
+        let baseline = environment["CODEXBAR_KIMI_MONTHLY_PROOF_BASELINE"] == "1"
+        XCTAssertEqual(automatic, baseline ? session : monthly)
+        let data = MenuBarLayoutRenderData(
+            provider: .kimi,
+            iconKey: "kimi",
+            providerName: "Kimi",
+            accountLabel: nil,
+            laneLabels: MenuBarLayoutLaneLabels(provider: .kimi, snapshot: snapshot),
+            primary: MenuBarLayoutRenderWindow(weekly),
+            secondary: MenuBarLayoutRenderWindow(session),
+            tertiary: nil,
+            session: MenuBarLayoutRenderWindow(session),
+            weekly: MenuBarLayoutRenderWindow(weekly),
+            scopedWeekly: nil,
+            scopedWeeklyTitle: nil,
+            automatic: MenuBarLayoutRenderWindow(automatic),
+            automaticText: nil,
+            sessionPace: nil,
+            weeklyPace: nil,
+            automaticPace: nil,
+            runsOut: nil,
+            balance: nil,
+            costToday: nil,
+            cost30d: nil,
+            metrics: .unavailable)
+        let app = NSApplication.shared
+        guard app.delegate == nil else { return XCTFail("Use a standalone test host") }
+        let previousApp = NSWorkspace.shared.frontmostApplication
+        let previousPolicy = app.activationPolicy()
+        let host = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 310),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        host.title = "CodexBar — Synthetic Kimi Monthly Usage"
+        host.isReleasedWhenClosed = false
+        defer {
+            host.close()
+            _ = app.setActivationPolicy(previousPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApp?.activate()
+            }
+        }
+        _ = app.setActivationPolicy(.regular)
+        app.finishLaunching()
+        host.center()
+        host.makeKeyAndOrderFront(nil)
+        app.activate(ignoringOtherApps: true)
+        var receipt: [String: Any] = ["baseline": baseline, "usedPercent": automatic.usedPercent]
+        for appearanceName in [NSAppearance.Name.aqua, .darkAqua] {
+            host.appearance = NSAppearance(named: appearanceName)
+            let content = NSView(frame: NSRect(x: 0, y: 0, width: 720, height: 310))
+            host.contentView = content
+            func label(_ text: String, y: CGFloat, size: CGFloat = 14) {
+                let field = NSTextField(labelWithString: text)
+                field.font = .systemFont(ofSize: size)
+                field.frame = NSRect(x: 28, y: y, width: 660, height: 28)
+                content.addSubview(field)
+            }
+            label(
+                baseline ? "Before: monthly exhaustion hidden" : "After: exhausted monthly pool selected",
+                y: 260,
+                size: 21)
+            label("Synthetic quotas: monthly 100% used · Code 7-day and 5-hour 0% used", y: 220)
+            label("Production menu-bar renderer · Automatic metric", y: 186)
+            for (index, showUsed) in [false, true].enumerated() {
+                let rendered = MenuBarLayoutRenderer().render(
+                    layout: MenuBarLayout(lines: [[
+                        .providerName,
+                        .space,
+                        .percent(window: .automatic),
+                        .space,
+                        .usageBar,
+                    ]]),
+                    data: data,
+                    icon: nil,
+                    options: MenuBarLayoutRenderOptions(
+                        size: .regular,
+                        highContrast: false,
+                        showUsed: showUsed,
+                        conditionals: [],
+                        appearanceName: appearanceName.rawValue,
+                        isDebugApp: false,
+                        now: now))
+                let expectedPercent = showUsed ? automatic.usedPercent : automatic.remainingPercent
+                let expectedBar = expectedPercent == 100 ? "▮▮▮" : "▯▯▯"
+                XCTAssertEqual(rendered.attributedTitle.string, "Kimi \(Int(expectedPercent))% \(expectedBar)")
+                let rowY = CGFloat(132 - index * 50)
+                label(showUsed ? "Used" : "Remaining", y: rowY)
+                if let image = rendered.statusImage {
+                    let imageView = NSImageView(image: image)
+                    imageView.imageScaling = .scaleNone
+                    imageView.imageAlignment = .alignLeft
+                    imageView.frame = NSRect(x: 230, y: rowY, width: 420, height: 28)
+                    content.addSubview(imageView)
+                } else {
+                    let field = NSTextField(labelWithAttributedString: rendered.attributedTitle)
+                    field.frame = NSRect(x: 230, y: rowY, width: 420, height: 28)
+                    content.addSubview(field)
+                }
+                receipt[showUsed ? "usedTitle" : "remainingTitle"] = rendered.attributedTitle.string
+                receipt[showUsed ? "usedStatusImage" : "remainingStatusImage"] = rendered.statusImage != nil
+            }
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.5))
+            let capture = Process()
+            capture.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+            capture.arguments = [
+                "-x", "-o", "-l", String(host.windowNumber),
+                output.appendingPathComponent("kimi-\(appearanceName.rawValue).png").path,
+            ]
+            try capture.run()
+            capture.waitUntilExit()
+            XCTAssertEqual(capture.terminationStatus, 0)
+        }
+        try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys, .prettyPrinted])
+            .write(to: output.appendingPathComponent("state.json"), options: .atomic)
+    }
+}

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -1123,6 +1123,18 @@ struct KimiUsageSnapshotConversionTests {
         #expect(monthly.window.usedPercent == 100)
         #expect(monthly.window.windowMinutes == ProviderPaceCapability.monthlyWindowSentinelMinutes)
         #expect(monthly.window.resetsAt == Self.date("2026-07-23T00:00:00Z"))
+
+        let resolution = KimiProviderDescriptor.descriptor.presentation.menuBarWindow(context: .init(
+            metric: .automatic,
+            snapshot: usageSnapshot,
+            supportsAverage: false,
+            prioritizesExhaustedQuotas: false,
+            now: now))
+        guard case let .resolved(window) = resolution else {
+            Issue.record("Kimi automatic usage should resolve the exhausted membership pool")
+            return
+        }
+        #expect(window == monthly.window)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -1,7 +1,7 @@
-import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
 @MainActor
 struct UsageStoreHighestUsageTests {
@@ -84,12 +84,11 @@ struct UsageStoreHighestUsageTests {
         #expect(highest?.usedPercent == 80)
     }
 
-    @Test
-    func `automatic metric uses rate limit for kimi when ranking highest usage`() {
-        let settings = SettingsStore(
-            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-kimi-automatic"),
-            zaiTokenStore: NoopZaiTokenStore(),
-            syntheticTokenStore: NoopSyntheticTokenStore())
+    @Test(arguments: [false, true])
+    func `automatic metric uses rate limit unless kimi membership is exhausted`(monthlyExhausted: Bool) {
+        let settings = testSettingsStore(
+            suiteName: "UsageStoreHighestUsageTests-kimi-automatic",
+            userDefaults: InMemoryUserDefaults())
         settings.refreshFrequency = .manual
         settings.statusChecksEnabled = false
         settings.setMenuBarMetricPreference(.automatic, for: .kimi)
@@ -102,8 +101,20 @@ struct UsageStoreHighestUsageTests {
             settings.setProviderEnabled(provider: .kimi, metadata: kimiMeta, enabled: true)
         }
 
-        let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let browserDetection = BrowserDetection(
+            homeDirectory: "/synthetic-kimi-proof",
+            cacheTTL: 0,
+            now: Date.init,
+            fileExists: { _ in false },
+            directoryContents: { _ in [] },
+            applicationURLs: { _ in [] },
+            profileAccessIssue: { _ in nil })
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: browserDetection,
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
 
         let codexSnapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 70, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
@@ -112,14 +123,20 @@ struct UsageStoreHighestUsageTests {
         let kimiSnapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 90, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
             secondary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            extraRateWindows: [NamedRateWindow(
+                id: "kimi-monthly", title: "Total usage", window: RateWindow(
+                    usedPercent: monthlyExhausted ? 100 : 50,
+                    windowMinutes: ProviderPaceCapability.monthlyWindowSentinelMinutes,
+                    resetsAt: nil,
+                    resetDescription: nil))],
             updatedAt: Date())
 
         store._setSnapshotForTesting(codexSnapshot, provider: .codex)
         store._setSnapshotForTesting(kimiSnapshot, provider: .kimi)
 
         let highest = store.providerWithHighestUsage()
-        #expect(highest?.provider == .codex)
-        #expect(highest?.usedPercent == 70)
+        #expect(highest?.provider == (monthlyExhausted ? .kimi : .codex))
+        #expect(highest?.usedPercent == (monthlyExhausted ? 100 : 70))
     }
 
     @Test

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -21,6 +21,7 @@ Code subscription credentials.
 - Displays membership from the API/CLI usage response, with the active web subscription title as a fallback
 - Detects the installed Kimi CLI version, including standalone installs outside the GUI app PATH
 - Enriches Code API/CLI usage with the monthly membership pool when a web session is available
+- Automatic menu-bar usage prioritizes an exhausted monthly Total usage pool over reset Code windows; explicit window selections remain authoritative
 - API-key, Kimi Code CLI, automatic cookie, and manual cookie authentication methods
 - Automatic refresh countdown
 


### PR DESCRIPTION
When Kimi's monthly membership pool is exhausted but Code's shorter windows have reset, Auto currently shows unused quota. This change includes the existing known `kimi-monthly` window in Kimi's exhausted-window selection, fixing both the menu-bar percentage and highest-usage ranking. Partial, absent, unknown and unrelated extra windows retain their existing behavior; explicit window choices still use the standard resolver.

This extracts the display correction from #3537 and partially addresses #3536. It does not resolve the authentication portion of either report, so both remain open. Thanks @OttoPrua for identifying the monthly-pool issue.

Validation:
- Five regression assertions failed against the unchanged descriptor, across API conversion, automatic selection, the shared status resolver and highest-usage ranking.
- 189 focused tests across 22 suites passed. `make check` reports zero violations across 2,173 Swift files. Independent P0–P2 review is clean.
- Developer-ID-signed native tests ran the actual baseline and fixed production resolver/renderer with identical synthetic quotas. Both used the status-image path in Aqua and Dark Aqua: baseline showed 100% remaining / 0% used; fixed shows 0% remaining / 100% used. Each native run passed with zero failures. Final rebuilt captures are byte-identical to the inspected images below.
- Full `make test` passed all 1,061 selections across 89 groups on the first attempt, with no retries or timeouts (815.3 seconds). [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34528506728) passed every Linux x64, Linux ARM64, musl and macOS check. Merged as `9f4f544a5bf81da276fe94176aa1165c9e296b4b`. The touched ranking fixture now uses in-memory settings and stubbed browser discovery.

Includes provider documentation and an Unreleased changelog entry.

<details>
<summary>Inspected synthetic native before/after proof</summary>

![Before, Light: Kimi automatic monthly usage](https://github.com/user-attachments/assets/5861e2d6-70c6-484e-b977-b26753fefbea)

![Before, Dark: Kimi automatic monthly usage](https://github.com/user-attachments/assets/f6cfc4fb-aa22-4a8c-9213-566cdc1f4cd9)

![After, Light: Kimi automatic monthly usage](https://github.com/user-attachments/assets/7280090c-33e0-4e76-83c1-9b0c646cda84)

![After, Dark: Kimi automatic monthly usage](https://github.com/user-attachments/assets/e77b023e-cb07-4afd-aeb5-a4f296a42194)

</details>
