### PR TITLE
fix(grok): skip discarded work after terminal billing failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Devin: honor hidden daily quotas even when the response includes daily usage, preserving weekly limits and extra balance (#3542). Thanks @dzienisz!
 - Codex accounts: honor Hide Personal Info in switcher labels and tooltips, redact embedded workspace emails, and preserve distinct account numbers in narrow menus (#3551). Thanks @zenibako!
 - Codex spend: keep waiting history files ahead of repeated migration revisits so large histories can finish bounded catch-up, preserving stored rows and checkpoints (#3548, related to #3411). Thanks @SergeiNikolenko!
+- Grok: skip discarded local-history scans and version probes after terminal CLI billing failures, allowing fallback to start sooner (extracted from #3236). Thanks @Yuxin-Qiao!
 
 ## 0.59.0 — 2026-09-10
 

--- a/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
@@ -84,6 +84,8 @@ public struct GrokStatusProbe: Sendable {
     }
 
     var settingsTransport: any ProviderHTTPTransport = ProviderHTTPClient.shared
+    var identityOnlyFallback: @Sendable (GrokCredentials?, Bool, Error?) -> Bool =
+        GrokStatusProbe.shouldUseIdentityOnlyFallback
 
     public init() {}
 
@@ -128,10 +130,7 @@ public struct GrokStatusProbe: Sendable {
             rpcError = error
         }
 
-        let isIdentityOnly = billing == nil && Self.shouldUseIdentityOnlyFallback(
-            credentials: credentials,
-            billingAttempted: billingAttempted,
-            error: rpcError)
+        let isIdentityOnly = billing == nil && self.identityOnlyFallback(credentials, billingAttempted, rpcError)
         // Terminal CLI failures must reach the provider's web fallback without scanning discarded history.
         guard billing != nil || isIdentityOnly else {
             throw rpcError ?? GrokRPCError.notAuthenticated
@@ -139,13 +138,17 @@ public struct GrokStatusProbe: Sendable {
 
         let localSummary = try await self.localSummary(env)
         let cliVersion = Self.detectVersion(env: env)
+        // Preserve the original eligibility checkpoint after potentially slow local work.
+        if isIdentityOnly, !self.identityOnlyFallback(credentials, billingAttempted, rpcError) {
+            throw rpcError ?? GrokRPCError.notAuthenticated
+        }
         let subscriptionTier = try await Self.loadSettingsTier(
             credentials: credentials,
             session: self.settingsTransport)
         return GrokUsageSnapshot(
             billing: billing,
             webBilling: nil,
-            credentials: Self.credentialsForSnapshot(
+            credentials: isIdentityOnly ? credentials : Self.credentialsForSnapshot(
                 credentials: credentials,
                 billing: billing,
                 webBilling: nil),

--- a/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
@@ -79,6 +79,12 @@ public struct GrokStatusProbe: Sendable {
     public static let usageUnavailableMessage =
         "Grok usage is unavailable because its billing sources did not report a usage percentage."
 
+    var localSummary: @Sendable ([String: String]) async throws -> GrokLocalSessionSummary? = {
+        try await GrokLocalSessionScanner.summarizeOffMainThread(env: $0)
+    }
+
+    var settingsTransport: any ProviderHTTPTransport = ProviderHTTPClient.shared
+
     public init() {}
 
     public static func detectVersion(env: [String: String] = ProcessInfo.processInfo.environment)
@@ -122,34 +128,20 @@ public struct GrokStatusProbe: Sendable {
             rpcError = error
         }
 
-        // Local fallback summary always succeeds (empty if no sessions yet).
-        let localSummary = try await GrokLocalSessionScanner.summarizeOffMainThread(env: env)
-        let cliVersion = Self.detectVersion(env: env)
-
-        // `localSummary` is *not* currently projected into a visible RateWindow or
-        // identity field, so a stale `~/.grok/sessions/` directory must not
-        // suppress the auth-required hint. CLI-only fetches need a billing
-        // response; the provider pipeline owns the separate web fallback.
-        if billing == nil,
-           let credentials,
-           Self.shouldUseIdentityOnlyFallback(
-               credentials: credentials,
-               billingAttempted: billingAttempted,
-               error: rpcError)
-        {
-            let subscriptionTier = try await Self.loadSettingsTier(credentials: credentials)
-            return Self.identityOnlySnapshot(
-                credentials: credentials,
-                localSummary: localSummary,
-                cliVersion: cliVersion,
-                subscriptionTier: subscriptionTier)
-        }
-
-        if billing == nil {
+        let isIdentityOnly = billing == nil && Self.shouldUseIdentityOnlyFallback(
+            credentials: credentials,
+            billingAttempted: billingAttempted,
+            error: rpcError)
+        // Terminal CLI failures must reach the provider's web fallback without scanning discarded history.
+        guard billing != nil || isIdentityOnly else {
             throw rpcError ?? GrokRPCError.notAuthenticated
         }
 
-        let subscriptionTier = try await Self.loadSettingsTier(credentials: credentials)
+        let localSummary = try await self.localSummary(env)
+        let cliVersion = Self.detectVersion(env: env)
+        let subscriptionTier = try await Self.loadSettingsTier(
+            credentials: credentials,
+            session: self.settingsTransport)
         return GrokUsageSnapshot(
             billing: billing,
             webBilling: nil,
@@ -160,6 +152,7 @@ public struct GrokStatusProbe: Sendable {
             localSummary: localSummary,
             cliVersion: cliVersion,
             updatedAt: Date(),
+            diagnostic: isIdentityOnly ? Self.teamUsageUnavailableMessage : nil,
             subscriptionTier: subscriptionTier)
     }
 

--- a/Tests/CodexBarTests/GrokFailedBillingWorkTests.swift
+++ b/Tests/CodexBarTests/GrokFailedBillingWorkTests.swift
@@ -5,9 +5,14 @@ import Testing
 struct GrokFailedBillingWorkTests {
     enum Scenario: String, CaseIterable, Sendable {
         case personalUnavailable, teamUnauthorized, initializationFailure, expiredTeam, teamFallback, billingSuccess
+        case expiresDuringScan, expiresDuringVersion, acceptedIdentity
 
         var acceptsSnapshot: Bool {
-            self == .teamFallback || self == .billingSuccess
+            self == .teamFallback || self == .billingSuccess || self == .acceptedIdentity
+        }
+
+        var scansBeforeResult: Bool {
+            self.acceptsSnapshot || self == .expiresDuringScan || self == .expiresDuringVersion
         }
 
         var errorMessage: String {
@@ -30,7 +35,8 @@ struct GrokFailedBillingWorkTests {
                     "key": "synthetic-token", "refresh_token": "synthetic-refresh",
                     "email": "team@example.com", "team_id": "example-team", "user_id": "example-user",
                     "auth_mode": "oidc", "principal_type": "Team",
-                    "expires_at": scenario == .expiredTeam ? "2000-01-01T00:00:00Z" : "2099-01-01T00:00:00Z",
+                    "expires_at": [.expiredTeam, .acceptedIdentity].contains(scenario)
+                        ? "2000-01-01T00:00:00Z" : "2099-01-01T00:00:00Z",
                 ],
             ])
             try auth.write(to: root.appendingPathComponent("auth.json"))
@@ -55,6 +61,7 @@ struct GrokFailedBillingWorkTests {
         let script = """
         #!/bin/sh
         if [ "$1" = "--version" ]; then
+            if [ "$GROK_TEST_MARK_EXPIRY" = "1" ]; then : > "$GROK_HOME/expiry-marker"; fi
             printf '%s\\n' 'grok synthetic-version'
             exit 0
         fi
@@ -70,6 +77,7 @@ struct GrokFailedBillingWorkTests {
             "GROK_HOME": root.path,
             "GROK_CLI_PATH": binary.path,
             "PATH": "/usr/bin:/bin",
+            "GROK_TEST_MARK_EXPIRY": scenario == .expiresDuringVersion ? "1" : "0",
         ]
         let calls = GrokFetchWorkRecorder()
         let summary = GrokLocalSessionSummary(
@@ -79,10 +87,22 @@ struct GrokFailedBillingWorkTests {
             primaryModel: "example-model",
             models: ["example-model"],
             daily: [.init(date: "2026-09-11", totalTokens: 42, sessionCount: 2, models: [])])
+        let expiryMarker = root.appendingPathComponent("expiry-marker")
         var probe = GrokStatusProbe()
+        if scenario == .expiresDuringScan || scenario == .expiresDuringVersion {
+            probe.identityOnlyFallback = { credentials, attempted, error in
+                GrokStatusProbe.shouldUseIdentityOnlyFallback(
+                    credentials: credentials, billingAttempted: attempted, error: error)
+                    && !FileManager.default.fileExists(atPath: expiryMarker.path)
+            }
+        } else if scenario == .acceptedIdentity {
+            // Model a prior accepted decision without racing a wall clock; the default expired case stays rejected.
+            probe.identityOnlyFallback = { _, _, _ in true }
+        }
         probe.localSummary = { receivedEnvironment in
             #expect(receivedEnvironment == environment)
             await calls.scanned()
+            if scenario == .expiresDuringScan { try Data().write(to: expiryMarker) }
             return summary
         }
         probe.settingsTransport = ProviderHTTPTransportHandler { request in
@@ -99,7 +119,7 @@ struct GrokFailedBillingWorkTests {
             #expect(snapshot.localSummary?.totalTokens == 42)
             #expect(snapshot.localSummary?.daily == summary.daily)
             #expect(snapshot.cliVersion == "synthetic-version")
-            if scenario == .teamFallback {
+            if scenario != .billingSuccess {
                 #expect(snapshot.billing == nil)
                 #expect(snapshot.credentials?.email == "team@example.com")
                 #expect(snapshot.diagnostic == GrokStatusProbe.teamUsageUnavailableMessage)
@@ -115,7 +135,7 @@ struct GrokFailedBillingWorkTests {
             }
             #expect(message == scenario.errorMessage)
         }
-        #expect(await calls.scans == (scenario.acceptsSnapshot ? 1 : 0))
+        #expect(await calls.scans == (scenario.scansBeforeResult ? 1 : 0))
         #expect(await calls.settings == (scenario == .teamFallback ? 1 : 0))
     }
 }

--- a/Tests/CodexBarTests/GrokFailedBillingWorkTests.swift
+++ b/Tests/CodexBarTests/GrokFailedBillingWorkTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct GrokFailedBillingWorkTests {
+    enum Scenario: String, CaseIterable, Sendable {
+        case personalUnavailable, teamUnauthorized, initializationFailure, expiredTeam, teamFallback, billingSuccess
+
+        var acceptsSnapshot: Bool {
+            self == .teamFallback || self == .billingSuccess
+        }
+
+        var errorMessage: String {
+            switch self {
+            case .teamUnauthorized: "Unauthorized"
+            case .initializationFailure: "Initialize failed"
+            default: "Method not found"
+            }
+        }
+    }
+
+    @Test(arguments: Scenario.allCases)
+    func `terminal billing failures skip local history and settings work`(_ scenario: Scenario) async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("grok-work-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        if scenario != .personalUnavailable, scenario != .billingSuccess {
+            let auth = try JSONSerialization.data(withJSONObject: [
+                "https://auth.x.ai::fake-client": [
+                    "key": "synthetic-token", "refresh_token": "synthetic-refresh",
+                    "email": "team@example.com", "team_id": "example-team", "user_id": "example-user",
+                    "auth_mode": "oidc", "principal_type": "Team",
+                    "expires_at": scenario == .expiredTeam ? "2000-01-01T00:00:00Z" : "2099-01-01T00:00:00Z",
+                ],
+            ])
+            try auth.write(to: root.appendingPathComponent("auth.json"))
+        }
+        let binary = root.appendingPathComponent("grok-fixture")
+        func reply(id: Int, result: [String: Any], error: String?) throws -> String {
+            var value: [String: Any] = ["jsonrpc": "2.0", "id": id]
+            if let error {
+                value["error"] = ["code": -32601, "message": error]
+            } else {
+                value["result"] = result
+            }
+            let data = try JSONSerialization.data(withJSONObject: value)
+            return try #require(String(bytes: data, encoding: .utf8))
+        }
+        let initialize = try reply(
+            id: 1, result: [:], error: scenario == .initializationFailure ? scenario.errorMessage : nil)
+        let billing = try reply(
+            id: 2,
+            result: ["monthlyLimit": ["val": 100], "usage": ["totalUsed": ["val": 25]]],
+            error: scenario == .billingSuccess ? nil : scenario.errorMessage)
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "--version" ]; then
+            printf '%s\\n' 'grok synthetic-version'
+            exit 0
+        fi
+        IFS= read -r initialize_request
+        printf '%s\\n' '\(initialize)'
+        IFS= read -r billing_request || exit 0
+        printf '%s\\n' '\(billing)'
+        """
+        try script.write(to: binary, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+        let environment = [
+            "HOME": root.path,
+            "GROK_HOME": root.path,
+            "GROK_CLI_PATH": binary.path,
+            "PATH": "/usr/bin:/bin",
+        ]
+        let calls = GrokFetchWorkRecorder()
+        let summary = GrokLocalSessionSummary(
+            sessionCount: 2,
+            totalTokens: 42,
+            lastSessionAt: nil,
+            primaryModel: "example-model",
+            models: ["example-model"],
+            daily: [.init(date: "2026-09-11", totalTokens: 42, sessionCount: 2, models: [])])
+        var probe = GrokStatusProbe()
+        probe.localSummary = { receivedEnvironment in
+            #expect(receivedEnvironment == environment)
+            await calls.scanned()
+            return summary
+        }
+        probe.settingsTransport = ProviderHTTPTransportHandler { request in
+            #expect(request.url == GrokCLISettingsFetcher.defaultEndpoint)
+            await calls.loadedSettings()
+            let response = try #require(HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil))
+            return (Data("{\"subscription_tier_display\":\"Grok Team\"}".utf8), response)
+        }
+
+        do {
+            let snapshot = try await probe.fetch(env: environment)
+            #expect(scenario.acceptsSnapshot)
+            #expect(snapshot.localSummary?.totalTokens == 42)
+            #expect(snapshot.localSummary?.daily == summary.daily)
+            #expect(snapshot.cliVersion == "synthetic-version")
+            if scenario == .teamFallback {
+                #expect(snapshot.billing == nil)
+                #expect(snapshot.credentials?.email == "team@example.com")
+                #expect(snapshot.diagnostic == GrokStatusProbe.teamUsageUnavailableMessage)
+            } else {
+                #expect(snapshot.billing?.monthlyUsedPercent == 25)
+                #expect(snapshot.diagnostic == nil)
+            }
+        } catch let error as GrokRPCError {
+            #expect(!scenario.acceptsSnapshot)
+            guard case let .requestFailed(message) = error else {
+                Issue.record("Unexpected RPC error: \(error)")
+                return
+            }
+            #expect(message == scenario.errorMessage)
+        }
+        #expect(await calls.scans == (scenario.acceptsSnapshot ? 1 : 0))
+        #expect(await calls.settings == (scenario == .teamFallback ? 1 : 0))
+    }
+}
+
+private actor GrokFetchWorkRecorder {
+    private(set) var scans = 0
+    private(set) var settings = 0
+    func scanned() {
+        self.scans += 1
+    }
+
+    func loadedSettings() {
+        self.settings += 1
+    }
+}

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -39,6 +39,7 @@ The grok.com billing gRPC-web endpoint remains a best-effort fallback.
      fallback, while a team principal degrades to identity-only with an explicit
      unsupported-team-usage diagnostic. When xAI exposes billing on the agent
      protocol, no code change is required.
+   - A terminal CLI billing failure returns before scanning local session history or probing the CLI version, so the provider fallback does not wait for data that would be discarded. Successful billing and the established identity-only team fallback retain local history and plan enrichment.
    - After a successful RPC billing result (or the identity-only team fallback),
      CodexBar still GETs `/v1/settings` for `subscription_tier_display` so the
      billed plan is not lost just because the CLI route succeeded first. The


### PR DESCRIPTION
Avoids a local-history scan whose result is discarded when CLI billing has already failed. The provider can reach its fallback sooner, without scanning the same history once in the failed CLI attempt and again in the later web strategy.

The probe now evaluates its existing acceptance policy first: successful billing or the narrowly defined unexpired Team identity-only fallback. Accepted results share one scan/version/settings path and snapshot constructor. Team eligibility is rechecked after local work at the original decision point; the identity admitted before optional settings enrichment remains captured afterward. Original errors, credential filtering, diagnostics, plan enrichment, public APIs and legacy history semantics are preserved. This is a **four-line production reduction**.

This extracts the lazy-scan observation from #3236; it does not implement that PR’s new log format, expand automatic reads, or claim to fix #3345’s token totals. Thanks @Yuxin-Qiao. Docs and 0.59.1 Unreleased notes are updated.

Validation:
- The actual Grok RPC client talks to a synthetic local CLI child. Four terminal cases reproduce an unwanted scan on the old ordering: personal method-unavailable, Team authorization failure, initialization failure, and expired Team credentials.
- The fixed tests require zero scan/settings calls for those failures and preserve exact errors. Successful billing and eligible Team fallback each scan once and retain summary, version and identity/diagnostic behavior.
- 48 focused tests across seven suites passed, including auth, account context, billing, settings, plan and child-process coverage. Five additional regression assertions caught changed expiry checkpoints in the first refactor; a nine-case matrix now preserves both late eligibility rejection and already-admitted identity using deterministic markers, without clock sleeps.
- `make check` passed with zero violations; final independent P0–P2 review is clean.
- The final expiry-checkpoint revision passed all 1,070 selections / 90 groups on the first pass in 926.5 seconds, with zero retries or timeouts, using an isolated temporary home.
- Superseded candidate CI was canceled; [final-head CI](https://github.com/steipete/CodexBar/actions/runs/34642009256) passed before merge.

All credentials and RPC responses in the proof are synthetic. Settings transport is injected; no live provider request or personal history is used. Successful presentation is unchanged, so no UI screenshot is claimed for this failed-path work reduction.
