### PR TITLE
fix(spend): honor civil days and bucket time zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Safer account menus:** preserve privacy in Codex account labels and reauthenticate the credential source shown by the selected row.
 
 ### Changes
+- Usage & Spend: count covered calendar days, align chart labels and ranges with the selected bucket time zone, and preserve historical-pace credits after midnight daylight-saving transitions (follow-up to #3565).
 - Usage & Spend: preserve heatmap coverage, token totals, and daily ledger rows across midnight daylight-saving transitions, retaining real gaps and unscanned days (#3565). Thanks @gabrielrojasc!
 - Cursor on Linux: restore automatic authentication from the signed-in app, honor absolute XDG/HOME paths, and preserve manual-cookie precedence and explicit web-mode isolation (#3539). Thanks @DonnieFi!
 - Codex spend: exclude time waiting behind other scans from automatic catch-up sleep calculations while preserving scan budgets, power safeguards, and complete-history publication (#3566, related to #3508 and #3411).
@@ -23,6 +24,7 @@
 - Documentation: link the community-maintained CodexBar for Windows companion and AI Monitor USB desk display (#3525, #3544). Thanks @hinneslung and @tobymarks!
 
 ### Development
+- Checks: interrupt the process-cleanup fixture after ownership is observed, so slow child startup cannot invalidate the cleanup test.
 - Checks: isolate Claude usage-retry tests from unrelated authentication subprocess startup.
 - Checks: allow process-fixture startup on loaded Macs before measuring cleanup deadlines, retaining all process-ownership and timeout assertions.
 - Logging: update SwiftLog to 1.15.1 for corrected legacy log forwarding and Swift 6.5 WASI compatibility.

--- a/Scripts/test_swift_test_process_cleanup.py
+++ b/Scripts/test_swift_test_process_cleanup.py
@@ -251,9 +251,6 @@ class ProcessCleanupTests(unittest.TestCase):
             try:
                 # Interpreter/file startup is setup; the cleanup deadlines below start afterward.
                 wait_until(lambda: (sentinel_root / "pid").exists(), timeout=10)
-                if interrupt:
-                    timer = threading.Timer(2, lambda: os.kill(os.getpid(), signal.SIGINT))
-                    timer.start()
                 started = time.monotonic()
                 command = [sys.executable, __file__, "--fixture", mode, str(child_root), str(ready_delay)]
                 original_refresh = runner.TestProcessOwnership.refresh
@@ -261,11 +258,15 @@ class ProcessCleanupTests(unittest.TestCase):
                 acknowledged = False
                 draining = False
                 def refresh(ownership, **kwargs):
-                    nonlocal acknowledged
+                    nonlocal acknowledged, timer
                     owned = original_refresh(ownership, **kwargs)
                     if not acknowledged and not draining:
                         acknowledged = release_observed_fixture(
                             child_root, owned, include_grandchild=mode == "success-session-tree")
+                        if acknowledged and interrupt:
+                            # Interrupt owned work, not interpreter startup before identities are visible.
+                            timer = threading.Timer(0.05, lambda: os.kill(os.getpid(), signal.SIGINT))
+                            timer.start()
                     return owned
                 def drain(ownership, process):
                     nonlocal draining
@@ -350,7 +351,7 @@ class ProcessCleanupTests(unittest.TestCase):
         self.exercise("failure", 23)
 
     def test_keyboard_interrupt_drains_children_and_propagates(self):
-        self.exercise("timeout", None, interrupt=True)
+        self.exercise("timeout", None, interrupt=True, ready_delay=3)
 
 
 class FixtureReadinessTests(unittest.TestCase):

--- a/Sources/CodexBar/HistoricalUsagePace.swift
+++ b/Sources/CodexBar/HistoricalUsagePace.swift
@@ -598,21 +598,21 @@ actor HistoricalUsageHistoryStore {
     private static func parseDayUsages(
         from breakdown: [OpenAIDashboardDailyBreakdown],
         asOf: Date,
-        fillingFrom expectedCoverageStart: Date? = nil) -> [DayUsage]
+        fillingFrom expectedCoverageStart: Date? = nil,
+        calendar: Calendar = gregorianCalendar()) -> [DayUsage]
     {
         var creditsByStart: [Date: Double] = [:]
         creditsByStart.reserveCapacity(breakdown.count)
 
         for day in breakdown {
-            guard let dayStart = Self.dayStart(for: day.day) else { continue }
+            guard let dayStart = Self.dayStart(for: day.day, calendar: calendar) else { continue }
             creditsByStart[dayStart, default: 0] += max(0, day.totalCreditsUsed)
         }
 
-        let calendar = Self.gregorianCalendar()
         var dayUsages: [DayUsage] = []
         dayUsages.reserveCapacity(creditsByStart.count)
         for (dayStart, credits) in creditsByStart {
-            guard let nominalEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else { continue }
+            guard let nominalEnd = calendar.dateInterval(of: .day, for: dayStart)?.end else { continue }
             let effectiveEnd: Date = if dayStart <= asOf, asOf < nominalEnd {
                 asOf
             } else {
@@ -626,17 +626,18 @@ actor HistoricalUsageHistoryStore {
         return Self.fillMissingZeroUsageDays(
             in: dayUsages,
             through: asOf,
-            fillingFrom: expectedCoverageStart)
+            fillingFrom: expectedCoverageStart,
+            calendar: calendar)
     }
 
     private static func fillMissingZeroUsageDays(
         in dayUsages: [DayUsage],
         through asOf: Date,
-        fillingFrom expectedCoverageStart: Date? = nil) -> [DayUsage]
+        fillingFrom expectedCoverageStart: Date? = nil,
+        calendar: Calendar) -> [DayUsage]
     {
         guard let firstStart = dayUsages.first?.start else { return [] }
 
-        let calendar = Self.gregorianCalendar()
         let fillStart: Date = if let expectedCoverageStart {
             min(firstStart, calendar.startOfDay(for: expectedCoverageStart))
         } else {
@@ -652,7 +653,7 @@ actor HistoricalUsageHistoryStore {
 
         var cursor = fillStart
         while cursor <= finalDayStart {
-            guard let nominalEnd = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
+            guard let nominalEnd = calendar.dateInterval(of: .day, for: cursor)?.end else { break }
             let effectiveEnd: Date = if cursor <= asOf, asOf < nominalEnd {
                 asOf
             } else {
@@ -663,14 +664,13 @@ actor HistoricalUsageHistoryStore {
                 start: cursor,
                 end: effectiveEnd,
                 creditsUsed: creditsByStart[cursor] ?? 0))
-            guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
-            cursor = next
+            cursor = nominalEnd
         }
 
         return filled
     }
 
-    private static func dayStart(for key: String) -> Date? {
+    private static func dayStart(for key: String, calendar: Calendar) -> Date? {
         let components = key.split(separator: "-", omittingEmptySubsequences: true)
         guard components.count == 3,
               let year = Int(components[0]),
@@ -680,17 +680,7 @@ actor HistoricalUsageHistoryStore {
             return nil
         }
 
-        let calendar = Self.gregorianCalendar()
-        var dateComponents = DateComponents()
-        dateComponents.calendar = calendar
-        dateComponents.timeZone = calendar.timeZone
-        dateComponents.year = year
-        dateComponents.month = month
-        dateComponents.day = day
-        dateComponents.hour = 0
-        dateComponents.minute = 0
-        dateComponents.second = 0
-        return dateComponents.date
+        return calendar.date(from: DateComponents(year: year, month: month, day: day))
     }
 
     private static func creditsUsed(from dayUsages: [DayUsage], between start: Date, and end: Date) -> Double {
@@ -742,16 +732,17 @@ actor HistoricalUsageHistoryStore {
 
     #if DEBUG
     nonisolated static func _dayStartForTesting(_ key: String) -> Date? {
-        self.dayStart(for: key)
+        self.dayStart(for: key, calendar: self.gregorianCalendar())
     }
 
     nonisolated static func _creditsUsedForTesting(
         breakdown: [OpenAIDashboardDailyBreakdown],
         asOf: Date,
         start: Date,
-        end: Date) -> Double
+        end: Date,
+        calendar: Calendar = gregorianCalendar()) -> Double
     {
-        let dayUsages = Self.parseDayUsages(from: breakdown, asOf: asOf)
+        let dayUsages = Self.parseDayUsages(from: breakdown, asOf: asOf, calendar: calendar)
         return Self.creditsUsed(from: dayUsages, between: start, and: end)
     }
     #endif

--- a/Sources/CodexBar/PreferencesSpendDashboardPane.swift
+++ b/Sources/CodexBar/PreferencesSpendDashboardPane.swift
@@ -631,7 +631,7 @@ struct SpendDashboardCurrencySection: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     if let selectedDay = self.group.selectedDay {
-                        Text(SpendActivityDateFormatting.mediumDateString(selectedDay))
+                        Text(SpendActivityDateFormatting.mediumDateString(selectedDay, calendar: self.group.calendar))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -650,6 +650,8 @@ struct SpendDashboardCurrencySection: View {
                 SpendHourlyChart(group: self.group)
             }
         }
+        .environment(\.timeZone, self.group.timeZone)
+        .environment(\.calendar, self.group.calendar)
     }
 }
 
@@ -897,7 +899,7 @@ private struct SpendDailyChart: View {
                         stackEnd: \.stackEnd)
                     Chart(self.group.dailyPoints) { point in
                         BarMark(
-                            x: .value(L("Day"), point.day, unit: .day),
+                            x: .value(L("Day"), point.day, unit: .day, calendar: self.group.calendar),
                             yStart: .value(L("Estimated spend"), point.stackStart),
                             yEnd: .value(L("Estimated spend"), point.stackEnd),
                             width: .ratio(0.72))
@@ -911,6 +913,7 @@ private struct SpendDailyChart: View {
                                 currencyCode: self.group.currencyCode)))
                     }
                     .chartXScale(domain: self.group.chartDomain)
+                    .chartXAxis { AxisMarks(format: self.dayFormat) }
                     .chartForegroundStyleScale(
                         domain: presentation.series.map(\.name),
                         range: presentation.series.map { self.providerColor($0.provider) })
@@ -935,9 +938,16 @@ private struct SpendDailyChart: View {
         }
     }
 
+    private var dayFormat: Date.FormatStyle {
+        Date.FormatStyle(
+            locale: codexBarLocalizedLocale(),
+            calendar: self.group.calendar,
+            timeZone: self.group.timeZone)
+            .month(.abbreviated).day()
+    }
+
     private func pointAccessibilityLabel(_ point: SpendDashboardModel.DailyPoint) -> String {
-        let day = point.day.formatted(
-            .dateTime.month(.abbreviated).day().locale(codexBarLocalizedLocale()))
+        let day = point.day.formatted(self.dayFormat)
         return "\(point.providerName), \(day)"
     }
 
@@ -1016,7 +1026,7 @@ private struct SpendHourlyChart: View {
     let group: SpendDashboardModel.CurrencyGroup
 
     var body: some View {
-        let calendar = Self.chartCalendar(timeZone: self.group.timeZone)
+        let calendar = self.group.calendar
         let presentation = SpendHourlyChartPresentation(
             hourlyPoints: self.group.hourlyPoints,
             calendar: calendar)
@@ -1034,7 +1044,7 @@ private struct SpendHourlyChart: View {
                         stackEnd: \.stackEnd)
                     Chart(self.group.hourlyPoints) { point in
                         BarMark(
-                            x: .value(L("Hour"), point.hour, unit: .hour),
+                            x: .value(L("Hour"), point.hour, unit: .hour, calendar: calendar),
                             yStart: .value(L("Estimated spend"), point.stackStart),
                             yEnd: .value(L("Estimated spend"), point.stackEnd),
                             width: .ratio(0.72))
@@ -1048,8 +1058,6 @@ private struct SpendHourlyChart: View {
                                 point.cost,
                                 currencyCode: self.group.currencyCode)))
                     }
-                    .environment(\.timeZone, self.group.timeZone)
-                    .environment(\.calendar, calendar)
                     .chartXScale(domain: self.group.hourlyChartDomain ?? self.group.chartDomain)
                     .chartForegroundStyleScale(
                         domain: presentation.series.map(\.name),
@@ -1089,12 +1097,6 @@ private struct SpendHourlyChart: View {
     private func providerColor(_ provider: UsageProvider) -> Color {
         let color = ProviderAccentPalette.color(for: provider)
         return Color(red: color.red, green: color.green, blue: color.blue)
-    }
-
-    private static func chartCalendar(timeZone: TimeZone) -> Calendar {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = timeZone
-        return calendar
     }
 }
 

--- a/Sources/CodexBar/SpendDashboardModel.swift
+++ b/Sources/CodexBar/SpendDashboardModel.swift
@@ -220,6 +220,10 @@ struct SpendDashboardModel: Equatable, Sendable {
         let hourlyChartDomain: ClosedRange<Date>?
         let timeZone: TimeZone
 
+        var calendar: Calendar {
+            SpendDashboardModel.gregorianCalendar(timeZone: self.timeZone)
+        }
+
         var id: String {
             self.currencyCode
         }
@@ -1144,7 +1148,7 @@ struct SpendDashboardModel: Equatable, Sendable {
     }
 
     private static func chartDomain(bounds: ClosedRange<Date>, calendar: Calendar) -> ClosedRange<Date> {
-        let end = calendar.date(byAdding: .day, value: 1, to: bounds.upperBound) ?? bounds.upperBound
+        let end = calendar.dateInterval(of: .day, for: bounds.upperBound)?.end ?? bounds.upperBound
         return bounds.lowerBound...end
     }
 
@@ -1192,8 +1196,11 @@ struct SpendDashboardModel: Equatable, Sendable {
     }
 
     private static func dayCount(in interval: ClosedRange<Date>?, calendar: Calendar) -> Int {
-        guard let interval else { return 0 }
-        return (calendar.dateComponents([.day], from: interval.lowerBound, to: interval.upperBound).day ?? 0) + 1
+        guard let interval,
+              let first = calendar.ordinality(of: .day, in: .era, for: interval.lowerBound),
+              let last = calendar.ordinality(of: .day, in: .era, for: interval.upperBound)
+        else { return 0 }
+        return last - first + 1
     }
 
     private static func day(
@@ -1399,8 +1406,7 @@ struct SpendDashboardModel: Equatable, Sendable {
     {
         if let selectedDay {
             let start = calendar.startOfDay(for: selectedDay)
-            let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
-            return start...end
+            return Self.chartDomain(bounds: start...start, calendar: calendar)
         }
         guard let first = points.map(\.hour).min(),
               let last = points.map(\.hour).max(),

--- a/Tests/CodexBarTests/HistoricalUsageMidnightDSTTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsageMidnightDSTTests.swift
@@ -1,0 +1,38 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct HistoricalUsageMidnightDSTTests {
+    @Test(arguments: [
+        ("America/Santiago", 9, 6),
+        ("America/New_York", 3, 8),
+        ("America/New_York", 11, 1),
+        ("UTC", 12, 31),
+    ])
+    func `backfill retains credits and civil day boundaries`(dateCase: (String, Int, Int)) throws {
+        let (zone, month, day) = dateCase
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: zone))
+        let first = try #require(calendar.date(from: DateComponents(year: 2026, month: month, day: day, hour: 12)))
+        let asOf = try #require(calendar.date(byAdding: .day, value: 1, to: first))
+        let firstStart = calendar.startOfDay(for: first)
+        let secondStart = calendar.startOfDay(for: asOf)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+        let breakdown = [(formatter.string(from: first), 23.0), (formatter.string(from: asOf), 12.0)]
+            .map { day, credits in
+                OpenAIDashboardDailyBreakdown(day: day, services: [], totalCreditsUsed: credits)
+            }
+        func credits(from start: Date, to end: Date) -> Double {
+            HistoricalUsageHistoryStore._creditsUsedForTesting(
+                breakdown: breakdown, asOf: asOf, start: start, end: end, calendar: calendar)
+        }
+        #expect(abs(credits(from: firstStart, to: asOf) - 35) < 0.001)
+        #expect(abs(credits(from: firstStart, to: secondStart) - 23) < 0.001)
+        #expect(abs(credits(from: secondStart, to: asOf) - 12) < 0.001)
+    }
+}

--- a/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
+++ b/Tests/CodexBarTests/ProviderArchitectureGatekeeperTests.swift
@@ -2465,7 +2465,7 @@ struct ProviderArchitectureGatekeeperTests {
             reason: "This exact shared construct dispatches a provider-owned capability at the generic integration boundary."),
         AllowedProviderConstruct(
             path: "Sources/CodexBar/SpendDashboardModel.swift",
-            line: 1229,
+            line: 1236,
             anchor: "guard provider == .mistral || provider == .openrouter || provider == .xai else { return displayCalendar }",
             expectedProviderIDs: ["mistral", "openrouter", "xai"],
             expectedReferenceCount: 3,

--- a/Tests/CodexBarTests/SpendDashboardMidnightDSTTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardMidnightDSTTests.swift
@@ -51,6 +51,7 @@ struct SpendDashboardMidnightDSTTests {
             #expect(group.dailySummaries.map(\.day) == Array(dates.prefix(requestedDays).reversed()))
             #expect(group.totalTokens == (1...requestedDays).reduce(0, +))
             if completeHistory {
+                #expect(group.coveredDayCount == requestedDays)
                 #expect(group.dailySummaries.compactMap(\.totalTokens) == Array((1...requestedDays).reversed()))
             }
             let series = SpendActivitySeries.make(from: model.tokenActivity, now: now, calendar: calendar)
@@ -58,5 +59,47 @@ struct SpendDashboardMidnightDSTTests {
             #expect(series.coveredDayCount == 365)
             #expect(series.daily.reduce(0, +) == (1...365).reduce(0, +))
         }
+    }
+
+    @Test
+    func `coverage and chart bounds use complete civil days around midnight DST`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "America/Santiago"))
+        let transition = try #require(calendar.date(from: DateComponents(year: 2026, month: 9, day: 6, hour: 12)))
+        let next = try #require(calendar.date(from: DateComponents(year: 2026, month: 9, day: 7, hour: 12)))
+        let nextStart = calendar.startOfDay(for: next)
+        let snapshot = CostUsageTokenSnapshot(
+            sessionTokens: 1,
+            sessionCostUSD: 1,
+            last30DaysTokens: 2,
+            last30DaysCostUSD: 2,
+            historyDays: 2,
+            historyCoverageIsEstablished: true,
+            daily: ["2026-09-06", "2026-09-07"].map {
+                .init(
+                    date: $0,
+                    inputTokens: 1,
+                    outputTokens: 0,
+                    totalTokens: 1,
+                    costUSD: 1,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil)
+            },
+            updatedAt: next)
+        let covered = SpendDashboardModel.build(
+            inputs: [.init(provider: .codex, displayName: "Synthetic Codex", snapshot: snapshot)],
+            requestedDays: 2,
+            now: next,
+            calendar: calendar)
+        #expect(covered.groups.first?.coveredDayCount == 2)
+        #expect(covered.groups.first?.providers.first?.coveredDayCount == 2)
+        let selected = SpendDashboardModel.build(
+            inputs: [.init(provider: .codex, displayName: "Synthetic Codex", snapshot: snapshot)],
+            requestedDays: 2,
+            now: transition,
+            calendar: calendar,
+            selectedDay: transition)
+        #expect(selected.groups.first?.chartDomain.upperBound == nextStart)
+        #expect(selected.groups.first?.hourlyChartDomain?.upperBound == nextStart)
     }
 }

--- a/Tests/CodexBarTests/SpendDashboardScreenshotRenderTests.swift
+++ b/Tests/CodexBarTests/SpendDashboardScreenshotRenderTests.swift
@@ -262,6 +262,42 @@ final class SpendDashboardScreenshotRenderTests: XCTestCase {
         try data.write(to: directory.appendingPathComponent("heatmap-dst.png"))
     }
 
+    func test_renderMidnightCoverage() throws {
+        guard let dir = ProcessInfo.processInfo.environment["CODEXBAR_DAY_BOUNDARY_PROOF_DIR"] else {
+            throw XCTSkip("Set CODEXBAR_DAY_BOUNDARY_PROOF_DIR for synthetic day-boundary proof.")
+        }
+        let directory = URL(fileURLWithPath: dir, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        var calendar = Self.gmtCalendar
+        calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "America/Santiago"))
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 9, day: 7, hour: 12)))
+        let snapshot = Self.snapshot(
+            entries: [
+                Self.entry(day: "2026-09-06", cost: 1, tokens: 1000, model: "fixture-model"),
+                Self.entry(day: "2026-09-07", cost: 1, tokens: 1000, model: "fixture-model"),
+            ],
+            historyDays: 2,
+            now: now)
+        let previous = try XCTUnwrap(calendar.date(byAdding: .day, value: -1, to: now))
+        for (name, selectedDay) in [("coverage", Date?.none), ("selected-day", Optional(previous))] {
+            let model = SpendDashboardModel.build(
+                inputs: [.init(provider: .codex, displayName: "Synthetic Codex", snapshot: snapshot)],
+                requestedDays: 7,
+                now: now,
+                calendar: calendar,
+                selectedDay: selectedDay)
+            let group = try XCTUnwrap(model.groups.first)
+            let view = AnyView(SpendDashboardCurrencySection(group: group, requestedDays: 7, hidePersonalInfo: true)
+                .padding(24).frame(width: 900)
+                .background(Color(nsColor: .windowBackgroundColor))
+                .preferredColorScheme(.light)
+                .environment(\.locale, Locale(identifier: "en_US_POSIX")))
+            try XCTUnwrap(Self.pngData(for: view)).write(to: directory.appendingPathComponent(name + ".png"))
+            try JSONEncoder().encode(["coveredDays": group.coveredDayCount])
+                .write(to: directory.appendingPathComponent(name + ".json"))
+        }
+    }
+
     private static func chrome(selectedDays: Int, group: SpendDashboardModel.CurrencyGroup) -> some View {
         VStack(alignment: .leading, spacing: 18) {
             HStack(alignment: .top, spacing: 16) {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -25,7 +25,8 @@ Settings → Usage & Spend is a local estimated-cost history page, not a billing
 card. Range choices are 7 / 30 / 90 days and All (the scan window is 365 days). Amounts are list-price equivalents
 unless a source also reports plan-metered spend, in which case both columns appear. Day buckets use a pinned IANA
 timezone stored when cost tracking is first enabled. Heatmap and ledger dates remain aligned to local calendar
-days across daylight-saving transitions, including zones where midnight is skipped.
+days across daylight-saving transitions, including zones where midnight is skipped. Coverage counts civil days,
+and daily/hourly chart labels use the bucket time zone. Their ranges end at the next local day boundary rather than a fixed 24 hours.
 
 Regular token-history publications also refresh outdated independent Usage & Spend sources, including Claude,
 through their own 365-day scan. The dashboard never substitutes the shorter menu history for that scan. Updates

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -120,7 +120,7 @@ model-generic token label while the rendered menu-bar prefix and accessibility l
 
 Pace compares your actual usage against the expected consumption rate for the current window. Most providers use an even-consumption budget; Codex can use historical pace data when historical tracking is available.
 
-The **Work days** setting selects the weekly pace model. **Automatic** uses Codex historical pace when enough data is available. Selecting 4, 5, or 7 days uses that explicit schedule for pace and ETA instead; CodexBar continues collecting history in the background, but does not use historical predictions until the setting returns to Automatic.
+The **Work days** setting selects the weekly pace model. **Automatic** uses Codex historical pace when enough data is available. Historical daily credits follow local calendar-day boundaries, including midnight daylight-saving transitions. Selecting 4, 5, or 7 days uses that explicit schedule for pace and ETA instead; CodexBar continues collecting history in the background, but does not use historical predictions until the setting returns to Automatic.
 
 - **On pace** – usage matches the expected rate.
 - **X% in deficit** – you're consuming faster than the even rate; at this pace you'll run out before the window resets.


### PR DESCRIPTION
Daily calendar arithmetic and display formatting still had several independent failures after #3565. Around Santiago's skipped midnight, two covered dates counted as one, chart ranges extended an hour into the following day, and historical pace backfill could replace following-day credits with zero. A bucket time zone different from the host also put chart bars/labels and the selected-day subtitle on the wrong dates.

Use actual calendar-day interval ends, civil-day ordinals, and one group calendar throughout chart ranges, bar binning, axis/accessibility labels, and the selected-day subtitle. Pass one calendar through historical parsing and reuse each day's end as the next cursor. The cleanup leaves production code **net -1 line**. Documentation and the Unreleased changelog are updated; this follows Gabriel Rojas's #3565 heatmap repair.

Validation: seven new calendar/credit assertions fail on main and pass after the fix; 145 focused tests cover dashboard, historical pace, and architecture, with additional 23/25-hour and year-boundary controls. Signed native component rendering on a Los Angeles host with synthetic Santiago data verifies1/7→2/7 coverage, Sep5→Sep6 selected-day text, and correctly aligned Sep6–7 bars. The renderer supplies no calendar/timezone workaround. Independent review through P2 is clean. `make check` and the final full local suite passed: 1,076 selections in 90 groups, all first pass with no retries/timeouts. [CI for the reviewed head](https://github.com/steipete/CodexBar/actions/runs/34672989978) passed with all checks green.

Validation also exposed a test-only cleanup race: its two-second interrupt could fire before fixture ownership was observed. A delayed-start regression proves it; interruption now starts after the existing ownership handshake, keeping cleanup/sentinel/grace assertions.

Before:

![Synthetic bucket-calendar baseline](https://github.com/user-attachments/assets/444d113a-d08f-448d-9506-3c0ba610a14a)

After:

![Synthetic bucket-calendar corrected output](https://github.com/user-attachments/assets/46036187-2ac3-4880-9eab-337b5111b832)
