### PR TITLE
fix(manus): validate selected credits envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Safer account menus:** preserve privacy in Codex account labels and reauthenticate the credential source shown by the selected row.
 
 ### Changes
+- Manus: reject empty and error-only credits envelopes in native and optional plugin fetching instead of displaying a false zero balance, preserving sparse responses and real zero credits.
 - Usage & Spend: preserve heatmap coverage, token totals, and daily ledger rows across midnight daylight-saving transitions, retaining real gaps and unscanned days (#3565). Thanks @gabrielrojasc!
 - Cursor on Linux: restore automatic authentication from the signed-in app, honor absolute XDG/HOME paths, and preserve manual-cookie precedence and explicit web-mode isolation (#3539). Thanks @DonnieFi!
 - Codex spend: exclude time waiting behind other scans from automatic catch-up sleep calculations while preserving scan budgets, power safeguards, and complete-history publication (#3566, related to #3508 and #3411).
@@ -23,6 +24,7 @@
 - Documentation: link the community-maintained CodexBar for Windows companion and AI Monitor USB desk display (#3525, #3544). Thanks @hinneslung and @tobymarks!
 
 ### Development
+- Checks: tolerate repeated kill delivery while a cleanup fixture's exit is pending, retaining termination order, grace-period, deadline, and confirmed-reap assertions.
 - Checks: isolate Claude usage-retry tests from unrelated authentication subprocess startup.
 - Checks: allow process-fixture startup on loaded Macs before measuring cleanup deadlines, retaining all process-ownership and timeout assertions.
 - Logging: update SwiftLog to 1.15.1 for corrected legacy log forwarding and Swift 6.5 WASI compatibility.

--- a/Scripts/test_swift_test_process_cleanup.py
+++ b/Scripts/test_swift_test_process_cleanup.py
@@ -872,7 +872,7 @@ class ReviewRegressionTests(unittest.TestCase):
                     with self.assertRaises(OSError):
                         runner.test_process(123)
 
-    def exercise_initialization_failure(self, failure):
+    def exercise_initialization_failure(self, failure, deferred_kills=0):
         with tempfile.TemporaryDirectory(prefix="codexbar-init-cleanup-") as directory:
             root = Path(directory)
             spawned = []
@@ -899,8 +899,12 @@ class ReviewRegressionTests(unittest.TestCase):
             sent = []
             original_kill = os.kill
             def kill(pid, sig):
+                nonlocal deferred_kills
                 if spawned and pid == spawned[0].pid:
                     sent.append((sig, time.monotonic() - started))
+                    if sig == signal.SIGKILL and deferred_kills:
+                        deferred_kills -= 1
+                        return
                 return original_kill(pid, sig)
             try:
                 with patch.object(runner.subprocess, "Popen", side_effect=spawn), \
@@ -916,8 +920,10 @@ class ReviewRegressionTests(unittest.TestCase):
                 self.assertEqual(len(spawned), 1)
                 self.assertIsNotNone(spawned[0].poll(), "initialization failure leaked direct child")
                 if failure is None:
-                    self.assertEqual([sig for sig, _ in sent], [signal.SIGTERM, signal.SIGKILL])
+                    self.assertEqual([sig for sig, _ in sent[:2]], [signal.SIGTERM, signal.SIGKILL])
+                    self.assertTrue(all(sig == signal.SIGKILL for sig, _ in sent[2:]))
                     self.assertGreaterEqual(sent[0][1], 2, "missing metadata shortened the command deadline")
+                    self.assertGreaterEqual(sent[1][1] - sent[0][1], 3, "cleanup shortened the termination grace")
                     self.assertEqual(spawned[0].returncode, -signal.SIGKILL)
                 self.assertLess(time.monotonic() - started, 9)
             finally:
@@ -936,7 +942,9 @@ class ReviewRegressionTests(unittest.TestCase):
         self.exercise_initialization_failure(KeyboardInterrupt())
 
     def test_initial_missing_metadata_times_out_and_reaps_term_ignoring_child(self):
-        self.exercise_initialization_failure(None)
+        for deferred_kills in (0, 2):
+            with self.subTest(deferred_kills=deferred_kills):
+                self.exercise_initialization_failure(None, deferred_kills=deferred_kills)
 
 
 class ExitTransitionTests(unittest.TestCase):

--- a/Sources/CodexBarCore/Providers/Manus/ManusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Manus/ManusUsageFetcher.swift
@@ -55,6 +55,9 @@ public struct ManusCreditsResponse: Decodable, Sendable {
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard container.allKeys.contains(where: { $0 != .nextRefreshTime && $0 != .refreshInterval }) else {
+            throw ManusAPIError.parseFailed("response missing expected credits fields")
+        }
         self.totalCredits = container.decodeLossyDoubleIfPresent(forKey: .totalCredits) ?? 0
         self.freeCredits = container.decodeLossyDoubleIfPresent(forKey: .freeCredits) ?? 0
         self.periodicCredits = container.decodeLossyDoubleIfPresent(forKey: .periodicCredits) ?? 0
@@ -127,36 +130,7 @@ public enum ManusUsageFetcher {
     }
 
     public static func parseResponse(_ data: Data) throws -> ManusCreditsResponse {
-        let decoder = JSONDecoder()
-
-        // Try envelope first — the direct decoder defaults missing fields to 0,
-        // so it would "succeed" on wrapped payloads and silently return zero credits.
-        if let envelope = try? decoder.decode(ManusCreditsEnvelope.self, from: data),
-           let response = envelope.data ?? envelope.result ?? envelope.response ?? envelope.availableCredits
-        {
-            return response
-        }
-
-        let response = try decoder.decode(ManusCreditsResponse.self, from: data)
-        // The custom decoder defaults every numeric field to 0, so an unrelated JSON
-        // object (e.g. an error payload) would otherwise surface as a bogus zero-credit
-        // snapshot. Require at least one known credits key in the raw payload.
-        guard Self.payloadContainsCreditsField(data: data) else {
-            throw ManusAPIError.parseFailed("response missing expected credits fields")
-        }
-        return response
-    }
-
-    private static let expectedCreditsKeys: Set<String> = [
-        "totalCredits", "freeCredits", "periodicCredits", "addonCredits",
-        "refreshCredits", "maxRefreshCredits", "proMonthlyCredits", "eventCredits",
-    ]
-
-    private static func payloadContainsCreditsField(data: Data) -> Bool {
-        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return false
-        }
-        return !Self.expectedCreditsKeys.isDisjoint(with: object.keys)
+        try JSONDecoder().decode(ManusCreditsEnvelope.self, from: data).credits
     }
 }
 
@@ -261,10 +235,20 @@ public enum ManusAPIError: LocalizedError, Equatable, Sendable {
 }
 
 private struct ManusCreditsEnvelope: Decodable {
-    let data: ManusCreditsResponse?
-    let result: ManusCreditsResponse?
-    let response: ManusCreditsResponse?
-    let availableCredits: ManusCreditsResponse?
+    let credits: ManusCreditsResponse
+
+    private enum CodingKeys: String, CodingKey {
+        case data, result, response, availableCredits
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.credits = try container.decodeIfPresent(ManusCreditsResponse.self, forKey: .data) ??
+            container.decodeIfPresent(ManusCreditsResponse.self, forKey: .result) ??
+            container.decodeIfPresent(ManusCreditsResponse.self, forKey: .response) ??
+            container.decodeIfPresent(ManusCreditsResponse.self, forKey: .availableCredits) ??
+            ManusCreditsResponse(from: decoder)
+    }
 }
 
 extension KeyedDecodingContainer where K: CodingKey {

--- a/Sources/CodexBarCore/Resources/Plugins/manus.js
+++ b/Sources/CodexBarCore/Resources/Plugins/manus.js
@@ -20,7 +20,20 @@ defineProvider({
     });
     if (response.status !== 200) throw new Error(`Manus API error: HTTP ${response.status}`);
     const root = response.json || {};
-    const data = root.data || root.result || root.response || root.availableCredits || root;
+    const data = root.data ?? root.result ?? root.response ?? root.availableCredits ?? root;
+    const creditKeys = [
+      "totalCredits",
+      "freeCredits",
+      "periodicCredits",
+      "addonCredits",
+      "refreshCredits",
+      "maxRefreshCredits",
+      "proMonthlyCredits",
+      "eventCredits",
+    ];
+    if (!creditKeys.some((key) => Object.prototype.hasOwnProperty.call(data, key))) {
+      throw new Error("Manus response missing expected credits fields");
+    }
     const number = (key) => Number(data[key] || 0);
     const total = number("totalCredits");
     const free = number("freeCredits");

--- a/Tests/CodexBarTests/ManusProviderTests.swift
+++ b/Tests/CodexBarTests/ManusProviderTests.swift
@@ -270,12 +270,39 @@ struct ManusProviderTests {
         #expect(snapshot.secondary?.resetDescription == "Daily: 0 / 300")
     }
 
-    @Test
-    func `parse response rejects payload without credits fields`() {
-        let data = Data(#"{"error":"unauthorized","message":"session expired"}"#.utf8)
+    @Test(arguments: ["", "data", "result", "response", "availableCredits"], [
+        "{}",
+        #"{"error":"unauthorized","message":"session expired"}"#,
+        #"{"nextRefreshTime":"2026-04-13T00:00:00Z","refreshInterval":"daily"}"#,
+    ])
+    func `parse response rejects payload without credits fields`(envelope: String, payload: String) {
+        let json = envelope.isEmpty ? payload : "{\"\(envelope)\":\(payload)}"
+        let data = Data(json.utf8)
 
-        #expect(throws: ManusAPIError.self) {
+        #expect(throws: ManusAPIError.parseFailed("response missing expected credits fields")) {
             try ManusUsageFetcher.parseResponse(data)
+        }
+    }
+
+    @Test(arguments: ["", "data", "result", "response", "availableCredits"], [
+        "totalCredits", "freeCredits", "periodicCredits", "addonCredits",
+        "refreshCredits", "maxRefreshCredits", "proMonthlyCredits", "eventCredits",
+    ])
+    func `parse response preserves sparse zero credit payloads`(envelope: String, creditKey: String) throws {
+        let payload = "{\"\(creditKey)\":0}"
+        let json = envelope.isEmpty ? payload : "{\"\(envelope)\":\(payload)}"
+        let response = try ManusUsageFetcher.parseResponse(Data(json.utf8))
+        #expect(response.totalCredits == 0)
+        #expect(response.toUsageSnapshot(now: Self.now).identity?.loginMethod == "Balance: 0 credits")
+    }
+
+    @Test(arguments: [
+        #"{"data":{},"result":{"totalCredits":5}}"#,
+        #"{"data":{},"totalCredits":5}"#,
+    ])
+    func `parse response rejects the selected invalid envelope`(body: String) {
+        #expect(throws: ManusAPIError.parseFailed("response missing expected credits fields")) {
+            try ManusUsageFetcher.parseResponse(Data(body.utf8))
         }
     }
 

--- a/Tests/CodexBarTests/ProviderPluginExtensionParityTests.swift
+++ b/Tests/CodexBarTests/ProviderPluginExtensionParityTests.swift
@@ -33,6 +33,50 @@ struct ProviderPluginExtensionParityTests {
         Self.expectCoreParity(swift, script)
     }
 
+    @Test(arguments: [
+        #"{"data":{"totalCredits":5},"result":{}}"#,
+        #"{"data":null,"result":{"totalCredits":5},"response":{"refreshInterval":"daily"}}"#,
+        #"{"response":{"totalCredits":5},"availableCredits":{}}"#,
+    ])
+    func `Manus ignores unused lower priority envelopes`(body: String) async throws {
+        let swift = try ManusUsageFetcher.parseResponse(Data(body.utf8)).toUsageSnapshot()
+        let script = try await ProviderPluginRuntime(bundledPlugin: "manus", transport: Self.transport { _ in body })
+            .fetchUsage(cookieResolver: { _, _ in "session_id=fixture-session" })
+        #expect(swift.identity?.loginMethod == "Balance: 5 credits")
+        #expect(script.identity?.loginMethod == swift.identity?.loginMethod)
+    }
+
+    @Test(arguments: ["0", "false", #""""#])
+    func `Manus rejects selected primitive envelopes`(payload: String) async throws {
+        let body = "{\"data\":\(payload),\"result\":{\"totalCredits\":5}}"
+        #expect(throws: (any Error).self) {
+            try ManusUsageFetcher.parseResponse(Data(body.utf8))
+        }
+        let runtime = try ProviderPluginRuntime(bundledPlugin: "manus", transport: Self.transport { _ in body })
+        await #expect(throws: ProviderPluginError.self) {
+            try await runtime.fetchUsage(cookieResolver: { _, _ in "session_id=fixture-session" })
+        }
+    }
+
+    @Test(arguments: ["", "data", "result", "response", "availableCredits"])
+    func `Manus plugin rejects missing credits and preserves explicit zero`(envelope: String) async throws {
+        for payload in ["{}", #"{"error":"session expired"}"#, #"{"refreshInterval":"daily"}"#] {
+            let body = envelope.isEmpty ? payload : "{\"\(envelope)\":\(payload)}"
+            let runtime = try ProviderPluginRuntime(bundledPlugin: "manus", transport: Self.transport { _ in body })
+            do {
+                _ = try await runtime.fetchUsage(cookieResolver: { _, _ in "session_id=fixture-session" })
+                Issue.record("Expected missing credits failure for \(body)")
+            } catch {
+                #expect(error.localizedDescription.contains("missing expected credits fields"))
+            }
+        }
+        let payload = #"{"totalCredits":0}"#
+        let body = envelope.isEmpty ? payload : "{\"\(envelope)\":\(payload)}"
+        let runtime = try ProviderPluginRuntime(bundledPlugin: "manus", transport: Self.transport { _ in body })
+        let snapshot = try await runtime.fetchUsage(cookieResolver: { _, _ in "session_id=fixture-session" })
+        #expect(snapshot.identity?.loginMethod == "Balance: 0 credits")
+    }
+
     @Test
     func `Perplexity cookie plugin matches Swift generic projection`() async throws {
         let fixture = #"{"balance_cents":900,"renewal_date_ts":1893456000,"current_period_purchased_cents":200,"credit_grants":[{"type":"recurring","amount_cents":1000},{"type":"promotional","amount_cents":300,"expires_at_ts":1893456000},{"type":"purchased","amount_cents":200}],"total_usage_cents":1100}"#

--- a/docs/manus.md
+++ b/docs/manus.md
@@ -46,7 +46,7 @@ A single API endpoint is fetched with a bearer token derived from the `session_i
 
 Cookie domain: `manus.im`. Valid `session_id` cookies are cached in Keychain and reused until the session expires.
 
-The response parser tolerates both a direct object and common envelope shapes (`data` / `result` / `response` / `availableCredits`). Payloads missing all expected credit fields are rejected as a parse error rather than surfacing a misleading zero-credit snapshot.
+The native parser and optional cookie plugin tolerate both a direct object and common envelope shapes (`data` / `result` / `response` / `availableCredits`). The selected credits object must contain at least one credit field; empty, error-only, and timing-only objects are rejected rather than surfacing a misleading zero-credit snapshot. Sparse responses and explicit zero balances remain valid.
 
 ## Token accounts
 


### PR DESCRIPTION
Manus rejects an unwrapped object with no credit fields, but the same empty/error/timing-only object inside any supported envelope bypasses that check and becomes a successful “Balance: 0 credits” snapshot. The optional cookie plugin has the same false-zero behavior.

Validate credit-field presence in the shared native decoder before applying sparse defaults, and apply the same rule in the plugin. Decode only the first selected envelope so unused branches cannot reject valid credits and an invalid selected branch cannot fall through. Remove the redundant raw JSON parse and string-key helper. Direct payloads and all four envelopes retain sparse data, explicit zero balances, and existing numeric conversion. Production code is **net -3 lines**, including the plugin guard. Documentation and the Unreleased changelog are updated.

Counterproof: unchanged production fails 12 native assertions and 15 plugin assertions for missing credit fields. The repaired native/parser and plugin parity tests pass, including all eight native credit fields at zero and the existing populated-response projections. Both QuickJS and JavaScriptCore runs pass using contained HTTP/cookie fixtures, without real provider credentials. Independent review through P2 is clean after correcting unused-envelope and primitive-envelope precedence, with additional failing-before/passing-after regressions. `make check` passed. After merging current main, focused tests, `make check`, and independent review through P2 are clean. The final serial full suite passed 1,090 selections in 91 groups (1,037.6 seconds). Two subprocess-timing groups recovered on their single retries; no groups timed out. [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34679340349) passed every check.

Validation also exposed an unrelated test-fixture race: cleanup can repeat SIGKILL while its child’s exit is pending, but one regression expected exactly two signal calls. A deferred-delivery fixture reproduces the mismatch. The test now checks TERM-then-KILL ordering, only KILL retries, the full grace period, command deadline, final signal exit and confirmed reap. Production process cleanup is unchanged.
