### PR TITLE
fix(menu): align window and display coordinate spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.59.1 — Unreleased
 
 ### Fixed
+- Menu bar: align window and display coordinates so monitors above or below the primary display do not cause missed or false startup recovery.
 - Devin: honor hidden daily quotas even when the response includes daily usage, preserving weekly limits and extra balance (#3542). Thanks @dzienisz!
 - Codex accounts: honor Hide Personal Info in switcher labels and tooltips, redact embedded workspace emails, and preserve distinct account numbers in narrow menus (#3551). Thanks @zenibako!
 - Codex spend: keep waiting history files ahead of repeated migration revisits so large histories can finish bounded catch-up, preserving stored rows and checkpoints (#3548, related to #3411). Thanks @SergeiNikolenko!

--- a/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
+++ b/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
@@ -15,13 +15,15 @@ struct MenuBarStatusItemWindowSnapshot: Equatable, CustomStringConvertible {
     }
 
     var isTahoeBlockedProxy: Bool {
-        self.ownerName == "Control Center"
+        // A primary-origin proxy can overlap an upper display below that display's menu bar.
+        let isPrimaryOriginProxy = self.bounds.maxY == 0 && self.displayBounds?.minY != self.bounds.minY
+        return self.ownerName == "Control Center"
             && self.isOnscreen
             && abs(self.bounds.minX) <= 1
             && self.bounds.maxY <= 0
             && self.bounds.width > 0
             && self.bounds.height > 0
-            && !self.isWithinDisplayBounds
+            && (!self.isWithinDisplayBounds || isPrimaryOriginProxy)
     }
 
     var description: String {

--- a/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
+++ b/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
@@ -39,16 +39,21 @@ enum MenuBarStatusItemWindowProbe {
         self.snapshots(
             matching: names,
             windowInfo: self.windowInfo(),
-            displayBounds: NSScreen.screens.map(\.frame))
+            screenFrames: NSScreen.screens.map(\.frame))
     }
 
     static func snapshots(
         matching names: Set<String>,
         windowInfo: [[String: Any]],
-        displayBounds: [CGRect])
+        screenFrames: [CGRect])
         -> [MenuBarStatusItemWindowSnapshot]
     {
         guard !names.isEmpty else { return [] }
+        // Cocoa screen frames and Quartz window bounds have opposite vertical origins.
+        let primaryHeight = screenFrames.first?.height ?? 0
+        let displayBounds = screenFrames.map {
+            CGRect(x: $0.minX, y: primaryHeight - $0.maxY, width: $0.width, height: $0.height)
+        }
         return windowInfo.compactMap { record in
             self.snapshot(record: record, matching: names, displayBounds: displayBounds)
         }
@@ -85,26 +90,8 @@ enum MenuBarStatusItemWindowProbe {
 
     private static func bounds(_ value: Any?) -> CGRect? {
         guard let dictionary = value as? [String: Any],
-              let x = self.double(dictionary["X"]),
-              let y = self.double(dictionary["Y"]),
-              let width = self.double(dictionary["Width"]),
-              let height = self.double(dictionary["Height"])
+              ["X", "Y", "Width", "Height"].allSatisfy({ dictionary[$0] is NSNumber })
         else { return nil }
-        return CGRect(x: x, y: y, width: width, height: height)
-    }
-
-    private static func double(_ value: Any?) -> Double? {
-        switch value {
-        case let number as NSNumber:
-            number.doubleValue
-        case let double as Double:
-            double
-        case let int as Int:
-            Double(int)
-        case let cgFloat as CGFloat:
-            Double(cgFloat)
-        default:
-            nil
-        }
+        return CGRect(dictionaryRepresentation: dictionary as CFDictionary)
     }
 }

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -4,6 +4,73 @@ import Testing
 @testable import CodexBar
 
 struct MenuBarVisibilityWatcherTests {
+    @Test(arguments: [
+        (CGRect(x: 0, y: -900, width: 1440, height: 900), CGRect(x: 0, y: -22, width: 76, height: 22), true),
+        (CGRect(x: 0, y: 1080, width: 1440, height: 900), CGRect(x: 0, y: -900, width: 76, height: 22), false),
+        (CGRect(x: 0, y: -900, width: 1440, height: 900), CGRect(x: 0, y: 1080, width: 76, height: 22), false),
+        (CGRect(x: -1440, y: 180, width: 1440, height: 900), CGRect(x: -100, y: 0, width: 76, height: 22), false),
+    ])
+    func `window probe aligns secondary screen coordinates before recovery decisions`(
+        _ screenFrame: CGRect, _ windowBounds: CGRect, _ blocked: Bool) throws
+    {
+        let windows = MenuBarStatusItemWindowProbe.snapshots(
+            matching: ["codexbar-merged"],
+            windowInfo: [[
+                kCGWindowName as String: "codexbar-merged",
+                kCGWindowOwnerName as String: "Control Center",
+                kCGWindowIsOnscreen as String: true,
+                kCGWindowBounds as String: windowBounds.dictionaryRepresentation,
+            ]],
+            screenFrames: [CGRect(x: 0, y: 0, width: 1920, height: 1080), screenFrame])
+        let window = try #require(windows.first)
+        #expect(window.isWithinDisplayBounds == !blocked)
+        #expect(window.isTahoeBlockedProxy == blocked)
+        let detached = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 76)
+        let launched = Date(timeIntervalSince1970: 1000)
+        #expect(MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launched,
+            now: launched.addingTimeInterval(2),
+            snapshots: [detached],
+            windowSnapshots: windows,
+            detectTahoeBlockedStatusItem: true) == blocked)
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launched,
+            now: launched.addingTimeInterval(2),
+            snapshots: [detached],
+            windowSnapshots: windows,
+            detectTahoeBlockedStatusItem: false))
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launched,
+            now: launched.addingTimeInterval(30),
+            snapshots: [detached],
+            windowSnapshots: windows,
+            detectTahoeBlockedStatusItem: true))
+    }
+
+    @Test
+    func `window probe rejects malformed rectangles and unmatched names`() {
+        let malformed: [[String: Any]] = [
+            [:],
+            ["X": 0, "Y": 0, "Width": 76],
+            ["X": "invalid", "Y": 0, "Width": 76, "Height": 22],
+        ]
+        var records = malformed.map {
+            [kCGWindowName as String: "codexbar-merged", kCGWindowBounds as String: $0] as [String: Any]
+        }
+        records.append([
+            kCGWindowName as String: "other-item",
+            kCGWindowBounds as String: CGRect(x: 0, y: 0, width: 76, height: 22).dictionaryRepresentation,
+        ])
+        #expect(MenuBarStatusItemWindowProbe.snapshots(
+            matching: ["codexbar-merged"], windowInfo: records, screenFrames: []).isEmpty)
+    }
+
     @Test
     func `does not flag intentionally hidden status item`() {
         let snapshot = StatusItemVisibilitySnapshot(
@@ -79,7 +146,7 @@ struct MenuBarVisibilityWatcherTests {
                     "Height": 24,
                 ],
             ]],
-            displayBounds: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
+            screenFrames: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
 
         #expect(snapshots.count == 1)
         #expect(snapshots.first?.name == "codexbar-merged")
@@ -103,7 +170,7 @@ struct MenuBarVisibilityWatcherTests {
                     "Height": 24,
                 ],
             ]],
-            displayBounds: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
+            screenFrames: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
 
         #expect(snapshots.count == 1)
         #expect(snapshots.first?.isOnscreen == true)

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -5,13 +5,16 @@ import Testing
 
 struct MenuBarVisibilityWatcherTests {
     @Test(arguments: [
-        (CGRect(x: 0, y: -900, width: 1440, height: 900), CGRect(x: 0, y: -22, width: 76, height: 22), true),
-        (CGRect(x: 0, y: 1080, width: 1440, height: 900), CGRect(x: 0, y: -900, width: 76, height: 22), false),
-        (CGRect(x: 0, y: -900, width: 1440, height: 900), CGRect(x: 0, y: 1080, width: 76, height: 22), false),
-        (CGRect(x: -1440, y: 180, width: 1440, height: 900), CGRect(x: -100, y: 0, width: 76, height: 22), false),
+        (CGRect(x: 0, y: -900, width: 1440, height: 900), CGRect(x: 0, y: -22, width: 76, height: 22), true, false),
+        (CGRect(x: 0, y: 1080, width: 1440, height: 900), CGRect(x: 0, y: -900, width: 76, height: 22), false, true),
+        (CGRect(x: 0, y: 1080, width: 1440, height: 900), CGRect(x: 0, y: -22, width: 76, height: 22), true, true),
+        (CGRect(x: 0, y: 1080, width: 1440, height: 900), CGRect(x: 0, y: -450, width: 76, height: 22), false, true),
+        (CGRect(x: 0, y: 1080, width: 1440, height: 22), CGRect(x: 0, y: -22, width: 76, height: 22), false, true),
+        (CGRect(x: 0, y: -900, width: 1440, height: 900), CGRect(x: 0, y: 1080, width: 76, height: 22), false, true),
+        (CGRect(x: -1440, y: 180, width: 1440, height: 900), CGRect(x: -100, y: 0, width: 76, height: 22), false, true),
     ])
     func `window probe aligns secondary screen coordinates before recovery decisions`(
-        _ screenFrame: CGRect, _ windowBounds: CGRect, _ blocked: Bool) throws
+        _ screenFrame: CGRect, _ windowBounds: CGRect, _ blocked: Bool, _ contained: Bool) throws
     {
         let windows = MenuBarStatusItemWindowProbe.snapshots(
             matching: ["codexbar-merged"],
@@ -23,7 +26,7 @@ struct MenuBarVisibilityWatcherTests {
             ]],
             screenFrames: [CGRect(x: 0, y: 0, width: 1920, height: 1080), screenFrame])
         let window = try #require(windows.first)
-        #expect(window.isWithinDisplayBounds == !blocked)
+        #expect(window.isWithinDisplayBounds == contained)
         #expect(window.isTahoeBlockedProxy == blocked)
         let detached = StatusItemVisibilitySnapshot(
             isVisible: true,


### PR DESCRIPTION
Fixes a coordinate-space mismatch in startup visibility recovery. The probe compared Cocoa screen frames (primary-display bottom-left origin) directly with Quartz window bounds (primary-display top-left origin). A lower monitor could hide a genuine blocked proxy, while a healthy window on an upper monitor could look blocked.

The injected probe now explicitly accepts primary-first screen frames and normalizes them before containment. The exact primary-origin blocked-proxy signature remains detectable when it overlaps the bottom of an upper display, while ordinary interior and top-edge windows keep their containment exemption. The same input boundary uses CoreGraphics’ rectangle decoder after checking numeric fields, removing the bespoke decoder. Existing displacement, on-screen, opt-in and startup-time guards are preserved. The change removes **11 production lines** and adds a 0.59.1 Unreleased note.

Validation:
- Eight baseline assertions fail across above/below/offset displays. The new tests exercise both window classification and the actual startup-recovery predicate.
- All 38 focused visibility tests pass, including the existing guard matrix and malformed rectangles. A further upper-display regression reproduced the review finding with two failed assertions, then passed with the narrow proxy exception; interior and top-edge windows remain protected. A malformed string fixture caught an Objective-C decoder exception during development; numeric validation now rejects it before decoding.
- `make check` passed with zero violations; independent P0–P2 review is clean.
- The final follow-up full suite passed all 1,069 selections / 90 groups first time, with no retries or timeouts (876.0 seconds), in a separate temporary preference home. An earlier revision had one recovered Claude PTY fixture retry.
- The superseded CI run was canceled. [Final-head CI](https://github.com/steipete/CodexBar/actions/runs/34639780555) passed before merge.

The coordinate contract follows [Cocoa screen coordinates](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CocoaDrawingGuide/Transforms/Transforms.html) and [CGWindow bounds](https://developer.apple.com/documentation/coregraphics/kcgwindowbounds). Proof is synthetic geometry through production decision code; this does not claim a live Tahoe reproduction or close the broader missing-pixel/position reports #3377 and #3355.
