### PR TITLE
fix(codex): exclude queue waiting from catch-up delays

### DIFF
--- a/Sources/CodexBar/UsageStore+CodexCostCatchUp.swift
+++ b/Sources/CodexBar/UsageStore+CodexCostCatchUp.swift
@@ -172,11 +172,10 @@ extension UsageStore {
                         return
                     }
 
-                    let passStartedAt = ContinuousClock.now
                     self.codexCostCatchUpPassIsRunning = true
-                    let nextStatus: CostUsageFetcher.CodexScanCatchUpStatus
+                    let result: CostUsageScanExecutor.TimedResult<CostUsageFetcher.CodexScanCatchUpStatus>
                     do {
-                        nextStatus = try await self.advanceCodexCostCatchUp(
+                        result = try await self.advanceCodexCostCatchUp(
                             now: Date(),
                             codexHomePath: context.codexHomePath,
                             historyDays: context.historyDays)
@@ -185,12 +184,8 @@ extension UsageStore {
                         self.codexCostCatchUpPassIsRunning = false
                         throw error
                     }
-                    let passDuration = ContinuousClock.now - passStartedAt
-                    let durationComponents = passDuration.components
-                    previousActiveDuration = max(
-                        0,
-                        Double(durationComponents.seconds)
-                            + Double(durationComponents.attoseconds) / 1_000_000_000_000_000_000)
+                    let nextStatus = result.value
+                    previousActiveDuration = result.activeDuration
                     didAdvance = true
                     guard self.codexCostCatchUpContextIsCurrent(context) else { return }
                     self.publishCodexCostCatchUpActivity(
@@ -343,10 +338,12 @@ extension UsageStore {
     private func advanceCodexCostCatchUp(
         now: Date,
         codexHomePath: String?,
-        historyDays: Int) async throws -> CostUsageFetcher.CodexScanCatchUpStatus
+        historyDays: Int) async throws -> CostUsageScanExecutor.TimedResult<CostUsageFetcher.CodexScanCatchUpStatus>
     {
         if let override = self._test_codexCostCatchUpAdvanceOverride {
-            return try await override(now, codexHomePath, historyDays)
+            return try await .init(
+                value: override(now, codexHomePath, historyDays),
+                activeDuration: self._test_codexCostCatchUpActiveDuration)
         }
         return try await self.costUsageFetcher.advanceCodexScanCatchUp(
             now: now,

--- a/Sources/CodexBar/UsageStore+SpendDashboardCodexCostCatchUp.swift
+++ b/Sources/CodexBar/UsageStore+SpendDashboardCodexCostCatchUp.swift
@@ -242,9 +242,8 @@ extension UsageStore {
                 }
 
                 let previousStatus = statuses[account.cacheIdentity]
-                let passStartedAt = ContinuousClock.now
                 self.spendDashboardCodexCostCatchUpPassIsRunning = true
-                let nextStatus: CostUsageFetcher.CodexScanCatchUpStatus
+                let result: CostUsageScanExecutor.TimedResult<CostUsageFetcher.CodexScanCatchUpStatus>
                 do {
                     defer {
                         // A cancelled pass can finish after its replacement has started.
@@ -252,13 +251,13 @@ extension UsageStore {
                             self.spendDashboardCodexCostCatchUpPassIsRunning = false
                         }
                     }
-                    nextStatus = try await self.advanceSpendDashboardCodexCostCatchUp(
+                    result = try await self.advanceSpendDashboardCodexCostCatchUp(
                         account: account,
                         now: Date(),
                         historyDays: context.historyDays)
                 }
-                previousActiveDuration = Self.spendDashboardCodexCatchUpDuration(
-                    since: passStartedAt)
+                let nextStatus = result.value
+                previousActiveDuration = result.activeDuration
                 didChangeCache = didChangeCache || nextStatus.progressKey != previousStatus?.progressKey
                 statuses[account.cacheIdentity] = nextStatus
                 if nextStatus.pending,
@@ -339,10 +338,12 @@ extension UsageStore {
     private func advanceSpendDashboardCodexCostCatchUp(
         account: CodexSpendScanRequest,
         now: Date,
-        historyDays: Int) async throws -> CostUsageFetcher.CodexScanCatchUpStatus
+        historyDays: Int) async throws -> CostUsageScanExecutor.TimedResult<CostUsageFetcher.CodexScanCatchUpStatus>
     {
         if let override = self._test_spendDashboardCodexCostCatchUpAdvanceOverride {
-            return try await override(account, now, historyDays)
+            return try await .init(
+                value: override(account, now, historyDays),
+                activeDuration: self._test_spendDashboardCodexCostCatchUpActiveDuration)
         }
         return try await CostUsageFetcher(
             cacheRoot: SpendDashboardSource.codexCacheRoot(for: account),
@@ -405,15 +406,5 @@ extension UsageStore {
         _ statuses: [String: CostUsageFetcher.CodexScanCatchUpStatus]) -> Bool
     {
         statuses.values.contains(where: \.pending)
-    }
-
-    private static func spendDashboardCodexCatchUpDuration(
-        since start: ContinuousClock.Instant) -> TimeInterval
-    {
-        let components = (ContinuousClock.now - start).components
-        return max(
-            0,
-            Double(components.seconds)
-                + Double(components.attoseconds) / 1_000_000_000_000_000_000)
     }
 }

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -299,6 +299,7 @@ final class UsageStore {
         Int) async throws -> CostUsageFetcher.CodexScanCatchUpStatus)?
     @ObservationIgnored var _test_codexCostCatchUpSleepOverride: (@MainActor (
         TimeInterval) async throws -> Void)?
+    @ObservationIgnored var _test_codexCostCatchUpActiveDuration: TimeInterval = 0
     @ObservationIgnored var _test_codexCostCatchUpResourceStateOverride: (@MainActor () -> (
         powerSource: CodexCostCatchUpPowerSource,
         lowPowerModeEnabled: Bool,
@@ -311,6 +312,7 @@ final class UsageStore {
         Int) async throws -> CostUsageFetcher.CodexScanCatchUpStatus)?
     @ObservationIgnored var _test_spendDashboardCodexCostCatchUpSleepOverride: (@MainActor (
         TimeInterval) async throws -> Void)?
+    @ObservationIgnored var _test_spendDashboardCodexCostCatchUpActiveDuration: TimeInterval = 0
     @ObservationIgnored var _test_spendDashboardCodexCostCatchUpResourceStateOverride: (@MainActor () -> (
         powerSource: CodexCostCatchUpPowerSource,
         lowPowerModeEnabled: Bool,

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -317,7 +317,7 @@ public struct CostUsageFetcher: Sendable {
         codexHomePath: String? = nil,
         historyDays: Int = 30,
         scanDurationPerRefresh: TimeInterval? = nil,
-        calendar: Calendar? = nil) async throws -> CodexScanCatchUpStatus
+        calendar: Calendar? = nil) async throws -> CostUsageScanExecutor.TimedResult<CodexScanCatchUpStatus>
     {
         var options = Self.resolvedScannerOptions(
             self.scannerOptions(calendar: calendar),
@@ -334,7 +334,7 @@ public struct CostUsageFetcher: Sendable {
             to: now) ?? now
         let scanOptions = options
         // Provider-specific by design: this catch-up step advances only the Codex incremental scanner.
-        return try await CostUsageScanExecutor.run { checkCancellation in
+        return try await CostUsageScanExecutor.runTimed { checkCancellation in
             _ = try CostUsageScanner.loadDailyReportCancellable(
                 provider: .codex,
                 since: since,

--- a/Sources/CodexBarCore/CostUsageScanExecutor.swift
+++ b/Sources/CodexBarCore/CostUsageScanExecutor.swift
@@ -11,6 +11,40 @@ public enum CostUsageScanExecutor {
 
     private static let queue = DispatchQueue(label: queueLabel, qos: .utility)
 
+    package struct TimedResult<Value: Sendable>: Sendable {
+        package let value: Value
+        package let activeDuration: TimeInterval
+
+        package init(value: Value, activeDuration: TimeInterval) {
+            self.value = value
+            self.activeDuration = activeDuration
+        }
+    }
+
+    package static func runTimed<T: Sendable>(
+        _ work: @escaping @Sendable (_ checkCancellation: @escaping @Sendable () throws -> Void) throws -> T)
+        async throws -> TimedResult<T>
+    {
+        try await self.runTimed(on: self.queue, work)
+    }
+
+    static func runTimed<T: Sendable>(
+        on queue: DispatchQueue,
+        _ work: @escaping @Sendable (_ checkCancellation: @escaping @Sendable () throws -> Void) throws -> T)
+        async throws -> TimedResult<T>
+    {
+        try await self.run(on: queue) { checkCancellation in
+            // Queue contention must not become active-work debt in the caller's duty-cycle policy.
+            let start = ContinuousClock.now
+            let value = try work(checkCancellation)
+            let duration = (ContinuousClock.now - start).components
+            return TimedResult(
+                value: value,
+                activeDuration: Double(duration.seconds)
+                    + Double(duration.attoseconds) / 1_000_000_000_000_000_000)
+        }
+    }
+
     private final class RunState<Value: Sendable>: @unchecked Sendable {
         private enum Phase {
             case initial

--- a/Tests/CodexBarTests/CostUsagePerformanceGateTests.swift
+++ b/Tests/CodexBarTests/CostUsagePerformanceGateTests.swift
@@ -1238,7 +1238,7 @@ struct CostUsagePerformanceGateTests {
         #expect(status.pending)
         var progressStates = [(pending: status.pending, key: status.progressKey)]
         for _ in 0..<12 where status.pending {
-            status = try await fetcher.advanceCodexScanCatchUp(now: day, historyDays: 1)
+            status = try await fetcher.advanceCodexScanCatchUp(now: day, historyDays: 1).value
             progressStates.append((pending: status.pending, key: status.progressKey))
         }
 

--- a/Tests/CodexBarTests/CostUsageScanExecutorTests.swift
+++ b/Tests/CodexBarTests/CostUsageScanExecutorTests.swift
@@ -13,6 +13,31 @@ struct CostUsageScanExecutorTests {
     }
 
     @Test
+    func `timed scans exclude queue waiting but include their own work`() async throws {
+        let queue = self.makeQueue()
+        let releaseBlocker = DispatchSemaphore(value: 0)
+        queue.async { releaseBlocker.wait() }
+        let submitted = LockedValue(false)
+        let start = ContinuousClock.now
+        let task = Task {
+            submitted.set(true)
+            return try await CostUsageScanExecutor.runTimed(on: queue) { _ in
+                Thread.sleep(forTimeInterval: 0.025)
+                return 42
+            }
+        }
+        #expect(await self.waitUntil { submitted.value })
+        try? await Task.sleep(for: .milliseconds(200))
+        releaseBlocker.signal()
+        let result = try await task.value
+        let elapsed = (ContinuousClock.now - start).components
+        let totalDuration = Double(elapsed.seconds) + Double(elapsed.attoseconds) / 1e18
+        #expect(result.value == 42)
+        #expect(result.activeDuration >= 0.025)
+        #expect(totalDuration - result.activeDuration >= 0.15)
+    }
+
+    @Test
     func `propagates thrown errors`() async {
         struct ScanFailure: Error {}
         let queue = self.makeQueue()

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -1085,25 +1085,25 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This provider-owned integration passes its fixed identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+CodexCostCatchUp.swift",
-            line: 285,
+            line: 280,
             anchor: "self.publishConfirmedEmptyTokenSnapshot(for: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-owned integration passes its fixed identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+CodexCostCatchUp.swift",
-            line: 288,
+            line: 283,
             anchor: "self.publishTokenSnapshot(snapshot, for: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-owned integration passes its fixed identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+CodexCostCatchUp.swift",
-            line: 326,
+            line: 321,
             anchor: "&& self.settings.isCostUsageEffectivelyEnabled(for: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-owned integration passes its fixed identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+CodexCostCatchUp.swift",
-            line: 327,
+            line: 322,
             anchor: "&& self.isEnabled(.codex)",
             expectedProviderIDs: ["codex"],
             reason: "This provider-owned integration passes its fixed identity to a shared helper."),
@@ -1193,13 +1193,13 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This Codex account projection passes its fixed provider identity to shared spend infrastructure."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+SpendDashboardCodexCostCatchUp.swift",
-            line: 315,
+            line: 314,
             anchor: "&& self.settings.isCostUsageEffectivelyEnabled(for: .codex)",
             expectedProviderIDs: ["codex"],
             reason: "This Codex account projection passes its fixed provider identity to shared spend infrastructure."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore+SpendDashboardCodexCostCatchUp.swift",
-            line: 316,
+            line: 315,
             anchor: "&& self.isEnabled(.codex)",
             expectedProviderIDs: ["codex"],
             reason: "This Codex account projection passes its fixed provider identity to shared spend infrastructure."),
@@ -1339,19 +1339,19 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "Claude widget quota ownership uses the selected Claude account's isolated snapshot key."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1081,
+            line: 1083,
             anchor: "provider: .deepseek,",
             expectedProviderIDs: ["deepseek"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1183,
+            line: 1185,
             anchor: "let sourceMode = self.sourceMode(for: .claude)",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
         SuppressedProviderReference(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1187,
+            line: 1189,
             anchor: "provider: .claude,",
             expectedProviderIDs: ["claude"],
             reason: "This provider-specific app branch passes its already-selected identity to a shared helper."),
@@ -2697,7 +2697,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+CodexCostCatchUp.swift",
-            line: 323,
+            line: 318,
             anchor: "&& self.settings.providerConfigRevision(for: .codex) == context.providerConfigRevision",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 3,
@@ -3050,7 +3050,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore+SpendDashboardCodexCostCatchUp.swift",
-            line: 312,
+            line: 311,
             anchor: "&& self.settings.providerConfigRevision(for: .codex) == context.providerConfigRevision",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3374,7 +3374,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 621,
+            line: 623,
             anchor: "self.metadata(for: .codex).browserCookieOrder ?? Browser.defaultImportOrder",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3382,7 +3382,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 673,
+            line: 675,
             anchor: "self.providerSpecs[provider]?.style ?? .codex",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3390,7 +3390,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 706,
+            line: 708,
             anchor: "guard provider != .codex else { return true }",
             expectedProviderIDs: ["codex"],
             expectedReferenceCount: 1,
@@ -3398,7 +3398,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1055,
+            line: 1057,
             anchor: "let claudeDebugConfiguration: ClaudeDebugLogConfiguration? = if provider == .claude {",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,
@@ -3406,7 +3406,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1078,
+            line: 1080,
             anchor: "let deepSeekHasTokenAccount = self.settings.selectedTokenAccount(for: .deepseek) != nil",
             expectedProviderIDs: ["deepseek"],
             expectedReferenceCount: 1,
@@ -3414,7 +3414,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1135,
+            line: 1137,
             anchor: "case .amp:",
             expectedProviderIDs: ["amp", "deepseek", "notion", "ollama", "warp"],
             expectedReferenceCount: 7,
@@ -3430,7 +3430,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact app-runtime bridge coordinates provider-owned state through the shared controller."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/UsageStore.swift",
-            line: 1190,
+            line: 1192,
             anchor: "let claudeSettings = snapshot.claude ?? ProviderSettingsSnapshot.ClaudeProviderSettings(",
             expectedProviderIDs: ["claude"],
             expectedReferenceCount: 1,

--- a/Tests/CodexBarTests/UsageStoreCodexCostCatchUpTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCodexCostCatchUpTests.swift
@@ -6,6 +6,30 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct UsageStoreCodexCostCatchUpTests {
+    @Test
+    func `automatic sleep uses active scan duration instead of awaited latency`() async throws {
+        let store = try Self.makeStore(suite: "active-duration")
+        store.settings.backgroundWorkLowPowerModePreference = .off
+        var sleeps: [TimeInterval] = []
+        store._test_codexCostCatchUpResourceStateOverride = { (.ac, false, .nominal) }
+        store._test_codexCostCatchUpStatusOverride = { _ in
+            .init(pending: true, progressKey: "pending")
+        }
+        store._test_codexCostCatchUpActiveDuration = 2
+        store._test_codexCostCatchUpAdvanceOverride = { _, _, _ in
+            try await Task.sleep(for: .milliseconds(20))
+            return .init(pending: true, progressKey: "progressed")
+        }
+        store._test_codexCostCatchUpSleepOverride = { delay in
+            sleeps.append(delay)
+            if sleeps.count == 2 { throw CancellationError() }
+        }
+        store.startCodexCostCatchUpIfNeeded()
+        let task = try #require(store.codexCostCatchUpTask)
+        await task.value
+        #expect(sleeps == [1998, 1998])
+    }
+
     @Test(arguments: [CodexCostCatchUpPowerSource.ac, .battery, .unknown])
     func `app low power mode floors automatic catch-up decisions`(source: CodexCostCatchUpPowerSource) throws {
         let store = try Self.makeStore(suite: "app-low-power-policy")
@@ -452,7 +476,8 @@ struct UsageStoreCodexCostCatchUpTests {
     }
 
     private static func makeStore(suite: String) throws -> UsageStore {
-        let settings = testSettingsStore(suiteName: "UsageStoreCodexCostCatchUpTests-\(suite)")
+        let settings = testSettingsStore(
+            suiteName: "UsageStoreCodexCostCatchUpTests-\(suite)", userDefaults: InMemoryUserDefaults())
         settings.costUsageEnabled = true
         settings.costUsageHistoryDays = 30
         let metadata = try #require(ProviderRegistry.shared.metadata[.codex])

--- a/Tests/CodexBarTests/UsageStoreSpendDashboardCodexCostCatchUpTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSpendDashboardCodexCostCatchUpTests.swift
@@ -6,6 +6,31 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct UsageStoreSpendDashboardCodexCostCatchUpTests {
+    @Test
+    func `automatic sleep uses active scan duration instead of awaited latency`() async throws {
+        let store = try Self.makeStore(suite: "active-duration")
+        store.settings.backgroundWorkLowPowerModePreference = .off
+        var sleeps: [TimeInterval] = []
+        store._test_spendDashboardCodexCostCatchUpResourceStateOverride = { (.ac, false, .nominal) }
+        store._test_spendDashboardCodexCostCatchUpStatusOverride = { _ in
+            .init(pending: true, progressKey: "pending")
+        }
+        store._test_spendDashboardCodexCostCatchUpActiveDuration = 2
+        store._test_spendDashboardCodexCostCatchUpAdvanceOverride = { _, _, _ in
+            try await Task.sleep(for: .milliseconds(20))
+            return .init(pending: true, progressKey: "progressed")
+        }
+        store._test_spendDashboardCodexCostCatchUpSleepOverride = { delay in
+            sleeps.append(delay)
+            if sleeps.count == 2 { throw CancellationError() }
+        }
+        store.startSpendDashboardCodexCostCatchUpIfNeeded(
+            accounts: [Self.account(id: "account", cacheIdentity: "cache-account")])
+        let task = try #require(store.spendDashboardCodexCostCatchUpTask)
+        await task.value
+        #expect(sleeps == [1998, 1998])
+    }
+
     @Test(arguments: [CodexCostCatchUpMode.automatic, .accelerated])
     func `app low power preference reaches successive catch-up passes`(mode: CodexCostCatchUpMode) async throws {
         let store = try Self.makeStore(suite: "app-low-power-worker")
@@ -733,7 +758,7 @@ struct UsageStoreSpendDashboardCodexCostCatchUpTests {
 
     private static func makeStore(suite: String) throws -> UsageStore {
         let settings = testSettingsStore(
-            suiteName: "UsageStoreSpendDashboardCodexCostCatchUpTests-\(suite)")
+            suiteName: "UsageStoreSpendDashboardCodexCostCatchUpTests-\(suite)", userDefaults: InMemoryUserDefaults())
         settings.costUsageEnabled = true
         let metadata = try #require(ProviderRegistry.shared.metadata[.codex])
         settings.setProviderEnabled(provider: .codex, metadata: metadata, enabled: true)

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -304,3 +304,7 @@ dashboard labels its values as local estimates and keeps currencies separate.
   `Sources/CodexBarCore/PiSessionCostScanner.swift`,
   `Sources/CodexBarCore/PiSessionCostCache.swift`,
   `Sources/CodexBarCore/Vendored/CostUsage/*`
+
+Automatic local-history catch-up bases its duty-cycle delay on time spent executing its own scan, including cache
+publication. Time waiting behind another account or provider on the shared scan queue does not increase that delay.
+The existing power, thermal, scan-budget, and complete-history publication rules still apply.


### PR DESCRIPTION
Automatic Codex history catch-up currently counts time waiting behind another account or provider on the shared serial scan queue as active work. Its duty-cycle policy then multiplies that wait into additional sleep. Measure the scan inside the executor and use its own active duration in both usage and Spend Dashboard workers.

Preserve the existing power/thermal policy, initial delay, scan budgets, cancellation, and complete-history publication boundary. Refs #3508 and #3411; these broader reports remain open. This does not change held PR #3509 or enable its dormant accelerated path. The changelog entry will be centralized in the final batch notes PR.

Validation so far: 48 focused regression tests passed, independent P0–P2 review clean, and a real integration executable using the production executor and policy parsed 10,000 synthetic JSON records. A 460 ms total await contained only 32 ms of active work: the old delay was 459 seconds, while the corrected delay was 32 seconds. The final full local suite passed 1,072 selections in 90 groups with zero failures or retries. Signed native menu smoke, make check, 41 architecture-gate tests, and final branch review pass. Exact-head CI is green: https://github.com/steipete/CodexBar/actions/runs/34658785497.
