### PR TITLE
fix(stepfun): preserve credit plans without balance data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Agent Sessions: add an opt-in setting to hide hosts whose session fetch failed, while keeping diagnostics visible by default (#3547). Thanks @warthurton!
 - Menu bar: align window and display coordinates so monitors above or below the primary display do not cause missed or false startup recovery.
 - Devin: honor hidden daily quotas even when the response includes daily usage, preserving weekly limits and extra balance (#3542). Thanks @dzienisz!
+- StepFun: keep credit plans without a populated balance from displaying exhausted five-hour and weekly quota bars, preserving genuine zero-credit balances and classic plan windows.
 - Grok: skip discarded local-history scans and version probes after terminal CLI billing failures, allowing fallback to start sooner (extracted from #3236). Thanks @Yuxin-Qiao!
 - Documentation: link the community-maintained CodexBar for Windows companion and AI Monitor USB desk display (#3525, #3544). Thanks @hinneslung and @tobymarks!
 

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
@@ -256,24 +256,19 @@ public struct StepFunUsageSnapshot: Sendable {
             accountOrganization: nil,
             loginMethod: loginMethod)
 
-        // Token Plan (Credit pool) carries no live 5h/weekly windows. Show the credit
-        // balance as the primary window and drop the meaningless 0%-left rate windows
-        // entirely. Coding Plan keeps its rolling windows and falls through below.
-        if self.isCreditPlan, let creditRate = self.creditLeftRate {
-            let creditUsedPercent = max(0, min(100, (1.0 - creditRate) * 100))
-            let resetDate = self.creditResetTime ?? Date.distantFuture
-            let resetDescription = UsageFormatter.resetDescription(from: resetDate)
-            // Populate windowMinutes so the monthly credit pool feeds the plan-utilization
-            // history + pace forecast, matching the Codex/Claude windows. Only when the credit
-            // pool has a real monthly reset (otherwise the pace projection is meaningless).
-            let creditWindowMinutes = self.creditResetTime == nil
-                ? nil
-                : ProviderPaceCapability.monthlyWindowSentinelMinutes
-            let creditWindow = RateWindow(
-                usedPercent: creditUsedPercent,
-                windowMinutes: creditWindowMinutes,
-                resetsAt: resetDate,
-                resetDescription: resetDescription)
+        // Credit plans have no rolling windows, even before a credit balance is available.
+        if self.isCreditPlan {
+            let creditWindow = self.creditLeftRate.map { creditRate in
+                let resetDate = self.creditResetTime ?? Date.distantFuture
+                // Only a real monthly reset can feed plan-utilization history and pace.
+                return RateWindow(
+                    usedPercent: max(0, min(100, (1.0 - creditRate) * 100)),
+                    windowMinutes: self.creditResetTime.map { _ in
+                        ProviderPaceCapability.monthlyWindowSentinelMinutes
+                    },
+                    resetsAt: resetDate,
+                    resetDescription: UsageFormatter.resetDescription(from: resetDate))
+            }
 
             return UsageSnapshot(
                 primary: creditWindow,

--- a/Tests/CodexBarTests/StepFunUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/StepFunUsageFetcherTests.swift
@@ -370,7 +370,13 @@ struct StepFunUsageFetcherParsingTests {
         {"status":1,"five_hour_usage_left_rate":0,"five_hour_usage_reset_time":"0",\
         "weekly_usage_left_rate":0,"weekly_usage_reset_time":"0","plan_family":1}
         """
-        #expect(try StepFunUsageFetcher._parseSnapshotForTesting(Data(creditFamily.utf8)).isCreditPlan == true)
+        let creditSnapshot = try StepFunUsageFetcher._parseSnapshotForTesting(Data(creditFamily.utf8))
+        #expect(creditSnapshot.isCreditPlan == true)
+        let usage = creditSnapshot.toUsageSnapshot()
+        #expect(usage.primary == nil)
+        #expect(usage.secondary == nil)
+        #expect(usage.identity?.providerID == .stepfun)
+        #expect(usage.updatedAt == creditSnapshot.updatedAt)
         #expect(try StepFunUsageFetcher._parseSnapshotForTesting(Data(windowFamily.utf8)).isCreditPlan == false)
     }
 

--- a/docs/stepfun.md
+++ b/docs/stepfun.md
@@ -57,6 +57,7 @@ authenticated via an Oasis-Token obtained through a username + password login fl
   - Without bucket sizes, uses `subscription_credit_left_rate` (or `topup_credit_left_rate` when
     no subscription rate exists); the independent percentages cannot be safely added.
   - No secondary window — credit plans don't have 5h/weekly rate-limit windows.
+  - Credit plans with no balance data yet display no quota windows until a credit balance is available.
   - `usedPercent = (1.0 - credit_left_rate) × 100`.
 - Plan name is shown as the `loginMethod` label in the menu card (e.g. "Plus").
 - When auth source is set to **Off**, no background refreshes occur.
@@ -72,4 +73,4 @@ authenticated via an Oasis-Token obtained through a username + password login fl
 - `Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift` (env var resolution)
 - `Sources/CodexBar/Providers/StepFun/StepFunProviderImplementation.swift` (settings fields + activation logic)
 - `Sources/CodexBar/Providers/StepFun/StepFunSettingsStore.swift` (SettingsStore extension)
-- `Tests/CodexBarTests/StepFunUsageFetcherTests.swift` (26 test cases)
+- `Tests/CodexBarTests/StepFunUsageFetcherTests.swift`


### PR DESCRIPTION
A new StepFun credit plan without a populated balance is already classified as a credit plan, but display conversion required both that classification and a credit rate. A missing rate therefore fell through to the classic plan path and turned zero placeholder fields into two exhausted five-hour/weekly bars with epoch resets.

Select the credit branch by plan classification, then map the optional balance into an optional primary bar. Preserve genuine zero-credit exhaustion, live classic windows, plan identity, update time, reset fallback, and monthly pace eligibility. Nearby simplification removes redundant conversion temporaries: production code is **net -5 lines**. Documentation and the Unreleased changelog are updated.

The existing missing-pool fixture now checks its projected snapshot: both bar assertions fail on unchanged production and pass with the fix. Focused StepFun tests and `make check` pass, including existing exhausted-credit and classic-window controls. Independent review through P2 is clean. The full local suite passed 1,079 selections in 90 groups, all first pass with no failures, retries, or timeouts (1,181.3 seconds). [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34678411043) passed with every check green. Proof uses contained parser/projection fixtures with no live credentials or provider calls.
