### PR TITLE
Add Linux provider ordering, tray meters, account actions and display settings

### DIFF
--- a/.github/workflows/omarchy.yml
+++ b/.github/workflows/omarchy.yml
@@ -34,3 +34,17 @@ jobs:
           qmake6 ../../Integrations/Linux/codexbar-linux.pro
           make -j2
       - run: python3 Integrations/Linux/tests/test_desktop.py
+      - name: Test account terminal actions
+        run: |
+          mkdir -p .local/linux-account-tests
+          cd .local/linux-account-tests
+          qmake6 ../../Integrations/Linux/tests/accounts.pro
+          make -j2
+          ./tst_accounts
+      - run: python3 Integrations/Linux/tests/test_package.py
+      - name: Package desktop
+        run: python3 Integrations/Linux/package.py --version ci
+      - uses: actions/upload-artifact@v4
+        with:
+          name: codexbar-linux
+          path: .local/packages/*.tar.gz

--- a/Integrations/Linux/DesktopController.cpp
+++ b/Integrations/Linux/DesktopController.cpp
@@ -15,6 +15,7 @@
 #include <QRegularExpression>
 #include <QSaveFile>
 #include <QStandardPaths>
+#include <algorithm>
 #include <csignal>
 #include <memory>
 #include <unistd.h>
@@ -38,10 +39,11 @@ void stop(QProcess &process) {
 }
 
 DesktopController::DesktopController(const QString &cliOverride, QObject *parent) : QObject(parent) {
-    m_usageModel = module(m_engine, ":/Shared/Usage.js", "rows:rows, costs:costs, command:command, summary:summary");
+    m_usageModel = module(m_engine, ":/Shared/Usage.js", "rows:rows, costs:costs, command:command, summary:summary, resetText:resetText");
     m_noticeModel = module(m_engine, ":/Shared/Notifications.js", "transition:transition, summary:summary");
     m_noticeState = m_engine.newObject();
     loadSettings(cliOverride);
+    loadProviders();
     connect(&m_poll, &QTimer::timeout, this, &DesktopController::refresh);
     m_poll.start(m_settings.value("refreshSeconds").toInt() * 1000);
     connect(&m_clock, &QTimer::timeout, this, &DesktopController::changed);
@@ -51,10 +53,10 @@ DesktopController::DesktopController(const QString &cliOverride, QObject *parent
 
 DesktopController::~DesktopController() {
     m_usage.disconnect(this); m_cost.disconnect(this);
-    stop(m_usage); stop(m_cost);
+    stop(m_usage); stop(m_cost); stop(m_catalog);
 }
 
-QJSValue DesktopController::call(const QJSValue &model, const QString &function, const QJSValueList &args) {
+QJSValue DesktopController::call(const QJSValue &model, const QString &function, const QJSValueList &args) const {
     return model.property(function).call(args);
 }
 
@@ -76,7 +78,25 @@ bool DesktopController::validate(QVariantMap &values) {
         if (!ok || number < min || number > max) { m_configError = QString("Invalid %1.").arg(key); return false; }
         values[key] = number;
     }
-    for (const auto &key : {"allAccounts", "showIdentity", "showCosts", "showStatus", "notifications", "showTray", "refreshOnOpen"})
+    const auto order = values.value("providerOrder").toStringList();
+    if (order.size() > 80 || (values.value("provider") == "custom" && order.isEmpty())) {
+        m_configError = "Choose at least one provider (maximum 80)."; return false;
+    }
+    QStringList unique;
+    for (const auto &id : order) {
+        if (!QRegularExpression("^[a-z0-9-]{1,80}$").match(id).hasMatch() ||
+            QStringList{"all", "both", "enabled", "custom"}.contains(id) || unique.contains(id)) {
+            m_configError = "The provider list contains an invalid or duplicate ID."; return false;
+        }
+        unique.append(id);
+    }
+    values["providerOrder"] = unique;
+    if (!QStringList{"remaining", "used"}.contains(values.value("quotaDisplay").toString()) ||
+        !QStringList{"countdown", "absolute", "both"}.contains(values.value("resetDisplay").toString()) ||
+        !QStringList{"meters", "icon"}.contains(values.value("trayStyle").toString())) {
+        m_configError = "Unsupported display preference."; return false;
+    }
+    for (const auto &key : {"allAccounts", "showIdentity", "showCosts", "showStatus", "notifications", "showTray", "refreshOnOpen", "showPace", "warningColors", "followOmarchyTheme"})
         values[key] = values.value(key).toBool();
     return true;
 }
@@ -84,7 +104,9 @@ bool DesktopController::validate(QVariantMap &values) {
 void DesktopController::loadSettings(const QString &cliOverride) {
     m_settings = {{"executable", "codexbar"}, {"provider", "codex"}, {"source", "auto"},
         {"refreshSeconds", 300}, {"accountIndex", 0}, {"notifyThreshold", 10}, {"allAccounts", false},
-        {"showIdentity", false}, {"showCosts", true}, {"showStatus", true}, {"notifications", false}, {"showTray", true}, {"refreshOnOpen", false}};
+        {"showIdentity", false}, {"showCosts", true}, {"showStatus", true}, {"notifications", false}, {"showTray", true}, {"refreshOnOpen", false}, {"providerOrder", QStringList{}},
+        {"quotaDisplay", "remaining"}, {"resetDisplay", "countdown"}, {"showPace", true},
+        {"warningColors", true}, {"trayStyle", "meters"}, {"followOmarchyTheme", false}};
     m_configPath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/codexbar/linux.json";
     QFile file(m_configPath);
     QVariantMap candidate = m_settings;
@@ -124,11 +146,19 @@ bool DesktopController::saveSettings(const QVariantMap &changes) {
     if (file.write(encoded) != encoded.size() || !file.commit()) {
         m_configError = "Cannot save application settings."; emit settingsChanged(); return false;
     }
-    m_settings = next; m_configError.clear(); ++m_generation;
-    m_entries.clear(); m_spending.clear(); m_summary.clear();
-    m_updated = 0; m_costUpdated = 0; m_noticeState = m_engine.newObject();
+    bool queryChanged = false;
+    for (const auto &key : {"provider", "providerOrder", "source", "executable", "accountIndex", "allAccounts", "showIdentity", "showStatus", "showCosts"})
+        queryChanged = queryChanged || next.value(key) != m_settings.value(key);
+    m_settings = next; m_configError.clear();
+    if (queryChanged) {
+        ++m_generation;
+        if (m_usage.state() == QProcess::NotRunning) { m_usageBatch = false; m_pendingProviders.clear(); }
+        m_entries.clear(); m_spending.clear(); m_updated = 0; m_costUpdated = 0;
+    }
+    m_summary = call(m_usageModel, "summary", {m_engine.toScriptValue(m_entries), m_settings.value("quotaDisplay").toString()}).toString();
+    m_noticeState = m_engine.newObject();
     m_poll.start(m_settings.value("refreshSeconds").toInt() * 1000);
-    emit settingsChanged(); emit changed(); refresh();
+    emit settingsChanged(); emit changed(); if (queryChanged) refresh();
     return true;
 }
 
@@ -143,7 +173,20 @@ QString DesktopController::updated() const {
 
 void DesktopController::refresh() {
     if (busy()) return;
-    auto args = call(m_usageModel, "command", {m_engine.toScriptValue(m_settings)}).toVariant().toStringList();
+    m_usageBatch = true; m_batchFailed = false; m_batchEntries.clear();
+    m_pendingProviders = m_settings.value("provider") == "custom" ? m_settings.value("providerOrder").toStringList() :
+        QStringList{m_settings.value("provider").toString()};
+    nextProvider();
+}
+
+void DesktopController::nextProvider() {
+    if (m_usage.state() != QProcess::NotRunning) return;
+    if (m_pendingProviders.isEmpty()) return;
+    m_currentProvider = m_pendingProviders.takeFirst();
+    auto selection = m_settings;
+    selection["provider"] = m_currentProvider;
+    if (m_settings.value("provider") == "custom") { selection["accountIndex"] = 0; selection["allAccounts"] = false; }
+    auto args = call(m_usageModel, "command", {m_engine.toScriptValue(selection)}).toVariant().toStringList();
     // Process deadlines and groups are managed here, without a coreutils dependency.
     args = args.mid(3);
     probe(m_usage, args, false);
@@ -166,6 +209,7 @@ void DesktopController::probe(QProcess &process, const QStringList &command, boo
         if (*complete) return;
         *complete = true; deadline->stop(); deadline->deleteLater();
         if (generation != m_generation) {
+            if (!cost) { m_usageBatch = false; m_pendingProviders.clear(); }
             QTimer::singleShot(0, this, cost ? &DesktopController::refreshCosts : &DesktopController::refresh);
             return;
         }
@@ -173,16 +217,36 @@ void DesktopController::probe(QProcess &process, const QStringList &command, boo
         QJSValueList arguments{QString::fromUtf8(*output)};
         if (!cost) arguments.append(m_settings.value("showIdentity").toBool());
         const auto parsed = call(m_usageModel, cost ? "costs" : "rows", arguments);
-        if (failed || parsed.isError() || !parsed.isArray() || output->size() > 8 * 1024 * 1024) {
-            if (cost) m_costError = "Local spending could not be refreshed. Previous data may be stale.";
-            else { m_error = "Usage unavailable. Check the CLI path and provider login, then refresh."; m_noticeState = m_engine.newObject(); }
-        } else if (cost) {
-            m_spending = parsed.toVariant().toList(); m_costError.clear(); m_costUpdated = QDateTime::currentMSecsSinceEpoch();
+        const bool invalid = failed || parsed.isError() || !parsed.isArray() || output->size() > 8 * 1024 * 1024;
+        if (cost) {
+            if (invalid) m_costError = "Local spending could not be refreshed. Previous data may be stale.";
+            else { m_spending = parsed.toVariant().toList(); m_costError.clear(); m_costUpdated = QDateTime::currentMSecsSinceEpoch(); }
         } else {
-            m_entries = parsed.toVariant().toList(); m_error.clear();
-            m_updated = QDateTime::currentMSecsSinceEpoch();
-            m_summary = call(m_usageModel, "summary", {parsed}).toString();
-            updateNotifications(m_entries);
+            if (invalid) {
+                m_batchFailed = true;
+                for (const auto &entry : m_entries) {
+                    if (m_settings.value("provider") != "custom" || entry.toMap().value("provider") == m_currentProvider)
+                        m_batchEntries.append(entry);
+                }
+                if (m_settings.value("provider") == "custom" && !std::any_of(m_batchEntries.begin(), m_batchEntries.end(),
+                    [this](const QVariant &entry) { return entry.toMap().value("provider") == m_currentProvider; }))
+                    m_batchEntries.append(QVariantMap{{"provider", m_currentProvider}, {"windows", QVariantList{}},
+                        {"error", "Usage unavailable"}, {"failed", true}});
+            } else m_batchEntries.append(parsed.toVariant().toList());
+            if (!m_pendingProviders.isEmpty()) {
+                QTimer::singleShot(0, this, &DesktopController::nextProvider);
+                return;
+            }
+            m_usageBatch = false;
+            m_entries = m_batchEntries;
+            const auto rows = m_engine.toScriptValue(m_entries);
+            m_summary = call(m_usageModel, "summary", {rows, m_settings.value("quotaDisplay").toString()}).toString();
+            if (m_batchFailed) {
+                m_error = "Some usage could not be refreshed. Previous results may be out of date.";
+                m_noticeState = m_engine.newObject();
+            } else {
+                m_error.clear(); m_updated = QDateTime::currentMSecsSinceEpoch(); updateNotifications(m_entries);
+            }
         }
         emit changed();
     };
@@ -231,12 +295,24 @@ QJsonObject DesktopController::snapshot() const {
     QJsonArray compact;
     for (const auto &entry : m_entries) {
         auto row = entry.toMap();
+        QJsonArray windows;
+        for (const auto &item : row.value("windows").toList()) {
+            auto window = item.toMap();
+            const auto remaining = window.value("remaining").toDouble();
+            window["displayValue"] = m_settings.value("quotaDisplay") == "used" ? 100 - remaining : remaining;
+            window["displaySuffix"] = m_settings.value("quotaDisplay") == "used" ? "used" : "left";
+            window["warning"] = m_settings.value("warningColors").toBool() && remaining <= m_settings.value("notifyThreshold").toInt();
+            // This model contains no identity; display fields keep adapters consistent with native windows.
+            window["resetText"] = call(m_usageModel, "resetText",
+                {window.value("resetsAt").toString(), double(QDateTime::currentMSecsSinceEpoch()), m_settings.value("resetDisplay").toString()}).toString();
+            windows.append(QJsonObject::fromVariantMap(window));
+        }
         compact.append(QJsonObject{{"provider", row.value("provider").toString()},
-            {"windows", QJsonArray::fromVariantList(row.value("windows").toList())},
+            {"windows", windows},
             {"error", row.value("error").toString()}});
     }
     return {{"schemaVersion", 1}, {"pid", QCoreApplication::applicationPid()}, {"summary", m_summary},
-        {"entries", compact}, {"busy", busy()}, {"stale", stale()}, {"error", m_error},
+        {"entries", compact}, {"quotaDisplay", m_settings.value("quotaDisplay").toString()}, {"busy", busy()}, {"stale", stale()}, {"error", m_error},
         {"updated", updated()}, {"costBusy", costBusy()}, {"costProviders", m_spending.size()}, {"costError", m_costError}};
 }
 
@@ -258,6 +334,11 @@ bool DesktopController::listen(const QString &socketPath) {
                 const auto command = request.value("command").toString();
                 QJsonObject response{{"ok", true}};
                 if (command == "snapshot" || command == "background") response = snapshot();
+                else if (command == "autostart") {
+                    const auto action = request.value("action").toString();
+                    const bool ok = action == "status" || ((action == "enable" || action == "disable") && setLaunchAtLogin(action == "enable"));
+                    response = {{"ok", ok}, {"enabled", launchAtLogin()}};
+                }
                 else if (command == "refresh") { refresh(); refreshCosts(); }
                 else if (command == "settings" || command == "usage" || command == "spending") showWindow(command);
                 else if (command == "configure" && request.value("settings").isObject()) {
@@ -271,4 +352,78 @@ bool DesktopController::listen(const QString &socketPath) {
         }
     });
     return true;
+}
+
+void DesktopController::loadProviders() {
+    for (const auto &id : {"codex", "claude", "cursor", "gemini", "copilot", "antigravity"})
+        m_providers.append(QVariantMap{{"provider", id}, {"displayName", QString(id)}});
+    auto output = std::make_shared<QByteArray>();
+    auto *deadline = new QTimer(&m_catalog);
+    deadline->setSingleShot(true);
+    connect(deadline, &QTimer::timeout, &m_catalog, [this] { stop(m_catalog); });
+    connect(&m_catalog, &QProcess::readyReadStandardOutput, this, [this, output] {
+        output->append(m_catalog.readAllStandardOutput());
+        if (output->size() > 1024 * 1024) stop(m_catalog);
+    });
+    connect(&m_catalog, &QProcess::readyReadStandardError, this, [this] { m_catalog.readAllStandardError(); });
+    connect(&m_catalog, &QProcess::finished, this, [this, output, deadline](int code, QProcess::ExitStatus status) {
+        deadline->stop();
+        if (code || status != QProcess::NormalExit || output->size() > 1024 * 1024) return;
+        const auto document = QJsonDocument::fromJson(*output);
+        if (!document.isArray()) return;
+        QVariantList providers;
+        for (const auto &item : document.array()) {
+            const auto row = item.toObject();
+            const auto id = row.value("provider").toString();
+            const auto name = row.value("displayName").toString();
+            if (QRegularExpression("^[a-z0-9-]{1,80}$").match(id).hasMatch() && !name.isEmpty())
+                providers.append(QVariantMap{{"provider", id}, {"displayName", name.left(100)}});
+        }
+        if (!providers.isEmpty()) { m_providers = providers; emit settingsChanged(); }
+    });
+    m_catalog.setChildProcessModifier([] { ::setsid(); });
+    m_catalog.start(m_settings.value("executable").toString(), {"config", "providers", "--format", "json"});
+    deadline->start(10000);
+}
+
+bool DesktopController::launchAtLogin() const {
+    QFile file(QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) +
+        "/autostart/com.steipete.CodexBar.desktop");
+    if (!file.open(QIODevice::ReadOnly)) return false;
+    return !QString::fromUtf8(file.readAll()).contains(QRegularExpression("(^|\n)Hidden\\s*=\\s*true(\n|$)"));
+}
+
+bool DesktopController::setLaunchAtLogin(bool enabled) {
+    const auto path = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) +
+        "/autostart/com.steipete.CodexBar.desktop";
+    QDir().mkpath(QFileInfo(path).absolutePath());
+    QString executable = QCoreApplication::applicationFilePath();
+    if (executable.contains('\n') || executable.contains('\r')) return false;
+    executable.replace("%", "%%");
+    for (const auto &character : {QString("\\"), QString("\""), QString("`"), QString("$")})
+        executable.replace(character, "\\" + character);
+    const auto content = QString("[Desktop Entry]\nType=Application\nName=CodexBar\nExec=\"%1\" --background\nIcon=codexbar\nTerminal=false\nHidden=%2\n")
+        .arg(executable, enabled ? "false" : "true").toUtf8();
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly) || file.write(content) != content.size() || !file.commit()) {
+        m_configError = "Cannot update login startup."; emit settingsChanged(); return false;
+    }
+    m_configError.clear(); emit settingsChanged(); return true;
+}
+
+bool DesktopController::accountAction(const QString &provider, const QString &action) {
+    if (!QStringList{"codex", "claude"}.contains(provider) || !QStringList{"login", "logout"}.contains(action)) return false;
+    const auto terminal = QStandardPaths::findExecutable("xdg-terminal-exec");
+    const auto cli = QStandardPaths::findExecutable(provider);
+    if (terminal.isEmpty() || cli.isEmpty()) {
+        m_configError = "Install xdg-terminal-exec and the provider CLI to manage sign-in.";
+        emit settingsChanged(); return false;
+    }
+    QStringList arguments{"--hold", "--", cli};
+    if (provider == "claude") arguments.append("auth");
+    arguments.append(action);
+    if (!QProcess::startDetached(terminal, arguments)) {
+        m_configError = "Could not open the sign-in terminal."; emit settingsChanged(); return false;
+    }
+    m_configError.clear(); emit settingsChanged(); return true;
 }

--- a/Integrations/Linux/DesktopController.h
+++ b/Integrations/Linux/DesktopController.h
@@ -10,6 +10,8 @@
 
 class DesktopController : public QObject {
     Q_OBJECT
+    Q_PROPERTY(QVariantList providers READ providers NOTIFY settingsChanged)
+    Q_PROPERTY(bool launchAtLogin READ launchAtLogin NOTIFY settingsChanged)
     Q_PROPERTY(QVariantList entries READ entries NOTIFY changed)
     Q_PROPERTY(QVariantList spending READ spending NOTIFY changed)
     Q_PROPERTY(QVariantMap settings READ settings NOTIFY settingsChanged)
@@ -26,6 +28,10 @@ public:
     explicit DesktopController(const QString &cliOverride, QObject *parent = nullptr);
     ~DesktopController() override;
     bool listen(const QString &socket);
+    QVariantList providers() const { return m_providers; }
+    bool launchAtLogin() const;
+    Q_INVOKABLE bool setLaunchAtLogin(bool enabled);
+    Q_INVOKABLE bool accountAction(const QString &provider, const QString &action);
     QVariantList entries() const { return m_entries; }
     QVariantList spending() const { return m_spending; }
     QVariantMap settings() const { return m_settings; }
@@ -33,7 +39,7 @@ public:
     QString costError() const { return m_costError; }
     QString configError() const { return m_configError; }
     QString summary() const { return m_summary; }
-    bool busy() const { return m_usage.state() != QProcess::NotRunning; }
+    bool busy() const { return m_usageBatch || m_usage.state() != QProcess::NotRunning; }
     bool costBusy() const { return m_cost.state() != QProcess::NotRunning; }
     bool stale() const;
     QString updated() const;
@@ -52,7 +58,13 @@ signals:
 private:
     QJSEngine m_engine;
     QJSValue m_usageModel, m_noticeModel, m_noticeState;
-    QProcess m_usage, m_cost;
+    QProcess m_usage, m_cost, m_catalog;
+    QVariantList m_providers, m_batchEntries;
+    QStringList m_pendingProviders;
+    QString m_currentProvider;
+    bool m_usageBatch = false, m_batchFailed = false;
+    void nextProvider();
+    void loadProviders();
     QTimer m_poll, m_clock;
     QLocalServer m_server;
     QVariantMap m_settings;
@@ -65,5 +77,5 @@ private:
     bool validate(QVariantMap &settings);
     void probe(QProcess &process, const QStringList &command, bool cost);
     void updateNotifications(const QVariantList &entries);
-    QJSValue call(const QJSValue &module, const QString &function, const QJSValueList &args);
+    QJSValue call(const QJSValue &module, const QString &function, const QJSValueList &args) const;
 };

--- a/Integrations/Linux/MAC_COMPARISON.md
+++ b/Integrations/Linux/MAC_COMPARISON.md
@@ -8,15 +8,19 @@ the two apps have matching interfaces.
 | Settings | Sidebar with General, Providers, Menu, Menu Bar, and other panes (`PreferencesView.swift`) | General, Providers, Advanced tabs; fewer controls fit better in tiled windows |
 | Usage layout | Adaptive metric/reset rows (`UsageMenuCardHeaderAndUsageSectionView.swift`) | Wrapping labels, compact cards, quota, reset countdown, pace and provider details |
 | Refresh | Interval and refresh-on-open preferences (`PreferencesGeneralPane.swift`) | Interval and optional refresh-on-open; Usage and Spending refresh independently |
-| Provider accounts | Provider ordering and login/account actions (`PreferencesProvidersPane.swift`) | Provider ID, source and account selection; login remains in provider CLI |
-| Tray | Configurable icons, layout and pace color (`PreferencesMenuBarPane.swift`) | Static standard tray icon and usage tooltip; Omarchy adds compact usage text and meters |
-| Display preferences | Reset format, pace visibility, warning markers (`PreferencesMenuPane.swift`) | Fixed remaining-quota display and reset countdowns |
+| Provider accounts | Provider ordering and login/account actions (`PreferencesProvidersPane.swift`) | CLI-discovered provider picker and ordered custom list; account selection; Codex/Claude sign-in and confirmed sign-out through a terminal |
+| Tray | Configurable icons, layout and pace color (`PreferencesMenuBarPane.swift`) | Two quota meters for the first displayed provider, low-quota/stale styling, optional static icon, and usage tooltip; Omarchy shares display preferences |
+| Display preferences | Reset format, pace visibility, warning markers (`PreferencesMenuPane.swift`) | Used/remaining quota, countdown/absolute/both reset formats, pace visibility and warning colors |
 | Local costs | Cost summaries and fetch status (`PreferencesMenuPane.swift`) | Separate Spending tab with daily history, coverage and token totals; retains stale data on failure |
-| Startup | Start-at-login toggle (`PreferencesGeneralPane.swift`) | Installer-managed XDG autostart; no settings toggle yet |
+| Startup | Start-at-login toggle (`PreferencesGeneralPane.swift`) | Immediate start-at-login control backed by XDG autostart |
 
-The most useful remaining work is provider selection/ordering without typing IDs,
-tray meters, a start-at-login control, and configurable reset/usage display.
-Account-management UI needs a Linux-specific credential flow; copying macOS browser
-or Keychain behavior would not provide that. KDE/GNOME testing and distro packaging
-are also outstanding. The Linux implementation currently uses Qt Fusion controls
-and does not yet follow every Omarchy theme change.
+Omarchy colors can follow its current theme, with the system palette as fallback.
+Other Linux desktops use Qt's system palette. Source builds and a tested portable
+archive installer are available; the archive requires compatible system Qt/glibc
+libraries and a separately installed CodexBar CLI.
+
+Mac-only managed account profiles, token-account editing, browser credential
+imports, advanced menu-bar layout/pace coloring, and macOS-specific surfaces remain
+outside this Linux frontend. The Linux sign-in controls operate on the provider
+CLI's active session; they do not create or switch saved Mac profiles. KDE/GNOME
+sessions and distro-native packages still need separate compatibility work.

--- a/Integrations/Linux/README.md
+++ b/Integrations/Linux/README.md
@@ -28,7 +28,18 @@ python3 Integrations/Linux/install.py --cli /absolute/path/to/codexbar
 Add `--omarchy` to install the compact Omarchy adapter. Add `--no-autostart` to
 disable starting at login. Installation is per user, preserves settings, and
 backs up existing preferences before changes. Reinstallation preserves disabled
-autostart. This source build is not yet a distro package or self-contained binary.
+autostart. A release archive can also be installed without a checkout:
+
+```sh
+# Inside an extracted codexbar-linux archive:
+python3 Integrations/Linux/install.py --cli /absolute/path/to/codexbar --omarchy
+```
+
+To create an archive from a local build, run
+`python3 Integrations/Linux/package.py --version 0.1.0`. The archive contains only
+the app, installer, icon, adapter, license, and instructions. It needs compatible
+system Qt/glibc libraries and a separately installed CodexBar CLI; it is not an
+AppImage or a distro-native package. Build on the oldest distro you intend to support.
 
 Qt supports Wayland and X11. The tray uses Qt's desktop integration (StatusNotifier
 or X11 tray host). GNOME may require a tray extension; the launcher and windows
@@ -41,11 +52,29 @@ Settings is divided into General, Providers, and Advanced. It controls
 provider/source selection, account index, all-account display,
 identity visibility, refresh interval, status, local spending, notifications, and
 tray visibility. Account selectors choose displayed usage; they do not change the
-provider CLI's login. Provider support follows the installed CLI. Browser imports
-and macOS account management are not implemented here.
+provider CLI's login. Choose `custom` to pick providers from the installed CLI's catalog and move them
+up or down. Only that ordered list is queried, sequentially; a failed provider
+retains its previous result while healthy providers update. Account selectors
+apply to a single-provider query; custom lists use each provider's default account.
 
-Usage displays remaining quota, reset times, pace, credits, status, generic provider
-details, and charts. Unknown values stay unknown. Identity is hidden by default.
+Sign in and Sign out open the Codex or Claude CLI in the default terminal using
+`xdg-terminal-exec` (an optional dependency). Sign out asks for confirmation.
+The app does not read terminal output or store credentials. Finish the flow, then
+refresh usage. These controls manage the active CLI session; browser imports,
+token-account editing and Mac managed profiles are not implemented here.
+
+Usage displays used or remaining quota, reset times, pace, credits, status, generic provider
+details, and charts. Unknown values stay unknown. Identity is hidden by default. Display preferences control reset countdowns,
+absolute times, pace visibility, and low-quota colors. The tray can show two quota
+meters for the first displayed provider or a static icon. Unknown meters remain
+empty tracks. The tooltip identifies the displayed providers and stale data.
+Omarchy's popup shares the quota/reset preferences.
+
+Start-at-login changes apply immediately from Settings. Other preferences use Save.
+Omarchy installation enables theme following by default: colors are read from
+`$XDG_STATE_HOME/omarchy/current/theme/colors.toml` (normally `~/.local/state`) and
+checked every ten seconds. Missing or incomplete themes fall back to Qt's system
+palette. The preference can be disabled on any desktop.
 Local Spending shows Codex/Claude history across accounts on this machine, with
 calendar-day and 30-day estimates, token mix, provenance, and coverage. Estimates
 are not invoices. Opening spending scans independently of quota polling, with a
@@ -76,16 +105,17 @@ codexbar-linux --spending
 codexbar-linux --refresh
 codexbar-linux --snapshot
 codexbar-linux --configure '{"provider":"both","refreshSeconds":300}'
+codexbar-linux --autostart status # also enable or disable
 codexbar-linux --quit
 ```
 
-Snapshot, refresh, configure, and quit require an existing process. UI commands
+Snapshot, refresh, configure, autostart, and quit require an existing process. UI commands
 start one when needed. IPC clients load no GUI plugin. `--cli PATH` and `--no-tray`
 apply when starting a new instance. The private, same-user local socket lives at
 `$XDG_RUNTIME_DIR/codexbar-linux/desktop.sock`; requests and replies are newline
 terminated JSON. Snapshot schema version 1 includes compact provider windows,
-summary, update time, busy/stale/error state, and spending availability. It excludes
-account identity and configuration. Adapters should check `schemaVersion`, tolerate
+summary, update time, busy/stale/error state, and spending availability. It excludes account identity, CLI paths, and credential configuration.
+It includes display values and reset text for adapters. Adapters should check `schemaVersion`, tolerate
 unknown fields, and treat a missing backend as unavailable.
 
 ## Validation and removal
@@ -94,6 +124,9 @@ unknown fields, and treat a missing backend as unavailable.
 node --test Integrations/Omarchy/test.mjs Integrations/Omarchy/notifications.test.mjs
 python3 Integrations/Omarchy/test_install.py
 python3 Integrations/Linux/tests/test_desktop.py
+python3 Integrations/Linux/tests/test_package.py
+# Account-action test: qmake6 Integrations/Linux/tests/accounts.pro in a build directory,
+# then make and run ./tst_accounts. Uses a fake terminal and fake provider CLIs.
 ```
 
 Runtime tests isolate HOME/XDG paths and use a fake CLI and offscreen Qt. Set

--- a/Integrations/Linux/Shared/Usage.js
+++ b/Integrations/Linux/Shared/Usage.js
@@ -112,10 +112,10 @@ function costs(text, today) {
     });
 }
 
-function summary(entries) {
+function summary(entries, mode) {
     var label = entries.slice(0, 2).map(function(entry) {
         var label = entry.provider === "codex" ? "CX" : entry.provider === "claude" ? "CL" : entry.provider;
-        return label + " " + (entry.windows.length ? entry.windows[0].remaining + "%" : "—");
+        return label + " " + (entry.windows.length ? quotaValue(entry.windows[0].remaining, mode) + "%" : "—");
     }).join("  ·  ");
     return label + (entries.length > 2 ? "  +" + (entries.length - 2) : "");
 }
@@ -134,4 +134,15 @@ function providerName(id) {
     var names = {codex: "Codex", claude: "Claude", copilot: "GitHub Copilot", gemini: "Gemini",
         cursor: "Cursor", antigravity: "Antigravity", openrouter: "OpenRouter", kiro: "Kiro"};
     return names[id] || (id ? id.charAt(0).toUpperCase() + id.slice(1) : "Unknown provider");
+}
+
+function quotaValue(remaining, mode) { return mode === "used" ? 100 - remaining : remaining; }
+
+function resetText(timestamp, now, mode) {
+    var date = new Date(timestamp);
+    if (!timestamp || !isFinite(date.getTime())) return "Reset time unavailable";
+    var absolute = date.toLocaleString();
+    if (mode === "absolute") return "Resets " + absolute;
+    if (mode === "both") return resetLabel(timestamp, now) + " · " + absolute;
+    return resetLabel(timestamp, now);
 }

--- a/Integrations/Linux/install.py
+++ b/Integrations/Linux/install.py
@@ -33,7 +33,7 @@ def quoted(path):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--binary', type=Path, default=REPO / '.local/linux-build/codexbar-linux')
+    parser.add_argument('--binary', type=Path, default=REPO / ('bin/codexbar-linux' if (REPO / 'bin/codexbar-linux').exists() else '.local/linux-build/codexbar-linux'))
     parser.add_argument('--cli', type=Path)
     parser.add_argument('--omarchy', action='store_true')
     parser.add_argument('--no-autostart', action='store_true')
@@ -73,6 +73,7 @@ def main():
         settings['provider'] = args.provider
     if args.omarchy:
         settings['showTray'] = False
+        settings.setdefault('followOmarchyTheme', True)
     stamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S-%f')
     if preferences.exists():
         shutil.copy2(preferences, preferences.with_name(f'linux.json.backup-{stamp}'))

--- a/Integrations/Linux/main.cpp
+++ b/Integrations/Linux/main.cpp
@@ -11,6 +11,8 @@
 #include <QLocalSocket>
 #include <QLockFile>
 #include <QMenu>
+#include <QPainter>
+#include <QRegularExpression>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickStyle>
@@ -49,16 +51,18 @@ int main(int argc, char **argv) {
     parser.addHelpOption(); parser.addVersionOption();
     for (const auto &name : {"snapshot", "refresh", "settings", "spending", "usage", "quit", "background", "no-tray"})
         parser.addOption(QCommandLineOption(name, QString("%1 the running desktop app").arg(name)));
+    parser.addOption(QCommandLineOption("autostart", "Set login startup: enable, disable, status", "action"));
     parser.addOption(QCommandLineOption("configure", "Update desktop settings through local IPC", "json"));
     parser.addOption(QCommandLineOption("cli", "CodexBar CLI executable for a new instance", "path"));
     parser.process(*application);
     QString command = "usage";
-    for (const auto &name : {"background", "usage", "settings", "spending", "refresh", "snapshot", "quit", "configure"})
+    for (const auto &name : {"background", "usage", "settings", "spending", "refresh", "snapshot", "quit", "configure", "autostart"})
         if (parser.isSet(name)) command = name;
-    const bool clientOnly = QStringList{"snapshot", "refresh", "quit", "configure"}.contains(command);
+    const bool clientOnly = QStringList{"snapshot", "refresh", "quit", "configure", "autostart"}.contains(command);
     const bool noTray = parser.isSet("no-tray");
     const auto cli = parser.value("cli");
     QJsonObject message{{"command", command}};
+    if (command == "autostart") message["action"] = parser.value("autostart");
     if (command == "configure") {
         QJsonParseError error;
         const auto document = QJsonDocument::fromJson(parser.value("configure").toUtf8(), &error);
@@ -100,6 +104,40 @@ int main(int argc, char **argv) {
     QQuickStyle::setStyle("Fusion");
     DesktopController controller(cli);
     if (!controller.listen(socketPath)) { std::fputs("Cannot start local IPC\n", stderr); return 1; }
+    QPalette systemPalette = app.palette();
+    bool themeApplied = false;
+    auto updateTheme = [&] {
+        if (!themeApplied) systemPalette = app.palette();
+        QPalette palette = systemPalette;
+        themeApplied = false;
+        if (controller.settings().value("followOmarchyTheme").toBool()) {
+            const auto state = qEnvironmentVariable("XDG_STATE_HOME", QDir::homePath() + "/.local/state");
+            QFile file(state + "/omarchy/current/theme/colors.toml");
+            if (file.open(QIODevice::ReadOnly) && file.size() <= 65536) {
+                const auto text = QString::fromUtf8(file.readAll());
+                QMap<QString, QColor> colors;
+                const QRegularExpression pattern("^([a-z_]+)\\s*=\\s*[\"'](#[0-9a-fA-F]{6})[\"']", QRegularExpression::MultilineOption);
+                auto matches = pattern.globalMatch(text);
+                while (matches.hasNext()) { const auto match = matches.next(); colors[match.captured(1)] = QColor(match.captured(2)); }
+                if (colors.contains("background") && colors.contains("foreground") && colors.contains("accent")) {
+                    themeApplied = true;
+                    const auto background = colors["background"], foreground = colors["foreground"];
+                    for (const auto role : {QPalette::Window, QPalette::Base, QPalette::Button, QPalette::ToolTipBase}) palette.setColor(role, background);
+                    for (const auto role : {QPalette::WindowText, QPalette::Text, QPalette::ButtonText, QPalette::ToolTipText}) palette.setColor(role, foreground);
+                    palette.setColor(QPalette::AlternateBase, colors.value("lighter_background", background.lighter(120)));
+                    palette.setColor(QPalette::Highlight, colors["accent"]);
+                    palette.setColor(QPalette::HighlightedText, background);
+                    for (const auto role : {QPalette::WindowText, QPalette::Text, QPalette::ButtonText})
+                        palette.setColor(QPalette::Disabled, role, colors.value("dark_foreground", foreground.darker(150)));
+                }
+            }
+        }
+        if (app.palette() != palette) app.setPalette(palette);
+    };
+    QTimer themeTimer;
+    QObject::connect(&themeTimer, &QTimer::timeout, &app, updateTheme);
+    QObject::connect(&controller, &DesktopController::settingsChanged, &app, updateTheme);
+    themeTimer.start(10000); updateTheme();
     QQmlApplicationEngine engine;
     QObject::connect(&engine, &QQmlApplicationEngine::quit, &app, &QCoreApplication::quit);
     engine.rootContext()->setContextProperty("desktop", &controller);
@@ -116,10 +154,30 @@ int main(int argc, char **argv) {
     QObject::connect(&tray, &QSystemTrayIcon::activated, &controller, [&controller](QSystemTrayIcon::ActivationReason reason) {
         if (reason == QSystemTrayIcon::Trigger || reason == QSystemTrayIcon::DoubleClick) controller.showWindow("usage");
     });
-    QObject::connect(&controller, &DesktopController::changed, &tray, [&] {
-        tray.setToolTip("CodexBar · " + (controller.summary().isEmpty() ? "Usage unavailable" : controller.summary()));
-    });
-    auto updateTray = [&] { tray.setVisible(!noTray && controller.settings().value("showTray").toBool()); };
+    auto updateTray = [&] {
+        tray.setVisible(!noTray && controller.settings().value("showTray").toBool());
+        tray.setToolTip("CodexBar · " + (controller.summary().isEmpty() ? "Usage unavailable" : controller.summary()) +
+            " · " + controller.settings().value("quotaDisplay").toString() + (controller.stale() ? " · out of date" : ""));
+        if (controller.settings().value("trayStyle") == "icon") { tray.setIcon(QIcon(":/icon.svg")); return; }
+        QVariantList windows;
+        if (!controller.entries().isEmpty()) windows = controller.entries().first().toMap().value("windows").toList();
+        QPixmap pixmap(64, 64); pixmap.fill(Qt::transparent);
+        QPainter painter(&pixmap); painter.setRenderHint(QPainter::Antialiasing);
+        painter.setPen(Qt::NoPen);
+        for (int index = 0; index < 2; ++index) {
+            const QRectF track(5, 12 + index * 25, 54, 15);
+            painter.setBrush(QColor("#777777")); painter.drawRoundedRect(track, 4, 4);
+            if (index >= windows.size()) continue;
+            const double remaining = qBound(0.0, windows[index].toMap().value("remaining").toDouble(), 100.0);
+            const bool warning = controller.settings().value("warningColors").toBool() &&
+                remaining <= controller.settings().value("notifyThreshold").toInt();
+            painter.setBrush(controller.stale() ? QColor("#aaaaaa") : warning ? QColor("#e59642") : QApplication::palette().highlight().color());
+            const double value = controller.settings().value("quotaDisplay") == "used" ? 100 - remaining : remaining;
+            painter.drawRoundedRect(QRectF(track.x(), track.y(), track.width() * value / 100, track.height()), 4, 4);
+        }
+        painter.end(); tray.setIcon(QIcon(pixmap));
+    };
+    QObject::connect(&controller, &DesktopController::changed, &tray, updateTray);
     QObject::connect(&controller, &DesktopController::settingsChanged, &tray, updateTray);
     updateTray();
     if (command != "background") QTimer::singleShot(0, &controller, [&] { controller.showWindow(command); });

--- a/Integrations/Linux/package.py
+++ b/Integrations/Linux/package.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Package a built Linux desktop app without bundling credentials or a provider CLI."""
+import argparse
+import platform
+from pathlib import Path
+import re
+import tarfile
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, default=REPO / '.local/linux-build/codexbar-linux')
+    parser.add_argument('--version', required=True)
+    parser.add_argument('--output', type=Path, default=REPO / '.local/packages')
+    args = parser.parse_args()
+    if not re.fullmatch(r'[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}', args.version):
+        parser.error('Version must contain only letters, numbers, dots, underscores and hyphens')
+    if not args.binary.is_file():
+        parser.error('Build the desktop app first, or supply --binary')
+    name = f'codexbar-linux-{args.version}-{platform.machine()}'
+    args.output.mkdir(parents=True, exist_ok=True)
+    destination = args.output / f'{name}.tar.gz'
+    files = {
+        'bin/codexbar-linux': args.binary,
+        'README.md': REPO / 'Integrations/Linux/README.md',
+        'LICENSE': REPO / 'LICENSE',
+    }
+    for path in ['Integrations/Linux/install.py', 'Integrations/Linux/icon.svg',
+                 'Integrations/Omarchy/Panel.qml', 'Integrations/Omarchy/manifest.json']:
+        files[path] = REPO / path
+    # Explicit allowlist: never archive the checkout, user config, or local CLI resource tree.
+    with tarfile.open(destination, 'w:gz') as archive:
+        for relative, source in files.items():
+            info = archive.gettarinfo(str(source), arcname=f'{name}/{relative}')
+            info.uid = info.gid = 0
+            info.uname = info.gname = ''
+            info.mode = 0o755 if relative == 'bin/codexbar-linux' else 0o644
+            with source.open('rb') as content:
+                archive.addfile(info, content)
+    print(destination)
+
+
+if __name__ == '__main__':
+    main()

--- a/Integrations/Linux/qml/SettingsWindow.qml
+++ b/Integrations/Linux/qml/SettingsWindow.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import "../Shared/Usage.js" as Usage
 
 ApplicationWindow {
     id: window
@@ -9,6 +10,12 @@ ApplicationWindow {
     minimumWidth: 500; minimumHeight: 480
     property string feedback: ""
     property int section: 0
+    property var providerOrder: []
+    function moveProvider(index, offset) {
+        var order = providerOrder.slice();
+        var item = order.splice(index, 1)[0]; order.splice(index + offset, 0, item);
+        providerOrder = order;
+    }
     onClosing: function(event) { event.accepted = false; hide(); }
     onVisibleChanged: if (visible) load()
     function load() {
@@ -17,6 +24,11 @@ ApplicationWindow {
         account.value = s.accountIndex; allAccounts.checked = s.allAccounts;
         identity.checked = s.showIdentity; costs.checked = s.showCosts; status.checked = s.showStatus;
         notices.checked = s.notifications; threshold.value = s.notifyThreshold; interval.value = s.refreshSeconds;
+        providerOrder = s.providerOrder.slice();
+        quota.currentIndex = quota.model.indexOf(s.quotaDisplay);
+        reset.currentIndex = reset.model.indexOf(s.resetDisplay);
+        trayStyle.currentIndex = trayStyle.model.indexOf(s.trayStyle);
+        theme.checked = s.followOmarchyTheme; pace.checked = s.showPace; warnings.checked = s.warningColors;
         refreshOnOpen.checked = s.refreshOnOpen;
         tray.checked = s.showTray; executable.text = s.executable; feedback = "";
     }
@@ -47,10 +59,38 @@ ApplicationWindow {
                         Label { text: "Provider" }
                         ComboBox {
                             id: provider; Layout.fillWidth: true; editable: true
-                            model: ["codex", "claude", "both", "enabled", "cursor", "gemini", "copilot", "antigravity", "all"]
+                            model: ["codex", "claude", "both", "enabled", "cursor", "gemini", "copilot", "antigravity", "custom", "all"]
                             validator: RegularExpressionValidator { regularExpression: /^[a-z0-9-]{1,80}$/ }
                         }
-                        Label { text: "Choose enabled to use your CLI configuration. Other provider IDs can be typed here."; Layout.fillWidth: true; wrapMode: Text.Wrap; opacity: 0.65 }
+                        ColumnLayout {
+                            visible: provider.editText === "custom"
+                            Layout.fillWidth: true
+                            RowLayout {
+                                Layout.fillWidth: true
+                                ComboBox { id: available; model: desktop.providers; textRole: "displayName"; Layout.fillWidth: true }
+                                Button {
+                                    text: "Add"
+                                    enabled: available.currentIndex >= 0
+                                    onClicked: {
+                                        var id = desktop.providers[available.currentIndex].provider;
+                                        if (window.providerOrder.indexOf(id) < 0) window.providerOrder = window.providerOrder.concat([id]);
+                                    }
+                                }
+                            }
+                            Repeater {
+                                model: window.providerOrder
+                                RowLayout {
+                                    required property string modelData
+                                    required property int index
+                                    Layout.fillWidth: true
+                                    Label { text: Usage.providerName(modelData); Layout.fillWidth: true; wrapMode: Text.Wrap }
+                                    Button { text: "↑"; Accessible.name: "Move " + modelData + " up"; enabled: index > 0; onClicked: window.moveProvider(index, -1) }
+                                    Button { text: "↓"; Accessible.name: "Move " + modelData + " down"; enabled: index < window.providerOrder.length - 1; onClicked: window.moveProvider(index, 1) }
+                                    Button { text: "Remove"; onClicked: { var order = window.providerOrder.slice(); order.splice(index, 1); window.providerOrder = order; } }
+                                }
+                            }
+                        }
+                        Label { text: "Choose custom to select and order providers, or enabled to follow your CLI configuration."; Layout.fillWidth: true; wrapMode: Text.Wrap; opacity: 0.65 }
                         RowLayout {
                             Layout.fillWidth: true
                             Label { text: "Source"; Layout.fillWidth: true }
@@ -59,11 +99,17 @@ ApplicationWindow {
                         RowLayout {
                             Layout.fillWidth: true
                             Label { text: "Account (0 = default)"; Layout.fillWidth: true; wrapMode: Text.Wrap }
-                            SpinBox { id: account; from: 0; to: 999; editable: true }
+                            SpinBox { enabled: !allAccounts.checked && ["custom", "both", "all", "enabled"].indexOf(provider.editText) < 0; id: account; from: 0; to: 999; editable: true }
                         }
-                        Option { id: allAccounts; text: "All accounts" }
+                        Option { enabled: ["custom", "both", "all", "enabled"].indexOf(provider.editText) < 0; id: allAccounts; text: "All accounts" }
                         Option { id: identity; text: "Show account identity" }
-                        Label { text: "Selects which account to display. Sign in with the provider CLI."; Layout.fillWidth: true; wrapMode: Text.Wrap; opacity: 0.65 }
+                        RowLayout {
+                            Layout.fillWidth: true
+                            ComboBox { id: loginProvider; model: ["codex", "claude"]; Layout.fillWidth: true }
+                            Button { text: "Sign in…"; onClicked: { if (desktop.accountAction(loginProvider.currentText, "login")) window.feedback = "Finish signing in in the terminal, then refresh usage."; } }
+                            Button { text: "Sign out…"; onClicked: signOut.open() }
+                        }
+                        Label { text: "Sign-in opens your provider CLI in a terminal. Account selection above only changes displayed usage."; Layout.fillWidth: true; wrapMode: Text.Wrap; opacity: 0.65 }
                     }
                 }
                 GroupBox {
@@ -89,9 +135,37 @@ ApplicationWindow {
                     title: "Desktop"; Layout.fillWidth: true; visible: window.section === 0
                     ColumnLayout {
                         anchors.fill: parent; spacing: 10
+                        Button {
+                            text: desktop.launchAtLogin ? "Disable start at login" : "Enable start at login"
+                            onClicked: desktop.setLaunchAtLogin(!desktop.launchAtLogin)
+                        }
                         Option { id: tray; text: "Tray icon" }
                         Label { text: "Optional with the Omarchy widget. CodexBar is also available in the application launcher."; Layout.fillWidth: true; wrapMode: Text.Wrap; opacity: 0.65 }
+                        RowLayout {
+                            Layout.fillWidth: true
+                            Label { text: "Tray style"; Layout.fillWidth: true }
+                            ComboBox { id: trayStyle; model: ["meters", "icon"] }
+                        }
                         Option { id: costs; text: "Local spending" }
+                    }
+                }
+                GroupBox {
+                    title: "Display"; Layout.fillWidth: true; visible: window.section === 0
+                    ColumnLayout {
+                        anchors.fill: parent; spacing: 10
+                        RowLayout {
+                            Layout.fillWidth: true
+                            Label { text: "Quota"; Layout.fillWidth: true }
+                            ComboBox { id: quota; model: ["remaining", "used"] }
+                        }
+                        RowLayout {
+                            Layout.fillWidth: true
+                            Label { text: "Reset time"; Layout.fillWidth: true }
+                            ComboBox { id: reset; model: ["countdown", "absolute", "both"] }
+                        }
+                        Option { id: theme; text: "Follow Omarchy theme colors" }
+                        Option { id: pace; text: "Show pace" }
+                        Option { id: warnings; text: "Highlight low quota" }
                     }
                 }
                 GroupBox {
@@ -116,10 +190,21 @@ ApplicationWindow {
                         accountIndex: account.value, allAccounts: allAccounts.checked, showIdentity: identity.checked,
                         showCosts: costs.checked, showStatus: status.checked, notifications: notices.checked,
                         notifyThreshold: threshold.value, refreshSeconds: interval.value,
+                        providerOrder: window.providerOrder, quotaDisplay: quota.currentText, resetDisplay: reset.currentText,
+                        followOmarchyTheme: theme.checked, showPace: pace.checked, warningColors: warnings.checked, trayStyle: trayStyle.currentText,
                         refreshOnOpen: refreshOnOpen.checked, showTray: tray.checked, executable: executable.text.trim()})) window.feedback = "Settings saved";
                 }
             }
         }
+    }
+    Dialog {
+        id: signOut
+        title: "Sign out of " + loginProvider.currentText + "?"
+        anchors.centerIn: parent
+        modal: true
+        standardButtons: Dialog.Cancel | Dialog.Ok
+        Label { text: "This signs out the provider CLI on this machine."; wrapMode: Text.Wrap; width: Math.min(window.width - 80, 350) }
+        onAccepted: desktop.accountAction(loginProvider.currentText, "logout")
     }
     component Option: CheckBox {
         Layout.fillWidth: true

--- a/Integrations/Linux/qml/UsageCard.qml
+++ b/Integrations/Linux/qml/UsageCard.qml
@@ -37,11 +37,11 @@ Frame {
                 RowLayout {
                     Layout.fillWidth: true
                     Label { text: modelData.label; Layout.fillWidth: true; wrapMode: Text.Wrap; textFormat: Text.PlainText }
-                    Label { text: modelData.remaining + "% left"; font.bold: true }
+                    Label { text: Usage.quotaValue(modelData.remaining, desktop.settings.quotaDisplay) + "% " + (desktop.settings.quotaDisplay === "used" ? "used" : "left"); font.bold: true }
                 }
-                ProgressBar { Layout.fillWidth: true; from: 0; to: 100; value: modelData.remaining }
-                Label { text: Usage.resetLabel(modelData.resetsAt, clock.now); opacity: 0.65; Layout.fillWidth: true; wrapMode: Text.Wrap }
-                Label { text: modelData.pace || ""; visible: text !== ""; Layout.fillWidth: true; wrapMode: Text.Wrap; opacity: 0.7 }
+                ProgressBar { Layout.fillWidth: true; from: 0; to: 100; value: Usage.quotaValue(modelData.remaining, desktop.settings.quotaDisplay); palette.highlight: desktop.settings.warningColors && modelData.remaining <= desktop.settings.notifyThreshold ? "#d97732" : root.accent }
+                Label { text: Usage.resetText(modelData.resetsAt, clock.now, desktop.settings.resetDisplay); opacity: 0.65; Layout.fillWidth: true; wrapMode: Text.Wrap }
+                Label { text: modelData.pace || ""; visible: desktop.settings.showPace && text !== ""; Layout.fillWidth: true; wrapMode: Text.Wrap; opacity: 0.7 }
             }
         }
         Label { text: "Credits: " + root.entry.credits; visible: root.entry.credits !== null && root.entry.credits !== undefined }

--- a/Integrations/Linux/tests/accounts.pro
+++ b/Integrations/Linux/tests/accounts.pro
@@ -1,0 +1,7 @@
+QT += core gui qml network dbus testlib
+CONFIG += c++17 testcase console
+CONFIG -= app_bundle
+TARGET = tst_accounts
+SOURCES += tst_accounts.cpp ../DesktopController.cpp
+HEADERS += ../DesktopController.h
+RESOURCES += ../desktop.qrc

--- a/Integrations/Linux/tests/test_desktop.py
+++ b/Integrations/Linux/tests/test_desktop.py
@@ -18,7 +18,7 @@ class DesktopTests(unittest.TestCase):
         self.runtime = self.root / 'runtime'
         self.runtime.mkdir(mode=0o700)
         self.environment = dict(os.environ, HOME=str(self.root), XDG_CONFIG_HOME=str(self.root / 'config'),
-                                XDG_DATA_HOME=str(self.root / 'data'), XDG_RUNTIME_DIR=str(self.runtime),
+                                XDG_DATA_HOME=str(self.root / 'data'), XDG_STATE_HOME=str(self.root / 'state'), XDG_RUNTIME_DIR=str(self.runtime),
                                 QT_QPA_PLATFORM=os.environ.get('CODEXBAR_TEST_PLATFORM', 'offscreen'), QT_QUICK_BACKEND='software', FIXTURE_HOME=str(self.root))
         self.fake = self.root / 'fake-cli'
         self.fake.write_text('''#!/usr/bin/env python3
@@ -27,9 +27,11 @@ root=pathlib.Path(os.environ['FIXTURE_HOME'])
 state=json.loads((root/'state.json').read_text()) if (root/'state.json').exists() else {}
 args=sys.argv[1:]
 provider=args[args.index('--provider')+1] if '--provider' in args else 'codex'
+if args[0]=='config':
+ print(json.dumps([{'provider':'codex','displayName':'Codex'},{'provider':'claude','displayName':'Claude'}])); sys.exit(0)
 with (root/'calls.jsonl').open('a') as log: log.write(json.dumps({'pid':os.getpid(),'args':args})+'\\n')
 time.sleep(state.get('delay',0))
-if state.get('invalid'): print('broken'); sys.exit(1)
+if state.get('invalid') or state.get('failProvider')==provider: print('broken'); sys.exit(1)
 if args[0]=='cost':
  print(json.dumps([{'provider':'codex','historyCoverageIsEstablished':True,'last30DaysCostUSD':12,
  'daily':[{'date':datetime.date.today().isoformat(),'totalCost':3}], 'totals':{'inputTokens':100}}]))
@@ -50,8 +52,12 @@ else:
         except (subprocess.TimeoutExpired, OSError):
             self.process.kill()
             self.process.wait()
+        self.log.flush(); self.log.seek(0)
+        log = self.log.read()
         self.log.close()
         self.temporary.cleanup()
+        for error in ['ReferenceError', 'TypeError', 'failed to load', 'Cannot assign', 'Unable to assign', 'Binding loop']:
+            self.assertNotIn(error, log)
 
     def client(self, *args, check=True):
         result = subprocess.run([str(APP), *args], env=self.environment, capture_output=True, text=True, timeout=5)
@@ -145,6 +151,57 @@ else:
         self.client('--refresh')
         value = self.wait_for(lambda value: bool(value.get('costError')))
         self.assertEqual(value['costProviders'], 1)
+
+    def test_custom_provider_order_and_selection(self):
+        self.client('--configure', '{"provider":"custom","providerOrder":["claude","codex"]}')
+        value = self.wait_for(lambda value: len(value.get('entries', [])) == 2 and not value['busy'])
+        self.assertEqual([row['provider'] for row in value['entries']], ['claude', 'codex'])
+        self.client('--settings')
+        self.client('--usage')
+        calls = [json.loads(line) for line in (self.root / 'calls.jsonl').read_text().splitlines()]
+        self.assertEqual([call['args'][call['args'].index('--provider') + 1] for call in calls[-2:]], ['claude', 'codex'])
+        self.assertFalse(self.client('--configure', '{"providerOrder":["codex","codex"]}', check=False)['ok'])
+        self.assertFalse(self.client('--configure', '{"providerOrder":[]}', check=False)['ok'])
+
+    def test_custom_provider_partial_failure_keeps_other_results(self):
+        self.client('--configure', '{"provider":"custom","providerOrder":["claude","codex"]}')
+        self.wait_for(lambda value: len(value.get('entries', [])) == 2 and not value['busy'])
+        (self.root / 'state.json').write_text('{"failProvider":"claude"}')
+        self.client('--refresh')
+        value = self.wait_for(lambda value: bool(value.get('error')) and not value['busy'])
+        self.assertEqual([row['provider'] for row in value['entries']], ['claude', 'codex'])
+        self.assertTrue(value['stale'])
+
+    def test_selection_change_during_custom_batch(self):
+        (self.root / 'state.json').write_text('{"delay":0.3}')
+        self.client('--configure', '{"provider":"custom","providerOrder":["claude","codex"]}')
+        self.wait_for(lambda value: value['busy'])
+        self.client('--configure', '{"provider":"gemini"}')
+        value = self.wait_for(lambda value: bool(value.get('entries')) and not value['busy'])
+        self.assertEqual([row['provider'] for row in value['entries']], ['gemini'])
+
+    def test_autostart_toggle_is_independent_of_preferences(self):
+        self.assertFalse(self.client('--autostart', 'status')['enabled'])
+        self.assertTrue(self.client('--autostart', 'enable')['enabled'])
+        path = self.root / 'config/autostart/com.steipete.CodexBar.desktop'
+        self.assertIn('--background', path.read_text())
+        self.assertFalse(self.client('--autostart', 'disable')['enabled'])
+        self.assertIn('Hidden=true', path.read_text())
+        self.assertFalse(self.client('--autostart', 'invalid', check=False)['ok'])
+
+    def test_display_changes_preserve_usage_without_a_provider_query(self):
+        count = len((self.root / 'calls.jsonl').read_text().splitlines())
+        self.client('--configure', '{"quotaDisplay":"used","resetDisplay":"absolute"}')
+        value = self.client('--snapshot')
+        self.assertEqual(value['summary'], 'CX 40%')
+        self.assertEqual(value['entries'][0]['windows'][0]['displayValue'], 40)
+        self.assertEqual(value['entries'][0]['windows'][0]['displaySuffix'], 'used')
+        self.assertFalse(value['busy'])
+        self.assertEqual(len((self.root / 'calls.jsonl').read_text().splitlines()), count)
+
+    def test_display_settings_validation(self):
+        self.assertTrue(self.client('--configure', '{"quotaDisplay":"used","resetDisplay":"both","showPace":false,"trayStyle":"icon","followOmarchyTheme":true}')['ok'])
+        self.assertFalse(self.client('--configure', '{"resetDisplay":"nonsense"}', check=False)['ok'])
 
     def test_windows_and_cost_scan_use_existing_backend(self):
         pid = self.client('--snapshot')['pid']

--- a/Integrations/Linux/tests/test_package.py
+++ b/Integrations/Linux/tests/test_package.py
@@ -1,0 +1,32 @@
+import os
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import unittest
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+class PackageTests(unittest.TestCase):
+    def test_archive_installs_without_a_checkout(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            subprocess.run(['python3', str(REPO / 'Integrations/Linux/package.py'), '--binary', '/usr/bin/true',
+                            '--version', 'test', '--output', str(root)], check=True, capture_output=True)
+            archive_path = next(root.glob('*.tar.gz'))
+            with tarfile.open(archive_path) as archive:
+                self.assertEqual(len(archive.getmembers()), 7)
+                self.assertFalse(any('linux.json' in name for name in archive.getnames()))
+                archive.extractall(root / 'unpacked', filter='data')
+            package = next((root / 'unpacked').iterdir())
+            home = root / 'home'
+            env = dict(os.environ, HOME=str(home), XDG_CONFIG_HOME=str(home / 'config'),
+                       XDG_DATA_HOME=str(home / 'data'))
+            subprocess.run(['python3', str(package / 'Integrations/Linux/install.py'), '--cli', '/usr/bin/true'],
+                           env=env, check=True, capture_output=True)
+            self.assertTrue((home / '.local/bin/codexbar-linux').is_file())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Integrations/Linux/tests/tst_accounts.cpp
+++ b/Integrations/Linux/tests/tst_accounts.cpp
@@ -1,0 +1,48 @@
+#include "../DesktopController.h"
+
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QtTest>
+
+class AccountActionsTest : public QObject {
+    Q_OBJECT
+private slots:
+    void onlySupportedActionsReachTheTerminal() {
+        QTemporaryDir temporary;
+        QVERIFY(temporary.isValid());
+        const QByteArray originalPath = qgetenv("PATH");
+        qputenv("HOME", temporary.path().toUtf8());
+        qputenv("XDG_CONFIG_HOME", (temporary.path() + "/config").toUtf8());
+        qputenv("PATH", temporary.path().toUtf8());
+        const auto writeExecutable = [&](const QString &name, const QByteArray &content) {
+            QFile file(temporary.filePath(name));
+            if (!file.open(QIODevice::WriteOnly) || file.write(content) != content.size()) return false;
+            return file.setPermissions(QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner);
+        };
+        QVERIFY(writeExecutable("codex", "#!/bin/sh\nexit 0\n"));
+        QVERIFY(writeExecutable("claude", "#!/bin/sh\nexit 0\n"));
+        QVERIFY(writeExecutable("fake-cli", "#!/bin/sh\nprintf '[]'\n"));
+        qputenv("ACCOUNT_TEST_LOG", temporary.filePath("arguments").toUtf8());
+        QVERIFY(writeExecutable("xdg-terminal-exec", "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$ACCOUNT_TEST_LOG\"\n"));
+        DesktopController controller(temporary.filePath("fake-cli"));
+        QVERIFY(!controller.accountAction("codex;anything", "login"));
+        QVERIFY(!controller.accountAction("codex", "unrecognized"));
+        QVERIFY(!QFile::exists(temporary.filePath("arguments")));
+        QVERIFY(controller.accountAction("claude", "login"));
+        QTRY_VERIFY(QFile::exists(temporary.filePath("arguments")));
+        QFile file(temporary.filePath("arguments"));
+        QVERIFY(file.open(QIODevice::ReadOnly));
+        QCOMPARE(file.readAll(), QByteArray("--hold\n--\n") + temporary.filePath("claude").toUtf8() + "\nauth\nlogin\n");
+        file.close(); file.remove();
+        QVERIFY(controller.accountAction("codex", "logout"));
+        QTRY_VERIFY(QFile::exists(temporary.filePath("arguments")));
+        QVERIFY(file.open(QIODevice::ReadOnly));
+        QCOMPARE(file.readAll(), QByteArray("--hold\n--\n") + temporary.filePath("codex").toUtf8() + "\nlogout\n");
+        qputenv("PATH", originalPath);
+    }
+};
+
+QTEST_GUILESS_MAIN(AccountActionsTest)
+#include "tst_accounts.moc"

--- a/Integrations/Omarchy/Panel.qml
+++ b/Integrations/Omarchy/Panel.qml
@@ -41,7 +41,7 @@ Panel {
         anchors.fill: parent
         bar: root.bar
         text: !root.available ? "CodexBar —" : (root.snapshot.stale ? "! " : "") + (root.snapshot.summary || "CodexBar —")
-        tooltipText: "CodexBar · quota remaining\nClick for usage · middle-click to refresh"
+        tooltipText: "CodexBar · quota " + (root.snapshot.quotaDisplay || "remaining") + "\nClick for usage · middle-click to refresh"
         onPressed: function(code) { if (code === Qt.MiddleButton) root.refresh(); else root.toggle(); }
     }
     KeyboardPanel {
@@ -78,17 +78,17 @@ Panel {
                                 Column {
                                     required property var modelData
                                     width: content.width; spacing: Style.space(4)
-                                    Caption { text: modelData.label + " · " + modelData.remaining + "% left" }
+                                    Caption { text: modelData.label + " · " + (modelData.displayValue === undefined ? modelData.remaining : modelData.displayValue) + "% " + (modelData.displaySuffix || "left") }
                                     Rectangle {
                                         width: parent.width; height: Style.space(5); radius: height / 2
                                         color: Qt.rgba(Color.foreground.r, Color.foreground.g, Color.foreground.b, 0.15)
                                         Rectangle {
-                                            width: parent.width * modelData.remaining / 100; height: parent.height; radius: height / 2
-                                            color: modelData.remaining <= 10 ? Color.urgent : Color.accent
+                                            width: parent.width * (modelData.displayValue === undefined ? modelData.remaining : modelData.displayValue) / 100; height: parent.height; radius: height / 2
+                                            color: modelData.warning ? Color.urgent : Color.accent
                                         }
                                     }
                                     Caption {
-                                        text: modelData.resetsAt ? "Resets " + Qt.formatDateTime(new Date(modelData.resetsAt), "ddd HH:mm") : ""
+                                        text: modelData.resetText || "Reset time unavailable"
                                         visible: text !== ""; opacity: 0.65
                                     }
                                 }

--- a/Integrations/Omarchy/README.md
+++ b/Integrations/Omarchy/README.md
@@ -29,8 +29,8 @@ use Qt/D-Bus, so the app also works outside Omarchy.
 
 The `steipete.codexbar` layout entry in `~/.config/omarchy/shell.json` now accepts
 only `desktopExecutable` (default `codexbar-linux`) in addition to its ID. Configure
-providers, accounts, status, costs, notifications, and polling in the Settings
-window. Enabling the standalone tray is optional; Omarchy installation hides it
+providers and their order, accounts, status, costs, notifications, display, and polling in the Settings
+window. Enabling the standalone tray with quota meters is optional; Omarchy installation hides it
 to avoid a duplicate indicator.
 
 Remove the layout entry and `~/.config/omarchy/plugins/steipete.codexbar` to remove

--- a/Integrations/Omarchy/test.mjs
+++ b/Integrations/Omarchy/test.mjs
@@ -76,3 +76,12 @@ test('provider detail rows redact emails unless explicitly enabled', () => {
     assert.equal(model.rows(input)[0].details[0].rows[0].value, '[hidden email]');
     assert.equal(model.rows(input, true)[0].details[0].rows[0].value, 'private@example.com');
 });
+
+test('display preferences keep underlying quota and reset data intact', () => {
+    assert.equal(model.quotaValue(60, 'used'), 40);
+    assert.equal(model.quotaValue(60, 'remaining'), 60);
+    assert.equal(model.resetText('invalid', 0, 'absolute'), 'Reset time unavailable');
+    const time = '2030-01-01T00:00:00Z';
+    assert.ok(model.resetText(time, 0, 'absolute').startsWith('Resets '));
+    assert.ok(model.resetText(time, 0, 'both').includes(' · '));
+});


### PR DESCRIPTION
Linux users can now choose and order providers without editing config, see quota meters in the tray, and control startup and usage presentation from Settings. Omarchy's compact popup shares the quota/reset preferences, and the desktop can follow Omarchy theme colors.

This is stacked on #3573. It adds:
- A provider catalog from the installed CLI and an ordered custom list. Only selected providers are queried, sequentially. Partial failures retain previous results, and selection changes discard old in-flight responses.
- Two tray meters for the first displayed provider, optional static icon, stale/low-quota styling, used/remaining quota, reset countdown/absolute/both, pace visibility and warning colors. Display changes preserve data without extra provider queries.
- Immediate XDG start-at-login controls and --autostart enable/disable/status.
- Codex/Claude sign-in and confirmed sign-out in the default terminal through xdg-terminal-exec. The desktop neither handles credentials nor reads terminal output. These affect the active CLI session, not saved Mac profiles.
- Optional Omarchy palette following with system fallback, a portable archive packager, isolated archive-install testing, and CI artifacts.

Validation: Qt build passes; 15 shared-model tests, 14 runtime tests, 2 installer tests, 1 archive-install test, and 1 Qt account-action test pass (the Qt runner additionally reports init/cleanup). Runtime tests also pass under X11/XWayland. Account actions use fake provider CLIs and a fake terminal; no real sign-in/out was performed. Installed and restarted the new app on Omarchy, verified service health and plugin validation. The source-checkout account and desktop documentation records remaining differences.

Required make test cannot start because Swift is missing. Required make check stops at missing macOS plutil. No Swift files changed. KDE/GNOME sessions and distro-native packages are not verified; archive binaries require compatible Qt/glibc. Managed Mac profiles, token-account editing and browser imports remain unimplemented on Linux.
