### PR TITLE
chore: collect maintenance notes and stabilize checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Documentation: link the community-maintained CodexBar for Windows companion and AI Monitor USB desk display (#3525, #3544). Thanks @hinneslung and @tobymarks!
 
 ### Development
+- Checks: allow process-fixture startup on loaded Macs before measuring cleanup deadlines, retaining all process-ownership and timeout assertions.
 - Logging: update SwiftLog to 1.15.1 for corrected legacy log forwarding and Swift 6.5 WASI compatibility.
 - Linting: update SwiftLint to 0.65.1, Oxlint to 1.82.0, and Oxfmt to 0.67.0 for correctness and performance fixes, retaining verified macOS and Linux downloads.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Documentation: link the community-maintained CodexBar for Windows companion and AI Monitor USB desk display (#3525, #3544). Thanks @hinneslung and @tobymarks!
 
 ### Development
+- Checks: isolate Claude usage-retry tests from unrelated authentication subprocess startup.
 - Checks: allow process-fixture startup on loaded Macs before measuring cleanup deadlines, retaining all process-ownership and timeout assertions.
 - Logging: update SwiftLog to 1.15.1 for corrected legacy log forwarding and Swift 6.5 WASI compatibility.
 - Linting: update SwiftLint to 0.65.1, Oxlint to 1.82.0, and Oxfmt to 0.67.0 for correctness and performance fixes, retaining verified macOS and Linux downloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,22 @@
 ## 0.59.1 — Unreleased
 
 ### Highlights
-- **More reliable local history:** recover Antigravity spend history from cleanly closed conversations and let large Codex histories finish bounded catch-up.
+- **Linux Cursor authentication:** reuse the signed-in Cursor app without manually copying cookies.
+- **More reliable local history:** recover Antigravity spend history and prevent scan-queue waiting from multiplying Codex catch-up delays.
 - **Safer account menus:** preserve privacy in Codex account labels and reauthenticate the credential source shown by the selected row.
 
-### Fixed
+### Changes
+- Cursor on Linux: restore automatic authentication from the signed-in app, honor absolute XDG/HOME paths, and preserve manual-cookie precedence and explicit web-mode isolation (#3539). Thanks @DonnieFi!
+- Codex spend: exclude time waiting behind other scans from automatic catch-up sleep calculations while preserving scan budgets, power safeguards, and complete-history publication (#3566, related to #3508 and #3411).
 - Antigravity: recover local token history from stable SQLite conversations without WAL sidecars while withholding results changed by concurrent writers (#3532). Thanks @urda!
 - Codex spend: keep waiting history files ahead of repeated migration revisits so large histories can finish bounded catch-up, preserving stored rows and checkpoints (#3548, related to #3411). Thanks @SergeiNikolenko!
 - Codex accounts: reauthenticate the credential source used by the visible row, fixing repeated re-auth on saved accounts that also represent the System login, and reject stale account actions (#3558). Thanks @Nek-12!
 - Codex accounts: honor Hide Personal Info in switcher labels and tooltips, redact embedded workspace emails, and preserve distinct account numbers in narrow menus (#3551). Thanks @zenibako!
+- Agent Sessions: add an opt-in setting to hide hosts whose session fetch failed, while keeping diagnostics visible by default (#3547). Thanks @warthurton!
 - Menu bar: align window and display coordinates so monitors above or below the primary display do not cause missed or false startup recovery.
 - Devin: honor hidden daily quotas even when the response includes daily usage, preserving weekly limits and extra balance (#3542). Thanks @dzienisz!
 - Grok: skip discarded local-history scans and version probes after terminal CLI billing failures, allowing fallback to start sooner (extracted from #3236). Thanks @Yuxin-Qiao!
+- Documentation: link the community-maintained CodexBar for Windows companion and AI Monitor USB desk display (#3525, #3544). Thanks @hinneslung and @tobymarks!
 
 ### Development
 - Logging: update SwiftLog to 1.15.1 for corrected legacy log forwarding and Swift 6.5 WASI compatibility.

--- a/Scripts/test_swift_test_process_cleanup.py
+++ b/Scripts/test_swift_test_process_cleanup.py
@@ -249,7 +249,8 @@ class ProcessCleanupTests(unittest.TestCase):
             )
             timer = None
             try:
-                wait_until(lambda: (sentinel_root / "pid").exists())
+                # Interpreter/file startup is setup; the cleanup deadlines below start afterward.
+                wait_until(lambda: (sentinel_root / "pid").exists(), timeout=10)
                 if interrupt:
                     timer = threading.Timer(2, lambda: os.kill(os.getpid(), signal.SIGINT))
                     timer.start()

--- a/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
@@ -80,8 +80,6 @@ struct ClaudeCLITimeoutRetryTests {
     @Test
     func `auto cli usage does not retry unrecoverable parse failure`() async throws {
         let attempts = AttemptRecorder()
-        let cliPath = try Self.makeLoggedInClaudeCLI()
-        defer { try? FileManager.default.removeItem(at: cliPath) }
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
             environment: [:],
@@ -94,8 +92,8 @@ struct ClaudeCLITimeoutRetryTests {
         }
 
         await #expect(throws: ClaudeStatusProbeError.self) {
-            try await self.withNoOAuthCredentials {
-                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(cliPath.path) {
+            try await self.withLoggedInCLIWithoutOAuth {
+                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
                     try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
                         try await fetcher.loadLatestUsage(model: "sonnet")
                     }
@@ -112,8 +110,6 @@ struct ClaudeCLITimeoutRetryTests {
     func `auto cli usage retries loading panel before stale web fallback`() async throws {
         let attempts = AttemptRecorder()
         let webRequests = WebRequestRecorder()
-        let cliPath = try Self.makeLoggedInClaudeCLI()
-        defer { try? FileManager.default.removeItem(at: cliPath) }
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
             environment: [:],
@@ -138,12 +134,12 @@ struct ClaudeCLITimeoutRetryTests {
                 rawText: "probe raw")
         }
 
-        let snapshot = try await self.withNoOAuthCredentials {
+        let snapshot = try await self.withLoggedInCLIWithoutOAuth {
             try await self.withClaudeWebStub(handler: { request in
                 webRequests.record(request.url?.path ?? "<missing>")
                 throw URLError(.userAuthenticationRequired)
             }, operation: {
-                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(cliPath.path) {
+                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
                     try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
                         try await fetcher.loadLatestUsage(model: "sonnet")
                     }
@@ -163,8 +159,6 @@ struct ClaudeCLITimeoutRetryTests {
     @Test
     func `auto cli usage retries timeout when cli is final source`() async throws {
         let attempts = AttemptRecorder()
-        let cliPath = try Self.makeLoggedInClaudeCLI()
-        defer { try? FileManager.default.removeItem(at: cliPath) }
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
             environment: [:],
@@ -189,8 +183,8 @@ struct ClaudeCLITimeoutRetryTests {
                 rawText: "probe raw")
         }
 
-        let snapshot = try await self.withNoOAuthCredentials {
-            try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(cliPath.path) {
+        let snapshot = try await self.withLoggedInCLIWithoutOAuth {
+            try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
                 try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
                     try await fetcher.loadLatestUsage(model: "sonnet")
                 }
@@ -333,7 +327,7 @@ struct ClaudeCLITimeoutRetryTests {
         #expect(ClaudeCLIRateLimitGate.currentBlockedUntil() == nil)
     }
 
-    private func withNoOAuthCredentials<T>(operation: () async throws -> T) async rethrows -> T {
+    private func withLoggedInCLIWithoutOAuth<T>(operation: () async throws -> T) async rethrows -> T {
         let missingCredentialsURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("missing-claude-creds-\(UUID().uuidString).json")
         return try await KeychainCacheStore.withServiceOverrideForTesting("rat-107-\(UUID().uuidString)") {
@@ -347,7 +341,7 @@ struct ClaudeCLITimeoutRetryTests {
                                 data: nil,
                                 fingerprint: nil)
                             {
-                                try await ClaudeCLIAuthStatusProbe.withTimeoutOverrideForTesting(30) {
+                                try await ClaudeCLIAuthStatusProbe.withResultOverrideForTesting(true) {
                                     try await operation()
                                 }
                             }
@@ -371,20 +365,5 @@ struct ClaudeCLITimeoutRetryTests {
             ClaudeAutoFetcherStubURLProtocol.handler = nil
         }
         return try await operation()
-    }
-
-    private static func makeLoggedInClaudeCLI() throws -> URL {
-        let executable = FileManager.default.temporaryDirectory
-            .appendingPathComponent("claude-auth-status-\(UUID().uuidString)")
-        try Data("""
-        #!/bin/sh
-        if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-          printf '%s\\n' '{"loggedIn":true,"authMethod":"claude.ai"}'
-          exit 0
-        fi
-        exit 88
-        """.utf8).write(to: executable)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
-        return executable
     }
 }


### PR DESCRIPTION
Collect the batch-six notes in the existing 0.59.1 Unreleased section, ordered by user impact, and fix a process-check setup flake observed repeatedly on a loaded Mac.

The Claude usage-retry fixtures now set their authenticated-CLI prerequisite through the existing task-scoped test hook, removing an unrelated shell startup and its potential 30-second timeout. Retry counts, timeouts, and dedicated authentication-probe tests are unchanged.

The sentinel's interpreter/file startup now gets up to ten seconds before cleanup timing begins. The actual two-second cleanup timeout, bounded teardown, child-ownership checks, and unrelated-sentinel assertions are unchanged. The 101-test process-cleanup suite passes with real subprocesses, and independent P0–P2 review is clean.

This is the only batch PR that changes CHANGELOG.md. Merge after #3539 (Linux Cursor), #3566 (Codex catch-up timing), #3547 (opt-in host hiding), #3525 (Windows companion link), and #3544 (AI Monitor link). Existing notes and contributor credit are retained; released sections are unchanged.

No newly stale small dependency was found beyond #3564's refresh. Previously held compiler/major-version migrations remain separate. The queue still needs another batch, so this does not authorize a tag or release. Exact-head CI passed: https://github.com/steipete/CodexBar/actions/runs/34659109403. The exact notes head also passed 27 focused Swift tests across retry, auth-status, and background-availability suites.
