### PR TITLE
fix(devin): honor hidden daily quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.59.1 — Unreleased
 
 ### Fixed
+- Devin: honor hidden daily quotas even when the response includes daily usage, preserving weekly limits and extra balance (#3542). Thanks @dzienisz!
 - Codex accounts: honor Hide Personal Info in switcher labels and tooltips, redact embedded workspace emails, and preserve distinct account numbers in narrow menus (#3551). Thanks @zenibako!
 - Codex spend: keep waiting history files ahead of repeated migration revisits so large histories can finish bounded catch-up, preserving stored rows and checkpoints (#3548, related to #3411). Thanks @SergeiNikolenko!
 

--- a/Sources/CodexBarCore/Providers/Devin/DevinUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Devin/DevinUsageSnapshot.swift
@@ -103,9 +103,15 @@ public enum DevinUsageParser {
     }
 
     public static func parse(_ object: Any, organization: String?, now: Date = Date()) throws -> DevinUsageSnapshot {
-        let current = (object as? [String: Any]).map(self.currentQuotaWindows)
-        let daily = current?.daily ?? self.findWindow(in: object, matching: self.isDailyKey)
-        let weekly = current?.weekly ?? self.findWindow(in: object, matching: self.isWeeklyKey)
+        let dictionary = object as? [String: Any]
+        let hideDaily = (dictionary?["hide_daily_quota"] as? NSNumber)
+            .map { CFGetTypeID($0) == CFBooleanGetTypeID() && $0.boolValue } ?? false
+        let daily = hideDaily ? nil : self.currentQuotaWindow(
+            percent: dictionary?["daily_percentage"],
+            resetsAt: dictionary?["daily_reset_at"]) ?? self.findWindow(in: object, matching: self.isDailyKey)
+        let weekly = self.currentQuotaWindow(
+            percent: dictionary?["weekly_percentage"],
+            resetsAt: dictionary?["weekly_reset_at"]) ?? self.findWindow(in: object, matching: self.isWeeklyKey)
         guard daily != nil || weekly != nil else {
             throw DevinUsageError.parseFailed("Missing Devin quota windows.")
         }
@@ -129,18 +135,6 @@ public enum DevinUsageParser {
     private static func nonnegativeFiniteDouble(_ value: Any?) -> Double? {
         guard let value = self.double(value), value.isFinite, value >= 0 else { return nil }
         return value
-    }
-
-    private static func currentQuotaWindows(_ dictionary: [String: Any])
-        -> (daily: DevinQuotaWindow?, weekly: DevinQuotaWindow?)
-    {
-        let daily = self.currentQuotaWindow(
-            percent: dictionary["daily_percentage"],
-            resetsAt: dictionary["daily_reset_at"])
-        let weekly = self.currentQuotaWindow(
-            percent: dictionary["weekly_percentage"],
-            resetsAt: dictionary["weekly_reset_at"])
-        return (daily, weekly)
     }
 
     private static func currentQuotaWindow(percent: Any?, resetsAt: Any?) -> DevinQuotaWindow? {

--- a/Tests/CodexBarTests/DevinQuotaVisibilityNativeProofTests.swift
+++ b/Tests/CodexBarTests/DevinQuotaVisibilityNativeProofTests.swift
@@ -1,0 +1,123 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+final class DevinQuotaVisibilityNativeProofTests: XCTestCase {
+    func test_dailyVisibilityInProductionCards() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["CODEXBAR_DEVIN_VISIBILITY_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_DEVIN_VISIBILITY_PROOF_DIR for signed synthetic UI proof")
+        }
+        let output = URL(fileURLWithPath: path, isDirectory: true)
+        guard SettingsStore.isRunningTests,
+              environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment[CodexCredentialFileAccess.isolationEnvironmentKey] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1",
+              NSHomeDirectory().hasPrefix(output.deletingLastPathComponent().path + "/")
+        else { return XCTFail("Use a contained home and credential/session isolation") }
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let baseline = environment["CODEXBAR_DEVIN_VISIBILITY_PROOF_BASELINE"] == "1"
+        let now = Date()
+        let models = try [true, false].map { hideDaily in
+            let snapshot = try DevinUsageParser.parse(
+                [
+                    "hide_daily_quota": hideDaily,
+                    "daily_percentage": 0,
+                    "weekly_percentage": 90,
+                    "daily_reset_at": now.addingTimeInterval(86400).timeIntervalSince1970,
+                    "weekly_reset_at": now.addingTimeInterval(172_800).timeIntervalSince1970,
+                ],
+                organization: nil,
+                now: now).toUsageSnapshot()
+            return try UsageMenuCardView.Model.make(.init(
+                provider: .devin,
+                metadata: XCTUnwrap(ProviderDefaults.metadata[.devin]),
+                snapshot: snapshot,
+                credits: nil,
+                creditsError: nil,
+                dashboard: nil,
+                dashboardError: nil,
+                tokenSnapshot: nil,
+                tokenError: nil,
+                account: AccountInfo(email: nil, plan: nil),
+                isRefreshing: false,
+                lastError: nil,
+                usageBarsShowUsed: false,
+                resetTimeDisplayStyle: .countdown,
+                tokenCostUsageEnabled: false,
+                showOptionalCreditsAndExtraUsage: true,
+                hidePersonalInfo: true,
+                now: now))
+        }
+        // Baseline expectations use the original parser binary with the same synthetic response.
+        XCTAssertEqual(models[0].metrics.map(\.id), baseline ? ["primary", "secondary"] : ["secondary"])
+        XCTAssertEqual(models[1].metrics.map(\.id), ["primary", "secondary"])
+        let app = NSApplication.shared
+        guard app.delegate == nil else { return XCTFail("Use a standalone test host") }
+        let previousApp = NSWorkspace.shared.frontmostApplication
+        let previousPolicy = app.activationPolicy()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        window.title = "CodexBar — Synthetic Devin Quota Visibility"
+        window.isReleasedWhenClosed = false
+        defer {
+            window.close()
+            _ = app.setActivationPolicy(previousPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApp?.activate()
+            }
+        }
+        _ = app.setActivationPolicy(.regular)
+        app.finishLaunching()
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        app.activate(ignoringOtherApps: true)
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            window.appearance = NSAppearance(named: appearance)
+            window.contentView = NSHostingView(rootView:
+                VStack(alignment: .leading, spacing: 18) {
+                    Text(baseline ? "Before: hidden daily quota still appears" :
+                        "After: daily visibility follows Devin")
+                        .font(.title2.bold())
+                    Text("Synthetic response · Weekly 90% used · Production parser and menu cards")
+                        .font(.caption)
+                    HStack(alignment: .top, spacing: 24) {
+                        ForEach(models.indices, id: \.self) { index in
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text(index == 0 ? "Daily hidden by provider" : "Daily visible (unchanged)")
+                                    .font(.headline)
+                                UsageMenuCardView(model: models[index], width: 360)
+                            }
+                        }
+                    }
+                    Spacer()
+                }.padding(24)
+                    .environment(\.locale, Locale(identifier: "en"))
+                    .preferredColorScheme(appearance == .aqua ? .light : .dark))
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 1))
+            let capture = Process()
+            capture.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+            capture.arguments = [
+                "-x", "-o", "-l", String(window.windowNumber),
+                output.appendingPathComponent("devin-\(appearance.rawValue).png").path,
+            ]
+            try capture.run()
+            capture.waitUntilExit()
+            XCTAssertEqual(capture.terminationStatus, 0)
+        }
+        let receipt: [String: Any] = [
+            "baseline": baseline,
+            "hiddenDailyMetrics": models[0].metrics.map(\.id),
+            "visibleDailyMetrics": models[1].metrics.map(\.id),
+        ]
+        try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys, .prettyPrinted])
+            .write(to: output.appendingPathComponent("state.json"), options: .atomic)
+    }
+}

--- a/Tests/CodexBarTests/DevinUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DevinUsageFetcherTests.swift
@@ -130,15 +130,60 @@ struct DevinUsageFetcherTests {
     @Test
     func `keeps weekly quota when current plan hides daily quota`() throws {
         let response: [String: Any] = [
+            "daily_percentage": 0,
+            "daily_reset_at": "2026-06-11T00:00:00-08:00",
             "weekly_percentage": 25,
             "weekly_reset_at": "2026-06-14T00:00:00-08:00",
             "hide_daily_quota": true,
+            "overage_balance": 12,
         ]
 
         let usage = try DevinUsageParser.parse(response, organization: nil, now: Self.now).toUsageSnapshot()
 
         #expect(usage.primary == nil)
         #expect(usage.secondary?.usedPercent == 25)
+        #expect(usage.secondary?.resetsAt?.timeIntervalSince1970 == 1_781_424_000)
+        #expect(usage.providerCost?.used == 12)
+    }
+
+    @Test(arguments: ["true", "false", "null", "1", "\"true\"", "absent"], [false, true])
+    func `daily visibility applies before current and fallback parsing`(_ flag: String, _ fallback: Bool) throws {
+        var response: [String: Any] = fallback ? [
+            "quota_usage": [
+                "daily_quota": ["used_percent": 0.25, "reset_at": "2026-06-11T00:00:00-08:00"],
+                "weekly_quota": ["used_percent": 0.9, "reset_at": "2026-06-14T00:00:00-08:00"],
+            ],
+        ] : [
+            "daily_percentage": 25,
+            "weekly_percentage": 90,
+            "daily_reset_at": "2026-06-11T00:00:00-08:00",
+            "weekly_reset_at": "2026-06-14T00:00:00-08:00",
+        ]
+        if flag != "absent" {
+            response["hide_daily_quota"] = try JSONSerialization.jsonObject(
+                with: Data(flag.utf8), options: [.fragmentsAllowed])
+        }
+        let data = try JSONSerialization.data(withJSONObject: response)
+        let usage = try DevinUsageParser.parse(data, organization: nil, now: Self.now).toUsageSnapshot()
+
+        #expect(usage.primary?.usedPercent == (flag == "true" ? nil : 25))
+        #expect(usage.primary?.resetsAt?.timeIntervalSince1970 == (flag == "true" ? nil : 1_781_164_800))
+        #expect(usage.secondary?.usedPercent == 90)
+        #expect(usage.secondary?.resetsAt?.timeIntervalSince1970 == 1_781_424_000)
+    }
+
+    @Test
+    func `hidden daily data cannot satisfy missing quota windows`() {
+        #expect(throws: DevinUsageError.self) {
+            try DevinUsageParser.parse(
+                [
+                    "hide_daily_quota": true,
+                    "daily_percentage": 0,
+                    "quota_usage": ["daily_quota": ["used_percent": 25]],
+                ],
+                organization: nil,
+                now: Self.now)
+        }
     }
 
     @Test

--- a/docs/devin.md
+++ b/docs/devin.md
@@ -61,5 +61,6 @@ CodexBar requests:
 GET https://app.devin.ai/api/<internal-org-id>/billing/quota/usage
 ```
 
-The response supplies daily and weekly usage percentages plus reset timestamps. If Devin changes or expires the browser
+The response supplies daily and weekly usage percentages plus reset timestamps. CodexBar omits the daily quota when Devin sets `hide_daily_quota` to `true`, while retaining weekly usage and extra balance.
+If Devin changes or expires the browser
 session, sign in again and refresh CodexBar.


### PR DESCRIPTION
Fixes #3542. CodexBar showed a Daily row even when Devin explicitly hid that quota. The parser now honors a root Boolean `hide_daily_quota: true` before both current-field and fallback parsing, while preserving weekly usage, reset timestamps, extra balance and percentage scaling. False, absent and malformed flag values retain their previous behavior. No plan-name heuristic is needed.

The existing hidden-daily test omitted daily data, so it could not catch the defect. The strengthened regression and new current/fallback cases fail six assertions on the old parser. Removing the single-use tuple wrapper keeps this fix at **six fewer production lines**. Provider docs and the 0.59.1 Unreleased changelog are updated. Thanks @dzienisz for the dashboard comparison.

Validation:
- 69 focused parser and architecture tests passed, including actual JSON Boolean/numeric/string/null flags and missing-visible-window behavior.
- `make check` passed with zero violations across 2,182 files. Two earlier test argument-formatting violations were corrected; those edits were verified whitespace-only.
- Independent P0–P2 review of the final staged patch is clean.
- Developer-ID-signed synthetic native before/after tests passed in Light and Dark appearances. The actual production parser feeds production menu cards: the hidden-daily card loses only Daily, Weekly remains 10% left, and the visible-daily card is unchanged. All four full captures were inspected before upload.
- Full `make test` passed all 1,069 selections across 90 groups on the first attempt, with no retries or timeouts (842.7 seconds).
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34616966632) passed all checks.

The reporter supplied a same-time dashboard comparison and confirmed weekly-only Max versus daily-and-weekly Pro; the exact live response was not shared. The proof here is synthetic and does not use real provider credentials. The separate account-switching question is outside this quota-visibility repair.

<details>
<summary>Signed synthetic native before/after proof</summary>

![Before, Light: synthetic Devin quota cards](https://github.com/user-attachments/assets/3bc7fe97-2c68-4cd0-bcc9-9f9f40fd6706)

![Before, Dark: synthetic Devin quota cards](https://github.com/user-attachments/assets/8b356668-f35a-4b4a-b3e3-f7399c3505a5)

![After, Light: synthetic Devin quota cards](https://github.com/user-attachments/assets/d0e42e7d-4bc9-469d-be2c-a5737a6ece8d)

![After, Dark: synthetic Devin quota cards](https://github.com/user-attachments/assets/79e3af6b-69e7-41bc-a5eb-2481230b4c79)

</details>
