### PR TITLE
Add Claude instances for multiple Claude Code profiles

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1105,11 +1105,12 @@ extension UsageMenuCardView.Model {
     }
 
     private static func email(from input: Input) -> String {
-        // Provider-specific by design: claude-swap accountOverride is the display label
-        // (alias or email · org). Other stacked sources keep fetched identity first.
+        // Provider-specific by design: claude-swap and Claude instance accountOverride is the display label
+        // (alias, email · org, or instance name). Other stacked sources keep fetched identity first.
         if input.accountIsAuthoritative,
            input.provider == .claude,
-           input.sourceLabel == ClaudeSwapAccountProjection.sourceLabel,
+           input.sourceLabel == ClaudeSwapAccountProjection.sourceLabel ||
+           input.sourceLabel == ClaudeInstanceAccountProjection.sourceLabel,
            let email = input.account.email, !email.isEmpty
         {
             return email

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -76,8 +76,13 @@ struct ProvidersPane: View {
             onRefresh: {
                 self.triggerRefresh(for: self.provider)
             },
-            showsSupplementarySettingsContent: self.codexAccountsSectionState(for: self.provider) != nil,
+            showsSupplementarySettingsContent: self.codexAccountsSectionState(for: self.provider) != nil ||
+                self.provider == .claude,
             supplementarySettingsContent: {
+                // Provider-specific by design: Claude instances configure extra Claude Code profiles.
+                if self.provider == .claude {
+                    ClaudeInstancesSectionView(settings: self.settings, store: self.store)
+                }
                 if let state = self.codexAccountsSectionState(for: self.provider) {
                     CodexAccountsSectionView(
                         state: state,

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -29,6 +29,8 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         _ = settings.claudeSwapEnabled
         _ = settings.claudeSwapShowSingleAccount
         _ = settings.claudeSwapExecutablePath
+        _ = settings.claudeInstancesEnabled
+        _ = settings.claudeInstances
     }
 
     @MainActor

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderRuntime.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderRuntime.swift
@@ -4,18 +4,23 @@ import CodexBarCore
 final class ClaudeProviderRuntime: ProviderRuntime {
     let id: UsageProvider = .claude
     private var lastSwapConfiguration: Configuration?
+    private var lastInstanceConfiguration: InstanceConfiguration?
 
     func start(context: ProviderRuntimeContext) {
         self.reconcileSwapConfiguration(context: context)
+        self.reconcileInstanceConfiguration(context: context)
     }
 
     func stop(context: ProviderRuntimeContext) {
         self.lastSwapConfiguration = nil
+        self.lastInstanceConfiguration = nil
         context.store.clearClaudeSwapAccountState()
+        context.store.clearClaudeInstanceState()
     }
 
     func settingsDidChange(context: ProviderRuntimeContext) {
         self.reconcileSwapConfiguration(context: context)
+        self.reconcileInstanceConfiguration(context: context)
     }
 
     private func reconcileSwapConfiguration(context: ProviderRuntimeContext) {
@@ -34,9 +39,31 @@ final class ClaudeProviderRuntime: ProviderRuntime {
         context.store.scheduleClaudeSwapAccountRefresh()
     }
 
+    private func reconcileInstanceConfiguration(context: ProviderRuntimeContext) {
+        let configuration = InstanceConfiguration(
+            providerEnabled: context.store.isEnabled(.claude),
+            enabled: context.settings.claudeInstancesEnabled,
+            instances: context.settings.claudeInstances)
+        guard configuration != self.lastInstanceConfiguration else { return }
+        self.lastInstanceConfiguration = configuration
+
+        // Cancel before clearing so a removed or edited instance can never repopulate the menu.
+        context.store.clearClaudeInstanceState()
+        guard configuration.providerEnabled, configuration.enabled, !configuration.instances.isEmpty else {
+            return
+        }
+        context.store.scheduleClaudeInstanceRefresh()
+    }
+
     private struct Configuration: Equatable {
         let providerEnabled: Bool
         let enabled: Bool
         let executablePath: String
+    }
+
+    private struct InstanceConfiguration: Equatable {
+        let providerEnabled: Bool
+        let enabled: Bool
+        let instances: [ClaudeInstanceConfig]
     }
 }

--- a/Sources/CodexBar/Providers/Claude/ClaudeSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeSettingsStore.swift
@@ -62,6 +62,10 @@ extension SettingsStore {
         set {
             self.updateProviderConfig(provider: .claude) { entry in
                 entry.claudeSwapEnabled = newValue
+                // claude-swap and Claude instances both replace the ambient cards, so only one can be on.
+                if newValue, entry.claudeInstancesEnabled == true {
+                    entry.claudeInstancesEnabled = false
+                }
             }
             self.logProviderModeChange(provider: .claude, field: "claudeSwapEnabled", value: String(newValue))
         }
@@ -91,6 +95,34 @@ extension SettingsStore {
                 field: "claudeSwapExecutablePath",
                 value: newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "cleared" : "set")
         }
+    }
+
+    var claudeInstancesEnabled: Bool {
+        get { self.configSnapshot.providerConfig(for: .claude)?.claudeInstancesEnabled ?? false }
+        set {
+            self.updateProviderConfig(provider: .claude) { entry in
+                entry.claudeInstancesEnabled = newValue
+                if newValue, entry.claudeSwapEnabled == true {
+                    entry.claudeSwapEnabled = false
+                }
+            }
+            self.logProviderModeChange(provider: .claude, field: "claudeInstancesEnabled", value: String(newValue))
+        }
+    }
+
+    var claudeInstances: [ClaudeInstanceConfig] {
+        get { self.configSnapshot.providerConfig(for: .claude)?.claudeInstances ?? [] }
+        set {
+            self.updateProviderConfig(provider: .claude) { entry in
+                entry.claudeInstances = newValue.isEmpty ? nil : newValue
+            }
+            self.logProviderModeChange(provider: .claude, field: "claudeInstances", value: String(newValue.count))
+        }
+    }
+
+    /// Config directories whose local logs feed Claude cost history while instances are on.
+    var claudeInstanceCostConfigDirectories: [String] {
+        self.configSnapshot.providerConfig(for: .claude)?.enabledClaudeInstanceConfigDirectories ?? []
     }
 }
 

--- a/Sources/CodexBar/Providers/Claude/PreferencesClaudeInstancesSection.swift
+++ b/Sources/CodexBar/Providers/Claude/PreferencesClaudeInstancesSection.swift
@@ -1,0 +1,239 @@
+import CodexBarCore
+import SwiftUI
+
+/// Editable copy of one instance; changes reach settings only on Save so typing never triggers refreshes.
+struct ClaudeInstanceDraft: Equatable, Identifiable {
+    var id: String
+    var name: String
+    var binaryPath: String
+    var configDirectory: String
+    var environmentText: String
+
+    init(instance: ClaudeInstanceConfig) {
+        self.id = instance.id
+        self.name = instance.name
+        self.binaryPath = instance.binaryPath ?? ""
+        self.configDirectory = instance.configDirectory
+        self.environmentText = ClaudeInstanceEnvironment.formatVariables(instance.environment)
+    }
+
+    static func new() -> ClaudeInstanceDraft {
+        ClaudeInstanceDraft(instance: ClaudeInstanceConfig(name: "", configDirectory: ""))
+    }
+
+    var hasValidConfigDirectory: Bool {
+        ClaudeInstanceEnvironment.normalizedAbsolutePath(self.configDirectory) != nil
+    }
+
+    var hasValidBinaryPath: Bool {
+        let trimmed = self.binaryPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty || ClaudeInstanceEnvironment.normalizedAbsolutePath(trimmed) != nil
+    }
+
+    var canSave: Bool {
+        self.hasValidConfigDirectory && self.hasValidBinaryPath
+    }
+
+    func makeInstance() -> ClaudeInstanceConfig? {
+        guard let configDirectory = ClaudeInstanceEnvironment.normalizedAbsolutePath(self.configDirectory),
+              self.hasValidBinaryPath
+        else { return nil }
+        let variables = ClaudeInstanceEnvironment.sanitizedVariables(
+            ClaudeInstanceEnvironment.parseVariables(self.environmentText))
+        return ClaudeInstanceConfig(
+            id: self.id,
+            name: self.name.trimmingCharacters(in: .whitespacesAndNewlines),
+            binaryPath: ClaudeInstanceEnvironment.normalizedAbsolutePath(self.binaryPath),
+            configDirectory: configDirectory,
+            environment: variables.isEmpty ? nil : variables)
+    }
+}
+
+extension SettingsStore {
+    /// Inserts a new instance or replaces the one with the same ID, keeping list order.
+    func saveClaudeInstance(_ instance: ClaudeInstanceConfig) {
+        var instances = self.claudeInstances
+        if let index = instances.firstIndex(where: { $0.id == instance.id }) {
+            instances[index] = instance
+        } else {
+            instances.append(instance)
+        }
+        self.claudeInstances = instances
+    }
+
+    func removeClaudeInstance(id: String) {
+        self.claudeInstances = self.claudeInstances.filter { $0.id != id }
+    }
+}
+
+@MainActor
+struct ClaudeInstancesSectionView: View {
+    @Bindable var settings: SettingsStore
+    @Bindable var store: UsageStore
+    @State private var editingDraft: ClaudeInstanceDraft?
+
+    var body: some View {
+        Section {
+            Toggle(isOn: self.$settings.claudeInstancesEnabled) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("Show Claude instances"))
+                    Text(L("claude_instances_toggle_subtitle"))
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            ForEach(Array(self.settings.claudeInstances.enumerated()), id: \.element.id) { index, instance in
+                ClaudeInstanceRowView(
+                    title: ClaudeInstanceAccountProjection.displayLabel(for: instance, index: index),
+                    configDirectory: instance.normalizedConfigDirectory ?? instance.configDirectory,
+                    status: self.status(for: instance),
+                    onEdit: { self.editingDraft = ClaudeInstanceDraft(instance: instance) },
+                    onRemove: { self.settings.removeClaudeInstance(id: instance.id) })
+            }
+
+            Button(L("Add Instance")) {
+                self.editingDraft = .new()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        } header: {
+            Text(L("Claude instances"))
+        }
+        .sheet(item: self.$editingDraft) { draft in
+            ClaudeInstanceEditorView(
+                draft: draft,
+                onSave: { instance in
+                    self.settings.saveClaudeInstance(instance)
+                    self.editingDraft = nil
+                },
+                onCancel: { self.editingDraft = nil })
+        }
+    }
+
+    private func status(for instance: ClaudeInstanceConfig) -> (text: String, isError: Bool)? {
+        guard self.settings.claudeInstancesEnabled else { return nil }
+        let id = ClaudeInstanceAccountProjection.identity(for: instance)
+        guard let account = self.store.claudeInstanceAccountSnapshots.first(where: { $0.id == id }) else {
+            return nil
+        }
+        if let error = account.error {
+            return (error, true)
+        }
+        guard let updatedAt = account.snapshot?.updatedAt else { return nil }
+        return (String(format: L("Updated %@"), updatedAt.relativeDescription()), false)
+    }
+}
+
+private struct ClaudeInstanceRowView: View {
+    let title: String
+    let configDirectory: String
+    let status: (text: String, isError: Bool)?
+    let onEdit: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(self.title)
+                    .font(.subheadline.weight(.semibold))
+                Text(self.configDirectory)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if let status {
+                    Text(status.text)
+                        .font(.caption)
+                        .foregroundStyle(status.isError ? .orange : .secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            Button(L("Edit")) {
+                self.onEdit()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+
+            Button(L("Remove")) {
+                self.onRemove()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+}
+
+private struct ClaudeInstanceEditorView: View {
+    @State var draft: ClaudeInstanceDraft
+    let onSave: (ClaudeInstanceConfig) -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Form {
+                TextField(L("Name"), text: self.$draft.name)
+                self.field(
+                    title: L("Binary path"),
+                    text: self.$draft.binaryPath,
+                    prompt: "claude",
+                    footnote: L("claude_instance_binary_footnote"),
+                    isValid: self.draft.hasValidBinaryPath)
+                self.field(
+                    title: L("CLAUDE_CONFIG_DIR path"),
+                    text: self.$draft.configDirectory,
+                    prompt: "~/.claude-work",
+                    footnote: L("claude_instance_config_dir_footnote"),
+                    isValid: self.draft.configDirectory.isEmpty || self.draft.hasValidConfigDirectory)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(L("Environment"))
+                    TextEditor(text: self.$draft.environmentText)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(minHeight: 70)
+                    Text(L("claude_instance_environment_footnote"))
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .formStyle(.grouped)
+
+            HStack {
+                Spacer()
+                Button(L("cancel"), role: .cancel) {
+                    self.onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+                Button(L("Save")) {
+                    if let instance = self.draft.makeInstance() {
+                        self.onSave(instance)
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!self.draft.canSave)
+            }
+            .padding([.horizontal, .bottom])
+        }
+        .frame(width: 460)
+    }
+
+    private func field(
+        title: String,
+        text: Binding<String>,
+        prompt: String,
+        footnote: String,
+        isValid: Bool) -> some View
+    {
+        VStack(alignment: .leading, spacing: 4) {
+            TextField(title, text: text, prompt: Text(prompt))
+            Text(isValid ? footnote : L("Use an absolute path or a path starting with ~."))
+                .font(.footnote)
+                .foregroundStyle(isValid ? Color.secondary : Color.orange)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}

--- a/Sources/CodexBar/Providers/Claude/StatusItemController+ClaudeInstanceMenu.swift
+++ b/Sources/CodexBar/Providers/Claude/StatusItemController+ClaudeInstanceMenu.swift
@@ -1,0 +1,125 @@
+import AppKit
+import CodexBarCore
+
+extension StatusItemController {
+    /// Renders claude-swap rows, else Claude instance cards, when either owns Claude account presentation.
+    /// Returns false when neither applies and the caller should continue with token-account or ambient cards.
+    func addClaudeAccountSourceMenuCards(
+        to menu: NSMenu,
+        captureMenu: NSMenu,
+        context: MenuCardContext) -> Bool
+    {
+        if ClaudeSwapMenuPrecedence.prefersClaudeSwap(
+            provider: context.currentProvider,
+            accountCount: self.store.claudeSwapAccountSnapshots.count,
+            showSingleAccount: self.settings.claudeSwapShowSingleAccount)
+        {
+            self.addClaudeSwapMenuCards(to: menu, captureMenu: captureMenu, context: context)
+            return true
+        }
+        if ClaudeSwapMenuPrecedence.prefersClaudeInstances(
+            provider: context.currentProvider,
+            instancesOwnPresentation: self.store.claudeInstancesOwnAccountPresentation)
+        {
+            self.addClaudeInstanceMenuCards(to: menu, captureMenu: captureMenu, context: context)
+            return true
+        }
+        return false
+    }
+
+    func addClaudeInstanceMenuCards(
+        to menu: NSMenu,
+        captureMenu: NSMenu,
+        context: MenuCardContext)
+    {
+        let accounts = self.store.claudeInstanceAccountSnapshots
+        if self.settings.multiAccountMenuLayout == .segmented, accounts.count > 1 {
+            let selectedID = accounts.first { $0.id == self.claudeInstanceInspectedAccountID }?.id ?? accounts[0].id
+            let item = NSMenuItem()
+            // Instances have no source-owned active account; the switcher highlights the inspected instance.
+            // Instance names are user-chosen labels, so they stay visible when personal info is hidden.
+            item.view = ClaudeSwapAccountSwitcherView(
+                display: ClaudeSwapAccountMenuDisplay(
+                    accounts: accounts.map { Self.claudeInstanceSwitcherAccount($0, selectedID: selectedID) },
+                    layout: .segmented,
+                    switchingAccountID: nil,
+                    errorAccountID: nil),
+                hidePersonalInfo: false,
+                width: context.menuWidth,
+                onSelect: { [weak self, weak captureMenu] id in
+                    self?.handleClaudeInstanceSelection(id, menu: captureMenu)
+                })
+            item.isEnabled = false
+            menu.addItem(item)
+            menu.addItem(.separator())
+            if let account = accounts.first(where: { $0.id == selectedID }) {
+                self.addStackedClaudeInstanceMenuCards(accounts: [account], to: menu, context: context)
+            }
+            return
+        }
+        let plan = self.compactAccountPlan(for: .claude, accounts: accounts)
+        guard plan.usesCompactLayout else {
+            self.addStackedClaudeInstanceMenuCards(accounts: accounts, to: menu, context: context)
+            return
+        }
+        self.addCompactAccountMenuRows(
+            CompactAccountMenuRendering(
+                plan: plan,
+                accounts: accounts,
+                idPrefix: "claudeInstance",
+                cardModel: { [weak self] account in
+                    self?.claudeInstanceCardModel(for: account)
+                },
+                planAction: nil),
+            to: menu,
+            captureMenu: captureMenu,
+            context: context)
+    }
+
+    func handleClaudeInstanceSelection(_ id: ProviderAccountIdentity, menu: NSMenu?) {
+        guard self.store.claudeInstanceAccountSnapshots.contains(where: { $0.id == id }) else { return }
+        self.advanceMenuInteraction(for: menu)
+        self.claudeInstanceInspectedAccountID = id
+        self.invalidateMenus()
+        if let menu {
+            self.deferSwitcherMenuRebuildIfStillVisible(menu, provider: .claude)
+        }
+    }
+
+    private func addStackedClaudeInstanceMenuCards(
+        accounts: [ProviderAccountUsageSnapshot],
+        to menu: NSMenu,
+        context: MenuCardContext)
+    {
+        self.addStackedMenuCards(
+            accounts.compactMap { self.claudeInstanceCardModel(for: $0) },
+            to: menu,
+            context: context)
+    }
+
+    private func claudeInstanceCardModel(for account: ProviderAccountUsageSnapshot) -> UsageMenuCardView.Model? {
+        let label = [account.displayLabel, account.accountEmail].compactMap(\.self).joined(separator: " · ")
+        return self.menuCardModel(
+            for: .claude,
+            snapshotOverride: account.snapshot,
+            errorOverride: account.error,
+            forceOverrideCard: account.snapshot == nil,
+            accountOverride: AccountInfo(email: label, plan: nil),
+            sourceLabelOverride: ClaudeInstanceAccountProjection.sourceLabel)
+    }
+
+    private static func claudeInstanceSwitcherAccount(
+        _ account: ProviderAccountUsageSnapshot,
+        selectedID: ProviderAccountIdentity) -> ProviderAccountUsageSnapshot
+    {
+        ProviderAccountUsageSnapshot(
+            id: account.id,
+            provider: account.provider,
+            displayLabel: account.displayLabel,
+            accountEmail: account.accountEmail,
+            isActive: account.id == selectedID,
+            snapshot: account.snapshot,
+            error: account.error,
+            sourceLabel: account.sourceLabel)
+    }
+}

--- a/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeInstancesRefresh.swift
+++ b/Sources/CodexBar/Providers/Claude/UsageStore+ClaudeInstancesRefresh.swift
@@ -1,0 +1,159 @@
+import CodexBarCore
+import Foundation
+
+typealias ClaudeInstanceUsageLoader = @Sendable (ClaudeInstanceConfig) async throws -> UsageSnapshot
+
+/// Observed instance-card state, kept in one stored `UsageStore` property.
+struct ClaudeInstanceState {
+    var accountSnapshots: [ProviderAccountUsageSnapshot] = []
+    var revision: UInt64 = 0
+    var lastRefreshAt: Date?
+}
+
+/// Unobserved refresh plumbing for instance cards.
+struct ClaudeInstanceRefreshHandle {
+    var task: Task<Void, Never>?
+    #if DEBUG
+    var usageLoaderOverride: ClaudeInstanceUsageLoader?
+    #endif
+}
+
+extension UsageStore {
+    var claudeInstanceAccountSnapshots: [ProviderAccountUsageSnapshot] {
+        get { self.claudeInstanceState.accountSnapshots }
+        set { self.claudeInstanceState.accountSnapshots = newValue }
+    }
+
+    var claudeInstanceRevision: UInt64 {
+        get { self.claudeInstanceState.revision }
+        set { self.claudeInstanceState.revision = newValue }
+    }
+
+    var claudeInstanceLastRefreshAt: Date? {
+        get { self.claudeInstanceState.lastRefreshAt }
+        set { self.claudeInstanceState.lastRefreshAt = newValue }
+    }
+
+    var claudeInstanceRefreshTask: Task<Void, Never>? {
+        get { self.claudeInstanceRefresh.task }
+        set { self.claudeInstanceRefresh.task = newValue }
+    }
+
+    #if DEBUG
+    var claudeInstanceUsageLoaderOverride: ClaudeInstanceUsageLoader? {
+        get { self.claudeInstanceRefresh.usageLoaderOverride }
+        set { self.claudeInstanceRefresh.usageLoaderOverride = newValue }
+    }
+    #endif
+
+    /// claude-swap first, then Claude instances; nil keeps the ambient Claude snapshot.
+    func claudeAccountSourceMenuBarSnapshotOverride(for instanceID: ProviderInstanceID) -> UsageSnapshot? {
+        self.claudeSwapMenuBarSnapshotOverride(for: instanceID)
+            ?? self.claudeInstanceMenuBarSnapshotOverride(for: instanceID)
+    }
+}
+
+extension UsageStore {
+    func shouldFetchClaudeInstances() -> Bool {
+        self.isEnabled(.claude) && self.settings.claudeInstancesEnabled && !self.settings.claudeInstances.isEmpty
+    }
+
+    /// Instance cards replace the ambient Claude card once the feature is on and any instance has reported.
+    var claudeInstancesOwnAccountPresentation: Bool {
+        self.settings.claudeInstancesEnabled && !self.claudeInstanceAccountSnapshots.isEmpty
+    }
+
+    /// The first instance with usable usage drives the menu bar so the indicator agrees with the menu cards.
+    func claudeInstanceMenuBarSnapshotOverride(for instanceID: ProviderInstanceID) -> UsageSnapshot? {
+        guard instanceID == UsageProvider.claude.instanceID, self.claudeInstancesOwnAccountPresentation else {
+            return nil
+        }
+        return self.claudeInstanceAccountSnapshots.lazy.compactMap(\.snapshot).first
+    }
+
+    func clearClaudeInstanceState() {
+        let hadState = !self.claudeInstanceAccountSnapshots.isEmpty || self.claudeInstanceLastRefreshAt != nil
+        self.claudeInstanceRefreshTask?.cancel()
+        self.claudeInstanceRefreshTask = nil
+        self.claudeInstanceAccountSnapshots = []
+        self.claudeInstanceLastRefreshAt = nil
+        if hadState {
+            self.claudeInstanceRevision &+= 1
+        }
+    }
+
+    /// Runs separately from the ambient Claude refresh so slow instance probes never delay it.
+    func scheduleClaudeInstanceRefresh(generation: UInt64? = nil) {
+        self.claudeInstanceRefreshTask?.cancel()
+        guard self.shouldFetchClaudeInstances() else {
+            self.clearClaudeInstanceState()
+            return
+        }
+
+        self.claudeInstanceRefreshTask = Task { @MainActor [weak self] in
+            await self?.refreshClaudeInstances(generation: generation)
+        }
+    }
+
+    /// Probes run one at a time: the shared Claude CLI session relaunches for each profile, and overlapping probes
+    /// would tear down each other's session. Each finished instance is published immediately.
+    func refreshClaudeInstances(generation: UInt64? = nil) async {
+        let instances = self.settings.claudeInstances
+        let loader = self.claudeInstanceUsageLoader()
+        let previousByID = Dictionary(
+            self.claudeInstanceAccountSnapshots.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first })
+        var refreshedByID: [ProviderAccountIdentity: ProviderAccountUsageSnapshot] = [:]
+
+        for (index, instance) in instances.enumerated() {
+            let result: Result<UsageSnapshot, Error>
+            do {
+                result = try await .success(loader(instance))
+            } catch is CancellationError {
+                return
+            } catch {
+                result = .failure(error)
+            }
+            guard !Task.isCancelled,
+                  self.isCurrentClaudeInstanceRefresh(instances: instances, generation: generation)
+            else { return }
+
+            let id = ClaudeInstanceAccountProjection.identity(for: instance)
+            refreshedByID[id] = ClaudeInstanceAccountProjection.accountSnapshot(
+                for: instance,
+                index: index,
+                result: result,
+                previous: previousByID[id])
+            self.claudeInstanceAccountSnapshots = instances.compactMap { instance in
+                let id = ClaudeInstanceAccountProjection.identity(for: instance)
+                return refreshedByID[id] ?? previousByID[id]
+            }
+            self.claudeInstanceRevision &+= 1
+        }
+        self.claudeInstanceLastRefreshAt = Date()
+    }
+
+    private func claudeInstanceUsageLoader() -> ClaudeInstanceUsageLoader {
+        #if DEBUG
+        if let override = self.claudeInstanceUsageLoaderOverride {
+            return override
+        }
+        #endif
+        let baseEnvironment = self.environmentBase
+        let browserDetection = self.browserDetection
+        let keepCLISessionsAlive = self.settings.debugKeepCLISessionsAlive
+        return { instance in
+            try await ClaudeInstanceUsageFetcher.fetchUsage(
+                for: instance,
+                baseEnvironment: baseEnvironment,
+                browserDetection: browserDetection,
+                keepCLISessionsAlive: keepCLISessionsAlive)
+        }
+    }
+
+    private func isCurrentClaudeInstanceRefresh(instances: [ClaudeInstanceConfig], generation: UInt64?) -> Bool {
+        self.isCurrentProviderRefreshGeneration(.claude, generation: generation) &&
+            self.isEnabled(.claude) && self.settings.claudeInstancesEnabled &&
+            self.settings.claudeInstances == instances
+    }
+}

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1554,3 +1554,18 @@
 "Color Pace Indicator" = "تلوين وتيرة الاستخدام";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "أخضر عندما يكون الاستخدام أبطأ من الوتيرة المتوقعة (احتياطي)؛ وأحمر عندما يكون أسرع (خطر النفاد مبكرًا).";
 "%@ weekly" = "%@ أسبوعيًا";
+
+"Claude instances" = "نسخ Claude";
+"Show Claude instances" = "إظهار نسخ Claude";
+"claude_instances_toggle_subtitle" = "يعرض بطاقة واحدة لكل ملف تعريف Claude Code، تُقرأ عبر Claude CLI الخاص بذلك الملف. يحل محل بطاقة Claude ويوقف claude-swap.";
+"Add Instance" = "إضافة نسخة";
+"Edit" = "تعديل";
+"Name" = "الاسم";
+"Binary path" = "مسار الملف الثنائي";
+"claude_instance_binary_footnote" = "مسار الملف الثنائي claude لهذه النسخة. اتركه فارغًا لاستخدام البحث المعتاد عن claude.";
+"CLAUDE_CONFIG_DIR path" = "مسار CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "مجلد إعدادات Claude Code لملف التعريف هذا. لا يقرأ CodexBar بيانات اعتماده أبدًا.";
+"Environment" = "البيئة";
+"claude_instance_environment_footnote" = "KEY=value واحد في كل سطر. يُخزَّن كنص عادي في ملف إعدادات CodexBar؛ ويتم تجاهل متغيرات تسجيل الدخول مثل ANTHROPIC_* ورموز OAuth.";
+"Save" = "حفظ";
+"Use an absolute path or a path starting with ~." = "استخدم مسارًا مطلقًا أو مسارًا يبدأ بـ ~.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -1552,3 +1552,18 @@
 "Color Pace Indicator" = "Acoloreix el ritme";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verd quan l’ús va per sota del ritme previst (reserva); vermell quan va per sobre (risc d’esgotar la quota abans d’hora).";
 "%@ weekly" = "%@ setmanal";
+
+"Claude instances" = "Instàncies de Claude";
+"Show Claude instances" = "Mostra les instàncies de Claude";
+"claude_instances_toggle_subtitle" = "Mostra una targeta per cada perfil de Claude Code, llegida a través de la Claude CLI pròpia d'aquest perfil. Substitueix la targeta de Claude i desactiva claude-swap.";
+"Add Instance" = "Afegiu instància";
+"Edit" = "Editeu";
+"Name" = "Nom";
+"Binary path" = "Camí del binari";
+"claude_instance_binary_footnote" = "Camí al binari claude per a aquesta instància. Deixeu-ho en blanc per utilitzar la cerca habitual de claude.";
+"CLAUDE_CONFIG_DIR path" = "Camí de CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Directori de configuració de Claude Code per a aquest perfil. El CodexBar mai no llegeix les seves credencials.";
+"Environment" = "Entorn";
+"claude_instance_environment_footnote" = "Un KEY=value per línia. Es desa en text pla al fitxer de configuració del CodexBar; les variables d'inici de sessió com ANTHROPIC_* i els testimonis OAuth s'ignoren.";
+"Save" = "Deseu";
+"Use an absolute path or a path starting with ~." = "Utilitzeu un camí absolut o un camí que comenci per ~.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1550,3 +1550,18 @@
 "Color Pace Indicator" = "Nutzungstempo einfärben";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Grün bei langsamerem Verbrauch als erwartet (Reserve); Rot bei schnellerem Verbrauch (Risiko einer vorzeitigen Ausschöpfung).";
 "%@ weekly" = "%@ wöchentlich";
+
+"Claude instances" = "Claude-Instanzen";
+"Show Claude instances" = "Claude-Instanzen anzeigen";
+"claude_instances_toggle_subtitle" = "Zeigt eine Karte pro Claude Code-Profil, gelesen über die eigene Claude CLI des jeweiligen Profils. Ersetzt die Claude-Karte und deaktiviert claude-swap.";
+"Add Instance" = "Instanz hinzufügen";
+"Edit" = "Bearbeiten";
+"Name" = "Name";
+"Binary path" = "Pfad zur Binärdatei";
+"claude_instance_binary_footnote" = "Pfad zur claude-Binärdatei für diese Instanz. Leer lassen, um die normale claude-Suche zu verwenden.";
+"CLAUDE_CONFIG_DIR path" = "CLAUDE_CONFIG_DIR-Pfad";
+"claude_instance_config_dir_footnote" = "Claude Code-Konfigurationsverzeichnis für dieses Profil. CodexBar liest niemals dessen Anmeldedaten.";
+"Environment" = "Umgebung";
+"claude_instance_environment_footnote" = "Ein KEY=value pro Zeile. Wird im Klartext in der CodexBar-Konfigurationsdatei gespeichert; Anmeldevariablen wie ANTHROPIC_* und OAuth-Tokens werden ignoriert.";
+"Save" = "Speichern";
+"Use an absolute path or a path starting with ~." = "Verwenden Sie einen absoluten Pfad oder einen Pfad, der mit ~ beginnt.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1553,3 +1553,18 @@
 "Color Pace Indicator" = "Color Pace Indicator";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)";
 "%@ weekly" = "%@ weekly";
+
+"Claude instances" = "Claude instances";
+"Show Claude instances" = "Show Claude instances";
+"claude_instances_toggle_subtitle" = "Shows one card per Claude Code profile, read through that profile's own Claude CLI. Replaces the Claude card and turns off claude-swap.";
+"Add Instance" = "Add Instance";
+"Edit" = "Edit";
+"Name" = "Name";
+"Binary path" = "Binary path";
+"claude_instance_binary_footnote" = "Path to the claude binary for this instance. Leave empty to use the normal claude lookup.";
+"CLAUDE_CONFIG_DIR path" = "CLAUDE_CONFIG_DIR path";
+"claude_instance_config_dir_footnote" = "Claude Code config directory for this profile. CodexBar never reads its credentials.";
+"Environment" = "Environment";
+"claude_instance_environment_footnote" = "One KEY=value per line. Stored in plain text in CodexBar's config file; login variables such as ANTHROPIC_* and OAuth tokens are ignored.";
+"Save" = "Save";
+"Use an absolute path or a path starting with ~." = "Use an absolute path or a path starting with ~.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -1548,3 +1548,18 @@
 "Color Pace Indicator" = "Colorear el ritmo";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verde cuando el uso va por debajo del ritmo previsto (reserva); rojo cuando va por encima (riesgo de agotar la cuota antes de tiempo).";
 "%@ weekly" = "%@ semanal";
+
+"Claude instances" = "Instancias de Claude";
+"Show Claude instances" = "Mostrar instancias de Claude";
+"claude_instances_toggle_subtitle" = "Muestra una tarjeta por cada perfil de Claude Code, leída a través de la propia Claude CLI de ese perfil. Sustituye la tarjeta de Claude y desactiva claude-swap.";
+"Add Instance" = "Añadir instancia";
+"Edit" = "Editar";
+"Name" = "Nombre";
+"Binary path" = "Ruta del binario";
+"claude_instance_binary_footnote" = "Ruta al binario claude para esta instancia. Déjalo vacío para usar la búsqueda habitual de claude.";
+"CLAUDE_CONFIG_DIR path" = "Ruta de CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Directorio de configuración de Claude Code para este perfil. CodexBar nunca lee sus credenciales.";
+"Environment" = "Entorno";
+"claude_instance_environment_footnote" = "Un KEY=value por línea. Se almacena en texto plano en el archivo de configuración de CodexBar; las variables de inicio de sesión como ANTHROPIC_* y los tokens de OAuth se ignoran.";
+"Save" = "Guardar";
+"Use an absolute path or a path starting with ~." = "Usa una ruta absoluta o una ruta que empiece por ~.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1554,3 +1554,18 @@
 "Color Pace Indicator" = "رنگ‌بندی آهنگ مصرف";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "سبز وقتی مصرف از آهنگ مورد انتظار عقب‌تر است (ذخیره)؛ قرمز وقتی جلوتر است (خطر تمام شدن زودهنگام سهمیه).";
 "%@ weekly" = "%@ هفتگی";
+
+"Claude instances" = "نمونه‌های Claude";
+"Show Claude instances" = "نمایش نمونه‌های Claude";
+"claude_instances_toggle_subtitle" = "برای هر نمایه Claude Code یک کارت نشان می‌دهد که از طریق Claude CLI همان نمایه خوانده می‌شود. جایگزین کارت Claude می‌شود و claude-swap را خاموش می‌کند.";
+"Add Instance" = "افزودن نمونه";
+"Edit" = "ویرایش";
+"Name" = "نام";
+"Binary path" = "مسیر فایل دودویی";
+"claude_instance_binary_footnote" = "مسیر فایل دودویی claude برای این نمونه. برای استفاده از جستجوی معمول claude خالی بگذارید.";
+"CLAUDE_CONFIG_DIR path" = "مسیر CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "پوشهٔ پیکربندی Claude Code برای این نمایه. CodexBar هرگز اطلاعات ورود آن را نمی‌خواند.";
+"Environment" = "محیط";
+"claude_instance_environment_footnote" = "در هر خط یک KEY=value. به صورت متن ساده در فایل پیکربندی CodexBar ذخیره می‌شود؛ متغیرهای ورود مانند ANTHROPIC_* و توکن‌های OAuth نادیده گرفته می‌شوند.";
+"Save" = "ذخیره";
+"Use an absolute path or a path starting with ~." = "از یک مسیر مطلق یا مسیری که با ~ شروع می‌شود استفاده کنید.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1549,3 +1549,18 @@
 "Color Pace Indicator" = "Colorer le rythme";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Vert si la consommation est inférieure au rythme prévu (réserve) ; rouge si elle est supérieure (risque d’épuisement anticipé).";
 "%@ weekly" = "%@ hebdomadaire";
+
+"Claude instances" = "Instances Claude";
+"Show Claude instances" = "Afficher les instances Claude";
+"claude_instances_toggle_subtitle" = "Affiche une carte par profil Claude Code, lue via la Claude CLI propre à ce profil. Remplace la carte Claude et désactive claude-swap.";
+"Add Instance" = "Ajouter une instance";
+"Edit" = "Modifier";
+"Name" = "Nom";
+"Binary path" = "Chemin du binaire";
+"claude_instance_binary_footnote" = "Chemin vers le binaire claude pour cette instance. Laissez vide pour utiliser la recherche habituelle de claude.";
+"CLAUDE_CONFIG_DIR path" = "Chemin CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Répertoire de configuration de Claude Code pour ce profil. CodexBar ne lit jamais ses identifiants.";
+"Environment" = "Environnement";
+"claude_instance_environment_footnote" = "Un KEY=value par ligne. Stocké en texte brut dans le fichier de configuration de CodexBar ; les variables de connexion comme ANTHROPIC_* et les jetons OAuth sont ignorés.";
+"Save" = "Enregistrer";
+"Use an absolute path or a path starting with ~." = "Utilisez un chemin absolu ou un chemin commençant par ~.";

--- a/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/gl.lproj/Localizable.strings
@@ -1549,3 +1549,18 @@
 "Color Pace Indicator" = "Colorear o ritmo";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verde cando o uso vai por debaixo do ritmo previsto (reserva); vermello cando vai por riba (risco de esgotar a cota antes de tempo).";
 "%@ weekly" = "%@ semanal";
+
+"Claude instances" = "Instancias de Claude";
+"Show Claude instances" = "Mostrar instancias de Claude";
+"claude_instances_toggle_subtitle" = "Mostra unha tarxeta por cada perfil de Claude Code, lida a través da propia Claude CLI dese perfil. Substitúe a tarxeta de Claude e desactiva claude-swap.";
+"Add Instance" = "Engadir instancia";
+"Edit" = "Editar";
+"Name" = "Nome";
+"Binary path" = "Ruta do binario";
+"claude_instance_binary_footnote" = "Ruta ao binario claude para esta instancia. Déixao en branco para usar a busca habitual de claude.";
+"CLAUDE_CONFIG_DIR path" = "Ruta de CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Directorio de configuración de Claude Code para este perfil. CodexBar nunca le as súas credenciais.";
+"Environment" = "Contorno";
+"claude_instance_environment_footnote" = "Un KEY=value por liña. Gárdase en texto sen formato no ficheiro de configuración de CodexBar; ignóranse as variables de inicio de sesión como ANTHROPIC_* e os tokens de OAuth.";
+"Save" = "Gardar";
+"Use an absolute path or a path starting with ~." = "Usa unha ruta absoluta ou unha ruta que comece por ~.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1553,3 +1553,18 @@
 "Color Pace Indicator" = "Warnai laju penggunaan";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Hijau saat penggunaan lebih lambat dari laju perkiraan (cadangan); merah saat lebih cepat (risiko kuota habis lebih awal).";
 "%@ weekly" = "%@ mingguan";
+
+"Claude instances" = "Instans Claude";
+"Show Claude instances" = "Tampilkan instans Claude";
+"claude_instances_toggle_subtitle" = "Menampilkan satu kartu per profil Claude Code, dibaca melalui Claude CLI milik profil tersebut. Menggantikan kartu Claude dan menonaktifkan claude-swap.";
+"Add Instance" = "Tambah Instans";
+"Edit" = "Edit";
+"Name" = "Nama";
+"Binary path" = "Path biner";
+"claude_instance_binary_footnote" = "Path ke biner claude untuk instans ini. Biarkan kosong untuk menggunakan pencarian claude biasa.";
+"CLAUDE_CONFIG_DIR path" = "Path CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Direktori konfigurasi Claude Code untuk profil ini. CodexBar tidak pernah membaca kredensialnya.";
+"Environment" = "Lingkungan";
+"claude_instance_environment_footnote" = "Satu KEY=value per baris. Disimpan sebagai teks biasa dalam file konfigurasi CodexBar; variabel login seperti ANTHROPIC_* dan token OAuth diabaikan.";
+"Save" = "Simpan";
+"Use an absolute path or a path starting with ~." = "Gunakan path absolut atau path yang diawali dengan ~.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1553,3 +1553,18 @@
 "Color Pace Indicator" = "Colora il ritmo";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verde quando il consumo è inferiore al ritmo previsto (riserva); rosso quando è superiore (rischio di esaurimento anticipato).";
 "%@ weekly" = "%@ settimanale";
+
+"Claude instances" = "Istanze Claude";
+"Show Claude instances" = "Mostra istanze Claude";
+"claude_instances_toggle_subtitle" = "Mostra una scheda per ogni profilo Claude Code, letta tramite la Claude CLI di quel profilo. Sostituisce la scheda Claude e disattiva claude-swap.";
+"Add Instance" = "Aggiungi istanza";
+"Edit" = "Modifica";
+"Name" = "Nome";
+"Binary path" = "Percorso del binario";
+"claude_instance_binary_footnote" = "Percorso del binario claude per questa istanza. Lascia vuoto per usare la normale ricerca di claude.";
+"CLAUDE_CONFIG_DIR path" = "Percorso CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Cartella di configurazione di Claude Code per questo profilo. CodexBar non legge mai le sue credenziali.";
+"Environment" = "Ambiente";
+"claude_instance_environment_footnote" = "Un KEY=value per riga. Memorizzato in chiaro nel file di configurazione di CodexBar; le variabili di accesso come ANTHROPIC_* e i token OAuth vengono ignorati.";
+"Save" = "Salva";
+"Use an absolute path or a path starting with ~." = "Usa un percorso assoluto o un percorso che inizia con ~.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1550,3 +1550,18 @@
 "Color Pace Indicator" = "使用ペースを色分け";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "想定より使用が遅い場合は緑（余裕あり）、速い場合は赤（上限に早く達するおそれ）で表示します。";
 "%@ weekly" = "%@（週間）";
+
+"Claude instances" = "Claude インスタンス";
+"Show Claude instances" = "Claude インスタンスを表示";
+"claude_instances_toggle_subtitle" = "Claude Code プロファイルごとにカードを 1 枚表示し、各プロファイル自身の Claude CLI から読み取ります。Claude カードを置き換え、claude-swap をオフにします。";
+"Add Instance" = "インスタンスを追加";
+"Edit" = "編集";
+"Name" = "名前";
+"Binary path" = "バイナリパス";
+"claude_instance_binary_footnote" = "このインスタンスで使う claude バイナリのパス。空欄のままにすると、通常の claude の検索を使用します。";
+"CLAUDE_CONFIG_DIR path" = "CLAUDE_CONFIG_DIR パス";
+"claude_instance_config_dir_footnote" = "このプロファイルの Claude Code 設定ディレクトリ。CodexBar がその認証情報を読み取ることはありません。";
+"Environment" = "環境変数";
+"claude_instance_environment_footnote" = "1 行につき 1 つの KEY=value。CodexBar の設定ファイルにプレーンテキストで保存されます。ANTHROPIC_* などのログイン変数や OAuth トークンは無視されます。";
+"Save" = "保存";
+"Use an absolute path or a path starting with ~." = "絶対パス、または ~ で始まるパスを使用してください。";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1519,3 +1519,18 @@
 "Color Pace Indicator" = "사용 속도 색상 표시";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "사용량이 예상 속도보다 낮으면 초록색(여유), 높으면 빨간색(조기 소진 위험)으로 표시합니다.";
 "%@ weekly" = "%@ 주간";
+
+"Claude instances" = "Claude 인스턴스";
+"Show Claude instances" = "Claude 인스턴스 표시";
+"claude_instances_toggle_subtitle" = "Claude Code 프로필마다 카드 하나를 표시하며, 각 프로필의 Claude CLI를 통해 읽습니다. Claude 카드를 대체하고 claude-swap을 끕니다.";
+"Add Instance" = "인스턴스 추가";
+"Edit" = "편집";
+"Name" = "이름";
+"Binary path" = "바이너리 경로";
+"claude_instance_binary_footnote" = "이 인스턴스에 사용할 claude 바이너리의 경로입니다. 기본 claude 검색을 사용하려면 비워 두세요.";
+"CLAUDE_CONFIG_DIR path" = "CLAUDE_CONFIG_DIR 경로";
+"claude_instance_config_dir_footnote" = "이 프로필의 Claude Code 설정 디렉터리입니다. CodexBar는 해당 자격 증명을 절대 읽지 않습니다.";
+"Environment" = "환경 변수";
+"claude_instance_environment_footnote" = "한 줄에 KEY=value 하나씩 입력하세요. CodexBar 설정 파일에 일반 텍스트로 저장되며, ANTHROPIC_* 및 OAuth 토큰 같은 로그인 변수는 무시됩니다.";
+"Save" = "저장";
+"Use an absolute path or a path starting with ~." = "절대 경로 또는 ~로 시작하는 경로를 사용하세요.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1549,3 +1549,18 @@
 "Color Pace Indicator" = "Gebruikstempo kleuren";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Groen als het verbruik achterloopt op het verwachte tempo (reserve); rood als het voorloopt (risico op vroegtijdige uitputting).";
 "%@ weekly" = "%@ wekelijks";
+
+"Claude instances" = "Claude-instanties";
+"Show Claude instances" = "Claude-instanties tonen";
+"claude_instances_toggle_subtitle" = "Toont één kaart per Claude Code-profiel, uitgelezen via de eigen Claude CLI van dat profiel. Vervangt de Claude-kaart en schakelt claude-swap uit.";
+"Add Instance" = "Instantie toevoegen";
+"Edit" = "Bewerken";
+"Name" = "Naam";
+"Binary path" = "Pad naar binair bestand";
+"claude_instance_binary_footnote" = "Pad naar het claude-binaire bestand voor deze instantie. Laat leeg om de normale zoekmethode voor claude te gebruiken.";
+"CLAUDE_CONFIG_DIR path" = "CLAUDE_CONFIG_DIR-pad";
+"claude_instance_config_dir_footnote" = "Claude Code-configuratiemap voor dit profiel. CodexBar leest nooit de inloggegevens ervan.";
+"Environment" = "Omgeving";
+"claude_instance_environment_footnote" = "Eén KEY=value per regel. Opgeslagen als platte tekst in het CodexBar-configuratiebestand; inlogvariabelen zoals ANTHROPIC_* en OAuth-tokens worden genegeerd.";
+"Save" = "Opslaan";
+"Use an absolute path or a path starting with ~." = "Gebruik een absoluut pad of een pad dat begint met ~.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1553,3 +1553,18 @@
 "Color Pace Indicator" = "Koloruj tempo zużycia";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Zielony, gdy zużycie jest wolniejsze od oczekiwanego (rezerwa); czerwony, gdy jest szybsze (ryzyko wcześniejszego wyczerpania limitu).";
 "%@ weekly" = "%@ tygodniowo";
+
+"Claude instances" = "Instancje Claude";
+"Show Claude instances" = "Pokaż instancje Claude";
+"claude_instances_toggle_subtitle" = "Pokazuje jedną kartę na każdy profil Claude Code, odczytywaną przez własne Claude CLI tego profilu. Zastępuje kartę Claude i wyłącza claude-swap.";
+"Add Instance" = "Dodaj instancję";
+"Edit" = "Edytuj";
+"Name" = "Nazwa";
+"Binary path" = "Ścieżka pliku binarnego";
+"claude_instance_binary_footnote" = "Ścieżka do pliku binarnego claude dla tej instancji. Pozostaw puste, aby użyć standardowego wyszukiwania claude.";
+"CLAUDE_CONFIG_DIR path" = "Ścieżka CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Katalog konfiguracji Claude Code dla tego profilu. CodexBar nigdy nie odczytuje jego danych logowania.";
+"Environment" = "Środowisko";
+"claude_instance_environment_footnote" = "Jedno KEY=value w wierszu. Przechowywane jako zwykły tekst w pliku konfiguracyjnym CodexBar; zmienne logowania, takie jak ANTHROPIC_*, oraz tokeny OAuth są ignorowane.";
+"Save" = "Zapisz";
+"Use an absolute path or a path starting with ~." = "Użyj ścieżki bezwzględnej lub ścieżki zaczynającej się od ~.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1550,3 +1550,18 @@
 "Color Pace Indicator" = "Colorir o ritmo";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Verde quando o uso está abaixo do ritmo previsto (reserva); vermelho quando está acima (risco de esgotar a cota antes da hora).";
 "%@ weekly" = "%@ semanal";
+
+"Claude instances" = "Instâncias do Claude";
+"Show Claude instances" = "Mostrar instâncias do Claude";
+"claude_instances_toggle_subtitle" = "Mostra um cartão por perfil do Claude Code, lido pela própria Claude CLI desse perfil. Substitui o cartão do Claude e desativa o claude-swap.";
+"Add Instance" = "Adicionar instância";
+"Edit" = "Editar";
+"Name" = "Nome";
+"Binary path" = "Caminho do binário";
+"claude_instance_binary_footnote" = "Caminho para o binário claude desta instância. Deixe em branco para usar a busca normal do claude.";
+"CLAUDE_CONFIG_DIR path" = "Caminho do CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Diretório de configuração do Claude Code para este perfil. O CodexBar nunca lê as credenciais dele.";
+"Environment" = "Ambiente";
+"claude_instance_environment_footnote" = "Um KEY=value por linha. Armazenado em texto simples no arquivo de configuração do CodexBar; variáveis de login como ANTHROPIC_* e tokens OAuth são ignorados.";
+"Save" = "Salvar";
+"Use an absolute path or a path starting with ~." = "Use um caminho absoluto ou um caminho que comece com ~.";

--- a/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ru.lproj/Localizable.strings
@@ -1551,3 +1551,18 @@
 "Color Pace Indicator" = "Цветовая индикация темпа";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Зелёный — расход ниже ожидаемого темпа (есть запас); красный — выше (риск досрочного исчерпания квоты).";
 "%@ weekly" = "%@ за неделю";
+
+"Claude instances" = "Экземпляры Claude";
+"Show Claude instances" = "Показывать экземпляры Claude";
+"claude_instances_toggle_subtitle" = "Показывает по одной карточке на каждый профиль Claude Code; данные читаются через собственный Claude CLI этого профиля. Заменяет карточку Claude и отключает claude-swap.";
+"Add Instance" = "Добавить экземпляр";
+"Edit" = "Изменить";
+"Name" = "Имя";
+"Binary path" = "Путь к бинарному файлу";
+"claude_instance_binary_footnote" = "Путь к бинарному файлу claude для этого экземпляра. Оставьте поле пустым, чтобы использовать обычный поиск claude.";
+"CLAUDE_CONFIG_DIR path" = "Путь CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Каталог конфигурации Claude Code для этого профиля. CodexBar никогда не читает его учётные данные.";
+"Environment" = "Окружение";
+"claude_instance_environment_footnote" = "По одной паре KEY=value на строку. Хранится открытым текстом в конфигурационном файле CodexBar; переменные входа, такие как ANTHROPIC_*, и токены OAuth игнорируются.";
+"Save" = "Сохранить";
+"Use an absolute path or a path starting with ~." = "Укажите абсолютный путь или путь, начинающийся с ~.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1549,3 +1549,18 @@
 "Color Pace Indicator" = "Färglägg förbrukningstakten";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Grönt när förbrukningen ligger under förväntad takt (reserv); rött när den ligger över (risk att kvoten tar slut i förtid).";
 "%@ weekly" = "%@ per vecka";
+
+"Claude instances" = "Claude-instanser";
+"Show Claude instances" = "Visa Claude-instanser";
+"claude_instances_toggle_subtitle" = "Visar ett kort per Claude Code-profil, läst via profilens egen Claude CLI. Ersätter Claude-kortet och stänger av claude-swap.";
+"Add Instance" = "Lägg till instans";
+"Edit" = "Redigera";
+"Name" = "Namn";
+"Binary path" = "Sökväg till binär";
+"claude_instance_binary_footnote" = "Sökväg till claude-binären för den här instansen. Lämna tomt för att använda den vanliga sökningen efter claude.";
+"CLAUDE_CONFIG_DIR path" = "Sökväg för CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Konfigurationsmapp för Claude Code för den här profilen. CodexBar läser aldrig dess inloggningsuppgifter.";
+"Environment" = "Miljö";
+"claude_instance_environment_footnote" = "En KEY=value per rad. Sparas i klartext i CodexBars konfigurationsfil; inloggningsvariabler som ANTHROPIC_* och OAuth-token ignoreras.";
+"Save" = "Spara";
+"Use an absolute path or a path starting with ~." = "Använd en absolut sökväg eller en sökväg som börjar med ~.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1554,3 +1554,18 @@
 "Color Pace Indicator" = "แสดงสีอัตราการใช้งาน";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "สีเขียวเมื่อใช้งานช้ากว่าอัตราที่คาดไว้ (มีโควตาสำรอง) สีแดงเมื่อเร็วกว่า (เสี่ยงหมดโควตาก่อนเวลา)";
 "%@ weekly" = "%@ รายสัปดาห์";
+
+"Claude instances" = "อินสแตนซ์ Claude";
+"Show Claude instances" = "แสดงอินสแตนซ์ Claude";
+"claude_instances_toggle_subtitle" = "แสดงการ์ดหนึ่งใบต่อโปรไฟล์ Claude Code โดยอ่านผ่าน Claude CLI ของโปรไฟล์นั้นเอง แทนที่การ์ด Claude และปิด claude-swap";
+"Add Instance" = "เพิ่มอินสแตนซ์";
+"Edit" = "แก้ไข";
+"Name" = "ชื่อ";
+"Binary path" = "เส้นทางไบนารี";
+"claude_instance_binary_footnote" = "เส้นทางไปยังไบนารี claude สำหรับอินสแตนซ์นี้ เว้นว่างไว้เพื่อใช้การค้นหา claude ตามปกติ";
+"CLAUDE_CONFIG_DIR path" = "เส้นทาง CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "โฟลเดอร์การกําหนดค่า Claude Code สำหรับโปรไฟล์นี้ CodexBar จะไม่อ่านข้อมูลรับรองของโปรไฟล์นี้";
+"Environment" = "สภาพแวดล้อม";
+"claude_instance_environment_footnote" = "หนึ่ง KEY=value ต่อบรรทัด จัดเก็บเป็นข้อความธรรมดาในไฟล์กําหนดค่า CodexBar ตัวแปรการเข้าสู่ระบบ เช่น ANTHROPIC_* และโทเค็น OAuth จะถูกละเว้น";
+"Save" = "บันทึก";
+"Use an absolute path or a path starting with ~." = "ใช้เส้นทางแบบสัมบูรณ์หรือเส้นทางที่ขึ้นต้นด้วย ~";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1552,3 +1552,18 @@
 "Color Pace Indicator" = "Kullanım hızını renklendir";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Kullanım beklenen hızın gerisindeyse yeşil (rezerv); ilerisindeyse kırmızı (kotanın erken tükenme riski).";
 "%@ weekly" = "%@ haftalık";
+
+"Claude instances" = "Claude örnekleri";
+"Show Claude instances" = "Claude örneklerini göster";
+"claude_instances_toggle_subtitle" = "Her Claude Code profili için, o profilin kendi Claude CLI'ı üzerinden okunan bir kart gösterir. Claude kartının yerini alır ve claude-swap'ı kapatır.";
+"Add Instance" = "Örnek ekle";
+"Edit" = "Düzenle";
+"Name" = "Ad";
+"Binary path" = "Çalıştırılabilir dosya yolu";
+"claude_instance_binary_footnote" = "Bu örnek için claude çalıştırılabilir dosyasının yolu. Normal claude aramasını kullanmak için boş bırakın.";
+"CLAUDE_CONFIG_DIR path" = "CLAUDE_CONFIG_DIR yolu";
+"claude_instance_config_dir_footnote" = "Bu profil için Claude Code yapılandırma dizini. CodexBar bu profilin kimlik bilgilerini hiçbir zaman okumaz.";
+"Environment" = "Ortam";
+"claude_instance_environment_footnote" = "Her satıra bir KEY=value. CodexBar yapılandırma dosyasında düz metin olarak depolanır; ANTHROPIC_* gibi oturum açma değişkenleri ve OAuth belirteçleri yok sayılır.";
+"Save" = "Kaydet";
+"Use an absolute path or a path starting with ~." = "Mutlak bir yol veya ~ ile başlayan bir yol kullanın.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1550,3 +1550,18 @@
 "Color Pace Indicator" = "Кольорова індикація темпу";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Зелений — витрати нижчі за очікуваний темп (є запас); червоний — вищі (ризик дострокового вичерпання квоти).";
 "%@ weekly" = "%@ за тиждень";
+
+"Claude instances" = "Екземпляри Claude";
+"Show Claude instances" = "Показувати екземпляри Claude";
+"claude_instances_toggle_subtitle" = "Показує по одній картці для кожного профілю Claude Code; дані зчитуються через власний Claude CLI цього профілю. Замінює картку Claude і вимикає claude-swap.";
+"Add Instance" = "Додати екземпляр";
+"Edit" = "Редагувати";
+"Name" = "Ім’я";
+"Binary path" = "Шлях до двійкового файлу";
+"claude_instance_binary_footnote" = "Шлях до двійкового файлу claude для цього екземпляра. Залиште поле порожнім, щоб використовувати звичайний пошук claude.";
+"CLAUDE_CONFIG_DIR path" = "Шлях CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Каталог конфігурації Claude Code для цього профілю. CodexBar ніколи не читає його облікові дані.";
+"Environment" = "Середовище";
+"claude_instance_environment_footnote" = "По одній парі KEY=value на рядок. Зберігається відкритим текстом у конфігураційному файлі CodexBar; змінні входу, як-от ANTHROPIC_*, і токени OAuth ігноруються.";
+"Save" = "Зберегти";
+"Use an absolute path or a path starting with ~." = "Використовуйте абсолютний шлях або шлях, що починається з ~.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1551,3 +1551,18 @@
 "Color Pace Indicator" = "Tô màu nhịp sử dụng";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "Xanh khi mức sử dụng chậm hơn nhịp dự kiến (còn dư); đỏ khi nhanh hơn (nguy cơ hết hạn mức sớm).";
 "%@ weekly" = "%@ hàng tuần";
+
+"Claude instances" = "Phiên bản Claude";
+"Show Claude instances" = "Hiển thị phiên bản Claude";
+"claude_instances_toggle_subtitle" = "Hiển thị một thẻ cho mỗi hồ sơ Claude Code, được đọc thông qua Claude CLI riêng của hồ sơ đó. Thay thế thẻ Claude và tắt claude-swap.";
+"Add Instance" = "Thêm phiên bản";
+"Edit" = "Sửa";
+"Name" = "Tên";
+"Binary path" = "Đường dẫn tệp nhị phân";
+"claude_instance_binary_footnote" = "Đường dẫn đến tệp nhị phân claude cho phiên bản này. Để trống để dùng cách tìm claude thông thường.";
+"CLAUDE_CONFIG_DIR path" = "Đường dẫn CLAUDE_CONFIG_DIR";
+"claude_instance_config_dir_footnote" = "Thư mục cấu hình Claude Code cho hồ sơ này. CodexBar không bao giờ đọc thông tin xác thực của hồ sơ.";
+"Environment" = "Môi trường";
+"claude_instance_environment_footnote" = "Mỗi dòng một KEY=value. Được lưu dưới dạng văn bản thuần trong tệp cấu hình CodexBar; các biến đăng nhập như ANTHROPIC_* và token OAuth sẽ bị bỏ qua.";
+"Save" = "Lưu";
+"Use an absolute path or a path starting with ~." = "Hãy dùng đường dẫn tuyệt đối hoặc đường dẫn bắt đầu bằng ~.";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1562,3 +1562,18 @@
 "Color Pace Indicator" = "用颜色显示使用节奏";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "使用量低于预期进度时显示绿色（有余量）；高于预期时显示红色（可能提前耗尽配额）。";
 "%@ weekly" = "%@ 每周";
+
+"Claude instances" = "Claude 实例";
+"Show Claude instances" = "显示 Claude 实例";
+"claude_instances_toggle_subtitle" = "为每个 Claude Code 配置文件显示一张卡片，通过该配置文件自己的 Claude CLI 读取。将替换 Claude 卡片并关闭 claude-swap。";
+"Add Instance" = "添加实例";
+"Edit" = "编辑";
+"Name" = "名称";
+"Binary path" = "二进制文件路径";
+"claude_instance_binary_footnote" = "此实例使用的 claude 二进制文件路径。留空则使用常规的 claude 查找方式。";
+"CLAUDE_CONFIG_DIR path" = "CLAUDE_CONFIG_DIR 路径";
+"claude_instance_config_dir_footnote" = "此配置文件的 Claude Code 配置目录。CodexBar 从不读取其凭据。";
+"Environment" = "环境变量";
+"claude_instance_environment_footnote" = "每行一个 KEY=value。以明文形式存储在 CodexBar 配置文件中；ANTHROPIC_* 等登录变量和 OAuth 令牌会被忽略。";
+"Save" = "保存";
+"Use an absolute path or a path starting with ~." = "请使用绝对路径或以 ~ 开头的路径。";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -1581,3 +1581,18 @@
 "Color Pace Indicator" = "以顏色顯示使用節奏";
 "Green pace indicator when behind pace, red when ahead of pace (risk of running out early)" = "使用量低於預期進度時顯示綠色（有餘裕）；高於預期時顯示紅色（可能提前用盡配額）。";
 "%@ weekly" = "%@ 每週";
+
+"Claude instances" = "Claude 執行個體";
+"Show Claude instances" = "顯示 Claude 執行個體";
+"claude_instances_toggle_subtitle" = "為每個 Claude Code 設定檔顯示一張卡片，並透過該設定檔自己的 Claude CLI 讀取。將取代 Claude 卡片並關閉 claude-swap。";
+"Add Instance" = "新增執行個體";
+"Edit" = "編輯";
+"Name" = "名稱";
+"Binary path" = "二進位檔案路徑";
+"claude_instance_binary_footnote" = "此執行個體使用的 claude 二進位檔案路徑。留空則使用一般的 claude 查找方式。";
+"CLAUDE_CONFIG_DIR path" = "CLAUDE_CONFIG_DIR 路徑";
+"claude_instance_config_dir_footnote" = "此設定檔的 Claude Code 設定目錄。CodexBar 絕不會讀取其憑證。";
+"Environment" = "環境變數";
+"claude_instance_environment_footnote" = "每行一個 KEY=value。以純文字儲存在 CodexBar 設定檔中；ANTHROPIC_* 等登入變數和 OAuth 權杖會被忽略。";
+"Save" = "儲存";
+"Use an absolute path or a path starting with ~." = "請使用絕對路徑或以 ~ 開頭的路徑。";

--- a/Sources/CodexBar/StatusItemController+AccountMenuDisplay.swift
+++ b/Sources/CodexBar/StatusItemController+AccountMenuDisplay.swift
@@ -12,6 +12,11 @@ enum ClaudeSwapMenuPrecedence {
             accountCount: accountCount,
             showSingleAccount: showSingleAccount)
     }
+
+    static func prefersClaudeInstances(provider: UsageProvider, instancesOwnPresentation: Bool) -> Bool {
+        // Provider-specific by design: configured Claude instances replace the ambient Claude cards.
+        provider == .claude && instancesOwnPresentation
+    }
 }
 
 extension StatusItemController {
@@ -48,7 +53,10 @@ extension StatusItemController {
         if ClaudeSwapMenuPrecedence.prefersClaudeSwap(
             provider: provider,
             accountCount: self.store.claudeSwapAccountSnapshots.count,
-            showSingleAccount: self.settings.claudeSwapShowSingleAccount)
+            showSingleAccount: self.settings.claudeSwapShowSingleAccount) ||
+            ClaudeSwapMenuPrecedence.prefersClaudeInstances(
+                provider: provider,
+                instancesOwnPresentation: self.store.claudeInstancesOwnAccountPresentation)
         {
             return nil
         }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -697,14 +697,9 @@ extension StatusItemController {
             return false
         }
 
-        // Eligible claude-swap rows take precedence over Claude token-account cards; otherwise
-        // the stacked token-account branch below would return before rendering the adapter rows.
-        if ClaudeSwapMenuPrecedence.prefersClaudeSwap(
-            provider: context.currentProvider,
-            accountCount: self.store.claudeSwapAccountSnapshots.count,
-            showSingleAccount: self.settings.claudeSwapShowSingleAccount)
-        {
-            self.addClaudeSwapMenuCards(to: menu, captureMenu: captureMenu ?? menu, context: context)
+        // Eligible claude-swap rows, then Claude instances, take precedence over Claude token-account cards;
+        // otherwise the stacked token-account branch below would return before rendering them.
+        if self.addClaudeAccountSourceMenuCards(to: menu, captureMenu: captureMenu ?? menu, context: context) {
             self.addFleetAccountMenuCards(fleetProjection.additionalAccounts, to: menu, context: context)
             return false
         }

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -120,6 +120,7 @@ extension StatusItemController {
             "credits=\(self.store.credits == nil ? "0" : "1")",
             "planHistoryRevision=\(self.store.planUtilizationHistoryRevision)",
             "claudeSwapRevision=\(self.store.claudeSwapRevision)",
+            "claudeInstanceRevision=\(self.store.claudeInstanceRevision)",
         ]
 
         for provider in self.store.enabledFirstPartyProvidersForDisplay() {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -387,6 +387,11 @@ extension StatusItemController {
                     parts.append(self.providerIdentitySignature(
                         accountSnapshot.snapshot?.identity(for: target.instanceID)))
                 }
+                for accountSnapshot in self.store.claudeInstanceAccountSnapshots {
+                    parts.append(Self.menuIdentityField(accountSnapshot.id.opaqueID))
+                    parts.append(self.providerIdentitySignature(
+                        accountSnapshot.snapshot?.identity(for: target.instanceID)))
+                }
             }
         }
         return parts.joined(separator: "|")

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -291,6 +291,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     /// Compact multi-account layout: accounts the user expanded to full cards this menu session.
     var compactAccountExpandedIDs: Set<ProviderAccountIdentity> = []
     var claudeSwapInspectedAccountID: ProviderAccountIdentity?
+    var claudeInstanceInspectedAccountID: ProviderAccountIdentity?
     /// Compact multi-account layout: providers whose collapsed healthy tail is revealed this menu session.
     var compactAccountExpandedHealthyTailProviders: Set<ProviderInstanceID> = []
     /// Keeps detached merged-menu tab content reusable while the same menu remains open.

--- a/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
+++ b/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
@@ -53,6 +53,7 @@ extension UsageStore {
         if provider == .claude {
             self.widgetUsagePreservationBlockedProviders.insert(provider.instanceID)
             self.clearClaudeSwapAccountState()
+            self.clearClaudeInstanceState()
         }
         self.clearTokenSnapshot(for: provider)
         self.clearSpendDashboardTokenSnapshot(for: provider)

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -374,6 +374,7 @@ extension UsageStore {
 
         if provider == .claude {
             self.scheduleClaudeSwapAccountRefresh(generation: generation)
+            self.scheduleClaudeInstanceRefresh(generation: generation)
         }
 
         let tokenAccountPreparation = self.tokenAccountRefreshPreparation(for: provider)

--- a/Sources/CodexBar/UsageStore+TokenCost.swift
+++ b/Sources/CodexBar/UsageStore+TokenCost.swift
@@ -82,6 +82,9 @@ extension UsageStore {
                 settings: self.settings,
                 tokenOverride: nil)
             : self.environmentBase
+        let claudeExtraConfigDirectories = provider == .claude
+            ? self.settings.claudeInstanceCostConfigDirectories
+            : []
         return try await withThrowingTaskGroup(of: CostUsageTokenSnapshot.self) { group in
             group.addTask(priority: .utility) {
                 try await fetcher.loadTokenSnapshot(
@@ -95,7 +98,8 @@ extension UsageStore {
                     cursorCookieHeaderOverride: cursorCookieHeaderOverride,
                     allowPricingRefresh: allowPricingRefresh,
                     bypassScannerDebounce: true,
-                    calendar: self.settings.costUsageBucketCalendar)
+                    calendar: self.settings.costUsageBucketCalendar,
+                    claudeExtraConfigDirectories: claudeExtraConfigDirectories)
             }
             group.addTask {
                 try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -19,7 +19,7 @@ extension UsageStore {
         _ = self.kiloScopeSnapshots
         _ = self.claudeSwapAccountSnapshots
         _ = self.claudeSwapLastError
-        _ = self.claudeSwapRevision
+        _ = (self.claudeSwapRevision, self.claudeInstanceState)
         _ = self.tokenSnapshots
         _ = self.tokenErrors
         _ = self.tokenRefreshInFlight
@@ -46,7 +46,7 @@ extension UsageStore {
     var iconObservationToken: Int {
         _ = self.snapshots
         _ = self.claudeSwapAccountSnapshots
-        _ = self.claudeSwapRevision
+        _ = (self.claudeSwapRevision, self.claudeInstanceState)
         _ = self.errors
         _ = self.diagnostics
         _ = self.knownLimitsAvailabilityByProvider
@@ -183,6 +183,8 @@ final class UsageStore {
     var claudeSwapRevision: UInt64 = 0
     @ObservationIgnored var claudeSwapRefreshTask: Task<Void, Never>?
     @ObservationIgnored var claudeSwapTransientState = ClaudeSwapTransientState()
+    var claudeInstanceState = ClaudeInstanceState()
+    @ObservationIgnored var claudeInstanceRefresh = ClaudeInstanceRefreshHandle()
     var tokenSnapshots: [ProviderInstanceID: CostUsageTokenSnapshot] = [:]
     var tokenSnapshotPublications: [ProviderInstanceID: TokenSnapshotPublication] = [:]
     var tokenSnapshotPublicationRevisions: [ProviderInstanceID: UInt64] = [:]
@@ -632,8 +634,8 @@ final class UsageStore {
     /// whenever the adapter is disabled, below its presentation threshold, or the
     /// active account has no usable usage windows.
     func menuBarSnapshot(for instanceID: ProviderInstanceID) -> UsageSnapshot? {
-        // Provider-specific by design: claude-swap adapter owns Claude menu-bar presentation; see #2731.
-        self.claudeSwapMenuBarSnapshotOverride(for: instanceID) ?? self.snapshot(for: instanceID)
+        // Provider-specific by design: claude-swap or Claude instances own Claude menu-bar presentation; see #2731.
+        self.claudeAccountSourceMenuBarSnapshotOverride(for: instanceID) ?? self.snapshot(for: instanceID)
     }
 
     func sourceLabel(for provider: UsageProvider) -> String {

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -237,11 +237,18 @@ public struct CostUsageFetcher: Sendable {
         refreshPricingInBackground: Bool = true,
         includePiSessions: Bool = true,
         bypassScannerDebounce: Bool,
-        calendar: Calendar? = nil) async throws -> CostUsageTokenSnapshot
+        calendar: Calendar? = nil,
+        claudeExtraConfigDirectories: [String] = []) async throws -> CostUsageTokenSnapshot
     {
         var options = self.scannerOptionsOverride() ?? CostUsageScanner.Options()
         if let calendar {
             options.calendar = calendar
+        }
+        let instanceRoots = Self.claudeProjectsRoots(forConfigDirectories: claudeExtraConfigDirectories)
+        if provider == .claude, !instanceRoots.isEmpty, options.claudeProjectsRoots == nil {
+            options.claudeProjectsRoots = CostUsageScanner.claudeProjectsRoots(
+                appendingInstanceRoots: instanceRoots,
+                options: options)
         }
         return try await Self.loadTokenSnapshot(
             provider: provider,
@@ -367,6 +374,12 @@ public struct CostUsageFetcher: Sendable {
     }
 
     private static let establishedEmptyCodexDailyReport = CostUsageDailyReport(data: [], summary: nil)
+
+    static func claudeProjectsRoots(forConfigDirectories directories: [String]) -> [URL] {
+        directories.compactMap(ClaudeInstanceEnvironment.normalizedAbsolutePath).map {
+            URL(fileURLWithPath: $0, isDirectory: true).appendingPathComponent("projects", isDirectory: true)
+        }
+    }
 
     private static func resolvedScannerOptions(
         _ override: CostUsageScanner.Options?,

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLIRateLimitGate.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLIRateLimitGate.swift
@@ -7,34 +7,45 @@ enum ClaudeCLIRateLimitGate {
     static let message = "Claude CLI usage endpoint is rate limited right now. Please try again later."
 
     static func blockedUntil(
+        environment: [String: String] = [:],
         interaction: ProviderInteraction = ProviderInteractionContext.current,
         now: Date = Date()) -> Date?
     {
         guard interaction != .userInitiated else { return nil }
-        return self.currentBlockedUntil(now: now)
+        return self.currentBlockedUntil(environment: environment, now: now)
     }
 
-    static func currentBlockedUntil(now: Date = Date()) -> Date? {
-        guard let raw = UserDefaults.standard.object(forKey: self.blockedUntilKey) as? Double else {
+    static func currentBlockedUntil(environment: [String: String] = [:], now: Date = Date()) -> Date? {
+        let key = self.storageKey(environment: environment)
+        guard let raw = UserDefaults.standard.object(forKey: key) as? Double else {
             return nil
         }
 
         let blockedUntil = Date(timeIntervalSince1970: raw)
         guard blockedUntil > now else {
-            UserDefaults.standard.removeObject(forKey: self.blockedUntilKey)
+            UserDefaults.standard.removeObject(forKey: key)
             return nil
         }
         return blockedUntil
     }
 
-    static func recordRateLimit(now: Date = Date()) {
+    static func recordRateLimit(environment: [String: String] = [:], now: Date = Date()) {
         UserDefaults.standard.set(
             now.addingTimeInterval(self.defaultCooldown).timeIntervalSince1970,
-            forKey: self.blockedUntilKey)
+            forKey: self.storageKey(environment: environment))
     }
 
-    static func recordSuccess() {
-        UserDefaults.standard.removeObject(forKey: self.blockedUntilKey)
+    static func recordSuccess(environment: [String: String] = [:]) {
+        UserDefaults.standard.removeObject(forKey: self.storageKey(environment: environment))
+    }
+
+    /// The default profile keeps the original key. Each explicit `CLAUDE_CONFIG_DIR` gets its own cooldown so one
+    /// rate-limited profile does not pause the others.
+    static func storageKey(environment: [String: String]) -> String {
+        guard let configDirectory = environment[ClaudeConfigPaths.configDirectoryEnvironmentKey],
+              !configDirectory.isEmpty
+        else { return self.blockedUntilKey }
+        return "\(self.blockedUntilKey).\(configDirectory)"
     }
 
     static func isRateLimitError(_ error: Error) -> Bool {
@@ -57,8 +68,8 @@ enum ClaudeCLIRateLimitGate {
     }
 
     #if DEBUG
-    static func resetForTesting() {
-        UserDefaults.standard.removeObject(forKey: self.blockedUntilKey)
+    static func resetForTesting(environment: [String: String] = [:]) {
+        UserDefaults.standard.removeObject(forKey: self.storageKey(environment: environment))
     }
     #endif
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeInstances/ClaudeInstanceAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeInstances/ClaudeInstanceAccountProjection.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Projects per-instance Claude CLI results into the provider-neutral account snapshot consumed by menus.
+/// Identity is the instance's stored ID (`claude-instance:<id>`), never an email or a path.
+public enum ClaudeInstanceAccountProjection {
+    public static let sourceName = "claude-instance"
+    public static let sourceLabel = "claude-instance"
+
+    public static func identity(for instance: ClaudeInstanceConfig) -> ProviderAccountIdentity {
+        ProviderAccountIdentity(source: self.sourceName, opaqueID: instance.id)
+    }
+
+    public static func displayLabel(for instance: ClaudeInstanceConfig, index: Int) -> String {
+        let name = instance.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? "Instance \(index + 1)" : name
+    }
+
+    /// A failed refresh keeps the instance's last successful usage and reports the error beside it.
+    public static func accountSnapshot(
+        for instance: ClaudeInstanceConfig,
+        index: Int,
+        result: Result<UsageSnapshot, Error>,
+        previous: ProviderAccountUsageSnapshot?) -> ProviderAccountUsageSnapshot
+    {
+        let snapshot: UsageSnapshot?
+        let error: String?
+        switch result {
+        case let .success(usage):
+            snapshot = usage
+            error = nil
+        case let .failure(failure):
+            let message = (failure as? LocalizedError)?.errorDescription ?? failure.localizedDescription
+            snapshot = previous?.snapshot
+            error = snapshot == nil
+                ? message
+                : ClaudeSwapAccountProjection.displayError(accountError: nil, adapterError: message)
+        }
+        return ProviderAccountUsageSnapshot(
+            id: self.identity(for: instance),
+            provider: .claude,
+            displayLabel: self.displayLabel(for: instance, index: index),
+            accountEmail: snapshot?.identity?.accountEmail,
+            isActive: false,
+            canActivate: false,
+            snapshot: snapshot,
+            error: error,
+            sourceLabel: self.sourceLabel)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeInstances/ClaudeInstanceConfig.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeInstances/ClaudeInstanceConfig.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// One user-configured Claude Code profile: an optional `claude` binary, a `CLAUDE_CONFIG_DIR`, and extra
+/// environment variables. CodexBar reads each instance's quota through that instance's own Claude CLI, so Claude
+/// Code stays the only reader of the profile's credentials.
+public struct ClaudeInstanceConfig: Codable, Hashable, Sendable, Identifiable {
+    public var id: String
+    public var name: String
+    public var binaryPath: String?
+    public var configDirectory: String
+    public var environment: [String: String]?
+
+    public init(
+        id: String = UUID().uuidString,
+        name: String,
+        binaryPath: String? = nil,
+        configDirectory: String,
+        environment: [String: String]? = nil)
+    {
+        self.id = id
+        self.name = name
+        self.binaryPath = binaryPath
+        self.configDirectory = configDirectory
+        self.environment = environment
+    }
+
+    public var normalizedConfigDirectory: String? {
+        ClaudeInstanceEnvironment.normalizedAbsolutePath(self.configDirectory)
+    }
+
+    public var normalizedBinaryPath: String? {
+        ClaudeInstanceEnvironment.normalizedAbsolutePath(self.binaryPath)
+    }
+}
+
+public enum ClaudeInstanceEnvironment {
+    public static let cliPathEnvironmentKey = "CLAUDE_CLI_PATH"
+
+    /// Keys that would route Claude Code to other credentials. They are dropped from the inherited environment
+    /// and cannot be set per instance, so an instance always reads its own profile's login.
+    private static let credentialKeys: Set<String> = [
+        ClaudeConfigPaths.secureStorageDirectoryEnvironmentKey,
+        ClaudeOAuthCredentialsStore.environmentTokenKey,
+        ClaudeOAuthCredentialsStore.environmentScopesKey,
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ]
+
+    /// Keys owned by the instance's dedicated fields.
+    private static let fieldOwnedKeys: Set<String> = [
+        ClaudeConfigPaths.configDirectoryEnvironmentKey,
+        cliPathEnvironmentKey,
+        "HOME",
+    ]
+
+    public static func isReservedKey(_ key: String) -> Bool {
+        self.isCredentialKey(key) || self.fieldOwnedKeys.contains(key)
+    }
+
+    /// POSIX environment variable names: a letter or underscore followed by letters, digits, or underscores.
+    public static func isValidKey(_ key: String) -> Bool {
+        guard let first = key.unicodeScalars.first, first.isASCII,
+              first == "_" || CharacterSet.letters.contains(first)
+        else { return false }
+        return key.unicodeScalars.allSatisfy { scalar in
+            scalar.isASCII && (scalar == "_" || CharacterSet.alphanumerics.contains(scalar))
+        }
+    }
+
+    /// Trimmed, valid, non-reserved variables; everything else is dropped.
+    public static func sanitizedVariables(_ variables: [String: String]?) -> [String: String] {
+        var result: [String: String] = [:]
+        for (rawKey, value) in variables ?? [:] {
+            let key = rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard self.isValidKey(key), !self.isReservedKey(key) else { continue }
+            result[key] = value
+        }
+        return result
+    }
+
+    /// Parses `KEY=value` lines. Blank lines, `#` comments, and lines without a valid key are skipped; values keep
+    /// everything after the first `=`.
+    public static func parseVariables(_ text: String) -> [String: String] {
+        var result: [String: String] = [:]
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, !line.hasPrefix("#"), let separator = line.firstIndex(of: "=") else { continue }
+            let key = line[..<separator].trimmingCharacters(in: .whitespaces)
+            guard self.isValidKey(key) else { continue }
+            result[key] = String(line[line.index(after: separator)...])
+        }
+        return result
+    }
+
+    public static func formatVariables(_ variables: [String: String]?) -> String {
+        (variables ?? [:]).sorted { $0.key < $1.key }.map { "\($0.key)=\($0.value)" }.joined(separator: "\n")
+    }
+
+    /// Tilde-expanded, standardized absolute path; nil when empty or relative.
+    public static func normalizedAbsolutePath(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        guard expanded.hasPrefix("/") else { return nil }
+        return URL(fileURLWithPath: expanded).standardizedFileURL.path
+    }
+
+    /// The environment one instance's Claude CLI runs with, or nil when it has no usable config directory.
+    public static func environment(
+        for instance: ClaudeInstanceConfig,
+        base: [String: String]) -> [String: String]?
+    {
+        guard let configDirectory = instance.normalizedConfigDirectory else { return nil }
+        var environment = base
+        for key in environment.keys where self.isCredentialKey(key) || key == self.cliPathEnvironmentKey {
+            environment.removeValue(forKey: key)
+        }
+        environment.merge(self.sanitizedVariables(instance.environment)) { _, instanceValue in instanceValue }
+        environment[ClaudeConfigPaths.configDirectoryEnvironmentKey] = configDirectory
+        if let binaryPath = instance.normalizedBinaryPath {
+            environment[self.cliPathEnvironmentKey] = binaryPath
+        }
+        return environment
+    }
+
+    private static func isCredentialKey(_ key: String) -> Bool {
+        key.hasPrefix("ANTHROPIC_") || self.credentialKeys.contains(key)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeInstances/ClaudeInstanceUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeInstances/ClaudeInstanceUsageFetcher.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Reads one Claude instance's quota through that instance's own Claude CLI.
+public enum ClaudeInstanceUsageFetcher {
+    public enum FetchError: LocalizedError, Equatable {
+        case invalidConfigDirectory
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidConfigDirectory:
+                "Set an absolute Claude config directory for this instance."
+            }
+        }
+    }
+
+    public static func fetchUsage(
+        for instance: ClaudeInstanceConfig,
+        baseEnvironment: [String: String],
+        browserDetection: BrowserDetection,
+        keepCLISessionsAlive: Bool = false) async throws -> UsageSnapshot
+    {
+        guard let environment = ClaudeInstanceEnvironment.environment(for: instance, base: baseEnvironment) else {
+            throw FetchError.invalidConfigDirectory
+        }
+        // CLI only: the instance's `claude` reads its own credentials, so CodexBar never touches the profile's
+        // Keychain item. Browser-cookie extras stay off because cookies are not scoped to a Claude profile.
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: browserDetection,
+            environment: environment,
+            runtime: .app,
+            dataSource: .cli,
+            useWebExtras: false,
+            keepCLISessionsAlive: keepCLISessionsAlive)
+        let usage = try await fetcher.loadLatestUsage(model: "sonnet")
+        return ClaudeOAuthFetchStrategy.snapshot(from: usage, dataConfidence: .percentOnly)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderConfig.swift
@@ -19,4 +19,20 @@ extension ProviderConfig {
     public var sanitizedClaudeSwapExecutablePath: String? {
         Self.clean(self.claudeSwapExecutablePath)
     }
+
+    public var claudeInstancesEnabled: Bool? {
+        get { self.extensionValue(forKey: "claudeInstancesEnabled") }
+        set { self.setExtensionValue(newValue, forKey: "claudeInstancesEnabled") }
+    }
+
+    public var claudeInstances: [ClaudeInstanceConfig]? {
+        get { self.extensionValue(forKey: "claudeInstances") }
+        set { self.setExtensionValue(newValue, forKey: "claudeInstances") }
+    }
+
+    /// Config directories of the configured instances when the feature is on; feeds local cost scanning.
+    public var enabledClaudeInstanceConfigDirectories: [String] {
+        guard self.claudeInstancesEnabled == true else { return [] }
+        return (self.claudeInstances ?? []).compactMap(\.normalizedConfigDirectory)
+    }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -737,7 +737,7 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
         return context.runtime == .app && context.sourceMode == .auto
     }
 
-    fileprivate static func snapshot(
+    static func snapshot(
         from usage: ClaudeUsageSnapshot,
         dataConfidence: UsageDataConfidence = .unknown) -> UsageSnapshot
     {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -679,7 +679,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         }
 
         private func loadViaCLI(model: String, timeout: TimeInterval) async throws -> ClaudeUsageSnapshot {
-            if ClaudeCLIRateLimitGate.blockedUntil() != nil {
+            if ClaudeCLIRateLimitGate.blockedUntil(environment: self.fetcher.environment) != nil {
                 throw ClaudeUsageError.parseFailed(ClaudeCLIRateLimitGate.message)
             }
 
@@ -691,7 +691,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                     throw error
                 }
                 if ClaudeUsageFetcher.isCLIRateLimitError(error) {
-                    ClaudeCLIRateLimitGate.recordRateLimit()
+                    ClaudeCLIRateLimitGate.recordRateLimit(environment: self.fetcher.environment)
                     throw error
                 }
                 guard Self.shouldTryDirectCLIUsage(after: error) else { throw error }
@@ -704,14 +704,14 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                         throw directError
                     }
                     if ClaudeUsageFetcher.isCLIRateLimitError(directError) {
-                        ClaudeCLIRateLimitGate.recordRateLimit()
+                        ClaudeCLIRateLimitGate.recordRateLimit(environment: self.fetcher.environment)
                         throw directError
                     }
                     guard Self.directCLIErrorShouldReplacePTYError(directError) else { throw ptyError }
                     throw directError
                 }
             }
-            ClaudeCLIRateLimitGate.recordSuccess()
+            ClaudeCLIRateLimitGate.recordSuccess(environment: self.fetcher.environment)
             snapshot = try await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
             return snapshot
         }

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
@@ -65,6 +65,12 @@ extension CostUsageScanner {
         return self.deduplicatedClaudeProjectRoots(roots)
     }
 
+    /// Default discovery plus Claude instance roots, deduplicated. Callers pass the result as the explicit root list
+    /// only when instances add roots, so the default scan configuration stays unchanged otherwise.
+    static func claudeProjectsRoots(appendingInstanceRoots instanceRoots: [URL], options: Options) -> [URL] {
+        self.deduplicatedClaudeProjectRoots(self.defaultClaudeProjectsRoots(options: options) + instanceRoots)
+    }
+
     private static func deduplicatedClaudeProjectRoots(_ roots: [URL]) -> [URL] {
         var seen: Set<String> = []
         var out: [URL] = []

--- a/Tests/CodexBarTests/ClaudeInstanceConfigTests.swift
+++ b/Tests/CodexBarTests/ClaudeInstanceConfigTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeInstanceConfigTests {
+    private static let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+
+    @Test
+    func `environment points Claude at the instance config directory and binary`() throws {
+        let instance = ClaudeInstanceConfig(
+            name: "Work",
+            binaryPath: "/opt/claude/bin/claude",
+            configDirectory: "~/.claude-work")
+
+        let environment = try #require(ClaudeInstanceEnvironment.environment(
+            for: instance,
+            base: ["HOME": Self.home, "PATH": "/usr/bin"]))
+
+        #expect(environment["CLAUDE_CONFIG_DIR"] == "\(Self.home)/.claude-work")
+        #expect(environment["CLAUDE_CLI_PATH"] == "/opt/claude/bin/claude")
+        #expect(environment["HOME"] == Self.home)
+        #expect(environment["PATH"] == "/usr/bin")
+    }
+
+    @Test
+    func `environment drops inherited credential routing and ignores reserved instance keys`() throws {
+        let instance = ClaudeInstanceConfig(
+            name: "Work",
+            configDirectory: "/tmp/claude-work",
+            environment: [
+                "HTTPS_PROXY": "http://proxy.local:8080",
+                "ANTHROPIC_API_KEY": "sk-ant-instance",
+                "CLAUDE_CODE_OAUTH_TOKEN": "instance-token",
+                "CLAUDE_CONFIG_DIR": "/tmp/elsewhere",
+                "HOME": "/tmp/fake-home",
+                "not a key": "ignored",
+            ])
+        let base = [
+            "HOME": Self.home,
+            "ANTHROPIC_AUTH_TOKEN": "inherited",
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/other-profile",
+            "CLAUDE_CLI_PATH": "/tmp/other-claude",
+            "CLAUDE_CONFIG_DIR": "/tmp/inherited-profile",
+        ]
+
+        let environment = try #require(ClaudeInstanceEnvironment.environment(for: instance, base: base))
+
+        #expect(environment["HTTPS_PROXY"] == "http://proxy.local:8080")
+        #expect(environment["CLAUDE_CONFIG_DIR"] == "/tmp/claude-work")
+        #expect(environment["HOME"] == Self.home)
+        for key in [
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+            "CLAUDE_CLI_PATH",
+            "not a key",
+        ] {
+            #expect(environment[key] == nil, "\(key) should not reach the instance CLI")
+        }
+    }
+
+    @Test
+    func `instances without an absolute config directory have no environment`() {
+        for directory in ["", "   ", "relative/profile"] {
+            let instance = ClaudeInstanceConfig(name: "Broken", configDirectory: directory)
+            #expect(ClaudeInstanceEnvironment.environment(for: instance, base: [:]) == nil)
+        }
+    }
+
+    @Test
+    func `environment text parses key value lines and formats them sorted`() {
+        let parsed = ClaudeInstanceEnvironment.parseVariables("""
+        # proxy for the work account
+        HTTPS_PROXY=http://proxy.local:8080
+
+        EXTRA=a=b
+        =missing-key
+        1BAD=value
+        """)
+
+        #expect(parsed == ["HTTPS_PROXY": "http://proxy.local:8080", "EXTRA": "a=b"])
+        #expect(ClaudeInstanceEnvironment.formatVariables(parsed) == "EXTRA=a=b\nHTTPS_PROXY=http://proxy.local:8080")
+    }
+
+    @Test
+    func `provider config round trips instances and only exposes cost directories while enabled`() throws {
+        var config = ProviderConfig(id: .claude)
+        config.claudeInstances = [
+            ClaudeInstanceConfig(id: "a", name: "Work", configDirectory: "/tmp/claude-work"),
+            ClaudeInstanceConfig(id: "b", name: "Broken", configDirectory: "relative"),
+        ]
+        #expect(config.enabledClaudeInstanceConfigDirectories.isEmpty)
+
+        config.claudeInstancesEnabled = true
+        let decoded = try JSONDecoder().decode(ProviderConfig.self, from: JSONEncoder().encode(config))
+
+        #expect(decoded.claudeInstances == config.claudeInstances)
+        #expect(decoded.claudeInstancesEnabled == true)
+        #expect(decoded.enabledClaudeInstanceConfigDirectories == ["/tmp/claude-work"])
+    }
+
+    @Test
+    func `failed refresh keeps the previous instance usage and labels unnamed instances`() {
+        let instance = ClaudeInstanceConfig(id: "a", name: "  ", configDirectory: "/tmp/claude-work")
+        let usage = UsageSnapshot(
+            primary: RateWindow(usedPercent: 40, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(timeIntervalSince1970: 0))
+        let first = ClaudeInstanceAccountProjection.accountSnapshot(
+            for: instance,
+            index: 1,
+            result: .success(usage),
+            previous: nil)
+
+        let failed = ClaudeInstanceAccountProjection.accountSnapshot(
+            for: instance,
+            index: 1,
+            result: .failure(ClaudeInstanceUsageFetcher.FetchError.invalidConfigDirectory),
+            previous: first)
+
+        #expect(first.id == ProviderAccountIdentity(source: "claude-instance", opaqueID: "a"))
+        #expect(first.displayLabel == "Instance 2")
+        #expect(first.error == nil)
+        #expect(failed.snapshot?.primary?.usedPercent == 40)
+        #expect(failed.error?.hasPrefix("Showing the last successful update:") == true)
+        #expect(failed.canActivate == false)
+    }
+
+    @Test
+    func `rate limit cooldown is scoped to each explicit config directory`() {
+        let work = ["CLAUDE_CONFIG_DIR": "/tmp/claude-rate-limit-work"]
+        let personal = ["CLAUDE_CONFIG_DIR": "/tmp/claude-rate-limit-personal"]
+        defer {
+            ClaudeCLIRateLimitGate.resetForTesting(environment: work)
+            ClaudeCLIRateLimitGate.resetForTesting(environment: personal)
+        }
+
+        #expect(ClaudeCLIRateLimitGate.storageKey(environment: [:]) == "claudeCLIUsageRateLimitBlockedUntilV1")
+        #expect(ClaudeCLIRateLimitGate.storageKey(environment: ["CLAUDE_CONFIG_DIR": ""]) ==
+            ClaudeCLIRateLimitGate.storageKey(environment: [:]))
+
+        ClaudeCLIRateLimitGate.recordRateLimit(environment: work)
+
+        #expect(ClaudeCLIRateLimitGate.currentBlockedUntil(environment: work) != nil)
+        #expect(ClaudeCLIRateLimitGate.currentBlockedUntil(environment: personal) == nil)
+    }
+
+    @Test
+    func `cost scanning appends instance projects roots to the default roots`() {
+        let instanceRoots = CostUsageFetcher.claudeProjectsRoots(
+            forConfigDirectories: ["/tmp/claude-work", "/tmp/claude-work/", "relative"])
+        #expect(instanceRoots.map(\.path) == ["/tmp/claude-work/projects", "/tmp/claude-work/projects"])
+
+        let options = CostUsageScanner.Options()
+        let defaults = CostUsageScanner.defaultClaudeProjectsRoots(options: options).map(\.path)
+        let roots = CostUsageScanner.claudeProjectsRoots(
+            appendingInstanceRoots: instanceRoots,
+            options: options).map(\.path)
+
+        #expect(Array(roots.prefix(defaults.count)) == defaults)
+        #expect(roots.count(where: { $0 == "/tmp/claude-work/projects" }) == 1)
+    }
+}

--- a/Tests/CodexBarTests/Fixtures/Config/provider-specific-full.json
+++ b/Tests/CodexBarTests/Fixtures/Config/provider-specific-full.json
@@ -1,6 +1,18 @@
 {
   "providers" : [
     {
+      "claudeInstances" : [
+        {
+          "binaryPath" : "\/opt\/homebrew\/bin\/claude",
+          "configDirectory" : "\/Users\/fixture\/.claude-work",
+          "environment" : {
+            "HTTPS_PROXY" : "http:\/\/proxy.fixture:8080"
+          },
+          "id" : "fixture-work",
+          "name" : "Work"
+        }
+      ],
+      "claudeInstancesEnabled" : false,
       "claudeSwapEnabled" : true,
       "claudeSwapExecutablePath" : "\/opt\/homebrew\/bin\/claude-swap",
       "claudeSwapShowSingleAccount" : false,

--- a/Tests/CodexBarTests/UsageStoreClaudeInstancesTests.swift
+++ b/Tests/CodexBarTests/UsageStoreClaudeInstancesTests.swift
@@ -1,0 +1,194 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct UsageStoreClaudeInstancesTests {
+    private static let work = ClaudeInstanceConfig(id: "work", name: "Work", configDirectory: "/tmp/claude-work")
+    private static let personal = ClaudeInstanceConfig(
+        id: "personal",
+        name: "Personal",
+        configDirectory: "/tmp/claude-personal")
+
+    @Test
+    func `instances refresh one at a time and publish cards in configured order`() async throws {
+        let (settings, store) = try self.makeStore()
+        let recorder = LoadRecorder()
+        store.claudeInstanceUsageLoaderOverride = { instance in
+            try await recorder.load(instance.id)
+        }
+        try await self.configure(settings: settings, store: store, recorder: recorder)
+
+        await store.refreshClaudeInstances()
+
+        #expect(store.claudeInstanceAccountSnapshots.map(\.displayLabel) == ["Work", "Personal"])
+        #expect(await recorder.order == ["work", "personal"])
+        #expect(await recorder.maxConcurrent == 1)
+        #expect(store.claudeInstancesOwnAccountPresentation)
+        #expect(store.menuBarSnapshot(for: UsageProvider.claude.instanceID)?.primary?.usedPercent == 10)
+    }
+
+    @Test
+    func `failed instance refresh keeps its last usage beside the error`() async throws {
+        let (settings, store) = try self.makeStore()
+        let recorder = LoadRecorder()
+        store.claudeInstanceUsageLoaderOverride = { instance in
+            try await recorder.load(instance.id)
+        }
+        try await self.configure(settings: settings, store: store, recorder: recorder)
+        await store.refreshClaudeInstances()
+
+        store.claudeInstanceUsageLoaderOverride = { instance in
+            if instance.id == "personal" {
+                throw ClaudeInstanceTestError()
+            }
+            return try await recorder.load(instance.id)
+        }
+        await store.refreshClaudeInstances()
+
+        let personal = try #require(store.claudeInstanceAccountSnapshots.last)
+        #expect(personal.snapshot?.primary?.usedPercent == 20)
+        #expect(personal.error?.hasPrefix("Showing the last successful update:") == true)
+        #expect(store.claudeInstanceAccountSnapshots.first?.error == nil)
+    }
+
+    @Test
+    func `results for an edited instance list are dropped`() async throws {
+        let (settings, store) = try self.makeStore()
+        let recorder = LoadRecorder()
+        store.claudeInstanceUsageLoaderOverride = { instance in
+            try await recorder.load(instance.id)
+        }
+        try await self.configure(settings: settings, store: store, recorder: recorder)
+        store.claudeInstanceUsageLoaderOverride = { instance in
+            await MainActor.run { settings.claudeInstances = [Self.personal] }
+            return try await recorder.load(instance.id)
+        }
+
+        await store.refreshClaudeInstances()
+
+        #expect(store.claudeInstanceAccountSnapshots.isEmpty)
+    }
+
+    @Test
+    func `claude-swap and Claude instances cannot both be enabled`() throws {
+        let (settings, _) = try self.makeStore()
+
+        settings.claudeSwapEnabled = true
+        settings.claudeInstancesEnabled = true
+        #expect(settings.claudeInstancesEnabled)
+        #expect(!settings.claudeSwapEnabled)
+
+        settings.claudeSwapEnabled = true
+        #expect(settings.claudeSwapEnabled)
+        #expect(!settings.claudeInstancesEnabled)
+    }
+
+    @Test
+    func `instance cards take precedence only for Claude`() {
+        #expect(ClaudeSwapMenuPrecedence.prefersClaudeInstances(provider: .claude, instancesOwnPresentation: true))
+        #expect(!ClaudeSwapMenuPrecedence.prefersClaudeInstances(provider: .claude, instancesOwnPresentation: false))
+        #expect(!ClaudeSwapMenuPrecedence.prefersClaudeInstances(provider: .codex, instancesOwnPresentation: true))
+    }
+
+    @Test
+    func `saving an instance draft normalizes paths and replaces the same instance in place`() throws {
+        let (settings, _) = try self.makeStore()
+        settings.claudeInstances = [Self.work, Self.personal]
+
+        var draft = ClaudeInstanceDraft(instance: Self.work)
+        draft.name = "  Work (renamed)  "
+        draft.configDirectory = "~/.claude-work"
+        draft.binaryPath = ""
+        draft.environmentText = "HTTPS_PROXY=http://proxy.local:8080\nANTHROPIC_API_KEY=sk-ant-ignored"
+        let instance = try #require(draft.makeInstance())
+        settings.saveClaudeInstance(instance)
+
+        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        #expect(settings.claudeInstances.map(\.id) == ["work", "personal"])
+        #expect(settings.claudeInstances.first?.name == "Work (renamed)")
+        #expect(settings.claudeInstances.first?.configDirectory == "\(home)/.claude-work")
+        #expect(settings.claudeInstances.first?.binaryPath == nil)
+        #expect(settings.claudeInstances.first?.environment == ["HTTPS_PROXY": "http://proxy.local:8080"])
+
+        settings.removeClaudeInstance(id: "work")
+        #expect(settings.claudeInstances.map(\.id) == ["personal"])
+    }
+
+    @Test
+    func `drafts with relative paths cannot be saved`() {
+        var draft = ClaudeInstanceDraft.new()
+        draft.configDirectory = "relative/profile"
+        #expect(!draft.canSave)
+        #expect(draft.makeInstance() == nil)
+
+        draft.configDirectory = "/tmp/claude-work"
+        draft.binaryPath = "bin/claude"
+        #expect(!draft.canSave)
+
+        draft.binaryPath = "/opt/claude/bin/claude"
+        #expect(draft.canSave)
+    }
+
+    /// Enables instances, then cancels any refresh the settings change scheduled so each test drives its own.
+    private func configure(settings: SettingsStore, store: UsageStore, recorder: LoadRecorder) async throws {
+        settings.claudeInstances = [Self.work, Self.personal]
+        settings.claudeInstancesEnabled = true
+        let scheduled = store.claudeInstanceRefreshTask
+        store.clearClaudeInstanceState()
+        await scheduled?.value
+        await recorder.reset()
+    }
+
+    private func makeStore() throws -> (SettingsStore, UsageStore) {
+        let suite = "UsageStoreClaudeInstancesTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let metadata = try #require(ProviderRegistry.shared.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: metadata, enabled: true)
+        return (settings, store)
+    }
+}
+
+private struct ClaudeInstanceTestError: LocalizedError {
+    var errorDescription: String? {
+        "Claude CLI is not logged in."
+    }
+}
+
+private actor LoadRecorder {
+    private(set) var order: [String] = []
+    private(set) var maxConcurrent = 0
+    private var running = 0
+
+    func reset() {
+        self.order = []
+        self.maxConcurrent = 0
+    }
+
+    func load(_ id: String) async throws -> UsageSnapshot {
+        self.running += 1
+        self.maxConcurrent = max(self.maxConcurrent, self.running)
+        self.order.append(id)
+        defer { self.running -= 1 }
+        try await Task.sleep(for: .milliseconds(10))
+        return UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: id == "work" ? 10 : 20,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+    }
+}

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -216,6 +216,38 @@ Model-scoped weekly-window proof (synthetic data, no real accounts or credential
 | --- | --- |
 | ![claude-swap card before scoped windows](screenshots/claude-swap-scoped-before.png) | ![claude-swap card with a Fable scoped weekly window](screenshots/claude-swap-scoped-after.png) |
 
+## Claude instances (opt-in)
+
+For people who run several Claude Code profiles side by side (one `CLAUDE_CONFIG_DIR` per account).
+
+- Setup: Preferences → Providers → Claude → **Claude instances** → Add Instance. Each instance has a name, an
+  optional `claude` binary path (empty uses the normal `claude` lookup), a config directory (becomes
+  `CLAUDE_CONFIG_DIR`; `~` is expanded when saved), and optional `KEY=value` environment variables. Turn on
+  **Show Claude instances** to use them.
+- Config: stored on the Claude provider as `claudeInstancesEnabled` and `claudeInstances`
+  (`id`, `name`, `binaryPath`, `configDirectory`, `environment`). Paths are machine-specific and are not cloud-synced.
+  Environment values are stored in plain text, so do not put secrets there.
+- Usage: on each Claude refresh, CodexBar runs each instance's own Claude CLI `/usage` (and `/status` for identity)
+  with that instance's environment, one instance at a time, separately from the ambient Claude refresh. Claude Code
+  reads its own credentials; CodexBar never reads the instance's Keychain item or credentials file, and web/cookie
+  extras stay off because browser cookies are not scoped to a profile. Cards therefore show percentages and reset
+  times only ("via Claude CLI" fidelity).
+- Environment guardrails: `ANTHROPIC_*`, `CLAUDE_CODE_OAUTH_TOKEN`, CodexBar's Claude OAuth token variables, and
+  `CLAUDE_SECURESTORAGE_CONFIG_DIR` are dropped from the inherited environment and ignored per instance, so an
+  instance always uses its own profile's login. `CLAUDE_CONFIG_DIR`, `CLAUDE_CLI_PATH`, and `HOME` belong to the
+  instance fields. Free-form launch arguments are not supported: the probe runs `claude` with tools disabled.
+- Display: when instances are on and have reported, one card per instance replaces the ambient and token-account
+  Claude cards (identity `claude-instance:<id>`, never an email or path). The card label is the instance name plus
+  the account email from `/status`. Stacked, compact (four or more), and segmented layouts are supported; there is no
+  active account, so the segmented switcher only chooses which instance card to show. The first instance with usable
+  usage drives the menu bar icon. A failed refresh keeps that instance's last successful usage with the error shown.
+- claude-swap and Claude instances are mutually exclusive: turning one on turns the other off.
+- Rate limits: the CLI rate-limit cooldown is keyed per explicit `CLAUDE_CONFIG_DIR`, so one rate-limited instance does
+  not pause the others. The default profile keeps its existing cooldown key.
+- Cost: while instances are on, local cost scanning also reads `<configDirectory>/projects` for every instance.
+  Messages that appear in more than one profile are counted once (by message and request ID).
+- Not yet covered: `codexbar cards`, widgets, and cloud-synced account snapshots still show the ambient Claude account.
+
 ## CLI PTY (fallback)
 - Runs `claude` in a PTY session (`ClaudeCLISession`).
 - Default behavior: exit after each probe; Debug → "Keep CLI sessions alive" keeps it running between probes.


### PR DESCRIPTION
## Summary

Adds opt-in **Claude instances** for people who run several Claude Code profiles side by side (one `CLAUDE_CONFIG_DIR` per account), modeled on how T3 Code lets you add more than one agent install.

Preferences → Providers → Claude → **Claude instances** lets you add any number of instances. Each has:

| Field | Notes |
|---|---|
| Name | Card label |
| Binary path | Optional; empty uses the normal `claude` lookup (`CLAUDE_CLI_PATH`) |
| Config directory | Becomes `CLAUDE_CONFIG_DIR`; `~` expanded on save; must be absolute |
| Environment | Optional `KEY=value` lines |

When **Show Claude instances** is on, the Claude menu shows one card per instance (stacked, compact for 4+, or segmented), and local cost history also scans every instance's `<configDirectory>/projects`.

## Credential boundary

This follows the same rule as the claude-swap adapter in `docs/claude-multi-account-and-status-items.md`: **CodexBar never reads the instance's credentials.**

- Each instance is probed only through its own Claude CLI (`/usage`, `/status`) with that instance's environment. Claude Code reads its own Keychain item or credentials file; no OAuth, Keychain, or credentials-file read happens in CodexBar for instances, so no Keychain prompts.
- Web/cookie extras are off for instances (browser cookies are not scoped to a Claude profile).
- `ANTHROPIC_*`, `CLAUDE_CODE_OAUTH_TOKEN`, CodexBar's Claude OAuth token variables, and `CLAUDE_SECURESTORAGE_CONFIG_DIR` are dropped from the inherited environment and ignored in instance environments, so an instance always uses its own profile's login. `CLAUDE_CONFIG_DIR`, `CLAUDE_CLI_PATH`, and `HOME` are owned by the instance fields.
- No free-form launch arguments: the probe runs `claude` with tools disabled, and arbitrary flags could undo that.
- Identity is `claude-instance:<stored id>`, never an email or path. Instances cannot activate/switch anything.

Because it crosses no new credential boundary, I kept it separate from (and mutually exclusive with) claude-swap rather than changing that design. Happy to adjust if you'd prefer a different shape.

## Behavior details

- Instances refresh **one at a time**, separately from the ambient Claude refresh, and publish each card as it finishes. (The shared `ClaudeCLISession` relaunches per profile; overlapping probes would tear each other down.)
- A failed refresh keeps that instance's last successful usage with the error shown.
- The CLI rate-limit cooldown is now keyed per explicit `CLAUDE_CONFIG_DIR`, so one rate-limited instance does not pause the others. The default profile keeps its existing key (no behavior change for current users).
- The first instance with usable usage drives the menu bar icon, mirroring the claude-swap override (#2731).
- Enabling instances turns claude-swap off and vice versa.
- Config: `claudeInstancesEnabled` and `claudeInstances` extension keys on the Claude provider. Not cloud-synced (machine-specific paths). Environment values are stored in plain text; the UI says so.
- Cost: extra roots are appended to the default discovery; roots are part of the report memo key, and rows are deduplicated by message/request ID across roots.

Not in this PR (follow-ups if wanted): `codexbar cards` / dashboard, widgets, and cloud-synced account snapshots still show the ambient Claude account.

## Translations

All 22 complete locales got the 14 new strings (`node Scripts/check-app-locales.mjs` passes). Terms a native speaker may want to revisit: vi/tr/ar/fa "instance", it "card" (scheda), and ja/ko/zh use "environment variables" for the Environment label.

## Commands run

- `swift build --target CodexBarCore` and `swift build --target CodexBarCLI` — pass.
- `make check` (with `TOOLCHAIN_DIR=/Library/Developer/CommandLineTools` so SwiftLint can load SourceKit without Xcode) — pass: app locales OK (22 catalogs), SwiftFormat clean, SwiftLint 0 violations in 2189 files.
- `Scripts/regenerate-codex-parser-hash.sh` inputs are untouched: the instance cost roots live in `CostUsageScanner+Claude.swift` and `CostUsageFetcher.swift`, so `CodexParserHash` (and existing Codex/pi caches) do not change.

**Not run locally:** the development Mac has only the Command Line Tools (no Xcode), and the app target uses SwiftUI `@Entry`, whose macro plugin ships only with Xcode. So the `CodexBar` app target, `CodexBarTests`, `make test`, and packaged UI screenshots could not be produced locally; I'm opening this as a draft and relying on CI to compile and run the suite. New tests:

- `Tests/CodexBarTests/ClaudeInstanceConfigTests.swift` — environment building and guardrails, env text parsing, config round trip, projection keeps last usage on failure, per-profile rate-limit keys, cost roots.
- `Tests/CodexBarTests/UsageStoreClaudeInstancesTests.swift` — sequential refresh + ordering, last-usage retention, stale config results dropped, swap/instances mutual exclusion, menu precedence, draft validation and save/remove.
- `provider-specific-full.json` fixture covers the new keys for byte-stable config encoding.

No screenshots yet; I can add synthetic-data screenshots once someone with Xcode can package the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
