### PR TITLE
fix(codex): reauthenticate the visible credential source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Devin: honor hidden daily quotas even when the response includes daily usage, preserving weekly limits and extra balance (#3542). Thanks @dzienisz!
 - Codex accounts: honor Hide Personal Info in switcher labels and tooltips, redact embedded workspace emails, and preserve distinct account numbers in narrow menus (#3551). Thanks @zenibako!
+- Codex accounts: reauthenticate the credential source used by the visible row, fixing repeated re-auth on saved accounts that also represent the System login, and reject stale account actions (#3558). Thanks @Nek-12!
 - Codex spend: keep waiting history files ahead of repeated migration revisits so large histories can finish bounded catch-up, preserving stored rows and checkpoints (#3548, related to #3411). Thanks @SergeiNikolenko!
 
 ## 0.59.0 — 2026-09-10

--- a/Sources/CodexBar/PreferencesCodexAccountsSection.swift
+++ b/Sources/CodexBar/PreferencesCodexAccountsSection.swift
@@ -55,11 +55,12 @@ struct CodexAccountsSectionState: Equatable {
     }
 
     var canAddAccount: Bool {
-        !self.hasUnreadableManagedAccountStore &&
-            !self.isAuthenticatingManagedAccount &&
-            !self.isRemovingManagedAccount &&
-            !self.isAuthenticatingLiveAccount &&
-            !self.isPromotingSystemAccount
+        !self.hasUnreadableManagedAccountStore && !self.hasAccountOperationInFlight
+    }
+
+    private var hasAccountOperationInFlight: Bool {
+        self.isAuthenticatingManagedAccount || self.isRemovingManagedAccount ||
+            self.isAuthenticatingLiveAccount || self.isPromotingSystemAccount
     }
 
     var addAccountTitle: String {
@@ -74,11 +75,7 @@ struct CodexAccountsSectionState: Equatable {
     }
 
     var isSystemSelectionDisabled: Bool {
-        self.hasUnreadableManagedAccountStore ||
-            self.isAuthenticatingManagedAccount ||
-            self.isRemovingManagedAccount ||
-            self.isAuthenticatingLiveAccount ||
-            self.isPromotingSystemAccount
+        !self.canAddAccount
     }
 
     func canPromoteToSystem(_ account: CodexVisibleAccount) -> Bool {
@@ -88,34 +85,29 @@ struct CodexAccountsSectionState: Equatable {
     }
 
     func canReauthenticate(_ account: CodexVisibleAccount) -> Bool {
-        guard account.canReauthenticate else { return false }
-        guard self.isAuthenticatingManagedAccount == false else { return false }
-        guard self.isRemovingManagedAccount == false else { return false }
-        guard self.isAuthenticatingLiveAccount == false else { return false }
-        guard self.isPromotingSystemAccount == false else { return false }
-        if account.storedAccountID != nil {
-            return self.hasUnreadableManagedAccountStore == false
+        guard account.canReauthenticate, !self.hasAccountOperationInFlight else { return false }
+        switch account.selectionSource {
+        case .managedAccount:
+            return !self.hasUnreadableManagedAccountStore
+        case .liveSystem:
+            return true
+        case .profileHome:
+            return false
         }
-        return true
     }
 
     func canRemove(_ account: CodexVisibleAccount) -> Bool {
-        guard account.canRemove else { return false }
-        guard self.isAuthenticatingManagedAccount == false else { return false }
-        guard self.isRemovingManagedAccount == false else { return false }
-        guard self.isAuthenticatingLiveAccount == false else { return false }
-        guard self.isPromotingSystemAccount == false else { return false }
-        return self.hasUnreadableManagedAccountStore == false
+        account.canRemove && self.canAddAccount
     }
 
     func reauthenticateTitle(for account: CodexVisibleAccount) -> String {
-        if let accountID = account.storedAccountID,
+        if case let .managedAccount(accountID) = account.selectionSource,
            self.isAuthenticatingManagedAccount,
            self.authenticatingManagedAccountID == accountID
         {
             return L("Re-authenticating…")
         }
-        if account.storedAccountID == nil, self.isAuthenticatingLiveAccount {
+        if account.selectionSource == .liveSystem, self.isAuthenticatingLiveAccount {
             return L("Re-authenticating…")
         }
         return L("Re-auth")

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -290,10 +290,15 @@ struct ProvidersPane: View {
 
     func reauthenticateCodexAccount(_ account: CodexVisibleAccount) async {
         self.codexAccountsNotice = nil
-        if let accountID = account.storedAccountID {
-            guard let state = self.codexAccountsSectionState(for: .codex), state.canReauthenticate(account) else {
-                return
-            }
+        self.settings.invalidateCodexAccountReconciliationSnapshotCache()
+        guard let state = self.codexAccountsSectionState(for: .codex),
+              let current = state.visibleAccounts.first(where: { $0.id == account.id }),
+              current.selectionSource == account.selectionSource,
+              current.storedAccountID == account.storedAccountID,
+              current.workspaceAccountID == account.workspaceAccountID,
+              state.canReauthenticate(current)
+        else { return }
+        if case let .managedAccount(accountID) = current.selectionSource {
             do {
                 _ = try await self.managedCodexAccountCoordinator
                     .authenticateManagedAccount(existingAccountID: accountID)
@@ -304,9 +309,7 @@ struct ProvidersPane: View {
             return
         }
 
-        guard let state = self.codexAccountsSectionState(for: .codex), state.canReauthenticate(account) else {
-            return
-        }
+        guard current.selectionSource == .liveSystem else { return }
 
         self.isAuthenticatingLiveCodexAccount = true
         self.codexAccountPromotionCoordinator.setLiveReauthenticationInProgress(true)

--- a/Tests/CodexBarTests/CodexReauthenticationNativeProofTests.swift
+++ b/Tests/CodexBarTests/CodexReauthenticationNativeProofTests.swift
@@ -1,0 +1,109 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+final class CodexReauthenticationNativeProofTests: XCTestCase {
+    func test_systemReauthenticationProgress() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let path = environment["CODEXBAR_REAUTH_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_REAUTH_PROOF_DIR for signed synthetic UI proof")
+        }
+        let output = URL(fileURLWithPath: path, isDirectory: true)
+        guard SettingsStore.isRunningTests,
+              environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] == "1",
+              environment[CodexCredentialFileAccess.isolationEnvironmentKey] == "1",
+              environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"] == "1",
+              environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] != "1",
+              NSHomeDirectory().hasPrefix(output.deletingLastPathComponent().path + "/")
+        else { return XCTFail("Use a contained home and credential/session isolation") }
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let baseline = environment["CODEXBAR_REAUTH_PROOF_BASELINE"] == "1"
+        let account = CodexVisibleAccount(
+            id: "account@example.com",
+            email: "account@example.com",
+            workspaceLabel: "Example Workspace",
+            storedAccountID: UUID(),
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: true,
+            canRemove: true)
+        let state = CodexAccountsSectionState(
+            visibleAccounts: [account],
+            activeVisibleAccountID: account.id,
+            liveVisibleAccountID: account.id,
+            hasUnreadableManagedAccountStore: false,
+            isAuthenticatingManagedAccount: false,
+            authenticatingManagedAccountID: nil,
+            isRemovingManagedAccount: false,
+            isAuthenticatingLiveAccount: true,
+            isPromotingSystemAccount: false,
+            notice: nil)
+        XCTAssertEqual(state.reauthenticateTitle(for: account), baseline ? "Re-auth" : "Re-authenticating…")
+        XCTAssertFalse(state.canReauthenticate(account))
+        let app = NSApplication.shared
+        guard app.delegate == nil else { return XCTFail("Use a standalone test host") }
+        let previousApp = NSWorkspace.shared.frontmostApplication
+        let previousPolicy = app.activationPolicy()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 660, height: 380),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        window.title = "CodexBar — Synthetic Re-authentication"
+        window.isReleasedWhenClosed = false
+        defer {
+            window.close()
+            _ = app.setActivationPolicy(previousPolicy)
+            if NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier {
+                previousApp?.activate()
+            }
+        }
+        _ = app.setActivationPolicy(.regular)
+        app.finishLaunching()
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        app.activate(ignoringOtherApps: true)
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            window.appearance = NSAppearance(named: appearance)
+            window.contentView = NSHostingView(rootView:
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(baseline ? "Before: System re-auth progress is missing" :
+                        "After: System re-auth progress is shown")
+                        .font(.title2.bold())
+                    Text("Synthetic saved + System account · System sign-in is in progress")
+                        .font(.caption)
+                    Form {
+                        CodexAccountsSectionView(
+                            state: state,
+                            setActiveVisibleAccount: { _ in XCTFail("Unexpected selection") },
+                            reauthenticateAccount: { _ in XCTFail("Unexpected login") },
+                            removeAccount: { _ in XCTFail("Unexpected removal") },
+                            requestSystemVisibleAccount: { _ in XCTFail("Unexpected promotion") },
+                            addAccount: { XCTFail("Unexpected account creation") })
+                    }
+                    .formStyle(.grouped)
+                }.padding(24)
+                    .environment(\.locale, Locale(identifier: "en"))
+                    .preferredColorScheme(appearance == .aqua ? .light : .dark))
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 1))
+            let capture = Process()
+            capture.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+            capture.arguments = [
+                "-x", "-o", "-l", String(window.windowNumber),
+                output.appendingPathComponent("reauth-\(appearance.rawValue).png").path,
+            ]
+            try capture.run()
+            capture.waitUntilExit()
+            XCTAssertEqual(capture.terminationStatus, 0)
+        }
+        try JSONSerialization.data(withJSONObject: [
+            "baseline": baseline, "title": state.reauthenticateTitle(for: account),
+            "canReauthenticate": state.canReauthenticate(account),
+        ], options: [.sortedKeys, .prettyPrinted])
+            .write(to: output.appendingPathComponent("state.json"), options: .atomic)
+    }
+}

--- a/Tests/CodexBarTests/CodexReauthenticationRoutingTests.swift
+++ b/Tests/CodexBarTests/CodexReauthenticationRoutingTests.swift
@@ -1,0 +1,221 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(CodexCredentialFixtures())
+struct CodexReauthenticationRoutingTests {
+    enum Kind: Sendable, Equatable {
+        case merged, managed, live
+    }
+
+    @Test(arguments: [Kind.merged, .managed, .live])
+    func `reauthentication follows the visible credential owner`(_ kind: Kind) async throws {
+        let fixture = try self.fixture(kind: kind)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        if kind == .merged {
+            #expect(row.storedAccountID != nil)
+            #expect(row.selectionSource == .liveSystem)
+        }
+
+        await fixture.pane._test_reauthenticateCodexAccount(row)
+
+        #expect(await fixture.runner.calls == [kind == .managed ? "managed" : "system"])
+        #expect(fixture.refreshes.value == (kind == .managed ? 0 : 1))
+        #expect(try fixture.managedStore.loadAccounts().accounts.map(\.managedHomePath) ==
+            fixture.snapshot.value.storedAccounts.map(\.managedHomePath))
+    }
+
+    @Test
+    func `queued reauthentication rejects a row whose credential owner changed`() async throws {
+        let fixture = try self.fixture(kind: .merged)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        let stored = try #require(fixture.snapshot.value.storedAccounts.first)
+        fixture.snapshot.setValue(Self.snapshot(
+            stored: stored,
+            live: nil,
+            activeSource: .managedAccount(id: stored.id)))
+        fixture.settings.invalidateCodexAccountReconciliationSnapshotCache()
+        let current = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        #expect(current.id == row.id)
+        #expect(current.selectionSource != row.selectionSource)
+
+        await fixture.pane._test_reauthenticateCodexAccount(row)
+
+        #expect(await fixture.runner.calls.isEmpty)
+        #expect(fixture.refreshes.value == 0)
+    }
+
+    @Test
+    func `queued reauthentication rejects a removed row`() async throws {
+        let fixture = try self.fixture(kind: .merged)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        fixture.snapshot.setValue(Self.snapshot(stored: nil, live: nil, activeSource: .liveSystem))
+        fixture.settings.invalidateCodexAccountReconciliationSnapshotCache()
+
+        await fixture.pane._test_reauthenticateCodexAccount(row)
+
+        #expect(await fixture.runner.calls.isEmpty)
+        #expect(fixture.refreshes.value == 0)
+    }
+
+    @Test
+    func `queued system reauthentication rejects a different workspace with the same row id`() async throws {
+        let fixture = try self.fixture(kind: .live)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        let live = ObservedSystemCodexAccount(
+            email: row.email,
+            workspaceAccountID: "workspace-other",
+            codexHomePath: CodexCredentialFixtures.root.appendingPathComponent("system").path,
+            observedAt: Date(),
+            identity: .providerAccount(id: "workspace-other"))
+        fixture.snapshot.setValue(Self.snapshot(stored: nil, live: live, activeSource: .liveSystem))
+        fixture.settings.invalidateCodexAccountReconciliationSnapshotCache()
+        let current = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        #expect(current.id == row.id)
+        #expect(current.selectionSource == row.selectionSource)
+        #expect(current.workspaceAccountID != row.workspaceAccountID)
+
+        await fixture.pane._test_reauthenticateCodexAccount(row)
+
+        #expect(await fixture.runner.calls.isEmpty)
+        #expect(fixture.refreshes.value == 0)
+    }
+
+    @Test
+    func `merged system row uses live progress and does not require the managed store`() throws {
+        let fixture = try self.fixture(kind: .merged)
+        defer { fixture.store.stopSharedSpendDashboardPublication() }
+        let row = try #require(fixture.pane._test_codexAccountsSectionState()?.visibleAccounts.first)
+        func state(unreadable: Bool, authenticatingLive: Bool) -> CodexAccountsSectionState {
+            CodexAccountsSectionState(
+                visibleAccounts: [row],
+                activeVisibleAccountID: row.id,
+                liveVisibleAccountID: row.id,
+                hasUnreadableManagedAccountStore: unreadable,
+                isAuthenticatingManagedAccount: false,
+                authenticatingManagedAccountID: nil,
+                isRemovingManagedAccount: false,
+                isAuthenticatingLiveAccount: authenticatingLive,
+                isPromotingSystemAccount: false,
+                notice: nil)
+        }
+        #expect(state(unreadable: false, authenticatingLive: true).reauthenticateTitle(for: row) ==
+            "Re-authenticating…")
+        #expect(!state(unreadable: false, authenticatingLive: true).canReauthenticate(row))
+        #expect(state(unreadable: true, authenticatingLive: false).canReauthenticate(row))
+    }
+
+    private func fixture(kind: Kind) throws -> Fixture {
+        let root = CodexCredentialFixtures.root
+        let environment = ["HOME": root.path, "CODEX_HOME": root.appendingPathComponent("system").path]
+        let config = CodexBarConfigStore(fileURL: root.appendingPathComponent("config.json"))
+        let settings = ProviderUsageItemVisibilityTests.settings(
+            defaults: InMemoryUserDefaults(values: ["codexbar.legacySecretsMigrationCompleted": true]),
+            configStore: config)
+        settings._test_codexReconciliationEnvironment = environment
+        settings.openAIWebAccessEnabled = false
+        settings.codexCookieSource = .off
+        settings.costUsageEnabled = false
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        let stored = kind == .live ? nil : ManagedCodexAccount(
+            id: UUID(),
+            email: "account@example.com",
+            providerAccountID: "workspace-example",
+            managedHomePath: root.appendingPathComponent("managed/original").path,
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let live = kind == .managed ? nil : ObservedSystemCodexAccount(
+            email: "account@example.com",
+            codexHomePath: environment["CODEX_HOME"]!,
+            observedAt: Date(),
+            identity: .providerAccount(id: "workspace-example"))
+        let activeSource: CodexActiveSource = kind == .managed ? .managedAccount(id: stored!.id) : .liveSystem
+        let snapshot = LockIsolated(Self.snapshot(stored: stored, live: live, activeSource: activeSource))
+        settings._test_codexAccountSnapshotLoader = { _ in snapshot.value }
+        settings.codexActiveSource = activeSource
+        let managedStore = FileManagedCodexAccountStore(fileURL: root.appendingPathComponent("accounts.json"))
+        try managedStore.storeAccounts(.init(
+            version: FileManagedCodexAccountStore.currentVersion, accounts: stored.map { [$0] } ?? []))
+        let runner = ReauthenticationRecordingRunner()
+        let coordinator = ManagedCodexAccountCoordinator(service: ManagedCodexAccountService(
+            store: managedStore,
+            homeFactory: ManagedCodexHomeFactory(root: root.appendingPathComponent("managed")),
+            loginRunner: runner,
+            identityReader: UnusedReauthenticationIdentityReader()))
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: environment),
+            browserDetection: BrowserDetection(homeDirectory: root.path, cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: environment)
+        let refreshes = LockIsolated(0)
+        store._test_providerRefreshOverride = { _ in refreshes.setValue(refreshes.value + 1) }
+        store._test_codexCreditsLoaderOverride = { throw UsageError.noRateLimitsFound }
+        store._test_widgetSnapshotSaveOverride = { _ in }
+        let pane = ProvidersPane(
+            settings: settings,
+            store: store,
+            managedCodexAccountCoordinator: coordinator,
+            codexAmbientLoginRunner: runner)
+        return Fixture(
+            settings: settings,
+            store: store,
+            pane: pane,
+            runner: runner,
+            snapshot: snapshot,
+            managedStore: managedStore,
+            refreshes: refreshes)
+    }
+
+    private static func snapshot(
+        stored: ManagedCodexAccount?, live: ObservedSystemCodexAccount?, activeSource: CodexActiveSource)
+        -> CodexAccountReconciliationSnapshot
+    {
+        CodexAccountReconciliationSnapshot(
+            storedAccounts: stored.map { [$0] } ?? [],
+            activeStoredAccount: stored,
+            liveSystemAccount: live,
+            matchingStoredAccountForLiveSystemAccount: live == nil ? nil : stored,
+            activeSource: activeSource,
+            hasUnreadableAddedAccountStore: false,
+            storedAccountRuntimeIdentities: stored.map { [$0.id: .providerAccount(id: "workspace-example")] } ?? [:])
+    }
+
+    private struct Fixture {
+        let settings: SettingsStore
+        let store: UsageStore
+        let pane: ProvidersPane
+        let runner: ReauthenticationRecordingRunner
+        let snapshot: LockIsolated<CodexAccountReconciliationSnapshot>
+        let managedStore: FileManagedCodexAccountStore
+        let refreshes: LockIsolated<Int>
+    }
+}
+
+private actor ReauthenticationRecordingRunner: CodexAmbientLoginRunning, ManagedCodexLoginRunning {
+    private(set) var calls: [String] = []
+
+    func run(timeout _: TimeInterval) async -> CLILoginRunner.Result {
+        self.calls.append("system")
+        return .init(outcome: .success, output: "synthetic system login")
+    }
+
+    func run(homePath _: String, timeout _: TimeInterval) async -> CLILoginRunner.Result {
+        self.calls.append("managed")
+        return .init(outcome: .cancelled, output: "synthetic managed login cancelled")
+    }
+}
+
+private struct UnusedReauthenticationIdentityReader: ManagedCodexIdentityReading {
+    func loadAccountIdentity(homePath _: String) throws -> CodexAuthBackedAccount {
+        throw ManagedCodexAccountServiceError.missingEmail
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2281,15 +2281,7 @@ struct ProviderArchitectureGatekeeperTests {
         AllowedProviderConstruct(
             path: "Sources/CodexBar/PreferencesProvidersPane.swift",
             line: 294,
-            anchor: "guard let state = self.codexAccountsSectionState(for: .codex), state.canReauthenticate(account) else {",
-            expectedProviderIDs: ["codex"],
-            expectedReferenceCount: 1,
-            expectedReferenceFingerprint: ["codex@0"],
-            reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
-        AllowedProviderConstruct(
-            path: "Sources/CodexBar/PreferencesProvidersPane.swift",
-            line: 307,
-            anchor: "guard let state = self.codexAccountsSectionState(for: .codex), state.canReauthenticate(account) else {",
+            anchor: "guard let state = self.codexAccountsSectionState(for: .codex),",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
             expectedReferenceFingerprint: ["codex@0"],

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -68,6 +68,7 @@ Usage source picker:
   Automatic mode also suppresses unscoped CLI fallback whenever a managed workspace is selected. Explicit
   managed-account workspace selection is stored in CodexBar's private managed-account metadata; it never edits the
   source `auth.json` or publishes an `account_id` change back to another application's credential file.
+- **Reauthenticate** follows the credential source shown by the account row: System rows use the existing system Codex login flow even when the same account is also saved; managed rows renew their private managed home. Credentials are not copied between those homes. A queued action is discarded if the row's source or workspace changes.
 - If native credentials need renewal, use **Reauthenticate** for the affected account in Settings → Providers → Codex.
   For CLI recovery, run `codex login` with that account's existing `CODEX_HOME` and select the intended workspace.
   The refresh error describes this manual recovery without promising automatic CLI fallback for managed workspaces.


### PR DESCRIPTION
Fixes #3558. A merged saved/System account row reads the System credential, but Re-auth previously chose the managed login solely because the row retained a storage ID. The action now follows the freshly reconciled credential source: System rows use the existing system Codex login runner; managed rows keep their private-home flow. Removed rows and changed source, stored slot, or workspace are rejected before login.

The shared action-exclusion refactor preserves add/remove/promotion guards and makes the merged System row show its live reauthentication progress. Profile homes remain non-reauthenticatable. Credential copying, automatic renewal, and the live-system projection preference are unchanged. Production code is **five lines smaller**. Docs and 0.59.1 Unreleased notes are updated. Thanks @Nek-12 for the credential-source comparison.

Validation:
- Six regression assertions fail on the old routing/state behavior. Injected runners verify the selected login owner, normal refresh completion, unchanged managed homes, and rejection of stale/removed rows.
- 94 focused tests across eight suites passed, including account state, settings, profile-home, promotion and architecture coverage. The final action also explicitly invalidates the projection cache before revalidation.
- `make check` passed with zero violations across 2,184 files; final independent P0–P2 review is clean.
- Signed synthetic native before/after captures verify the production account section’s busy label in Light and Dark mode. These pictures show the progress-state correction; login routing is tested with injected runners, not real credentials.
- The final full suite passed all 1,071 selections / 90 groups first time, with no retries or timeouts (1,110.7 seconds), using a separate temporary HOME/CFFIXED_USER_HOME.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34636830120) passed all checks.

<details>
<summary>Signed synthetic progress-state proof</summary>

![Before — Aqua](https://github.com/user-attachments/assets/08588936-a3b0-423b-ad28-afc14ee239d9)

![Before — DarkAqua](https://github.com/user-attachments/assets/59fee61c-6a35-4505-b734-9bf7e99a18b6)

![After — Aqua](https://github.com/user-attachments/assets/2a3475d3-0bd9-431d-b2a4-39f5623c17fd)

![After — DarkAqua](https://github.com/user-attachments/assets/677561b7-306d-4d4d-9cfd-030b4ff7841b)

</details>
