### PR TITLE
Add native Omarchy usage widget

### DIFF
--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -1,0 +1,23 @@
+name: Omarchy integration
+on:
+  pull_request:
+    paths:
+      - 'Integrations/Omarchy/**'
+      - '.github/workflows/omarchy.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Integrations/Omarchy/**'
+      - '.github/workflows/omarchy.yml'
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: node --test Integrations/Omarchy/test.mjs
+      - run: python3 Integrations/Omarchy/test_install.py

--- a/Integrations/Omarchy/Panel.qml
+++ b/Integrations/Omarchy/Panel.qml
@@ -1,0 +1,183 @@
+import QtQuick
+import QtQuick.Controls
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+import "Usage.js" as Usage
+
+Panel {
+    id: root
+    moduleName: "steipete.codexbar"
+    ipcTarget: moduleName
+    manageIpc: false
+    property var entries: []
+    property string failure: ""
+    property double now: Date.now()
+    property double lastRefresh: 0
+    property string output: ""
+    property int lastExitCode: -1
+    readonly property color foreground: bar ? bar.foreground : Color.foreground
+    readonly property bool stale: lastRefresh > 0 && (failure !== "" || now - lastRefresh > 600000)
+    implicitWidth: button.implicitWidth
+    implicitHeight: button.implicitHeight
+
+    function refresh() {
+        if (probe.running) return;
+        output = "";
+        probe.running = true;
+    }
+    Component.onCompleted: Qt.callLater(refresh)
+    onSettingsChanged: Qt.callLater(refresh)
+    IpcHandler {
+        target: root.ipcTarget
+        function open(): void { root.open(); }
+        function close(): void { root.close(); }
+        function refresh(): void { root.refresh(); }
+        function status(): string {
+            return JSON.stringify({running: probe.running, exitCode: root.lastExitCode,
+                outputBytes: root.output.length, providers: root.entries.length,
+                summary: Usage.summary(root.entries), failure: root.failure});
+        }
+    }
+    Timer {
+        interval: Math.max(60, Number(root.setting("refreshSeconds", 300)) || 300) * 1000
+        running: true
+        repeat: true
+        onTriggered: root.refresh()
+    }
+    Timer {
+        interval: 30000
+        running: true
+        repeat: true
+        onTriggered: root.now = Date.now()
+    }
+    Process {
+        id: probe
+        command: ["timeout", "60", String(root.setting("executable", "codexbar")), "usage",
+            "--provider", String(root.setting("provider", "codex")), "--format", "json", "--json-only"]
+        stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.output = text }
+        // Provider diagnostics may contain personal data; never forward them to shell logs.
+        stderr: StdioCollector {}
+        onExited: function(code, status) {
+            root.lastExitCode = code;
+            try {
+                var parsed = Usage.rows(root.output);
+                root.entries = parsed;
+                root.failure = "";
+                root.lastRefresh = Date.now();
+            } catch (error) {
+                root.failure = code === 124 ? "Refresh timed out. Press R to retry." :
+                    "Unable to fetch usage. Check the CLI path and provider login; press R to retry.";
+            }
+            root.now = Date.now();
+        }
+    }
+    WidgetButton {
+        id: button
+        anchors.fill: parent
+        bar: root.bar
+        text: (root.stale ? "! " : "") + (root.entries.length ? Usage.summary(root.entries) : "CX —")
+        tooltipText: "CodexBar · quota remaining\nClick for details · middle-click to refresh"
+        onPressed: function(code) {
+            if (code === Qt.MiddleButton || code === Qt.RightButton) root.refresh();
+            else root.toggle();
+        }
+    }
+    KeyboardPanel {
+        id: popup
+        anchorItem: button
+        owner: root
+        bar: root.bar
+        open: root.opened
+        focusTarget: keys
+        contentWidth: fittedContentWidth(Style.space(360))
+        contentHeight: fittedContentHeight(content.implicitHeight, Style.space(560))
+        PanelKeyCatcher {
+            id: keys
+            anchors.fill: parent
+            onCloseRequested: root.close()
+            onTabRequested: function(direction) { root.switchPanel(direction); }
+            onTextKey: function(text) { if (text.toLowerCase() === "r") root.refresh(); }
+            Flickable {
+                anchors.fill: parent
+                contentWidth: width
+                contentHeight: content.implicitHeight
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+                ScrollBar.vertical: ScrollBar {}
+                Column {
+                    id: content
+                    width: parent.width
+                    spacing: Style.space(14)
+                    Text {
+                        text: "CodexBar"
+                        color: root.foreground
+                        font.family: Style.font.family
+                        font.pixelSize: Style.font.heading
+                        font.bold: true
+                    }
+                    DetailText {
+                        text: probe.running ? "Refreshing…" : root.failure || (root.lastRefresh ?
+                            "Quota remaining · updated " + Qt.formatTime(new Date(root.lastRefresh), "HH:mm") : "Waiting for usage…")
+                    }
+                    Repeater {
+                        model: root.entries
+                        Column {
+                            required property var modelData
+                            width: content.width
+                            spacing: Style.space(8)
+                            DetailText {
+                                text: modelData.provider.toUpperCase() + (modelData.source ? " · " + modelData.source : "")
+                                font.bold: true
+                            }
+                            DetailText { text: modelData.error; visible: text !== "" }
+                            Repeater {
+                                model: modelData.windows
+                                Column {
+                                    required property var modelData
+                                    width: content.width
+                                    spacing: Style.space(4)
+                                    DetailText { text: modelData.label + " · " + modelData.remaining + "% left" }
+                                    Rectangle {
+                                        width: parent.width
+                                        height: Style.space(6)
+                                        radius: height / 2
+                                        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.15)
+                                        Rectangle {
+                                            width: parent.width * modelData.remaining / 100
+                                            height: parent.height
+                                            radius: height / 2
+                                            color: modelData.remaining <= 10 ? Color.urgent : Color.accent
+                                        }
+                                    }
+                                    DetailText {
+                                        text: Usage.resetLabel(modelData.resetsAt, root.now)
+                                        opacity: 0.65
+                                    }
+                                }
+                            }
+                            DetailText {
+                                visible: modelData.credits !== null
+                                text: "Credits: " + modelData.credits
+                            }
+                        }
+                    }
+                    DetailText { visible: root.stale; text: "Showing older data"; color: Color.urgent }
+                    Button {
+                        text: probe.running ? "Refreshing…" : "Refresh  ·  R"
+                        enabled: !probe.running
+                        onClicked: root.refresh()
+                    }
+                }
+            }
+        }
+    }
+    component DetailText: Text {
+        width: parent.width
+        color: root.foreground
+        font.family: Style.font.family
+        font.pixelSize: Style.font.body
+        textFormat: Text.PlainText
+        wrapMode: Text.Wrap
+    }
+}

--- a/Integrations/Omarchy/README.md
+++ b/Integrations/Omarchy/README.md
@@ -1,0 +1,40 @@
+# CodexBar for Omarchy
+
+Native Quickshell bar widget for Omarchy's plugin-based shell. Uses the official
+Linux CLI, the current Omarchy theme, and its standard keyboard-aware popup.
+No separate daemon or network listener. This does not support older Waybar-based
+Omarchy installations.
+
+Install a Linux `codexbar` release (keep its resource bundle alongside the binary),
+then run from the repository root:
+
+```sh
+python3 Integrations/Omarchy/install.py --executable /absolute/path/to/codexbar
+```
+
+The installer backs up `shell.json`, copies the plugin into the user plugin
+directory, and adds it to the right side of the bar. The shell hot-reloads it and
+loads it again at login. Existing layout entries are preserved.
+
+The default provider is Codex. Authenticate with the provider's CLI first. Use
+`--provider both` for Codex and Claude or another CodexBar provider ID. Provider
+support and authentication are the same as the installed Linux CLI; this is a
+usage frontend, not a port of macOS account management or browser imports.
+
+Click the bar label for usage windows, credits and reset countdowns. Percentages
+show **remaining** quota. Middle/right-click or press **R** in the popup to
+refresh; **Escape** closes it. Polling defaults to five minutes, never overlaps,
+and has a 60-second deadline. Failed refreshes keep the last response with a
+stale warning. Provider failures remain separate from successful providers.
+The widget does not display account identities or raw provider errors.
+
+The `steipete.codexbar` entry in `~/.config/omarchy/shell.json` accepts `executable`,
+`provider`, and `refreshSeconds` (minimum 60). To remove the widget, remove its
+layout entry and user plugin directory, or use `omarchy plugin remove`.
+
+Validation:
+
+```sh
+node --test Integrations/Omarchy/test.mjs
+omarchy plugin validate Integrations/Omarchy
+```

--- a/Integrations/Omarchy/Usage.js
+++ b/Integrations/Omarchy/Usage.js
@@ -1,0 +1,51 @@
+// Pure model shared by the QML frontend and offline Node tests.
+function remaining(window) {
+    if (!window || typeof window.usedPercent !== "number" || !isFinite(window.usedPercent)) return null;
+    return Math.round(Math.max(0, Math.min(100, 100 - window.usedPercent)));
+}
+
+function rows(text) {
+    var decoded = JSON.parse(text);
+    var entries = Array.isArray(decoded) ? decoded : [decoded];
+    if (!entries.length || entries.some(function(e) { return !e || typeof e.provider !== "string"; }))
+        throw new Error("Invalid usage response");
+    return entries.map(function(entry) {
+        var usage = entry.usage || {};
+        var windows = [];
+        ["primary", "secondary", "tertiary"].forEach(function(key, index) {
+            var window = usage[key];
+            var left = remaining(window);
+            if (left === null) return;
+            var minutes = window.windowMinutes;
+            var label = minutes >= 1440 ? (minutes / 1440) + " day" :
+                minutes > 0 ? (minutes / 60) + " hour" : ["Session", "Weekly", "Additional"][index];
+            windows.push({label: label, remaining: left, resetsAt: window.resetsAt || ""});
+        });
+        return {
+            provider: entry.provider,
+            source: entry.source || "",
+            windows: windows,
+            updatedAt: usage.updatedAt || "",
+            credits: entry.credits && typeof entry.credits.remaining === "number" ? entry.credits.remaining : null,
+            error: entry.error ? "Usage unavailable. Check this provider’s CodexBar login/configuration." :
+                windows.length ? "" : "No quota windows reported."
+        };
+    });
+}
+
+function summary(entries) {
+    return entries.map(function(entry) {
+        var label = entry.provider === "codex" ? "CX" : entry.provider === "claude" ? "CL" : entry.provider;
+        return label + " " + (entry.windows.length ? entry.windows[0].remaining + "%" : "—");
+    }).join("  ·  ");
+}
+
+function resetLabel(value, now) {
+    var timestamp = Date.parse(value);
+    if (!isFinite(timestamp)) return "Reset time unavailable";
+    var minutes = Math.ceil((timestamp - now) / 60000);
+    if (minutes <= 0) return "Reset due · refresh to update";
+    if (minutes < 60) return "Resets in " + minutes + "m";
+    if (minutes < 1440) return "Resets in " + Math.floor(minutes / 60) + "h " + minutes % 60 + "m";
+    return "Resets in " + Math.floor(minutes / 1440) + "d " + Math.floor(minutes % 1440 / 60) + "h";
+}

--- a/Integrations/Omarchy/install.py
+++ b/Integrations/Omarchy/install.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Install this checkout's plugin and preserve the existing Omarchy layout."""
+import argparse
+import datetime
+import json
+import os
+from pathlib import Path
+import shutil
+import tempfile
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--executable', required=True, type=Path)
+parser.add_argument('--provider', default='codex')
+args = parser.parse_args()
+executable = args.executable.resolve()
+if not executable.is_file() or not os.access(executable, os.X_OK):
+    parser.error('--executable must be an executable CodexBar Linux CLI')
+config = Path(os.environ.get('XDG_CONFIG_HOME', Path.home() / '.config')) / 'omarchy'
+shell = config / 'shell.json'
+data = json.loads(shell.read_text())
+plugin_id = 'steipete.codexbar'
+destination = config / 'plugins' / plugin_id
+source = Path(__file__).resolve().parent
+stamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S-%f')
+shutil.copy2(shell, shell.with_name(f'shell.json.codexbar-backup-{stamp}'))
+if destination.exists():
+    backup = config / 'backups' / f'{plugin_id}-{stamp}'
+    backup.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(destination, backup)
+destination.mkdir(parents=True, exist_ok=True)
+for name in ['manifest.json', 'Panel.qml', 'Usage.js']:
+    shutil.copy2(source / name, destination / name)
+entry = None
+layout = data.setdefault('bar', {}).setdefault('layout', {})
+for section in layout.values():
+    if not isinstance(section, list):
+        continue
+    for existing in section:
+        if isinstance(existing, dict) and existing.get('id') == plugin_id:
+            entry = existing
+if entry is None:
+    entry = {'id': plugin_id}
+    layout.setdefault('right', []).insert(0, entry)
+entry.update(executable=str(executable), provider=args.provider, refreshSeconds=300)
+with tempfile.NamedTemporaryFile(mode='w', dir=config, delete=False) as handle:
+    temporary = Path(handle.name)
+    json.dump(data, handle, indent=2)
+    handle.write('\n')
+    handle.flush()
+    os.fsync(handle.fileno())
+temporary.chmod(shell.stat().st_mode & 0o777)
+temporary.replace(shell)
+print(f'Installed {destination}; Omarchy will hot-reload the widget.')

--- a/Integrations/Omarchy/manifest.json
+++ b/Integrations/Omarchy/manifest.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "id": "steipete.codexbar",
+  "name": "CodexBar",
+  "version": "1.0.0",
+  "author": "steipete",
+  "description": "AI usage meters powered by the CodexBar Linux CLI",
+  "kinds": ["bar-widget"],
+  "entryPoints": {"barWidget": "Panel.qml"},
+  "barWidget": {
+    "displayName": "CodexBar",
+    "description": "Usage, reset times, and credits for your AI providers",
+    "category": "Info",
+    "allowMultiple": false
+  }
+}

--- a/Integrations/Omarchy/test.mjs
+++ b/Integrations/Omarchy/test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import test from 'node:test';
+
+const model = vm.createContext({});
+vm.runInContext(fs.readFileSync(new URL('./Usage.js', import.meta.url), 'utf8'), model);
+test('quota is clamped, missing quota stays unknown', () => {
+    assert.equal(model.remaining({usedPercent: 28}), 72);
+    assert.equal(model.remaining({usedPercent: 150}), 0);
+    assert.equal(model.remaining({usedPercent: -5}), 100);
+    for (const value of [null, {}, {usedPercent: null}, {usedPercent: '12'}, {usedPercent: Infinity}])
+        assert.equal(model.remaining(value), null);
+});
+test('partial provider failures preserve healthy rows without leaking raw errors or identity', () => {
+    const rows = model.rows(JSON.stringify([
+        {provider: 'codex', usage: {primary: {usedPercent: 28, windowMinutes: 300}, identity: {accountEmail: 'private@example.com'}}},
+        {provider: 'claude', error: {message: 'secret upstream response'}}
+    ]));
+    assert.equal(model.summary(rows), 'CX 72%  ·  CL —');
+    assert.equal(rows[0].windows[0].label, '5 hour');
+    assert.ok(rows[1].error);
+    assert.ok(!JSON.stringify(rows).includes('secret'));
+    assert.ok(!JSON.stringify(rows).includes('private'));
+});
+test('malformed and unrecognized responses cannot replace the last good snapshot', () => {
+    for (const value of ['', '[]', '{}', 'null', '[null]', 'oops'])
+        assert.throws(() => model.rows(value));
+});
+test('reset countdown handles invalid and elapsed timestamps', () => {
+    const now = Date.parse('2026-01-01T00:00:00Z');
+    assert.equal(model.resetLabel('bad', now), 'Reset time unavailable');
+    assert.equal(model.resetLabel('2025-12-31T23:00:00Z', now), 'Reset due · refresh to update');
+    assert.equal(model.resetLabel('2026-01-01T01:30:00Z', now), 'Resets in 1h 30m');
+});

--- a/Integrations/Omarchy/test_install.py
+++ b/Integrations/Omarchy/test_install.py
@@ -1,0 +1,32 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+class InstallTests(unittest.TestCase):
+    def test_reinstall_preserves_layout_and_keeps_backups_out_of_discovery(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            config = Path(temporary)
+            shell = config / 'omarchy' / 'shell.json'
+            shell.parent.mkdir()
+            shell.write_text(json.dumps({'bar': {'layout': {'right': [{'id': 'omarchy.clock'}]}},
+                                         'idle': {'lock': 123}}))
+            script = Path(__file__).with_name('install.py')
+            environment = dict(os.environ, XDG_CONFIG_HOME=str(config))
+            for _ in range(2):
+                subprocess.run(['python3', str(script), '--executable', '/usr/bin/true'],
+                               env=environment, check=True, capture_output=True)
+            result = json.loads(shell.read_text())
+            self.assertEqual(result['idle'], {'lock': 123})
+            self.assertEqual([e['id'] for e in result['bar']['layout']['right']],
+                             ['steipete.codexbar', 'omarchy.clock'])
+            manifests = list((shell.parent / 'plugins').glob('*/manifest.json'))
+            self.assertEqual(len(manifests), 1)
+            self.assertEqual(len(list((shell.parent / 'backups').iterdir())), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ CLI install:
 - [CodexBar for Windows](https://github.com/hinneslung/CodexBar-for-Windows) — Native Windows tray app powered by the original CodexBar CLI through WSL2; x64 and ARM64 installers.
 
 ## Linux desktop integration?
+- [Omarchy native widget](Integrations/Omarchy/README.md) — Quickshell bar usage meters, reset countdowns, credits, and keyboard-aware popup using the Linux CLI.
 - [codexbar-waybar](https://github.com/Marouan-chak/codexbar-waybar) — Waybar custom module + GTK4 popover for Hyprland / Sway / other Wayland compositors, built on top of the bundled Linux CLI.
 - [codexbar-cosmic-applet](https://github.com/andrew-verde/codexbar-cosmic-applet) — Native COSMIC (System76) desktop panel applet with a tab per provider, pace projections, and cost/token stats, built on top of the bundled Linux CLI.
 - [Codexbar GNOME](https://extensions.gnome.org/extension/9841/codexbar/) — GNOME Shell extension that brings CodexBar usage into the desktop panel.

--- a/VISION.md
+++ b/VISION.md
@@ -25,3 +25,4 @@ CodexBar is the menu bar control surface for AI provider limits, credits, spend,
 - The CLI (`codexbar`) is cross-platform: macOS and Linux are supported today, with feature parity for usage, cost, serve, and hooks wherever platform APIs allow.
 - Windows is an aspiration, not a commitment: if Swift's Windows support matures enough to stop fighting us, shipping the CLI (and eventually more) there would be welcome. Contributions keeping the core portable are valued now.
 - Desktop-environment integrations beyond macOS (KDE widgets, GNOME extensions, etc.) belong in separate, community-maintained projects consuming `codexbar serve` or `codexbar usage --json`; we link good ones from the README rather than absorbing them.
+- Omarchy is an owner-requested exception: `Integrations/Omarchy` maintains a native shell frontend consuming the Linux CLI. Provider fetching and authentication remain in the shared core/CLI.


### PR DESCRIPTION
Adds an owner-requested native Omarchy shell widget backed by the existing Linux CLI. The bar shows remaining quota and opens a theme-aware, keyboard-accessible popup with quota windows, reset countdowns, credits, refresh controls, and explicit unavailable/stale states. This also records the Omarchy exception to the repository’s desktop integration policy.

The installer preserves the existing bar layout, backs up configuration outside plugin discovery, and configures startup through Omarchy’s normal shell. No dependencies were added to the Swift app or CLI.

Validation: four offline usage-model tests and the isolated reinstall test pass; Omarchy manifest validation and `git diff --check` pass. Installed on Omarchy/Quickshell and verified popup rendering and successful background CLI fetch after shell restart. The live account returns no quota windows, correctly displayed as unavailable. The official Linux CLI 0.59.0 was checksum verified. Dedicated Linux integration CI is included.

Full repository checks were attempted: `make test` requires the absent Swift toolchain; `make check` stops at the macOS-only `plutil` locale check. No Swift source changes.
