### PR TITLE
Add Omarchy usage insights and local spending

### DIFF
--- a/Integrations/Omarchy/Panel.qml
+++ b/Integrations/Omarchy/Panel.qml
@@ -16,7 +16,7 @@ Panel {
     property double lastRefresh: 0
     property string output: ""
     property int lastExitCode: -1
-    property bool settingsOpen: false
+    property int page: 0
     property string activeRequest: ""
     property string dataRequest: ""
     property var costEntries: []
@@ -66,10 +66,12 @@ Panel {
         function open(): void { root.open(); }
         function close(): void { root.close(); }
         function refresh(): void { root.refresh(); }
+        function view(index: int): void { root.page = Math.max(0, Math.min(2, index)); root.open(); }
         function status(): string {
             return JSON.stringify({running: probe.running, exitCode: root.lastExitCode,
                 outputBytes: root.output.length, providers: root.entries.length,
-                summary: Usage.summary(root.entries), failure: root.failure});
+                summary: Usage.summary(root.entries), failure: root.failure,
+                costProviders: root.costEntries.length, costFailure: root.costFailure, page: root.page});
         }
     }
     Timer {
@@ -173,12 +175,29 @@ Panel {
                         font.pixelSize: Style.font.heading
                         font.bold: true
                     }
+                    Row {
+                        width: parent.width
+                        spacing: Style.space(4)
+                        Repeater {
+                            model: ["Usage", "Spending", "Settings"]
+                            Button {
+                                focusable: true
+                                required property string modelData
+                                required property int index
+                                text: modelData
+                                width: (content.width - Style.space(8)) / 3
+                                selected: root.page === index
+                                onClicked: { root.page = index; scroll.contentY = 0; }
+                            }
+                        }
+                    }
                     DetailText {
+                        visible: root.page === 0
                         text: probe.running ? "Refreshing…" : root.failure || (root.lastRefresh ?
                             "Quota remaining · updated " + Qt.formatTime(new Date(root.lastRefresh), "HH:mm") : "Waiting for usage…")
                     }
                     Repeater {
-                        model: root.entries
+                        model: root.page === 0 ? root.entries : []
                         Column {
                             required property var modelData
                             width: content.width
@@ -245,7 +264,7 @@ Panel {
                     }
                     Column {
                         width: parent.width
-                        visible: root.setting("showCosts", true)
+                        visible: root.page === 1 && root.setting("showCosts", true)
                         spacing: Style.space(10)
                         DetailText { text: "LOCAL SPENDING · CODEX & CLAUDE"; font.bold: true }
                         DetailText { text: "All local sessions, independent of the selected account. List-price estimates are not invoices."; opacity: 0.65 }
@@ -259,11 +278,11 @@ Panel {
                                 required property var modelData
                                 width: content.width
                                 spacing: Style.space(5)
-                                DetailText { text: modelData.provider.toUpperCase() + " · " + modelData.provenance; font.bold: true }
+                                DetailText { text: modelData.provider.toUpperCase() + " · " + Usage.provenance(modelData.provenance); font.bold: true }
                                 DetailText { text: modelData.error; visible: text !== "" }
                                 DetailText { text: "Today " + Usage.money(modelData.today) + " · 30 days " + Usage.money(modelData.month) }
-                                DetailText { text: "Tokens · " + (modelData.tokens === null ? "Unavailable" : modelData.tokens.toLocaleString()) }
-                                DetailText { text: "Input " + (modelData.input ?? "—") + " · output " + (modelData.output ?? "—") + " · cached " + (modelData.cached ?? "—"); opacity: 0.7 }
+                                DetailText { text: "Tokens · " + Usage.count(modelData.tokens) }
+                                DetailText { text: "Input " + Usage.count(modelData.input) + " · output " + Usage.count(modelData.output) + " · cached " + Usage.count(modelData.cached); opacity: 0.7 }
                                 DetailText { text: modelData.coverage; opacity: 0.7 }
                                 UsageChart { width: parent.width; chart: modelData.chart; foreground: root.foreground }
                             }
@@ -271,17 +290,15 @@ Panel {
                     }
                     DetailText { visible: root.stale; text: "Showing older data"; color: Color.urgent }
                     Button {
+                        focusable: true
                         text: probe.running ? "Refreshing…" : "Refresh  ·  R"
                         enabled: !probe.running
                         onClicked: root.refresh()
                     }
-                    Button {
-                        text: root.settingsOpen ? "Hide settings" : "Settings"
-                        onClicked: root.settingsOpen = !root.settingsOpen
-                    }
+                    DetailText { visible: root.page === 1 && !root.setting("showCosts", true); text: "Enable local spending in Settings." }
                     Column {
                         width: parent.width
-                        visible: root.settingsOpen
+                        visible: root.page === 2
                         spacing: Style.space(8)
                         DetailText { text: "Provider ID (enabled uses your CodexBar configuration)" }
                         TextField {
@@ -308,6 +325,7 @@ Panel {
                         DetailText { text: "Refresh interval in seconds" }
                         SpinBox { id: intervalInput; from: 60; to: 3600; stepSize: 60; value: Number(root.setting("refreshSeconds", 300)) }
                         Button {
+                            focusable: true
                             text: "Apply"
                             enabled: providerInput.acceptableInput
                             onClicked: {
@@ -315,7 +333,7 @@ Panel {
                                     accountIndex: accountInput.value, allAccounts: allInput.checked,
                                     showIdentity: identityInput.checked, showCosts: costsInput.checked,
                                     showStatus: statusInput.checked, refreshSeconds: intervalInput.value});
-                                root.settingsOpen = false;
+                                root.page = 0;
                             }
                         }
                         DetailText { text: "Account selection changes this display only. Sign in and manage credentials with the provider CLI."; opacity: 0.7 }

--- a/Integrations/Omarchy/Panel.qml
+++ b/Integrations/Omarchy/Panel.qml
@@ -19,6 +19,10 @@ Panel {
     property bool settingsOpen: false
     property string activeRequest: ""
     property string dataRequest: ""
+    property var costEntries: []
+    property double costUpdated: 0
+    property string costOutput: ""
+    property string costFailure: ""
     readonly property string request: JSON.stringify(Usage.command(settings))
     readonly property color foreground: bar ? bar.foreground : Color.foreground
     readonly property bool stale: lastRefresh > 0 && (failure !== "" || now - lastRefresh > 600000)
@@ -26,6 +30,7 @@ Panel {
     implicitHeight: button.implicitHeight
 
     function refresh() {
+        if (opened) refreshCosts();
         if (probe.running) return;
         if (dataRequest !== request) {
             entries = [];
@@ -36,13 +41,26 @@ Panel {
         output = "";
         probe.running = true;
     }
+    function refreshCosts() {
+        if (costProbe.running || !setting("showCosts", true)) return;
+        costOutput = "";
+        costProbe.command = ["timeout", "--kill-after=5", "60", String(setting("executable", "codexbar")),
+            "cost", "--provider", "both", "--format", "json", "--days", "30"];
+        costProbe.running = true;
+    }
+    onOpenedChanged: if (opened && Date.now() - costUpdated > 300000) refreshCosts()
     function saveSettings(changes) {
         if (!bar || !bar.shell) return;
         var merged = Object.assign({}, settings, changes);
         bar.shell.updateEntryInline(moduleName, merged);
     }
     Component.onCompleted: Qt.callLater(refresh)
-    onSettingsChanged: Qt.callLater(refresh)
+    onSettingsChanged: {
+        if (output && dataRequest === request) {
+            try { entries = Usage.rows(output, setting("showIdentity", false)); } catch (error) {}
+        }
+        Qt.callLater(refresh);
+    }
     IpcHandler {
         target: root.ipcTarget
         function open(): void { root.open(); }
@@ -65,6 +83,18 @@ Panel {
         running: true
         repeat: true
         onTriggered: root.now = Date.now()
+    }
+    Process {
+        id: costProbe
+        stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.costOutput = text }
+        stderr: StdioCollector {}
+        onExited: function(code) {
+            try {
+                root.costEntries = Usage.costs(root.costOutput);
+                root.costFailure = "";
+                root.costUpdated = Date.now();
+            } catch (error) { root.costFailure = "Local cost refresh failed. Previous results may be stale."; }
+        }
     }
     Process {
         id: probe
@@ -162,6 +192,7 @@ Panel {
                                 visible: text !== ""
                             }
                             DetailText { text: modelData.plan; visible: text !== ""; opacity: 0.7 }
+                            DetailText { text: modelData.status; visible: text !== ""; opacity: 0.7 }
                             DetailText { text: modelData.error; visible: text !== "" }
                             Repeater {
                                 model: modelData.windows
@@ -186,11 +217,55 @@ Panel {
                                         text: Usage.resetLabel(modelData.resetsAt, root.now)
                                         opacity: 0.65
                                     }
+                                    DetailText { text: modelData.pace; visible: text !== ""; opacity: 0.7 }
                                 }
                             }
                             DetailText {
                                 visible: modelData.credits !== null
                                 text: "Credits: " + modelData.credits
+                            }
+                            Repeater {
+                                model: modelData.details
+                                Column {
+                                    required property var modelData
+                                    width: content.width
+                                    spacing: Style.space(5)
+                                    DetailText { text: modelData.title; visible: text !== ""; font.bold: true }
+                                    Repeater {
+                                        model: modelData.rows
+                                        DetailText {
+                                            required property var modelData
+                                            text: modelData.label + ": " + modelData.value + (modelData.secondaryValue ? " · " + modelData.secondaryValue : "")
+                                        }
+                                    }
+                                    UsageChart { width: parent.width; chart: modelData.chart; foreground: root.foreground }
+                                }
+                            }
+                        }
+                    }
+                    Column {
+                        width: parent.width
+                        visible: root.setting("showCosts", true)
+                        spacing: Style.space(10)
+                        DetailText { text: "LOCAL SPENDING · CODEX & CLAUDE"; font.bold: true }
+                        DetailText { text: "All local sessions, independent of the selected account. List-price estimates are not invoices."; opacity: 0.65 }
+                        DetailText {
+                            text: costProbe.running ? "Loading local history…" : root.costFailure
+                            visible: text !== ""
+                        }
+                        Repeater {
+                            model: root.costEntries
+                            Column {
+                                required property var modelData
+                                width: content.width
+                                spacing: Style.space(5)
+                                DetailText { text: modelData.provider.toUpperCase() + " · " + modelData.provenance; font.bold: true }
+                                DetailText { text: modelData.error; visible: text !== "" }
+                                DetailText { text: "Today " + Usage.money(modelData.today) + " · 30 days " + Usage.money(modelData.month) }
+                                DetailText { text: "Tokens · " + (modelData.tokens === null ? "Unavailable" : modelData.tokens.toLocaleString()) }
+                                DetailText { text: "Input " + (modelData.input ?? "—") + " · output " + (modelData.output ?? "—") + " · cached " + (modelData.cached ?? "—"); opacity: 0.7 }
+                                DetailText { text: modelData.coverage; opacity: 0.7 }
+                                UsageChart { width: parent.width; chart: modelData.chart; foreground: root.foreground }
                             }
                         }
                     }
@@ -228,6 +303,8 @@ Panel {
                         SpinBox { id: accountInput; from: 0; to: 999; value: Number(root.setting("accountIndex", 0)) }
                         CheckBox { id: allInput; text: "Show all accounts"; checked: root.setting("allAccounts", false) }
                         CheckBox { id: identityInput; text: "Show account identity"; checked: root.setting("showIdentity", false) }
+                        CheckBox { id: costsInput; text: "Show local spending"; checked: root.setting("showCosts", true) }
+                        CheckBox { id: statusInput; text: "Fetch provider service status"; checked: root.setting("showStatus", true) }
                         DetailText { text: "Refresh interval in seconds" }
                         SpinBox { id: intervalInput; from: 60; to: 3600; stepSize: 60; value: Number(root.setting("refreshSeconds", 300)) }
                         Button {
@@ -236,7 +313,8 @@ Panel {
                             onClicked: {
                                 root.saveSettings({provider: providerInput.text, source: sourceInput.currentText,
                                     accountIndex: accountInput.value, allAccounts: allInput.checked,
-                                    showIdentity: identityInput.checked, refreshSeconds: intervalInput.value});
+                                    showIdentity: identityInput.checked, showCosts: costsInput.checked,
+                                    showStatus: statusInput.checked, refreshSeconds: intervalInput.value});
                                 root.settingsOpen = false;
                             }
                         }

--- a/Integrations/Omarchy/README.md
+++ b/Integrations/Omarchy/README.md
@@ -41,6 +41,18 @@ shows at most two account/provider summaries, with an overflow count; the popup
 shows all results. Changing provider/source discards the previous selection's
 data, including a response that completes after the selection changed.
 
+Provider cards also display service status, pace summaries, and the CLI's generic
+detail sections with bar/line charts. Email values in detail rows are redacted
+unless identity display is enabled. Hover charts to inspect recorded values.
+Unknown data stays unavailable; absent daily history is not filled into charts.
+
+The separate Local Spending section scans Codex and Claude session history when
+the popup opens, caches it for five minutes, and refreshes alongside manual usage
+refreshes. It shows calendar-day cost, 30-day cost, token mix, provenance, history
+coverage, and recorded daily costs. This is machine-local history across accounts,
+not the selected quota account's bill. Cost fetching cannot delay usage results.
+Both spending and service-status fetching can be disabled in Settings.
+
 Validation:
 
 ```sh

--- a/Integrations/Omarchy/Usage.js
+++ b/Integrations/Omarchy/Usage.js
@@ -20,13 +20,21 @@ function rows(text, showIdentity) {
             var minutes = window.windowMinutes;
             var label = minutes >= 1440 ? (minutes / 1440) + " day" :
                 minutes > 0 ? (minutes / 60) + " hour" : ["Session", "Weekly", "Additional"][index];
-            windows.push({label: label, remaining: left, resetsAt: window.resetsAt || ""});
+            windows.push({key: key, label: label, remaining: left, resetsAt: window.resetsAt || "",
+                pace: entry.pace && entry.pace[key] ? String(entry.pace[key].summary || "") : ""});
         });
         return {
             provider: entry.provider,
             accountLabel: showIdentity ? String(identity.accountEmail || usage.accountEmail || "") : "",
             accountNumber: entryIndex + 1,
             plan: String(identity.loginMethod || usage.loginMethod || ""),
+            status: entry.status ? String(entry.status.description || entry.status.indicator || "Unknown") : "",
+            details: Array.isArray(usage.details) ? usage.details.slice(0, 8).map(function(section) {
+                return {title: String(section.title || ""), rows: (section.rows || []).slice(0, 24).map(function(row) {
+                    return {label: String(row.label || ""), value: displayText(row.value, showIdentity),
+                        secondaryValue: displayText(row.secondaryValue, showIdentity)};
+                }), chart: chart(section.chart)};
+            }) : [],
             source: entry.source || "",
             windows: windows,
             updatedAt: usage.updatedAt || "",
@@ -44,12 +52,54 @@ function command(settings) {
     if (provider !== "enabled") args.push("--provider", provider);
     var source = String(settings.source || "auto");
     if (source !== "auto") args.push("--source", source);
+    if (settings.showStatus !== false) args.push("--status");
     if (["enabled", "all", "both"].indexOf(provider) === -1) {
         if (settings.allAccounts === true) args.push("--all-accounts");
         else if (Number.isInteger(Number(settings.accountIndex)) && Number(settings.accountIndex) > 0)
             args.push("--account-index", String(settings.accountIndex));
     }
     return args;
+}
+
+function displayText(value, showIdentity) {
+    var text = String(value || "").slice(0, 500);
+    return showIdentity ? text : text.replace(/[^\s@]+@[^\s@]+/g, "[hidden email]");
+}
+
+function chart(value) {
+    if (!value || !Array.isArray(value.points)) return null;
+    var points = value.points.slice(0, 120).filter(function(point) {
+        return point && typeof point.value === "number" && isFinite(point.value);
+    }).map(function(point) { return {label: String(point.label || ""), value: point.value}; });
+    return {title: String(value.title || ""), unit: String(value.unit || ""),
+        kind: value.kind === "line" ? "line" : "bars", points: points};
+}
+
+function number(value) { return typeof value === "number" && isFinite(value) ? value : null; }
+
+function money(value) { return number(value) === null ? "Unavailable" : "$" + value.toFixed(2); }
+
+function costs(text, today) {
+    if (!today) {
+        var now = new Date();
+        today = now.getFullYear() + "-" + String(now.getMonth() + 1).padStart(2, "0") + "-" + String(now.getDate()).padStart(2, "0");
+    }
+    var decoded = JSON.parse(text);
+    if (!Array.isArray(decoded) || decoded.some(function(row) { return !row || typeof row.provider !== "string"; }))
+        throw new Error("Invalid cost response");
+    return decoded.map(function(row) {
+        var totals = row.totals || {};
+        var daily = Array.isArray(row.daily) ? row.daily.slice(-30) : [];
+        var todayRow = daily.find(function(day) { return day.date === today; });
+        return {provider: row.provider, today: todayRow ? number(todayRow.totalCost) :
+                row.historyCoverageIsEstablished === true && !row.error ? 0 : null, month: number(row.last30DaysCostUSD),
+            tokens: number(row.last30DaysTokens), input: number(totals.inputTokens), output: number(totals.outputTokens),
+            cached: number(totals.cacheReadTokens), provenance: String(row.provenance || "unknown"),
+            coverage: row.historyCoverageIsEstablished === true ? "Local history" : "History may be incomplete",
+            error: row.error ? "Local cost history unavailable" : "",
+            chart: chart({title: "Recorded daily cost · USD", unit: "USD", kind: "bars",
+                points: daily.map(function(day) { return {label: day.date, value: day.totalCost}; })})};
+    });
 }
 
 function summary(entries) {

--- a/Integrations/Omarchy/Usage.js
+++ b/Integrations/Omarchy/Usage.js
@@ -79,6 +79,14 @@ function number(value) { return typeof value === "number" && isFinite(value) ? v
 
 function money(value) { return number(value) === null ? "Unavailable" : "$" + value.toFixed(2); }
 
+function count(value) {
+    return number(value) === null ? "—" : Math.round(value).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+function provenance(value) {
+    return {listPriceEstimate: "List-price estimate", actual: "Reported cost", unknown: "Cost source unavailable"}[value] || value;
+}
+
 function costs(text, today) {
     if (!today) {
         var now = new Date();

--- a/Integrations/Omarchy/UsageChart.qml
+++ b/Integrations/Omarchy/UsageChart.qml
@@ -45,7 +45,10 @@ Column {
                 if (root.chart.kind === "line") {
                     if (index === 0) ctx.moveTo(step * (index + 0.5), y);
                     else ctx.lineTo(step * (index + 0.5), y);
-                } else ctx.fillRect(step * index + 1, Math.min(y, baseline), Math.max(1, step - 2), Math.max(1, Math.abs(baseline - y)));
+                } else {
+                    var barWidth = Math.max(1, Math.min(Style.space(16), step - 2));
+                    ctx.fillRect(step * (index + 0.5) - barWidth / 2, Math.min(y, baseline), barWidth, Math.max(1, Math.abs(baseline - y)));
+                }
             });
             if (root.chart.kind === "line") ctx.stroke();
         }

--- a/Integrations/Omarchy/UsageChart.qml
+++ b/Integrations/Omarchy/UsageChart.qml
@@ -1,0 +1,76 @@
+import QtQuick
+import qs.Commons
+
+Column {
+    id: root
+    required property var chart
+    property color foreground: Color.foreground
+    property int selected: -1
+    readonly property var points: chart ? chart.points : []
+    readonly property real minimum: Math.min(0, ...points.map(p => p.value))
+    readonly property real maximum: Math.max(1, ...points.map(p => p.value))
+    spacing: Style.space(4)
+    visible: points.length > 0
+    Text {
+        width: parent.width
+        text: root.chart ? root.chart.title : ""
+        textFormat: Text.PlainText
+        color: root.foreground
+        font.family: Style.font.family
+        font.pixelSize: Style.font.body
+        wrapMode: Text.Wrap
+    }
+    Canvas {
+        id: canvas
+        width: parent.width
+        height: Style.space(65)
+        onWidthChanged: requestPaint()
+        onPaint: {
+            var ctx = getContext("2d");
+            ctx.reset();
+            if (!root.points.length) return;
+            var step = width / root.points.length;
+            var range = root.maximum - root.minimum;
+            var baseline = height * root.maximum / range;
+            ctx.strokeStyle = root.foreground;
+            ctx.globalAlpha = 0.25;
+            ctx.beginPath(); ctx.moveTo(0, baseline); ctx.lineTo(width, baseline); ctx.stroke();
+            ctx.globalAlpha = 1;
+            ctx.fillStyle = Color.accent;
+            ctx.strokeStyle = Color.accent;
+            ctx.lineWidth = Style.space(2);
+            ctx.beginPath();
+            root.points.forEach(function(point, index) {
+                var y = height * (root.maximum - point.value) / range;
+                if (root.chart.kind === "line") {
+                    if (index === 0) ctx.moveTo(step * (index + 0.5), y);
+                    else ctx.lineTo(step * (index + 0.5), y);
+                } else ctx.fillRect(step * index + 1, Math.min(y, baseline), Math.max(1, step - 2), Math.max(1, Math.abs(baseline - y)));
+            });
+            if (root.chart.kind === "line") ctx.stroke();
+        }
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onPositionChanged: function(mouse) {
+                root.selected = Math.min(root.points.length - 1, Math.floor(mouse.x / width * root.points.length));
+            }
+            onExited: root.selected = -1
+        }
+    }
+    onChartChanged: { selected = -1; canvas.requestPaint(); }
+    onForegroundChanged: canvas.requestPaint()
+    Connections { target: Color; function onAccentChanged() { canvas.requestPaint(); } }
+    Text {
+        width: parent.width
+        text: root.selected >= 0 && root.selected < root.points.length ?
+            root.points[root.selected].label + " · " + root.points[root.selected].value.toFixed(2) + " " + root.chart.unit :
+            (root.points.length ? root.points[0].label + " → " + root.points[root.points.length - 1].label : "")
+        textFormat: Text.PlainText
+        color: root.foreground
+        opacity: 0.65
+        font.family: Style.font.family
+        font.pixelSize: Style.font.body
+        wrapMode: Text.Wrap
+    }
+}

--- a/Integrations/Omarchy/install.py
+++ b/Integrations/Omarchy/install.py
@@ -28,7 +28,7 @@ if destination.exists():
     backup.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(destination, backup)
 destination.mkdir(parents=True, exist_ok=True)
-for name in ['manifest.json', 'Panel.qml', 'Usage.js']:
+for name in ['manifest.json', 'Panel.qml', 'Usage.js', 'UsageChart.qml']:
     shutil.copy2(source / name, destination / name)
 entry = None
 layout = data.setdefault('bar', {}).setdefault('layout', {})

--- a/Integrations/Omarchy/test.mjs
+++ b/Integrations/Omarchy/test.mjs
@@ -68,6 +68,8 @@ test('generic charts bound data and keep negative values', () => {
     assert.equal(result.points.length, 1);
     assert.equal(result.points[0].value, -4);
     assert.equal(model.chart(null), null);
+    assert.equal(model.count(5358220), '5,358,220');
+    assert.equal(model.count(null), '—');
 });
 test('provider detail rows redact emails unless explicitly enabled', () => {
     const input = JSON.stringify({provider: 'codex', usage: {details: [{rows: [{label: 'Account', value: 'private@example.com'}]}]}});

--- a/Integrations/Omarchy/test.mjs
+++ b/Integrations/Omarchy/test.mjs
@@ -52,3 +52,25 @@ test('identity is opt-in and stays within its provider row', () => {
     assert.equal(model.rows(input, true)[1].accountLabel, '');
     assert.equal(model.rows(input, true)[1].plan, '');
 });
+test('cost history preserves unknown amounts and uses the actual calendar day', () => {
+    const input = JSON.stringify([{provider: 'codex', sessionCostUSD: 99, last30DaysCostUSD: 5,
+        historyCoverageIsEstablished: true, daily: [{date: '2026-01-01', totalCost: 5}, {date: '2026-01-02', totalCost: null}]}]);
+    const row = model.costs(input, '2026-01-02')[0];
+    assert.equal(row.today, null);
+    assert.equal(row.month, 5);
+    assert.equal(row.chart.points.length, 1);
+    assert.equal(model.costs(input, '2026-01-03')[0].today, 0);
+    assert.equal(model.money(null), 'Unavailable');
+    assert.equal(model.money(0), '$0.00');
+});
+test('generic charts bound data and keep negative values', () => {
+    const result = model.chart({kind: 'line', points: [{label: 'a', value: -4}, {label: 'b', value: null}, {label: 'c', value: Infinity}]});
+    assert.equal(result.points.length, 1);
+    assert.equal(result.points[0].value, -4);
+    assert.equal(model.chart(null), null);
+});
+test('provider detail rows redact emails unless explicitly enabled', () => {
+    const input = JSON.stringify({provider: 'codex', usage: {details: [{rows: [{label: 'Account', value: 'private@example.com'}]}]}});
+    assert.equal(model.rows(input)[0].details[0].rows[0].value, '[hidden email]');
+    assert.equal(model.rows(input, true)[0].details[0].rows[0].value, 'private@example.com');
+});


### PR DESCRIPTION
Adds separate Usage, Spending, and Settings views to the Omarchy widget. Provider cards display service status, pace summaries, and generic provider detail rows with bar/line charts. Local spending shows Codex/Claude calendar-day and 30-day cost, token mix, provenance, coverage, and recorded daily history.

Local spending is explicitly separate from the selected quota account, and estimates are labeled. Its subprocess cannot delay usage results. Missing values remain unavailable; charts do not fabricate absent days. The UI uses bounded chart data, readable numeric formatting, scrolling, and keyboard-focusable actions.

Depends on #3569. Validation: nine model tests and the isolated installer test pass; Omarchy manifest validation and diff whitespace checks pass. Installed and visually checked the native popup and spending charts on Omarchy; usage and local spending both fetch successfully without QML runtime errors. Full Swift/app checks remain limited locally by missing Swift and macOS plutil; no Swift files changed.
