### PR TITLE
README: add AI Monitor desk display to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ CLI install:
 - [CodexBar Plasma](https://github.com/Lucenx9/codexbar-plasma) — KDE Plasma 6 widget with multi-provider views, account selection, cost history, notifications, configurable providers, and installable `.plasmoid` releases, powered by the bundled Linux CLI.
 - [CodexBar Meter](https://github.com/noctalia-dev/community-plugins/tree/main/codexbar-meter) — Noctalia v5 bar widget and panel showing every enabled provider's quota windows, credits, and pace, installable from Noctalia's plugin store, built on the bundled Linux CLI.
 
+## Desk display
+- [AI Monitor](https://github.com/tobymarks/esp32-ai-monitor) — ESP32 desk display (Cheap Yellow Display) plus a macOS companion app that shows Claude, ChatGPT, Gemini, Copilot, Cursor and Antigravity limits as rings or bars, fed over USB by the bundled CLI. No Wi-Fi on the device, 3D-printable case.
+
 ## Status bar & terminal integration
 - [showy-quota](https://github.com/enieuwy/showy-quota) — always-on AI plan quota strips for SketchyBar, tmux, and Zellij (standalone WASM plugin), built on `codexbar serve` / the bundled CLI.
 - [AI Usage Limits](https://github.com/lenadweb/stream-deck-ai-limits) — Elgato Stream Deck integration for macOS: shows a selected CodexBar provider, account, and configurable quota or payload metrics on keys and Stream Deck+ dials, using local `codexbar serve`.


### PR DESCRIPTION
Adds AI Monitor to the integrations list: an ESP32 desk display (Cheap Yellow Display) with a macOS companion app that shows Claude, ChatGPT, Gemini, Copilot, Cursor and Antigravity limits as rings or bars. It is fed over USB by the bundled CLI, so the device needs no Wi-Fi. Open source (MIT), 3D-printable case, site with photos: https://tobymarks.github.io/esp32-ai-monitor/

![AI Monitor desk display showing ChatGPT weekly limit](https://tobymarks.github.io/esp32-ai-monitor/assets/display-chatgpt-front.jpg)

Thanks for CodexBar, it is what made this project possible.
