### PR TITLE
Recognize unexpired Grok Bot trial usage

### DIFF
--- a/Sources/CodexBarCore/Providers/Cursor/CursorSandUsage.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorSandUsage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Grok Bot (internally "Sand") weekly included usage from Cursor's dashboard.
+/// Grok Bot (internally "Sand") included or trial usage from Cursor's dashboard.
 ///
 /// `POST /api/dashboard/get-sand-usage-status` with the same session cookie as
 /// `/api/usage-summary`. Missing or failed responses must not fail Cursor usage.
@@ -14,28 +14,49 @@ public struct CursorSandUsageStatus: Decodable, Sendable, Equatable {
     public let usagePercent: Double?
     public let hasAvailableUsage: Bool?
     public let hasNonZeroIncludedLimit: Bool?
+    public let sandTrialExpiresAt: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case currentPeriodStart, nextResetTimestampUtc, usagePercent, hasAvailableUsage, hasNonZeroIncludedLimit
+        case sandTrialExpiresAt
+    }
 
     public init(
         currentPeriodStart: String?,
         nextResetTimestampUtc: String?,
         usagePercent: Double?,
         hasAvailableUsage: Bool?,
-        hasNonZeroIncludedLimit: Bool?)
+        hasNonZeroIncludedLimit: Bool?,
+        sandTrialExpiresAt: String? = nil)
     {
         self.currentPeriodStart = currentPeriodStart
         self.nextResetTimestampUtc = nextResetTimestampUtc
         self.usagePercent = usagePercent
         self.hasAvailableUsage = hasAvailableUsage
         self.hasNonZeroIncludedLimit = hasNonZeroIncludedLimit
+        self.sandTrialExpiresAt = sandTrialExpiresAt
     }
 
-    /// Weekly Grok Bot bar, or `nil` when the account has no included Bot allowance.
-    public func extraRateWindow(resetDescription: (Date) -> String) -> NamedRateWindow? {
-        guard self.hasNonZeroIncludedLimit == true, let usagePercent = self.usagePercent else {
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.currentPeriodStart = try container.decodeIfPresent(String.self, forKey: .currentPeriodStart)
+        self.nextResetTimestampUtc = try container.decodeIfPresent(String.self, forKey: .nextResetTimestampUtc)
+        self.usagePercent = try container.decodeIfPresent(Double.self, forKey: .usagePercent)
+        self.hasAvailableUsage = try container.decodeIfPresent(Bool.self, forKey: .hasAvailableUsage)
+        self.hasNonZeroIncludedLimit = try container.decodeIfPresent(Bool.self, forKey: .hasNonZeroIncludedLimit)
+        // An optional trial field must not discard an otherwise valid paid allowance.
+        self.sandTrialExpiresAt = try? container.decodeIfPresent(String.self, forKey: .sandTrialExpiresAt)
+    }
+
+    /// Grok Bot bar, or `nil` when neither an included allowance nor an unexpired trial is reported.
+    public func extraRateWindow(now: Date = .init(), resetDescription: (Date) -> String) -> NamedRateWindow? {
+        let isTrial = Self.parseISO8601(self.sandTrialExpiresAt).map { $0 > now } ?? false
+        guard self.hasNonZeroIncludedLimit == true || isTrial, let usagePercent = self.usagePercent else {
             return nil
         }
-        let start = Self.parseISO8601(self.currentPeriodStart)
-        let resetsAt = Self.parseISO8601(self.nextResetTimestampUtc)
+        // Trial credit expires rather than replenishing; neither reset text nor weekly semantics apply.
+        let start = isTrial ? nil : Self.parseISO8601(self.currentPeriodStart)
+        let resetsAt = isTrial ? nil : Self.parseISO8601(self.nextResetTimestampUtc)
         return NamedRateWindow(
             id: Self.extraWindowID,
             title: Self.extraWindowTitle,

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -469,7 +469,7 @@ public struct CursorStatusSnapshot: Sendable {
     }
 
     /// Convert to UsageSnapshot for the common provider interface
-    public func toUsageSnapshot() -> UsageSnapshot {
+    public func toUsageSnapshot(now: Date = .init()) -> UsageSnapshot {
         let cursorRequests: CursorRequestUsage? = if let used = self.requestsUsed,
                                                      let limit = self.requestsLimit,
                                                      limit > 0
@@ -513,14 +513,14 @@ public struct CursorStatusSnapshot: Sendable {
                 resetDescription: self.billingCycleEnd.map { Self.formatResetDate($0) })
         }
 
-        // Grok Bot is a weekly included allowance on the same Cursor account, not the monthly
+        // Grok Bot is an included or trial allowance on the same Cursor account, not the monthly
         // Total/Cursor/Third Party bars. Hide it on legacy request plans so it cannot sit next
         // to a request quota that does not share that token-based breakdown.
         let extraRateWindows: [NamedRateWindow]? = if cursorRequests != nil {
             nil
         } else {
             self.sandUsage.flatMap { status in
-                status.extraRateWindow(resetDescription: Self.formatResetDate)
+                status.extraRateWindow(now: now, resetDescription: Self.formatResetDate)
             }.map { [$0] }
         }
 
@@ -558,7 +558,7 @@ public struct CursorStatusSnapshot: Sendable {
                 period: "Monthly",
                 resetsAt: self.billingCycleEnd,
                 personalUsed: personalOnDemandUsed,
-                updatedAt: Date())
+                updatedAt: now)
         } else {
             nil
         }
@@ -580,7 +580,7 @@ public struct CursorStatusSnapshot: Sendable {
                     .makeRow(label: "Request quota", value: "\(requests.used) / \(requests.limit)"),
                 ])]
             } ?? [],
-            updatedAt: Date(),
+            updatedAt: now,
             identity: identity)
     }
 

--- a/Tests/CodexBarTests/CursorSandTrialUsageTests.swift
+++ b/Tests/CodexBarTests/CursorSandTrialUsageTests.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct CursorSandTrialUsageTests {
+    private static let now = Date(timeIntervalSince1970: 1_789_084_800) // 2026-09-11T00:00:00Z
+
+    @Test(arguments: [false, true])
+    func `unexpired trial does not require available or included usage`(available: Bool) throws {
+        let status = try Self.decodeTrial(available: available)
+        let extra = try #require(status.extraRateWindow(now: Self.now, resetDescription: { _ in "reset" }))
+
+        #expect(extra.id == CursorSandUsageStatus.extraWindowID)
+        #expect(extra.title == "Grok Bot")
+        #expect(extra.window.usedPercent == 13.55)
+        #expect(extra.window.windowMinutes == nil)
+        #expect(extra.window.resetsAt == nil)
+        #expect(extra.window.resetDescription == nil)
+    }
+
+    @Test
+    func `exhausted unexpired trial stays visible`() throws {
+        let status = try Self.decodeTrial(percent: "100", available: false)
+        let extra = try #require(status.extraRateWindow(now: Self.now, resetDescription: { _ in "reset" }))
+        #expect(extra.window.usedPercent == 100)
+        #expect(extra.window.resetsAt == nil)
+    }
+
+    @Test(arguments: [
+        "null", "42", "{}", "\"invalid\"", "\"2026-09-10T23:59:59Z\"", "\"2026-09-11T00:00:00Z\"",
+    ])
+    func `unavailable trial does not turn available usage into an allowance`(expiry: String) throws {
+        let status = try Self.decodeTrial(expiry: expiry, available: true)
+        #expect(status.extraRateWindow(now: Self.now, resetDescription: { _ in "reset" }) == nil)
+    }
+
+    @Test(arguments: [
+        "null", "42", "{}", "\"invalid\"", "\"2026-09-10T23:59:59Z\"", "\"2026-09-11T00:00:00Z\"",
+    ])
+    func `invalid or ended trial preserves paid weekly allowance`(expiry: String) throws {
+        let status = try Self.decodeTrial(expiry: expiry, included: true)
+        let extra = try #require(status.extraRateWindow(now: Self.now, resetDescription: { _ in "reset" }))
+        #expect(extra.window.usedPercent == 13.55)
+        #expect(extra.window.windowMinutes == 10080)
+        #expect(extra.window.resetsAt != nil)
+        #expect(extra.window.resetDescription == "reset")
+    }
+
+    @Test
+    func `future trial takes precedence over included weekly timing`() throws {
+        let status = try Self.decodeTrial(expiry: "\"2026-09-14T00:00:00.123Z\"", included: true)
+        let extra = try #require(status.extraRateWindow(now: Self.now, resetDescription: { _ in "reset" }))
+        #expect(extra.window.windowMinutes == nil)
+        #expect(extra.window.resetsAt == nil)
+        #expect(extra.window.resetDescription == nil)
+    }
+
+    @Test
+    func `unexpired trial without a percentage stays hidden`() throws {
+        let status = try Self.decodeTrial(percent: "null")
+        #expect(status.extraRateWindow(now: Self.now, resetDescription: { _ in "reset" }) == nil)
+    }
+
+    @Test
+    func `unknown trial objects do not establish eligibility`() throws {
+        let data = Data(#"{"usagePercent":13.55,"hasAvailableUsage":true,"sandTrial":{"active":true}}"#.utf8)
+        let status = try JSONDecoder().decode(CursorSandUsageStatus.self, from: data)
+        #expect(status.extraRateWindow(now: Self.now, resetDescription: { _ in "reset" }) == nil)
+    }
+
+    @Test
+    func `legacy request plan still hides trial usage`() throws {
+        let status = try Self.snapshot(sandUsage: Self.decodeTrial(), requestsUsed: 1, requestsLimit: 50)
+        let snapshot = status.toUsageSnapshot(now: Self.now)
+        #expect(snapshot.primary?.usedPercent == 2)
+        #expect(snapshot.extraRateWindows == nil)
+    }
+
+    @Test(arguments: [13.55, 100.0])
+    func `trial fetch preserves monthly usage without creating weekly semantics`(percent: Double) async throws {
+        // Synthetic REST fixture: the native Grok Bot protocol confirms the field and lifecycle,
+        // but a trial response from the web endpoint still needs independent verification.
+        let session = CursorStatusProbeTestSession { request in
+            let url = try #require(request.url)
+            switch url.path {
+            case "/api/usage-summary":
+                return makeCursorStatusProbeResponse(
+                    url: url,
+                    body: """
+                    {"membershipType":"pro","individualUsage":{"plan":{"used":0,"limit":2000,"totalPercentUsed":0}}}
+                    """,
+                    statusCode: 200)
+            case "/api/auth/me":
+                return makeCursorStatusProbeResponse(url: url, body: "{}", statusCode: 200)
+            case CursorSandUsageStatus.endpointPath:
+                return makeCursorStatusProbeResponse(
+                    url: url,
+                    body: Self.trialJSON(percent: String(percent), available: percent < 100),
+                    statusCode: 200)
+            default:
+                throw URLError(.badURL)
+            }
+        }
+        let status = try await CursorStatusProbe(
+            baseURL: #require(URL(string: "https://cursor.test")),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            urlSession: session.urlSession).fetchWithManualCookies("auth=test")
+        let snapshot = status.toUsageSnapshot(now: Self.now)
+        let extra = try #require(snapshot.extraRateWindows?.first)
+
+        #expect(snapshot.primary?.usedPercent == 0)
+        #expect(snapshot.loginMethod(for: .cursor) == "Cursor Pro")
+        #expect(extra.window.usedPercent == percent)
+        #expect(ProviderUsagePresentation.standardSemanticWindows(snapshot: snapshot).weekly == nil)
+        #expect(ProviderUsagePresentation.standardPlanUtilizationSeries(snapshot: snapshot) == nil)
+        #expect(UsageFormatter.resetLine(for: extra.window, style: .countdown, now: Self.now) == nil)
+    }
+
+    @Test(arguments: [13.55, 100.0])
+    func `automatic metric respects usable monthly subquota alongside trial`(percent: Double) throws {
+        let snapshot = try Self.snapshot(sandUsage: Self.decodeTrial(percent: String(percent)))
+            .toUsageSnapshot(now: Self.now)
+        let selected = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .cursor,
+            snapshot: snapshot,
+            supportsAverage: false,
+            now: Self.now)
+        #expect(selected?.usedPercent == (percent < 100 ? percent : 0))
+    }
+
+    @Test
+    func `trial card retains percentage without promising a reset`() throws {
+        let snapshot = try Self.snapshot(sandUsage: Self.decodeTrial()).toUsageSnapshot(now: Self.now)
+        let model = try UsageMenuCardView.Model.make(.init(
+            provider: .cursor,
+            metadata: #require(ProviderDefaults.metadata[.cursor]),
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: Self.now))
+
+        #expect(model.metrics.map(\.title) == ["Total", "Cursor", "Third Party", "Grok Bot"])
+        #expect(model.metrics.last?.percentLabel == "86% left")
+        #expect(model.metrics.last?.resetText == nil)
+    }
+
+    private static func decodeTrial(
+        expiry: String = "\"2026-09-14T00:00:00Z\"",
+        percent: String = "13.55",
+        available: Bool = true,
+        included: Bool = false) throws -> CursorSandUsageStatus
+    {
+        try JSONDecoder().decode(CursorSandUsageStatus.self, from: Data(self.trialJSON(
+            expiry: expiry, percent: percent, available: available, included: included).utf8))
+    }
+
+    private static func trialJSON(
+        expiry: String = "\"2026-09-14T00:00:00Z\"",
+        percent: String = "13.55",
+        available: Bool = true,
+        included: Bool = false) -> String
+    {
+        """
+        {
+          "currentPeriodStart": "2026-09-07T00:00:00Z",
+          "nextResetTimestampUtc": "2026-09-14T00:00:00Z",
+          "usagePercent": \(percent),
+          "hasAvailableUsage": \(available),
+          "hasNonZeroIncludedLimit": \(included),
+          "sandTrialExpiresAt": \(expiry)
+        }
+        """
+    }
+
+    private static func snapshot(
+        sandUsage: CursorSandUsageStatus,
+        requestsUsed: Int? = nil,
+        requestsLimit: Int? = nil) -> CursorStatusSnapshot
+    {
+        CursorStatusSnapshot(
+            planPercentUsed: 0,
+            autoPercentUsed: 0,
+            apiPercentUsed: 0,
+            planUsedUSD: 0,
+            planLimitUSD: 20,
+            onDemandUsedUSD: 0,
+            onDemandLimitUSD: nil,
+            teamOnDemandUsedUSD: nil,
+            teamOnDemandLimitUSD: nil,
+            billingCycleEnd: nil,
+            membershipType: "pro",
+            accountEmail: nil,
+            accountName: nil,
+            rawJSON: nil,
+            sandUsage: sandUsage,
+            requestsUsed: requestsUsed,
+            requestsLimit: requestsLimit)
+    }
+}

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -73,7 +73,7 @@ Manual option:
 - `GET https://cursor.com/api/usage?user=ID`
   - Legacy request-based plan usage (request counts + limits).
 - `POST https://cursor.com/api/dashboard/get-sand-usage-status`
-  - Grok Bot weekly included usage (`usagePercent`, `nextResetTimestampUtc`). Same session cookie;
+  - Grok Bot usage (`usagePercent`, `nextResetTimestampUtc`, optional `sandTrialExpiresAt`). Same session cookie;
     requires `Origin: https://cursor.com`. Best-effort: a failure leaves Cursor's monthly bars intact.
 
 ## Cookie file paths
@@ -126,14 +126,18 @@ Caching: the app holds the snapshot for an in-memory hourly TTL, keyed by the hi
 - Primary: plan usage percent (included plan).
 - Secondary: Cursor (Cursor models) usage percent.
 - Tertiary: Third Party usage percent.
-- Extra: Grok Bot weekly included usage from `get-sand-usage-status` when the account has a non-zero Bot allowance.
+- Extra: Grok Bot usage from `get-sand-usage-status` when the account has a non-zero Bot allowance or reports
+  a future ISO 8601 `sandTrialExpiresAt`. An exhausted trial remains visible until expiry; `hasAvailableUsage`
+  alone does not establish an allowance. Missing or malformed trial expiry preserves the included-allowance behavior.
 - Provider cost: Extra usage USD. A capped individual budget wins; team accounts without a user cap use the shared team on-demand budget.
-- Reset: billing cycle end date for monthly bars; Grok Bot uses `nextResetTimestampUtc` (weekly).
+- Reset: billing cycle end date for monthly bars; included Grok Bot usage uses `nextResetTimestampUtc` (weekly).
+  An unexpired Grok Bot trial takes precedence over included timing and has no recurring reset metadata,
+  because trial credit expires instead of replenishing. It does not create a weekly utilization series.
 
 ## Key files
 - `Sources/CodexBarCore/Providers/Cursor/CursorAppAuth.swift`
 - `Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift`
-- `Sources/CodexBarCore/Providers/Cursor/CursorSandUsage.swift` (Grok Bot weekly included usage)
+- `Sources/CodexBarCore/Providers/Cursor/CursorSandUsage.swift` (Grok Bot included and trial usage)
 - `Sources/CodexBar/CursorLoginRunner.swift` (login flow)
 - `Sources/CodexBar/Providers/Cursor/CursorLoginFlow.swift` (menu integration)
 - `Sources/CodexBar/CursorLoginBrowserRouter.swift` (browser routing and selection)


### PR DESCRIPTION
Related to #3530.

Cursor's Grok Bot projection currently requires `hasNonZeroIncludedLimit == true`, which hides the reported trial percentage when that flag is false. This draft also accepts a top-level `sandTrialExpiresAt` strictly later than the snapshot time. Exhausted, unexpired trials remain visible; ended or malformed trial data falls back to the existing paid-allowance rule.

Trial windows omit duration and reset metadata. This avoids calling a seven-day expiry a weekly reset or creating a recurring weekly utilization series. Paid weekly windows, monthly Cursor bars, legacy request plans, and authentication/fetch behavior are preserved.

### Draft blocker: verify the web response

The official [Grok Bot 0.47.0 distribution](https://downloads.cursor.com/grokbot/stable/c1e7d7a46549956d25f53e9c0b9f59666e03aa3a/linux/x64/grok-bot_0.47.0_amd64.deb), linked from [Cursor's download page](https://cursor.com/download/bot), confirms a top-level trial-expiry field in the native `GetSandUsageStatus` RPC and uses a strict future-expiry check, independently of usage availability or cancellation eligibility. Its trial presentation takes precedence over included weekly timing.

That native RPC evidence does **not** establish the JSON shape returned by CodexBar's `/api/dashboard/get-sand-usage-status` endpoint. Issue #3530 abbreviates the trial fields as `sandTrial: <active trial data present>`. The new REST fixture is synthetic, and the decoder deliberately does not guess a nested trial schema. A sanitized response from that exact endpoint is needed before marking this ready or claiming #3530 fixed; if the shape differs, the decoder and fixture must be updated.

### Validation

- Focused parser, probe, card-model, and menu-selection tests: 104 tests across six suites passed.
- `make check`: passed, zero lint violations.
- `make test`: all 1,065 selections in 89 groups passed on the first attempt, with no retries or timeouts. Keychain access was suppressed and live-test opt-in was unset.

Focused command (with Keychain and local-session isolation enabled):

```sh
CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 \
CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS=0 \
CODEXBAR_TEST_CODEX_FILE_ISOLATION=1 \
CODEXBAR_TEST_SESSION_FILE_ISOLATION=1 \
swift test --filter 'CursorSand|CursorStatusProbe|CursorMenuCardModel|MenuBarMetricWindowResolver'
```

Coverage includes exhausted trials, exact expiry, expired/malformed expiry, paid timing fallback, trial timing precedence, missing percentage, legacy suppression, stubbed fetch-to-snapshot projection, card reset text, automatic menu selection, and absence of weekly semantic/utilization windows. No live account probe or app-level UI verification was performed.
