### PR TITLE
Add Omarchy provider and account settings

### DIFF
--- a/Integrations/Omarchy/Panel.qml
+++ b/Integrations/Omarchy/Panel.qml
@@ -196,11 +196,13 @@ Panel {
                     }
                     DetailText { visible: root.stale; text: "Showing older data"; color: Color.urgent }
                     Button {
+                        focusable: true
                         text: probe.running ? "Refreshing…" : "Refresh  ·  R"
                         enabled: !probe.running
                         onClicked: root.refresh()
                     }
                     Button {
+                        focusable: true
                         text: root.settingsOpen ? "Hide settings" : "Settings"
                         onClicked: root.settingsOpen = !root.settingsOpen
                     }
@@ -231,6 +233,7 @@ Panel {
                         DetailText { text: "Refresh interval in seconds" }
                         SpinBox { id: intervalInput; from: 60; to: 3600; stepSize: 60; value: Number(root.setting("refreshSeconds", 300)) }
                         Button {
+                            focusable: true
                             text: "Apply"
                             enabled: providerInput.acceptableInput
                             onClicked: {

--- a/Integrations/Omarchy/Panel.qml
+++ b/Integrations/Omarchy/Panel.qml
@@ -110,13 +110,22 @@ Panel {
         focusTarget: keys
         contentWidth: fittedContentWidth(Style.space(360))
         contentHeight: fittedContentHeight(content.implicitHeight, Style.space(560))
-        PanelKeyCatcher {
+        FocusScope {
             id: keys
             anchors.fill: parent
-            onCloseRequested: root.close()
-            onTabRequested: function(direction) { root.switchPanel(direction); }
-            onTextKey: function(text) { if (text.toLowerCase() === "r") root.refresh(); }
+            focus: true
+            Keys.priority: Keys.AfterItem
+            Keys.onPressed: function(event) {
+                if (event.key === Qt.Key_Escape) { root.close(); event.accepted = true; }
+                else if (event.key === Qt.Key_R && !providerInput.activeFocus) { root.refresh(); event.accepted = true; }
+                else if (event.key === Qt.Key_Down || event.key === Qt.Key_Up) {
+                    scroll.contentY = Math.max(0, Math.min(scroll.contentHeight - scroll.height,
+                        scroll.contentY + (event.key === Qt.Key_Down ? 40 : -40)));
+                    event.accepted = true;
+                }
+            }
             Flickable {
+                id: scroll
                 anchors.fill: parent
                 contentWidth: width
                 contentHeight: content.implicitHeight

--- a/Integrations/Omarchy/Panel.qml
+++ b/Integrations/Omarchy/Panel.qml
@@ -16,6 +16,10 @@ Panel {
     property double lastRefresh: 0
     property string output: ""
     property int lastExitCode: -1
+    property bool settingsOpen: false
+    property string activeRequest: ""
+    property string dataRequest: ""
+    readonly property string request: JSON.stringify(Usage.command(settings))
     readonly property color foreground: bar ? bar.foreground : Color.foreground
     readonly property bool stale: lastRefresh > 0 && (failure !== "" || now - lastRefresh > 600000)
     implicitWidth: button.implicitWidth
@@ -23,8 +27,19 @@ Panel {
 
     function refresh() {
         if (probe.running) return;
+        if (dataRequest !== request) {
+            entries = [];
+            lastRefresh = 0;
+        }
+        activeRequest = request;
+        probe.command = JSON.parse(activeRequest);
         output = "";
         probe.running = true;
+    }
+    function saveSettings(changes) {
+        if (!bar || !bar.shell) return;
+        var merged = Object.assign({}, settings, changes);
+        bar.shell.updateEntryInline(moduleName, merged);
     }
     Component.onCompleted: Qt.callLater(refresh)
     onSettingsChanged: Qt.callLater(refresh)
@@ -53,16 +68,19 @@ Panel {
     }
     Process {
         id: probe
-        command: ["timeout", "60", String(root.setting("executable", "codexbar")), "usage",
-            "--provider", String(root.setting("provider", "codex")), "--format", "json", "--json-only"]
         stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.output = text }
         // Provider diagnostics may contain personal data; never forward them to shell logs.
         stderr: StdioCollector {}
         onExited: function(code, status) {
             root.lastExitCode = code;
+            if (root.activeRequest !== root.request) {
+                Qt.callLater(root.refresh);
+                return;
+            }
             try {
-                var parsed = Usage.rows(root.output);
+                var parsed = Usage.rows(root.output, root.setting("showIdentity", false));
                 root.entries = parsed;
+                root.dataRequest = root.activeRequest;
                 root.failure = "";
                 root.lastRefresh = Date.now();
             } catch (error) {
@@ -76,7 +94,7 @@ Panel {
         id: button
         anchors.fill: parent
         bar: root.bar
-        text: (root.stale ? "! " : "") + (root.entries.length ? Usage.summary(root.entries) : "CX —")
+        text: (root.stale ? "! " : "") + (root.entries.length ? Usage.summary(root.entries) : "CodexBar —")
         tooltipText: "CodexBar · quota remaining\nClick for details · middle-click to refresh"
         onPressed: function(code) {
             if (code === Qt.MiddleButton || code === Qt.RightButton) root.refresh();
@@ -130,6 +148,11 @@ Panel {
                                 text: modelData.provider.toUpperCase() + (modelData.source ? " · " + modelData.source : "")
                                 font.bold: true
                             }
+                            DetailText {
+                                text: (root.setting("showIdentity", false) ? modelData.accountLabel : "") || (root.setting("allAccounts", false) ? "Account " + modelData.accountNumber : "")
+                                visible: text !== ""
+                            }
+                            DetailText { text: modelData.plan; visible: text !== ""; opacity: 0.7 }
                             DetailText { text: modelData.error; visible: text !== "" }
                             Repeater {
                                 model: modelData.windows
@@ -167,6 +190,48 @@ Panel {
                         text: probe.running ? "Refreshing…" : "Refresh  ·  R"
                         enabled: !probe.running
                         onClicked: root.refresh()
+                    }
+                    Button {
+                        text: root.settingsOpen ? "Hide settings" : "Settings"
+                        onClicked: root.settingsOpen = !root.settingsOpen
+                    }
+                    Column {
+                        width: parent.width
+                        visible: root.settingsOpen
+                        spacing: Style.space(8)
+                        DetailText { text: "Provider ID (enabled uses your CodexBar configuration)" }
+                        TextField {
+                            id: providerInput
+                            width: parent.width
+                            text: String(root.setting("provider", "codex"))
+                            placeholderText: "codex, claude, both, enabled…"
+                            selectByMouse: true
+                            validator: RegularExpressionValidator { regularExpression: /^[a-z0-9-]+$/ }
+                        }
+                        DetailText { text: "Source" }
+                        ComboBox {
+                            id: sourceInput
+                            width: parent.width
+                            model: ["auto", "oauth", "cli", "api", "web"]
+                            currentIndex: Math.max(0, model.indexOf(root.setting("source", "auto")))
+                        }
+                        DetailText { text: "Account number (0 uses the default; single provider only)" }
+                        SpinBox { id: accountInput; from: 0; to: 999; value: Number(root.setting("accountIndex", 0)) }
+                        CheckBox { id: allInput; text: "Show all accounts"; checked: root.setting("allAccounts", false) }
+                        CheckBox { id: identityInput; text: "Show account identity"; checked: root.setting("showIdentity", false) }
+                        DetailText { text: "Refresh interval in seconds" }
+                        SpinBox { id: intervalInput; from: 60; to: 3600; stepSize: 60; value: Number(root.setting("refreshSeconds", 300)) }
+                        Button {
+                            text: "Apply"
+                            enabled: providerInput.acceptableInput
+                            onClicked: {
+                                root.saveSettings({provider: providerInput.text, source: sourceInput.currentText,
+                                    accountIndex: accountInput.value, allAccounts: allInput.checked,
+                                    showIdentity: identityInput.checked, refreshSeconds: intervalInput.value});
+                                root.settingsOpen = false;
+                            }
+                        }
+                        DetailText { text: "Account selection changes this display only. Sign in and manage credentials with the provider CLI."; opacity: 0.7 }
                     }
                 }
             }

--- a/Integrations/Omarchy/README.md
+++ b/Integrations/Omarchy/README.md
@@ -32,6 +32,15 @@ The `steipete.codexbar` entry in `~/.config/omarchy/shell.json` accepts `executa
 `provider`, and `refreshSeconds` (minimum 60). To remove the widget, remove its
 layout entry and user plugin directory, or use `omarchy plugin remove`.
 
+The popup's Settings section persists provider, source, account number, all-account
+display, identity visibility, and polling interval in the same layout entry. Use
+`enabled` to follow providers enabled in the CodexBar config. Account selectors
+apply only to single-provider queries and select the displayed account; they do
+not change the provider CLI's active login. Identity is hidden by default. The bar
+shows at most two account/provider summaries, with an overflow count; the popup
+shows all results. Changing provider/source discards the previous selection's
+data, including a response that completes after the selection changed.
+
 Validation:
 
 ```sh

--- a/Integrations/Omarchy/Usage.js
+++ b/Integrations/Omarchy/Usage.js
@@ -4,13 +4,14 @@ function remaining(window) {
     return Math.round(Math.max(0, Math.min(100, 100 - window.usedPercent)));
 }
 
-function rows(text) {
+function rows(text, showIdentity) {
     var decoded = JSON.parse(text);
     var entries = Array.isArray(decoded) ? decoded : [decoded];
     if (!entries.length || entries.some(function(e) { return !e || typeof e.provider !== "string"; }))
         throw new Error("Invalid usage response");
-    return entries.map(function(entry) {
+    return entries.map(function(entry, entryIndex) {
         var usage = entry.usage || {};
+        var identity = usage.identity || {};
         var windows = [];
         ["primary", "secondary", "tertiary"].forEach(function(key, index) {
             var window = usage[key];
@@ -23,6 +24,9 @@ function rows(text) {
         });
         return {
             provider: entry.provider,
+            accountLabel: showIdentity ? String(identity.accountEmail || usage.accountEmail || "") : "",
+            accountNumber: entryIndex + 1,
+            plan: String(identity.loginMethod || usage.loginMethod || ""),
             source: entry.source || "",
             windows: windows,
             updatedAt: usage.updatedAt || "",
@@ -33,11 +37,27 @@ function rows(text) {
     });
 }
 
+function command(settings) {
+    var provider = String(settings.provider || "codex");
+    var args = ["timeout", "--kill-after=5", "60", String(settings.executable || "codexbar"),
+        "usage", "--format", "json", "--json-only"];
+    if (provider !== "enabled") args.push("--provider", provider);
+    var source = String(settings.source || "auto");
+    if (source !== "auto") args.push("--source", source);
+    if (["enabled", "all", "both"].indexOf(provider) === -1) {
+        if (settings.allAccounts === true) args.push("--all-accounts");
+        else if (Number.isInteger(Number(settings.accountIndex)) && Number(settings.accountIndex) > 0)
+            args.push("--account-index", String(settings.accountIndex));
+    }
+    return args;
+}
+
 function summary(entries) {
-    return entries.map(function(entry) {
+    var label = entries.slice(0, 2).map(function(entry) {
         var label = entry.provider === "codex" ? "CX" : entry.provider === "claude" ? "CL" : entry.provider;
         return label + " " + (entry.windows.length ? entry.windows[0].remaining + "%" : "—");
     }).join("  ·  ");
+    return label + (entries.length > 2 ? "  +" + (entries.length - 2) : "");
 }
 
 function resetLabel(value, now) {

--- a/Integrations/Omarchy/test.mjs
+++ b/Integrations/Omarchy/test.mjs
@@ -33,3 +33,22 @@ test('reset countdown handles invalid and elapsed timestamps', () => {
     assert.equal(model.resetLabel('2025-12-31T23:00:00Z', now), 'Reset due · refresh to update');
     assert.equal(model.resetLabel('2026-01-01T01:30:00Z', now), 'Resets in 1h 30m');
 });
+test('account selection is scoped to a single provider and arguments never use a shell', () => {
+    const command = model.command({provider: 'both', allAccounts: true, accountIndex: 2});
+    assert.ok(!command.includes('--all-accounts'));
+    assert.ok(!command.includes('--account-index'));
+    assert.ok(!model.command({provider: 'enabled'}).includes('--provider'));
+    const single = model.command({provider: 'codex', allAccounts: true, source: 'oauth', executable: '/a path/codexbar'});
+    assert.ok(single.includes('--all-accounts'));
+    assert.ok(single.includes('/a path/codexbar'));
+    assert.ok(single.includes('oauth'));
+    assert.ok(!model.command({accountIndex: '2;bad'}).includes('--account-index'));
+});
+test('identity is opt-in and stays within its provider row', () => {
+    const input = JSON.stringify([{provider: 'codex', usage: {identity: {accountEmail: 'one@example.com', loginMethod: 'pro'}}},
+        {provider: 'claude', usage: {}}]);
+    assert.equal(model.rows(input)[0].accountLabel, '');
+    assert.equal(model.rows(input, true)[0].accountLabel, 'one@example.com');
+    assert.equal(model.rows(input, true)[1].accountLabel, '');
+    assert.equal(model.rows(input, true)[1].plan, '');
+});


### PR DESCRIPTION
Adds persistent Omarchy popup settings for provider/source, displayed account number, all-account views, identity visibility, and refresh interval. `enabled` follows CodexBar’s configured providers. Account selection changes the display only; credentials and active provider login remain CLI-owned.

Provider changes discard the previous selection’s data and reject an in-flight response for the old selection. Identity stays hidden by default, provider identities remain siloed, and the bar caps account/provider summaries with an overflow count.

Validation: six model tests and the isolated installer test pass; Omarchy manifest validation and `git diff --check` pass. Installed and restarted the native shell; background CLI refresh succeeds. Full Swift/app checks have the same local toolchain limitations documented in #3568; no Swift files changed.
