### PR TITLE
fix: recover Claude menu refresh interactions

### DIFF
--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -355,10 +355,11 @@ struct ClaudeProviderImplementation: ProviderImplementation {
             accountCount: context.store.claudeSwapAccountSnapshots.count,
             showSingleAccount: context.settings.claudeSwapShowSingleAccount)
         guard !context.hasAccount || swapOwnsAccountPresentation else { return nil }
-        if !swapOwnsAccountPresentation, context.store.hasSatisfiedUsageFetch(for: .claude) {
-            return nil
-        }
         return (L("Sign in with Claude Code..."), .switchAccount(.claude))
+    }
+
+    func allowsInteractiveMenuRefresh(error: String?) -> Bool {
+        ClaudeOAuthCredentialsError.isCredentialRecoveryError(description: error)
     }
 
     @MainActor

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -355,6 +355,9 @@ struct ClaudeProviderImplementation: ProviderImplementation {
             accountCount: context.store.claudeSwapAccountSnapshots.count,
             showSingleAccount: context.settings.claudeSwapShowSingleAccount)
         guard !context.hasAccount || swapOwnsAccountPresentation else { return nil }
+        if !swapOwnsAccountPresentation, context.store.hasSatisfiedUsageFetch(for: .claude) {
+            return nil
+        }
         return (L("Sign in with Claude Code..."), .switchAccount(.claude))
     }
 

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementation.swift
@@ -92,6 +92,9 @@ protocol ProviderImplementation: Sendable {
     func loginMenuAction(context: ProviderMenuLoginContext) -> (
         label: String, action: MenuDescriptor.MenuAction)?
 
+    /// Whether an open-menu retry may run the provider's prompt-capable recovery path.
+    func allowsInteractiveMenuRefresh(error: String?) -> Bool
+
     /// Optional provider-specific login flow. Returns whether to refresh after completion.
     @MainActor
     func runLoginFlow(context: ProviderLoginContext) async -> Bool
@@ -207,6 +210,10 @@ extension ProviderImplementation {
         -> (label: String, action: MenuDescriptor.MenuAction)?
     {
         nil
+    }
+
+    func allowsInteractiveMenuRefresh(error _: String?) -> Bool {
+        false
     }
 
     @MainActor

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1185,6 +1185,7 @@ extension StatusItemController {
             let enabledProviders = self.store.enabledProvidersForBackgroundWork()
             let visibleProviders = self.delayedRefreshRetryProviders(for: menu)
             let visibleInstanceIDs = visibleProviders.map(\.instanceID)
+            let visibleProviderSet = Set(visibleInstanceIDs)
             let plan = MenuOpenRefreshPlan.resolve(.init(
                 refreshAllOnOpen: refreshAllOnOpen,
                 enabledProviders: enabledProviders,
@@ -1222,7 +1223,9 @@ extension StatusItemController {
                 // wait for any in-flight refresh (e.g. a manual refresh) instead of overriding it.
                 await withTaskGroup(of: Void.self) { group in
                     for provider in retryProviders {
-                        let interaction = self.openMenuRefreshInteraction(for: provider)
+                        let interaction = self.openMenuRefreshInteraction(
+                            for: provider,
+                            visibleProviders: visibleProviderSet)
                         group.addTask {
                             await ProviderInteractionContext.$current.withValue(interaction) {
                                 await self.store.refreshProvider(provider, coalesceIfRefreshing: true)
@@ -1233,7 +1236,9 @@ extension StatusItemController {
             } else {
                 for provider in retryProviders {
                     guard !Task.isCancelled else { return }
-                    let interaction = self.openMenuRefreshInteraction(for: provider)
+                    let interaction = self.openMenuRefreshInteraction(
+                        for: provider,
+                        visibleProviders: visibleProviderSet)
                     await ProviderInteractionContext.$current.withValue(interaction) {
                         await self.store.refreshProvider(provider, coalesceIfRefreshing: true)
                     }
@@ -1254,15 +1259,24 @@ extension StatusItemController {
         }
     }
 
-    private func openMenuRefreshInteraction(for provider: UsageProvider) -> ProviderInteraction {
-        Self.openMenuRefreshInteraction(provider: provider, error: self.store.error(for: provider))
+    private func openMenuRefreshInteraction(
+        for provider: UsageProvider,
+        visibleProviders: Set<ProviderInstanceID>) -> ProviderInteraction
+    {
+        Self.openMenuRefreshInteraction(
+            provider: provider,
+            error: self.store.error(for: provider),
+            visibleProviders: visibleProviders)
     }
 
     nonisolated static func openMenuRefreshInteraction(
         provider: UsageProvider,
-        error: String?) -> ProviderInteraction
+        error: String?,
+        visibleProviders: Set<ProviderInstanceID>) -> ProviderInteraction
     {
-        guard provider == .claude, let error, UsageStore.isClaudeCredentialRecoveryError(error) else {
+        guard visibleProviders.contains(provider.instanceID),
+              ProviderCatalog.implementation(for: provider)?.allowsInteractiveMenuRefresh(error: error) == true
+        else {
             return .background
         }
         return .userInitiated

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1216,21 +1216,25 @@ extension StatusItemController {
                 return
             }
             self.deferredMenuInteractionRefreshProviders.formUnion(retryInstanceIDs)
-            await ProviderInteractionContext.$current.withValue(.background) {
-                if plan.scheduling == .concurrent {
-                    // Refresh concurrently so one slow provider doesn't delay the rest, mirroring the
-                    // periodic refresh in `UsageStore.runRefresh`. `coalesceIfRefreshing` makes each call
-                    // wait for any in-flight refresh (e.g. a manual refresh) instead of overriding it.
-                    await withTaskGroup(of: Void.self) { group in
-                        for provider in retryProviders {
-                            group.addTask {
+            if plan.scheduling == .concurrent {
+                // Refresh concurrently so one slow provider doesn't delay the rest, mirroring the
+                // periodic refresh in `UsageStore.runRefresh`. `coalesceIfRefreshing` makes each call
+                // wait for any in-flight refresh (e.g. a manual refresh) instead of overriding it.
+                await withTaskGroup(of: Void.self) { group in
+                    for provider in retryProviders {
+                        let interaction = self.openMenuRefreshInteraction(for: provider)
+                        group.addTask {
+                            await ProviderInteractionContext.$current.withValue(interaction) {
                                 await self.store.refreshProvider(provider, coalesceIfRefreshing: true)
                             }
                         }
                     }
-                } else {
-                    for provider in retryProviders {
-                        guard !Task.isCancelled else { return }
+                }
+            } else {
+                for provider in retryProviders {
+                    guard !Task.isCancelled else { return }
+                    let interaction = self.openMenuRefreshInteraction(for: provider)
+                    await ProviderInteractionContext.$current.withValue(interaction) {
                         await self.store.refreshProvider(provider, coalesceIfRefreshing: true)
                     }
                 }
@@ -1248,6 +1252,20 @@ extension StatusItemController {
                 deferOpenParentMenuRebuild: false,
                 allowStaleContentDuringDataRefresh: true)
         }
+    }
+
+    private func openMenuRefreshInteraction(for provider: UsageProvider) -> ProviderInteraction {
+        Self.openMenuRefreshInteraction(provider: provider, error: self.store.error(for: provider))
+    }
+
+    nonisolated static func openMenuRefreshInteraction(
+        provider: UsageProvider,
+        error: String?) -> ProviderInteraction
+    {
+        guard provider == .claude, let error, UsageStore.isClaudeCredentialRecoveryError(error) else {
+            return .background
+        }
+        return .userInitiated
     }
 
     private func menuNeedsDelayedRefreshRetry(for menu: NSMenu) -> Bool {

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -764,6 +764,10 @@ extension UsageStore {
             }
             self.lastSourceLabels[provider.instanceID] = result.sourceLabel
             self.recordProviderFetchSuccessErrorState(provider: provider)
+            if provider == .claude, result.strategyKind == .cli {
+                // A successful Claude CLI fallback is authoritative for the displayed quota.
+                self.errors[provider.instanceID] = nil
+            }
             self.diagnostics[provider.instanceID] = result.diagnostic
             if let tokenAccount = currentTokenAccount {
                 self.cacheTokenAccountSnapshot(
@@ -980,6 +984,19 @@ extension UsageStore {
         let activeAccountUuid: String?
         let activeAccountIdentity: String?
         let wasStable: Bool
+    }
+
+    nonisolated static func isClaudeCredentialRecoveryError(_ error: String) -> Bool {
+        if ClaudeOAuthUnreadableCredentialsError.matches(description: error) {
+            return true
+        }
+        return [
+            ClaudeOAuthCredentialsError.missingOAuth.localizedDescription,
+            ClaudeOAuthCredentialsError.missingAccessToken.localizedDescription,
+            ClaudeOAuthCredentialsError.notFound.localizedDescription,
+            ClaudeOAuthCredentialsError.keychainAccessRevoked.localizedDescription,
+            ClaudeOAuthCredentialsError.noRefreshToken.localizedDescription,
+        ].contains(error)
     }
 
     private nonisolated static func claudeCredentialsChanged(

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -764,10 +764,6 @@ extension UsageStore {
             }
             self.lastSourceLabels[provider.instanceID] = result.sourceLabel
             self.recordProviderFetchSuccessErrorState(provider: provider)
-            if provider == .claude, result.strategyKind == .cli {
-                // A successful Claude CLI fallback is authoritative for the displayed quota.
-                self.errors[provider.instanceID] = nil
-            }
             self.diagnostics[provider.instanceID] = result.diagnostic
             if let tokenAccount = currentTokenAccount {
                 self.cacheTokenAccountSnapshot(
@@ -984,19 +980,6 @@ extension UsageStore {
         let activeAccountUuid: String?
         let activeAccountIdentity: String?
         let wasStable: Bool
-    }
-
-    nonisolated static func isClaudeCredentialRecoveryError(_ error: String) -> Bool {
-        if ClaudeOAuthUnreadableCredentialsError.matches(description: error) {
-            return true
-        }
-        return [
-            ClaudeOAuthCredentialsError.missingOAuth.localizedDescription,
-            ClaudeOAuthCredentialsError.missingAccessToken.localizedDescription,
-            ClaudeOAuthCredentialsError.notFound.localizedDescription,
-            ClaudeOAuthCredentialsError.keychainAccessRevoked.localizedDescription,
-            ClaudeOAuthCredentialsError.noRefreshToken.localizedDescription,
-        ].contains(error)
     }
 
     private nonisolated static func claudeCredentialsChanged(

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -261,6 +261,20 @@ public enum ClaudeOAuthCredentialsError: LocalizedError, Sendable {
     case noRefreshToken
     case refreshDelegatedToClaudeCLI
 
+    public static func isCredentialRecoveryError(description: String?) -> Bool {
+        if ClaudeOAuthUnreadableCredentialsError.matches(description: description) {
+            return true
+        }
+        return [
+            Self.missingOAuth.localizedDescription,
+            Self.mcpOAuthOnlyKeychain.localizedDescription,
+            Self.missingAccessToken.localizedDescription,
+            Self.notFound.localizedDescription,
+            Self.keychainAccessRevoked.localizedDescription,
+            Self.noRefreshToken.localizedDescription,
+        ].contains(description)
+    }
+
     public var errorDescription: String? {
         switch self {
         case .decodeFailed:

--- a/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
@@ -6,6 +6,19 @@ import Testing
 
 extension StatusMenuTests {
     @Test
+    func `only Claude credential recovery errors elevate menu retries`() {
+        #expect(StatusItemController.openMenuRefreshInteraction(
+            provider: .claude,
+            error: ClaudeOAuthCredentialsError.notFound.localizedDescription) == .userInitiated)
+        #expect(StatusItemController.openMenuRefreshInteraction(
+            provider: .claude,
+            error: "Temporary Claude API failure") == .background)
+        #expect(StatusItemController.openMenuRefreshInteraction(
+            provider: .codex,
+            error: ClaudeOAuthCredentialsError.notFound.localizedDescription) == .background)
+    }
+
+    @Test
     func `opening fresh menu does not schedule deferred refresh`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
@@ -9,13 +9,20 @@ extension StatusMenuTests {
     func `only Claude credential recovery errors elevate menu retries`() {
         #expect(StatusItemController.openMenuRefreshInteraction(
             provider: .claude,
-            error: ClaudeOAuthCredentialsError.notFound.localizedDescription) == .userInitiated)
+            error: ClaudeOAuthCredentialsError.notFound.localizedDescription,
+            visibleProviders: [.claude.instanceID]) == .userInitiated)
         #expect(StatusItemController.openMenuRefreshInteraction(
             provider: .claude,
-            error: "Temporary Claude API failure") == .background)
+            error: ClaudeOAuthCredentialsError.mcpOAuthOnlyKeychain.localizedDescription,
+            visibleProviders: [.claude.instanceID]) == .userInitiated)
         #expect(StatusItemController.openMenuRefreshInteraction(
             provider: .codex,
-            error: ClaudeOAuthCredentialsError.notFound.localizedDescription) == .background)
+            error: ClaudeOAuthCredentialsError.notFound.localizedDescription,
+            visibleProviders: [.codex.instanceID]) == .background)
+        #expect(StatusItemController.openMenuRefreshInteraction(
+            provider: .claude,
+            error: ClaudeOAuthCredentialsError.notFound.localizedDescription,
+            visibleProviders: [.codex.instanceID]) == .background)
     }
 
     @Test


### PR DESCRIPTION
Fix Claude menu refresh behavior after credential recovery failures.

Summary:
- Keep refresh-all retries for providers that are not shown in the open menu in background interaction.
- Allow prompt-capable Claude recovery only when Claude is one of the rendered providers and its provider policy recognizes the persisted credential error.
- Cover MCP-only Keychain state alongside the existing unreadable and missing-credential recovery cases.
- Keep the existing account-action decision as the single source for Claude sign-in presentation.
- Add regression coverage for visible-provider scoping and MCP-only recovery.

Validation:
- `git diff --check` passes.
- `swiftc -frontend -parse` passes for the changed implementation files.
- `swift test --filter StatusMenuInstantOpenTests` is blocked locally because the repository requires Swift 6.2 and the installed toolchain is Swift 6.1.
- `swiftformat` and `swiftlint` are not installed in this environment.