### PR TITLE
Add Omarchy notifications and native desktop controls

### DIFF
--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - run: node --test Integrations/Omarchy/test.mjs
+      - run: node --test Integrations/Omarchy/test.mjs Integrations/Omarchy/notifications.test.mjs
       - run: python3 Integrations/Omarchy/test_install.py

--- a/Integrations/Omarchy/Notifications.js
+++ b/Integrations/Omarchy/Notifications.js
@@ -1,0 +1,44 @@
+// In-memory transitions only: never notify on startup, errors, or ambiguous accounts.
+function transition(previous, entries, threshold) {
+    var limit = Math.max(1, Math.min(99, Number(threshold) || 10));
+    var counts = {};
+    entries.forEach(function(row) { counts[row.provider] = (counts[row.provider] || 0) + 1; });
+    var next = {};
+    var events = [];
+    entries.forEach(function(row) {
+        if (counts[row.provider] !== 1 || row.failed) return;
+        row.windows.forEach(function(window) {
+            var key = row.provider + "/" + window.key;
+            var old = previous[key];
+            next[key] = {remaining: window.remaining, reset: window.resetsAt};
+            if (!old) return;
+            if (old.remaining > limit && window.remaining <= limit) {
+                events.push({kind: "low", provider: row.provider,
+                    message: window.label + ": " + window.remaining + "% quota remaining."});
+            } else if (old.reset && window.resetsAt && old.reset !== window.resetsAt && window.remaining > old.remaining) {
+                events.push({kind: "reset", provider: row.provider,
+                    message: window.label + " quota reset · " + window.remaining + "% remaining."});
+            }
+        });
+        var level = row.statusLevel;
+        if (["none", "minor", "major", "critical", "maintenance"].indexOf(level) !== -1) {
+            var key = row.provider + "/status";
+            var old = previous[key];
+            next[key] = {level: level};
+            if (old && old.level !== level) {
+                if (level === "none") events.push({kind: "status", provider: row.provider, message: "Service has recovered."});
+                else events.push({kind: "status", provider: row.provider, message: "Service status changed: " + level + "."});
+            }
+        }
+    });
+    return {state: next, events: events};
+}
+
+function summary(entries) {
+    return entries.map(function(row) {
+        var text = row.provider.toUpperCase();
+        row.windows.forEach(function(window) { text += "\n" + window.label + ": " + window.remaining + "% remaining"; });
+        if (row.error) text += "\n" + row.error;
+        return text;
+    }).join("\n\n");
+}

--- a/Integrations/Omarchy/Panel.qml
+++ b/Integrations/Omarchy/Panel.qml
@@ -1,9 +1,11 @@
 import QtQuick
 import QtQuick.Controls
+import Quickshell
 import Quickshell.Io
 import qs.Commons
 import qs.Ui
 import "Usage.js" as Usage
+import "Notifications.js" as Notices
 
 Panel {
     id: root
@@ -23,9 +25,13 @@ Panel {
     property double costUpdated: 0
     property string costOutput: ""
     property string costFailure: ""
+    property var noticeState: ({})
+    property string noticeSettings: ""
+    property string clipboardMessage: ""
     readonly property string request: JSON.stringify(Usage.command(settings))
     readonly property color foreground: bar ? bar.foreground : Color.foreground
-    readonly property bool stale: lastRefresh > 0 && (failure !== "" || now - lastRefresh > 600000)
+    readonly property bool stale: lastRefresh > 0 && (failure !== "" || now - lastRefresh >
+        Math.max(600000, (Number(setting("refreshSeconds", 300)) || 300) * 2000))
     implicitWidth: button.implicitWidth
     implicitHeight: button.implicitHeight
 
@@ -35,11 +41,25 @@ Panel {
         if (dataRequest !== request) {
             entries = [];
             lastRefresh = 0;
+            noticeState = {};
         }
         activeRequest = request;
         probe.command = JSON.parse(activeRequest);
         output = "";
         probe.running = true;
+    }
+    function notifyChanges(parsed) {
+        var configuration = JSON.stringify([request, setting("notifications", false), setting("notifyThreshold", 10)]);
+        if (noticeSettings !== configuration) { noticeState = {}; noticeSettings = configuration; }
+        var result = Notices.transition(noticeState, parsed, setting("notifyThreshold", 10));
+        noticeState = result.state;
+        if (!setting("notifications", false)) return;
+        // Each monitor has a widget; only the first bar sends desktop notifications.
+        if (bar && typeof bar.moduleWidgets === "function" && bar.moduleWidgets(moduleName)[0] !== root) return;
+        result.events.forEach(function(event) {
+            Quickshell.execDetached(["notify-send", "--app-name=CodexBar", "--",
+                "CodexBar · " + event.provider, event.message]);
+        });
     }
     function refreshCosts() {
         if (costProbe.running || !setting("showCosts", true)) return;
@@ -87,6 +107,13 @@ Panel {
         onTriggered: root.now = Date.now()
     }
     Process {
+        id: clipboard
+        command: ["wl-copy"]
+        stdinEnabled: true
+        onStarted: { write(Notices.summary(root.entries)); stdinEnabled = false; }
+        onExited: function(code) { root.clipboardMessage = code === 0 ? "Copied usage summary" : "Copy failed (wl-copy required)"; }
+    }
+    Process {
         id: costProbe
         stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.costOutput = text }
         stderr: StdioCollector {}
@@ -111,11 +138,13 @@ Panel {
             }
             try {
                 var parsed = Usage.rows(root.output, root.setting("showIdentity", false));
+                root.notifyChanges(parsed);
                 root.entries = parsed;
                 root.dataRequest = root.activeRequest;
                 root.failure = "";
                 root.lastRefresh = Date.now();
             } catch (error) {
+                root.noticeState = {};
                 root.failure = code === 124 ? "Refresh timed out. Press R to retry." :
                     "Unable to fetch usage. Check the CLI path and provider login; press R to retry.";
             }
@@ -295,6 +324,14 @@ Panel {
                         enabled: !probe.running
                         onClicked: root.refresh()
                     }
+                    Button {
+                        focusable: true
+                        text: "Copy usage summary"
+                        visible: root.page === 0
+                        enabled: root.entries.length > 0 && !clipboard.running
+                        onClicked: { clipboard.stdinEnabled = true; clipboard.running = true; }
+                    }
+                    DetailText { text: root.clipboardMessage; visible: root.page === 0 && text !== "" }
                     DetailText { visible: root.page === 1 && !root.setting("showCosts", true); text: "Enable local spending in Settings." }
                     Column {
                         width: parent.width
@@ -310,29 +347,34 @@ Panel {
                             validator: RegularExpressionValidator { regularExpression: /^[a-z0-9-]+$/ }
                         }
                         DetailText { text: "Source" }
-                        ComboBox {
+                        Dropdown {
                             id: sourceInput
                             width: parent.width
-                            model: ["auto", "oauth", "cli", "api", "web"]
-                            currentIndex: Math.max(0, model.indexOf(root.setting("source", "auto")))
+                            options: ["auto", "oauth", "cli", "api", "web"]
+                            value: root.setting("source", "auto")
+                            onChanged: function(value) { sourceInput.value = value; }
                         }
                         DetailText { text: "Account number (0 uses the default; single provider only)" }
-                        SpinBox { id: accountInput; from: 0; to: 999; value: Number(root.setting("accountIndex", 0)) }
-                        CheckBox { id: allInput; text: "Show all accounts"; checked: root.setting("allAccounts", false) }
-                        CheckBox { id: identityInput; text: "Show account identity"; checked: root.setting("showIdentity", false) }
-                        CheckBox { id: costsInput; text: "Show local spending"; checked: root.setting("showCosts", true) }
-                        CheckBox { id: statusInput; text: "Fetch provider service status"; checked: root.setting("showStatus", true) }
+                        NumberField { onModified: function(next) { value = next; } id: accountInput; from: 0; to: 999; value: Number(root.setting("accountIndex", 0)) }
+                        Toggle { width: parent.width; onClicked: checked = !checked; id: allInput; label: "Show all accounts"; checked: root.setting("allAccounts", false) }
+                        Toggle { width: parent.width; onClicked: checked = !checked; id: identityInput; label: "Show account identity"; checked: root.setting("showIdentity", false) }
+                        Toggle { width: parent.width; onClicked: checked = !checked; id: costsInput; label: "Show local spending"; checked: root.setting("showCosts", true) }
+                        Toggle { width: parent.width; onClicked: checked = !checked; id: statusInput; label: "Service status"; checked: root.setting("showStatus", true) }
+                        Toggle { width: parent.width; onClicked: checked = !checked; id: noticesInput; label: "Notifications"; description: "Low quota, resets and service changes"; checked: root.setting("notifications", false) }
+                        DetailText { text: "Low quota threshold (%)" }
+                        NumberField { onModified: function(next) { value = next; } id: thresholdInput; from: 1; to: 99; value: Number(root.setting("notifyThreshold", 10)) }
                         DetailText { text: "Refresh interval in seconds" }
-                        SpinBox { id: intervalInput; from: 60; to: 3600; stepSize: 60; value: Number(root.setting("refreshSeconds", 300)) }
+                        NumberField { onModified: function(next) { value = next; } id: intervalInput; from: 60; to: 3600; stepSize: 60; value: Number(root.setting("refreshSeconds", 300)) }
                         Button {
                             focusable: true
                             text: "Apply"
                             enabled: providerInput.acceptableInput
                             onClicked: {
-                                root.saveSettings({provider: providerInput.text, source: sourceInput.currentText,
+                                root.saveSettings({provider: providerInput.text, source: sourceInput.value,
                                     accountIndex: accountInput.value, allAccounts: allInput.checked,
                                     showIdentity: identityInput.checked, showCosts: costsInput.checked,
-                                    showStatus: statusInput.checked, refreshSeconds: intervalInput.value});
+                                    showStatus: statusInput.checked, notifications: noticesInput.checked,
+                                    notifyThreshold: thresholdInput.value, refreshSeconds: intervalInput.value});
                                 root.page = 0;
                             }
                         }

--- a/Integrations/Omarchy/README.md
+++ b/Integrations/Omarchy/README.md
@@ -53,9 +53,22 @@ coverage, and recorded daily costs. This is machine-local history across account
 not the selected quota account's bill. Cost fetching cannot delay usage results.
 Both spending and service-status fetching can be disabled in Settings.
 
+Optional desktop notifications use Omarchy's existing notification daemon via
+`notify-send`. Enable them and choose a remaining-quota threshold in Settings.
+They fire on threshold crossings, observed reset-window changes with replenished
+quota, and service-status transitions. Startup, unchanged results, unknown data,
+and provider errors stay silent. Only one bar instance emits notifications. To
+avoid attributing an alert to the wrong account, notifications skip providers
+with multiple account rows; select one account for alerts. State is in memory and
+restarts quietly after shell reload. No account identities appear in notifications.
+
+Copy usage summary sends a plain-text, identity-free summary to the Wayland
+clipboard through `wl-copy`. Neither action needs another daemon or network port.
+
 Validation:
 
 ```sh
-node --test Integrations/Omarchy/test.mjs
+node --test Integrations/Omarchy/test.mjs Integrations/Omarchy/notifications.test.mjs
+python3 Integrations/Omarchy/test_install.py
 omarchy plugin validate Integrations/Omarchy
 ```

--- a/Integrations/Omarchy/Usage.js
+++ b/Integrations/Omarchy/Usage.js
@@ -25,10 +25,12 @@ function rows(text, showIdentity) {
         });
         return {
             provider: entry.provider,
+            failed: !!entry.error,
             accountLabel: showIdentity ? String(identity.accountEmail || usage.accountEmail || "") : "",
             accountNumber: entryIndex + 1,
             plan: String(identity.loginMethod || usage.loginMethod || ""),
             status: entry.status ? String(entry.status.description || entry.status.indicator || "Unknown") : "",
+            statusLevel: entry.status ? String(entry.status.indicator || "unknown") : "unknown",
             details: Array.isArray(usage.details) ? usage.details.slice(0, 8).map(function(section) {
                 return {title: String(section.title || ""), rows: (section.rows || []).slice(0, 24).map(function(row) {
                     return {label: String(row.label || ""), value: displayText(row.value, showIdentity),

--- a/Integrations/Omarchy/install.py
+++ b/Integrations/Omarchy/install.py
@@ -10,7 +10,7 @@ import tempfile
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--executable', required=True, type=Path)
-parser.add_argument('--provider', default='codex')
+parser.add_argument('--provider', help='Provider ID; preserves the existing selection on reinstall')
 args = parser.parse_args()
 executable = args.executable.resolve()
 if not executable.is_file() or not os.access(executable, os.X_OK):
@@ -28,7 +28,7 @@ if destination.exists():
     backup.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(destination, backup)
 destination.mkdir(parents=True, exist_ok=True)
-for name in ['manifest.json', 'Panel.qml', 'Usage.js', 'UsageChart.qml']:
+for name in ['manifest.json', 'Panel.qml', 'Usage.js', 'UsageChart.qml', 'Notifications.js']:
     shutil.copy2(source / name, destination / name)
 entry = None
 layout = data.setdefault('bar', {}).setdefault('layout', {})
@@ -41,7 +41,11 @@ for section in layout.values():
 if entry is None:
     entry = {'id': plugin_id}
     layout.setdefault('right', []).insert(0, entry)
-entry.update(executable=str(executable), provider=args.provider, refreshSeconds=300)
+entry['executable'] = str(executable)
+if args.provider is not None:
+    entry['provider'] = args.provider
+entry.setdefault('provider', 'codex')
+entry.setdefault('refreshSeconds', 300)
 with tempfile.NamedTemporaryFile(mode='w', dir=config, delete=False) as handle:
     temporary = Path(handle.name)
     json.dump(data, handle, indent=2)

--- a/Integrations/Omarchy/notifications.test.mjs
+++ b/Integrations/Omarchy/notifications.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import test from 'node:test';
+
+const model = vm.createContext({});
+vm.runInContext(fs.readFileSync(new URL('./Notifications.js', import.meta.url), 'utf8'), model);
+const row = (remaining, reset = '2026-01-01', statusLevel = 'none') => ({
+    provider: 'codex', windows: [{key: 'primary', label: 'Session', remaining, resetsAt: reset}], statusLevel
+});
+test('startup is silent and low quota only notifies on crossing', () => {
+    const baseline = model.transition({}, [row(50)], 10);
+    assert.equal(baseline.events.length, 0);
+    const low = model.transition(baseline.state, [row(10)], 10);
+    assert.equal(low.events.length, 1);
+    assert.equal(low.events[0].kind, 'low');
+    assert.equal(model.transition(low.state, [row(5)], 10).events.length, 0);
+});
+test('reset and outage transitions notify once', () => {
+    const old = model.transition({}, [row(5)], 10).state;
+    const reset = model.transition(old, [row(100, '2026-01-02', 'major')], 10);
+    assert.deepEqual(Array.from(reset.events, e => e.kind), ['reset', 'status']);
+    assert.equal(model.transition(reset.state, [row(100, '2026-01-02', 'major')], 10).events.length, 0);
+});
+test('provider errors and ambiguous account ordering cannot generate alerts', () => {
+    const old = model.transition({}, [row(50)], 10).state;
+    assert.equal(model.transition(old, [{...row(0), failed: true}], 10).events.length, 0);
+    assert.equal(model.transition(old, [row(50), row(0)], 10).events.length, 0);
+});
+test('provider ordering does not affect quota transitions', () => {
+    const claude = {...row(50), provider: 'claude'};
+    const old = model.transition({}, [row(50), claude], 10).state;
+    const next = model.transition(old, [claude, row(5)], 10);
+    assert.equal(next.events.length, 1);
+    assert.equal(next.events[0].provider, 'codex');
+});
+test('copied summaries omit account identity and credentials', () => {
+    const summary = model.summary([{...row(50), accountLabel: 'private@example.com', token: 'secret'}]);
+    assert.equal(summary, 'CODEX\nSession: 50% remaining');
+});

--- a/Integrations/Omarchy/test_install.py
+++ b/Integrations/Omarchy/test_install.py
@@ -16,11 +16,17 @@ class InstallTests(unittest.TestCase):
                                          'idle': {'lock': 123}}))
             script = Path(__file__).with_name('install.py')
             environment = dict(os.environ, XDG_CONFIG_HOME=str(config))
-            for _ in range(2):
+            for attempt in range(2):
+                if attempt == 1:
+                    custom = json.loads(shell.read_text())
+                    custom['bar']['layout']['right'][0].update(provider='claude', refreshSeconds=900)
+                    shell.write_text(json.dumps(custom))
                 subprocess.run(['python3', str(script), '--executable', '/usr/bin/true'],
                                env=environment, check=True, capture_output=True)
             result = json.loads(shell.read_text())
             self.assertEqual(result['idle'], {'lock': 123})
+            self.assertEqual(result['bar']['layout']['right'][0]['provider'], 'claude')
+            self.assertEqual(result['bar']['layout']['right'][0]['refreshSeconds'], 900)
             self.assertEqual([e['id'] for e in result['bar']['layout']['right']],
                              ['steipete.codexbar', 'omarchy.clock'])
             manifests = list((shell.parent / 'plugins').glob('*/manifest.json'))


### PR DESCRIPTION
Adds optional Omarchy notifications for low-quota crossings, observed quota resets, and service-status changes, plus a Wayland clipboard usage-summary action. Notification startup and steady state are silent; errors, unknown data, and ambiguous multi-account rows do not trigger quota alerts. Notifications and copied summaries omit account identity.

Settings now use Omarchy's themed dropdown, number fields, and toggles. Reinstallation preserves provider and polling preferences. Staleness follows the configured refresh interval. All subprocess arguments are passed directly without a shell.

Depends on #3570 (which builds on #3569). Validation: 14 offline model tests and the isolated reinstall test pass, plus Omarchy manifest validation and diff whitespace checks. Native settings and popup rendering were checked live with no QML errors; usage/status and local spending fetch successfully. Notification transitions and clipboard text are covered offline; no synthetic desktop alerts or clipboard replacements were sent during verification. Full Swift/app checks remain limited locally by absent Swift/macOS plutil; no Swift files changed.
