### PR TITLE
perf: speed up native test runs and menu fixture setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,10 +157,10 @@ jobs:
         run: ./Scripts/lint.sh lint-macos
 
       - name: Swift Test
-        # Keep small batches to reduce SwiftPM process overhead without returning to one aggregate run.
+        # Batch short suites; the runner isolates expensive suites without changing their deadlines.
         timeout-minutes: 50
         run: |
-          CODEXBAR_TEST_GROUP_SIZE=4 \
+          CODEXBAR_TEST_GROUP_SIZE=8 \
             CODEXBAR_TEST_SUITE_TIMEOUT=120 \
             CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES=0 \
             CODEXBAR_TEST_SHARD_INDEX=${{ matrix.shard-index }} \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Share provider settings bindings, cookie pickers, deferred link actions, cookie-source persistence, and typed cookie snapshots; replace the app's mutable provider registry with its immutable generated catalog.
 - Remove retired menu views, unused provider helpers, and no-op credential-loading hooks; reuse shared config accessors and simplify redundant menu and account state.
 - Tests: fix native macOS SwiftPM test launches when Sparkle is staged beside the test bundle (from #3584). Thanks @hhh2210!
-- Tests: add contained native focused and skip-build commands, preserve literal SwiftPM filters, isolate expensive suites to avoid batch retries, and restore CLI entry coverage on Apple-Silicon CI (#3584). Thanks @hhh2210!
+- Tests: add contained native focused and skip-build commands, avoid redundant menu-fixture config writes, isolate expensive suites without relaxing deadlines, and restore CLI entry coverage on Apple-Silicon CI (#3584). Thanks @hhh2210!
 - Consolidate status feeds, legacy Keychain string operations, API-token strategies, quota presentation, test-runner detection, and checked usage totals under shared owners while preserving provider-specific behavior.
 - Share browser-profile cookie merging, legacy cookie-file encoding, short-lived import caches, OpenCode web parsing, OneConsole quota projection, and terminal scan buffers without merging provider identities or authentication policies.
 - Centralize Chromium local-storage discovery, plugin management-auth policy, and Codex spend-limit number decoding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Share provider settings bindings, cookie pickers, deferred link actions, cookie-source persistence, and typed cookie snapshots; replace the app's mutable provider registry with its immutable generated catalog.
 - Remove retired menu views, unused provider helpers, and no-op credential-loading hooks; reuse shared config accessors and simplify redundant menu and account state.
 - Tests: fix native macOS SwiftPM test launches when Sparkle is staged beside the test bundle (from #3584). Thanks @hhh2210!
+- Tests: add contained native focused and skip-build commands, preserve literal SwiftPM filters, isolate expensive suites to avoid batch retries, and restore CLI entry coverage on Apple-Silicon CI (#3584). Thanks @hhh2210!
 - Consolidate status feeds, legacy Keychain string operations, API-token strategies, quota presentation, test-runner detection, and checked usage totals under shared owners while preserving provider-specific behavior.
 - Share browser-profile cookie merging, legacy cookie-file encoding, short-lived import caches, OpenCode web parsing, OneConsole quota projection, and terminal scan buffers without merging provider identities or authentication policies.
 - Centralize Chromium local-storage discovery, plugin management-auth policy, and Codex spend-limit number decoding.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 SHELL := /bin/bash
 
-.PHONY: build check docs-list format lint release restart start start-debug start-release stop test test-live test-tty
+# Keep FILTER literal, including Make expressions, shell syntax, and apostrophes.
+unexport FILTER
+test_filter_arg = $(if $(value FILTER),--filter '$(subst ','"'"',$(value FILTER))')
+
+.PHONY: build check docs-list format lint release restart start start-debug start-release stop test test-fast test-skip-build test-live test-tty
 
 start:
 	./Scripts/compile_and_run.sh
@@ -32,6 +36,12 @@ build:
 
 test:
 	./Scripts/test.sh
+
+test-fast:
+	./Scripts/test_fast.sh $(test_filter_arg)
+
+test-skip-build:
+	./Scripts/test_fast.sh --skip-build $(test_filter_arg)
 
 test-tty:
 	CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1 swift test --filter TTYIntegrationTests

--- a/Scripts/ci_swift_test_by_suite.py
+++ b/Scripts/ci_swift_test_by_suite.py
@@ -642,9 +642,33 @@ def print_timing_summary(stats: RunStats) -> None:
         print(f"- {field}: {value}", flush=True)
 
 
-def chunks(items: list[TestSelection], size: int) -> Iterable[list[TestSelection]]:
-    for index in range(0, len(items), size):
-        yield items[index : index + size]
+ISOLATED_SUITES = {
+    "CodexBarTests.CostUsageBoundedProgressTests",
+    "CodexBarTests.CostUsageCacheWideMigrationTests",
+    "CodexBarTests.CostUsageFairSchedulingTests",
+    "CodexBarTests.CostUsagePerformanceGateTests",
+    "CodexBarTests.KiroStatusProbeTests",
+    "CodexBarTests.StatusMenuTests",
+    "CodexBarTests.TTYIntegrationTests",
+}
+
+
+def test_groups(items: list[TestSelection], size: int) -> Iterable[list[TestSelection]]:
+    # Measured slow suites keep their own deadline instead of forcing a whole batch to retry.
+    pending: list[TestSelection] = []
+    for item in items:
+        if item.suite_name in ISOLATED_SUITES:
+            if pending:
+                yield pending
+                pending = []
+            yield [item]
+            continue
+        pending.append(item)
+        if len(pending) == size:
+            yield pending
+            pending = []
+    if pending:
+        yield pending
 
 
 def shard_groups(groups: list[list[TestSelection]], shard_index: int | None, shard_count: int | None) -> list[list[TestSelection]]:
@@ -664,19 +688,6 @@ def prioritized_suites(suites: list[TestSelection]) -> list[TestSelection]:
     ordered = [suite for name in priority for suite in suites if suite.suite_name == name]
     ordered.extend(suite for suite in suites if suite.suite_name not in priority)
     return ordered
-
-
-def filtered_suites_for_environment(suites: list[TestSelection]) -> list[TestSelection]:
-    if os.environ.get("GITHUB_ACTIONS") != "true" or sys.platform != "darwin":
-        return suites
-
-    # SwiftPM hangs before suite output for this executable-target suite on the Intel macOS runner.
-    # Linux CI still runs it in the full Swift test lane, and local macOS runs it directly.
-    skipped = {"CodexBarTests.CLIEntryTests"}
-    filtered = [suite for suite in suites if suite.suite_name not in skipped]
-    if len(filtered) != len(suites):
-        print(f"Skipping macOS CI-only suites: {', '.join(sorted(skipped))}", flush=True)
-    return filtered
 
 
 def filter_for(suites: list[TestSelection]) -> str:
@@ -730,12 +741,12 @@ def main() -> int:
     try:
         discovery_started = time.monotonic()
         try:
-            suites = prioritized_suites(filtered_suites_for_environment(swift_test_list(swift_command)))
+            suites = prioritized_suites(swift_test_list(swift_command))
         finally:
             stats.discovery_seconds = time.monotonic() - discovery_started
         stats.discovered_selections = len(suites)
 
-        suite_groups = list(chunks(suites, args.group_size))
+        suite_groups = list(test_groups(suites, args.group_size))
         try:
             suite_groups = shard_groups(suite_groups, args.shard_index, args.shard_count)
         except ValueError as error:

--- a/Scripts/run_swift_test.py
+++ b/Scripts/run_swift_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Run native SwiftPM selection with the shared test-process containment."""
+
+import os
+import sys
+
+from ci_swift_test_by_suite import containment_support_error, run_command
+
+
+def main() -> int:
+    try:
+        timeout = int(os.environ.get("CODEXBAR_TEST_NATIVE_TIMEOUT", "1800"))
+        if timeout <= 0:
+            raise ValueError
+    except ValueError:
+        print("CODEXBAR_TEST_NATIVE_TIMEOUT must be a positive integer", file=sys.stderr)
+        return 2
+
+    error = containment_support_error()
+    if error is not None:
+        print(error, file=sys.stderr)
+        return 2
+    return run_command(["swift", "test", "--no-parallel", *sys.argv[1:]], timeout=timeout)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        raise SystemExit(130) from None

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -9,16 +9,7 @@ RETRY_NON_TIMEOUT_FAILURES="${CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES:-1}"
 
 cd "${ROOT_DIR}"
 
-# Inherited by release-built tests and arbitrary CLI children as well as the test runner.
-export CODEXBAR_TEST_CODEX_FILE_ISOLATION=1
-unset CODEXBAR_TEST_CODEX_FILE_FIXTURES
-export CODEXBAR_TEST_SESSION_FILE_ISOLATION=1
-
-# Defense in depth: test processes also self-detect, but keep this explicit so runner changes cannot
-# expose the user's login Keychain. Deliberate isolated Keychain tests must opt in by setting the allow flag.
-if [[ "${CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS:-}" != "1" ]]; then
-  export CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1
-fi
+source "${ROOT_DIR}/Scripts/test_environment.sh"
 
 ARGS=(
   --group-size "${GROUP_SIZE}"

--- a/Scripts/test_environment.sh
+++ b/Scripts/test_environment.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Inherited by test runners and their CLI children.
+export CODEXBAR_TEST_CODEX_FILE_ISOLATION=1
+unset CODEXBAR_TEST_CODEX_FILE_FIXTURES
+export CODEXBAR_TEST_SESSION_FILE_ISOLATION=1
+
+if [[ "${CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS:-}" != "1" ]]; then
+  export CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1
+fi

--- a/Scripts/test_fast.sh
+++ b/Scripts/test_fast.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+source "${ROOT_DIR}/Scripts/test_environment.sh"
+unset MAKEFLAGS MFLAGS MAKEOVERRIDES
+
+exec python3 "${ROOT_DIR}/Scripts/run_swift_test.py" "$@"

--- a/Scripts/test_fast_runner.py
+++ b/Scripts/test_fast_runner.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Black-box coverage for native test arguments and shared isolation."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from ci_swift_test_by_suite import ISOLATED_SUITES, TestSelection, shard_groups, test_groups
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class NativeTestRunnerTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="codexbar-native-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.capture = self.directory / "arguments.json"
+        binary = self.directory / "swift"
+        binary.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, sys\n"
+            "from pathlib import Path\n"
+            "keys = ['CODEXBAR_TEST_CODEX_FILE_ISOLATION', 'CODEXBAR_TEST_SESSION_FILE_ISOLATION', "
+            "'CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS', 'CODEXBAR_TEST_CODEX_FILE_FIXTURES', "
+            "'DYLD_FRAMEWORK_PATH', 'MAKEFLAGS', 'MFLAGS', 'MAKEOVERRIDES']\n"
+            "Path(os.environ['NATIVE_TEST_CAPTURE']).write_text(json.dumps("
+            "{'arguments': sys.argv[1:], 'environment': {key: os.environ.get(key) for key in keys}}))\n"
+            "if sys.argv[1:] == ['test', 'list']: print('CodexBarTests.FixtureTests/example()')\n"
+            "raise SystemExit(int(os.environ.get('NATIVE_TEST_EXIT', '0')))\n",
+            encoding="utf-8",
+        )
+        binary.chmod(0o755)
+        self.environment = os.environ.copy()
+        self.environment.update({
+            "PATH": f"{self.directory}:{os.environ['PATH']}",
+            "NATIVE_TEST_CAPTURE": str(self.capture),
+            "CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS": "0",
+            "CODEXBAR_TEST_CODEX_FILE_FIXTURES": "must-not-be-inherited",
+            "CODEXBAR_TEST_NATIVE_TIMEOUT": "10",
+        })
+        self.environment.pop("CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS", None)
+        self.environment.pop("DYLD_FRAMEWORK_PATH", None)
+
+    def run_command(self, arguments):
+        return subprocess.run(
+            arguments, cwd=ROOT, env=self.environment, text=True,
+            capture_output=True, timeout=20,
+        )
+
+    def test_native_arguments_and_repeated_filters_remain_literal(self):
+        filters = ["(?<suite>AdaptiveRefreshPolicyTests)", r"Suite/has `spaces` and \\slashes"]
+        arguments = ["--skip-build", "--filter", filters[0], "--filter", filters[1],
+                     "--scratch-path", str(self.directory / "path with spaces"), "--parallel"]
+        result = self.run_command(["bash", str(ROOT / "Scripts/test_fast.sh"), *arguments])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        captured = json.loads(self.capture.read_text())
+        self.assertEqual(captured["arguments"], ["test", "--no-parallel", *arguments])
+        self.assertEqual(captured["environment"], {
+            "CODEXBAR_TEST_CODEX_FILE_ISOLATION": "1",
+            "CODEXBAR_TEST_SESSION_FILE_ISOLATION": "1",
+            "CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS": "1",
+            "CODEXBAR_TEST_CODEX_FILE_FIXTURES": None,
+            "DYLD_FRAMEWORK_PATH": None,
+            "MAKEFLAGS": None,
+            "MFLAGS": None,
+            "MAKEOVERRIDES": None,
+        })
+
+    def test_make_filters_cannot_execute_make_or_shell_expressions(self):
+        sentinel = self.directory / "must-not-exist"
+        value = f"(?<suite>Alpha)|`touch {sentinel}`|$(touch {sentinel})|$(shell touch {sentinel})|'quoted'"
+        for target, prefix in [("test-fast", []), ("test-skip-build", ["--skip-build"])]:
+            with self.subTest(target=target):
+                result = self.run_command(["make", "-s", target, f"FILTER={value}"])
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertFalse(sentinel.exists())
+                self.assertEqual(json.loads(self.capture.read_text())["arguments"],
+                                 ["test", "--no-parallel", *prefix, "--filter", value])
+
+    def test_native_exit_code_is_preserved(self):
+        self.environment["NATIVE_TEST_EXIT"] = "23"
+        result = self.run_command(["bash", str(ROOT / "Scripts/test_fast.sh"), "--filter", "Example"])
+        self.assertEqual(result.returncode, 23, result.stderr)
+
+    def test_invalid_deadline_fails_before_launch(self):
+        for value in ["0", "-1", "invalid"]:
+            with self.subTest(value=value):
+                self.environment["CODEXBAR_TEST_NATIVE_TIMEOUT"] = value
+                result = self.run_command(["bash", str(ROOT / "Scripts/test_fast.sh"), "--filter", "Example"])
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("positive integer", result.stderr)
+                self.assertFalse(self.capture.exists())
+
+    def test_explicit_keychain_opt_in_retains_existing_policy(self):
+        self.environment["CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"] = "1"
+        for runner in ["test.sh", "test_fast.sh"]:
+            with self.subTest(runner=runner):
+                result = self.run_command(["bash", str(ROOT / "Scripts" / runner)])
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIsNone(json.loads(self.capture.read_text())["environment"]["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"])
+
+    def test_both_runners_override_inherited_unsafe_test_environment(self):
+        self.environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"] = "0"
+        for runner in ["test.sh", "test_fast.sh"]:
+            with self.subTest(runner=runner):
+                result = self.run_command(["bash", str(ROOT / "Scripts" / runner)])
+                self.assertEqual(result.returncode, 0, result.stderr)
+                environment = json.loads(self.capture.read_text())["environment"]
+                self.assertEqual(environment["CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS"], "1")
+                self.assertEqual(environment["CODEXBAR_TEST_CODEX_FILE_ISOLATION"], "1")
+                self.assertEqual(environment["CODEXBAR_TEST_SESSION_FILE_ISOLATION"], "1")
+                self.assertIsNone(environment["CODEXBAR_TEST_CODEX_FILE_FIXTURES"])
+
+
+class TestGroupTests(unittest.TestCase):
+    def test_expensive_suites_keep_their_own_deadline_without_losing_selections(self):
+        names = ["CodexBarTests.Before", *sorted(ISOLATED_SUITES), "CodexBarTests.After"]
+        selections = [TestSelection(name, f"^{name}/", name) for name in names]
+        for size in [1, 4, 8, 12]:
+            with self.subTest(size=size):
+                groups = list(test_groups(selections, size))
+                self.assertEqual([item for group in groups for item in group], selections)
+                self.assertTrue(all(0 < len(group) <= size for group in groups))
+                for group in groups:
+                    if any(item.suite_name in ISOLATED_SUITES for item in group):
+                        self.assertEqual(len(group), 1)
+                sharded = [item for shard in range(2)
+                           for group in shard_groups(groups, shard, 2) for item in group]
+                self.assertCountEqual(sharded, selections)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/test_swift_test_sharding.sh
+++ b/Scripts/test_swift_test_sharding.sh
@@ -276,6 +276,7 @@ grep -Fq "Recovered SwiftPM Sparkle test runtime; retrying discovery once." \
   "${TEMP_DIR}/sparkle-recovery.log"
 unset FAKE_SWIFT_BIN_PATH
 
+python3 "${ROOT_DIR}/Scripts/test_fast_runner.py"
 python3 "${ROOT_DIR}/Scripts/test_swift_test_process_cleanup.py"
 
 echo "Swift test sharding tests passed."

--- a/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
@@ -21,10 +21,16 @@ struct KeychainPromptSafetyAuditTests {
 
     @Test
     func `default test runner explicitly suppresses real keychain access`() throws {
-        let script = try Self.readRepoFile("Scripts/test.sh")
+        let script = try Self.readRepoFile("Scripts/test_environment.sh")
 
         #expect(script.contains("CODEXBAR_ALLOW_TEST_KEYCHAIN_ACCESS"))
         #expect(script.contains("export CODEXBAR_SUPPRESS_TEST_KEYCHAIN_ACCESS=1"))
+        for runner in ["Scripts/test.sh", "Scripts/test_fast.sh"] {
+            let source = try Self.readRepoFile(runner)
+            let environment = try #require(source.range(of: "source \"${ROOT_DIR}/Scripts/test_environment.sh\""))
+            let launch = try #require(source.range(of: "exec python3"))
+            #expect(environment.upperBound < launch.lowerBound)
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -212,12 +212,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            if let metadata = registry.metadata[provider] {
-                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
-            }
-        }
+        enableTestProviders([.codex], settings: settings)
 
         let controller = self.makeRecyclingController(settings: settings)
         defer { controller.releaseStatusItemsForTesting() }
@@ -250,16 +245,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
         settings.mergedMenuLastSelectedWasOverview = false
-        let registry = ProviderRegistry.shared
-        let enabled: Set<UsageProvider> = [.codex, .claude]
-        for provider in UsageProvider.allCases {
-            if let metadata = registry.metadata[provider] {
-                settings.setProviderEnabled(
-                    provider: provider,
-                    metadata: metadata,
-                    enabled: enabled.contains(provider))
-            }
-        }
+        enableTestProviders([.codex, .claude], settings: settings)
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
             store: store,

--- a/Tests/CodexBarTests/ProviderSelectionFixtureTests.swift
+++ b/Tests/CodexBarTests/ProviderSelectionFixtureTests.swift
@@ -1,0 +1,61 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct ProviderSelectionFixtureTests {
+    @Test(arguments: [nil, .codex, .claude, .gemini] as [ProviderInstanceID?])
+    func `fixture selection preserves setter results and persisted fields`(_ selection: ProviderInstanceID?) throws {
+        var config = testConfigWithAllProvidersDisabled()
+        for index in config.providers.indices {
+            switch config.providers[index].id {
+            case .codex:
+                config.providers[index].enabled = nil
+                config.providers[index].apiKey = "fixture-key"
+            case .claude:
+                config.providers[index].enabled = nil
+                config.providers[index].extrasEnabled = true
+            default: break
+            }
+        }
+        let original = testSettingsStore(
+            suiteName: "provider-fixture-original", userDefaults: InMemoryUserDefaults(), config: config)
+        let arranged = testSettingsStore(
+            suiteName: "provider-fixture-arranged", userDefaults: InMemoryUserDefaults(), config: config)
+        original.selectedMenuProvider = selection
+        arranged.selectedMenuProvider = selection
+        let metadata = ProviderRegistry.shared.metadata
+        // Other entries already have explicit false values; cover each distinct transition without repeated disk
+        // writes.
+        for provider in [UsageProvider.codex, .claude, .zai, .gemini] {
+            let value = try #require(metadata[provider])
+            original.setProviderEnabled(
+                provider: provider, metadata: value, enabled: provider == .codex || provider == .zai)
+        }
+
+        enableTestProviders([.codex, .zai], settings: arranged)
+
+        #expect(arranged.selectedMenuProvider == original.selectedMenuProvider)
+        #expect(arranged.providerEnablement == original.providerEnablement)
+        let originalConfig = try #require(try original.configStore.load())
+        let arrangedConfig = try #require(try arranged.configStore.load())
+        #expect(arrangedConfig.providerConfig(for: .codex)?.apiKey == "fixture-key")
+        #expect(arrangedConfig.providerConfig(for: .claude)?.extrasEnabled == true)
+        let originalData = try original.configStore.encodedData(for: originalConfig)
+        let arrangedData = try arranged.configStore.encodedData(for: arrangedConfig)
+        #expect(arrangedData == originalData)
+    }
+
+    @Test
+    func `arranging unchanged unselected providers does not repeat config work`() {
+        let settings = testSettingsStore(suiteName: "provider-fixture-work", userDefaults: InMemoryUserDefaults())
+        settings.selectedMenuProvider = nil
+        enableTestProviders([.codex], settings: settings)
+        let revision = settings.configRevision
+
+        enableTestProviders([.codex], settings: settings)
+
+        #expect(settings.configRevision == revision)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
@@ -37,12 +37,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            if let metadata = registry.metadata[provider] {
-                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
-            }
-        }
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -88,12 +83,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            if let metadata = registry.metadata[provider] {
-                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
-            }
-        }
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -150,12 +140,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            if let metadata = registry.metadata[provider] {
-                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
-            }
-        }
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -263,12 +248,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            if let metadata = registry.metadata[provider] {
-                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
-            }
-        }
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(

--- a/Tests/CodexBarTests/StatusMenuCostSummaryDisplayStyleTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCostSummaryDisplayStyleTests.swift
@@ -18,14 +18,7 @@ extension StatusMenuTests {
             settings.costUsageEnabled = true
             settings.costSummaryDisplayStyle = style
 
-            let registry = ProviderRegistry.shared
-            for provider in UsageProvider.allCases {
-                guard let metadata = registry.metadata[provider] else { continue }
-                settings.setProviderEnabled(
-                    provider: provider,
-                    metadata: metadata,
-                    enabled: provider == .codex)
-            }
+            enableTestProviders([.codex], settings: settings)
 
             let fetcher = UsageFetcher()
             let store = UsageStore(

--- a/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
@@ -42,11 +42,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
-        }
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -292,14 +288,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(
-                provider: provider,
-                metadata: metadata,
-                enabled: provider == .codex || provider == .claude)
-        }
+        enableTestProviders([.codex, .claude], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(

--- a/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
@@ -12,7 +12,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         var providerRefreshCount = 0
@@ -67,7 +67,7 @@ extension StatusMenuTests {
         settings.refreshAllProvidersOnMenuOpen = true
         // Enable several providers; only the available ones land in background work. The
         // assertion below compares against that resolved set, so it stays robust regardless.
-        self.enableProvidersForInstantOpenTesting([.codex, .claude, .factory], settings: settings)
+        enableTestProviders([.codex, .claude, .factory], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         // Give every enabled provider a fresh, non-stale snapshot so the ONLY reason to refresh on
@@ -134,7 +134,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.refreshAllProvidersOnMenuOpen = false
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         var providerRefreshCount = 0
@@ -180,7 +180,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -225,7 +225,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -290,7 +290,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         var providerRefreshCount = 0
@@ -357,7 +357,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -425,7 +425,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(
@@ -467,7 +467,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
         settings.mergedMenuLastSelectedWasOverview = true
-        self.enableProvidersForInstantOpenTesting([.codex, .claude], settings: settings)
+        enableTestProviders([.codex, .claude], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(
@@ -513,7 +513,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
         settings.multiAccountMenuLayout = .stacked
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(
@@ -592,7 +592,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -633,7 +633,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -678,7 +678,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -731,7 +731,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -786,7 +786,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableProvidersForInstantOpenTesting([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(
@@ -829,7 +829,7 @@ extension StatusMenuTests {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let refreshGate = BlockingInstantOpenProviderRefresh()
@@ -872,7 +872,7 @@ extension StatusMenuTests {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let refreshGate = BlockingInstantOpenProviderRefresh()
@@ -911,7 +911,7 @@ extension StatusMenuTests {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
-        self.enableProvidersForInstantOpenTesting([.claude], settings: settings)
+        enableTestProviders([.claude], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let refreshes = OrderedInstantOpenProviderRefresh()
@@ -972,7 +972,7 @@ extension StatusMenuTests {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
-        self.enableProvidersForInstantOpenTesting([.stepfun], settings: settings)
+        enableTestProviders([.stepfun], settings: settings)
         settings.stepfunToken = "initial-token"
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
@@ -1023,7 +1023,7 @@ extension StatusMenuTests {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
-        self.enableProvidersForInstantOpenTesting([.stepfun], settings: settings)
+        enableTestProviders([.stepfun], settings: settings)
         settings.stepfunToken = "initial-token"
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
@@ -1069,7 +1069,7 @@ extension StatusMenuTests {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let refreshGate = BlockingInstantOpenProviderRefresh()
@@ -1098,7 +1098,7 @@ extension StatusMenuTests {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let refreshGate = BlockingInstantOpenProviderRefresh()
@@ -1136,7 +1136,7 @@ extension StatusMenuTests {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(
@@ -1174,7 +1174,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableProvidersForInstantOpenTesting([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -1216,7 +1216,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableProvidersForInstantOpenTesting([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -1264,7 +1264,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
         settings.mergedMenuLastSelectedWasOverview = true
-        self.enableProvidersForInstantOpenTesting([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -1298,7 +1298,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
         settings.mergedMenuLastSelectedWasOverview = true
-        self.enableProvidersForInstantOpenTesting([.codex, .openai], settings: settings)
+        enableTestProviders([.codex, .openai], settings: settings)
         settings.updateProviderConfig(provider: .openai) { config in
             config.apiKey = "test-openai-key"
         }
@@ -1346,7 +1346,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -1405,7 +1405,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnlyCodexForInstantOpenTesting(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -1466,10 +1466,6 @@ extension StatusMenuTests {
         #expect(!controller.deferredMenuInteractionRefreshPending)
     }
 
-    private func enableOnlyCodexForInstantOpenTesting(_ settings: SettingsStore) {
-        self.enableProvidersForInstantOpenTesting([.codex], settings: settings)
-    }
-
     private func instantOpenSnapshot(
         email: String,
         provider: UsageProvider = .codex,
@@ -1488,20 +1484,6 @@ extension StatusMenuTests {
                 accountEmail: email,
                 accountOrganization: nil,
                 loginMethod: "ChatGPT"))
-    }
-
-    private func enableProvidersForInstantOpenTesting(
-        _ enabledProviders: Set<UsageProvider>,
-        settings: SettingsStore)
-    {
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(
-                provider: provider,
-                metadata: metadata,
-                enabled: enabledProviders.contains(provider))
-        }
     }
 }
 

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -69,7 +69,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -136,7 +136,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -193,7 +193,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -238,7 +238,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -292,7 +292,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -341,7 +341,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -379,7 +379,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -423,7 +423,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -465,7 +465,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -506,7 +506,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -878,7 +878,7 @@ extension StatusMenuTests {
         settings.openAIWebAccessEnabled = true
         settings.openAIWebBatterySaverEnabled = true
         settings.codexCookieSource = .auto
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store.openAIDashboard = nil
@@ -939,7 +939,7 @@ extension StatusMenuTests {
         settings.openAIWebAccessEnabled = true
         settings.openAIWebBatterySaverEnabled = true
         settings.codexCookieSource = .auto
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store.openAIDashboard = nil
@@ -990,7 +990,7 @@ extension StatusMenuTests {
         settings.openAIWebAccessEnabled = true
         settings.openAIWebBatterySaverEnabled = true
         settings.codexCookieSource = .auto
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store.openAIDashboard = nil
@@ -1040,7 +1040,7 @@ extension StatusMenuTests {
         settings.openAIWebAccessEnabled = true
         settings.openAIWebBatterySaverEnabled = true
         settings.codexCookieSource = .auto
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -1097,7 +1097,7 @@ extension StatusMenuTests {
         settings.openAIWebAccessEnabled = true
         settings.openAIWebBatterySaverEnabled = true
         settings.codexCookieSource = .auto
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(nil, provider: .codex)
@@ -1159,7 +1159,7 @@ extension StatusMenuTests {
         settings.openAIWebAccessEnabled = true
         settings.openAIWebBatterySaverEnabled = true
         settings.codexCookieSource = .auto
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store.openAIDashboard = self.makeOpenAIDashboard(dailyBreakdown: [], updatedAt: Date())
@@ -1214,7 +1214,7 @@ extension StatusMenuTests {
         settings.openAIWebAccessEnabled = true
         settings.openAIWebBatterySaverEnabled = true
         settings.codexCookieSource = .auto
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let now = Date()
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
@@ -1256,7 +1256,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.showOptionalCreditsAndExtraUsage = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let now = Date()
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: true)
@@ -1308,7 +1308,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.showOptionalCreditsAndExtraUsage = true
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let now = Date(timeIntervalSince1970: 100)
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: true)
@@ -1363,7 +1363,7 @@ extension StatusMenuTests {
         settings.mergeIcons = false
         settings.costUsageEnabled = true
         settings.costSummaryDisplayStyle = .both
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -1407,7 +1407,7 @@ extension StatusMenuTests {
         settings.mergeIcons = false
         settings.costUsageEnabled = true
         settings.costSummaryDisplayStyle = .both
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setTokenSnapshotForTesting(
@@ -1463,7 +1463,7 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let controller = StatusItemController(
@@ -1510,7 +1510,7 @@ extension StatusMenuTests {
         settings.mergeIcons = false
         settings.openAIWebAccessEnabled = true
         settings.codexCookieSource = .auto
-        self.enableOnlyCodex(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let now = Date()
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
@@ -1546,14 +1546,6 @@ extension StatusMenuTests {
         #expect(controller.menuVersions[key] == openedVersion)
 
         await self.closeMenuAndWaitUntilFresh(controller, menu: menu, key: key)
-    }
-
-    private func enableOnlyCodex(_ settings: SettingsStore) {
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
-        }
     }
 
     private func menuItem(in menu: NSMenu, id: String) -> NSMenuItem? {

--- a/Tests/CodexBarTests/StatusMenuOverviewSpendTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOverviewSpendTests.swift
@@ -72,10 +72,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.costUsageEnabled = false
         settings.codexLocalSessionCostLedgerEnabled = true
-        for provider in UsageProvider.allCases {
-            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
-        }
+        enableTestProviders([.codex], settings: settings)
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let now = Date(timeIntervalSince1970: 1_787_079_600)
         let configuration = SpendDashboardSource.configuration(settings: settings, store: store)
@@ -142,10 +139,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.costUsageEnabled = true
         let providers: [UsageProvider] = [.codex, .claude]
-        for provider in UsageProvider.allCases {
-            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: providers.contains(provider))
-        }
+        enableTestProviders(Set(providers), settings: settings)
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let now = Date(timeIntervalSince1970: 1_787_079_600)
         func input(id: String, provider: UsageProvider, cost: Double) -> SpendDashboardModel.ProviderInput {
@@ -232,10 +226,7 @@ extension StatusMenuTests {
         settings.costSummaryDisplayStyle = .both
         let selected: [UsageProvider] = [.openai, .claude, .gemini, .antigravity, .openrouter, .grok]
         settings.mergedOverviewSelectedProviders = selected
-        for provider in UsageProvider.allCases {
-            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: selected.contains(provider))
-        }
+        enableTestProviders(Set(selected), settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let now = Date(timeIntervalSince1970: 1_787_079_600)
@@ -305,10 +296,7 @@ extension StatusMenuTests {
             .grok,
             .codex,
         ]
-        for provider in UsageProvider.allCases {
-            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: connected.contains(provider))
-        }
+        enableTestProviders(Set(connected), settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let enabledRoster = store.enabledFirstPartyProvidersForDisplay()
@@ -420,12 +408,7 @@ extension StatusMenuTests {
         settings.costSummaryDisplayStyle = style
         settings.costUsageEnabled = costUsageEnabled
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .claude], settings: settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         let now = Date()

--- a/Tests/CodexBarTests/StatusMenuOverviewSubmenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOverviewSubmenuTests.swift
@@ -16,12 +16,7 @@ extension StatusMenuTests {
         settings.costUsageEnabled = true
         settings.costSummaryDisplayStyle = .both
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .openai || provider == .codex
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.openai, .codex], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -79,12 +74,7 @@ extension StatusMenuTests {
         // unconditionally preferring cost history the way mistral's Overview row does.
         settings.costSummaryDisplayStyle = .inlineSummary
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .opencodego || provider == .codex
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.opencodego, .codex], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -143,12 +133,7 @@ extension StatusMenuTests {
         settings.selectedMenuProvider = .claude
         settings.mergedMenuLastSelectedWasOverview = true
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .zai || provider == .claude
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.zai, .claude], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -219,12 +204,7 @@ extension StatusMenuTests {
         settings.selectedMenuProvider = .codex
         settings.mergedMenuLastSelectedWasOverview = true
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .cursor
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .cursor], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -293,12 +273,7 @@ extension StatusMenuTests {
         settings.selectedMenuProvider = .codex
         settings.mergedMenuLastSelectedWasOverview = true
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .cursor
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .cursor], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -134,13 +134,6 @@ struct StatusMenuPersistentRefreshTests {
         ]
     }
 
-    private func enableOnly(_ providers: Set<UsageProvider>, settings: SettingsStore) {
-        for provider in UsageProvider.allCases {
-            guard let metadata = ProviderRegistry.shared.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: providers.contains(provider))
-        }
-    }
-
     private static func makeTokenSnapshot() -> CostUsageTokenSnapshot {
         CostUsageTokenSnapshot(
             sessionTokens: 123,
@@ -436,7 +429,7 @@ struct StatusMenuPersistentRefreshTests {
     @Test
     func `refresh monitor publishes compatible core and pins it until final reconciliation`() throws {
         let settings = self.makeSettings()
-        self.enableOnly([.codex], settings: settings)
+        enableTestProviders([.codex], settings: settings)
         let controller = self.makeController(settings: settings)
         defer { controller.releaseStatusItemsForTesting() }
         let monitor = controller.menuCardRefreshMonitor
@@ -496,7 +489,7 @@ struct StatusMenuPersistentRefreshTests {
     @Test
     func `refresh monitor keeps incompatible core frozen until reconciliation`() throws {
         let settings = self.makeSettings()
-        self.enableOnly([.codex], settings: settings)
+        enableTestProviders([.codex], settings: settings)
         let controller = self.makeController(settings: settings)
         defer { controller.releaseStatusItemsForTesting() }
         let monitor = controller.menuCardRefreshMonitor
@@ -548,7 +541,7 @@ struct StatusMenuPersistentRefreshTests {
     @Test
     func `refresh monitor publishes compatible core error honestly`() throws {
         let settings = self.makeSettings()
-        self.enableOnly([.codex], settings: settings)
+        enableTestProviders([.codex], settings: settings)
         let controller = self.makeController(settings: settings)
         defer { controller.releaseStatusItemsForTesting() }
         let monitor = controller.menuCardRefreshMonitor
@@ -1003,7 +996,7 @@ extension StatusMenuPersistentRefreshTests {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnly([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
 
         let controller = self.makeController(settings: settings)
         let menu = try #require(controller.makeMenu(for: .claude) as? StatusItemMenu)
@@ -1049,7 +1042,7 @@ extension StatusMenuPersistentRefreshTests {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnly([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
 
         let controller = self.makeController(settings: settings)
         let menu = try #require(controller.makeMenu(for: .claude) as? StatusItemMenu)
@@ -1077,7 +1070,7 @@ extension StatusMenuPersistentRefreshTests {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnly([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
         settings.mergedMenuLastSelectedWasOverview = true
 
         let controller = self.makeController(settings: settings)
@@ -1116,7 +1109,7 @@ extension StatusMenuPersistentRefreshTests {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.statusChecksEnabled = true
-        self.enableOnly([.synthetic], settings: settings)
+        enableTestProviders([.synthetic], settings: settings)
 
         let controller = self.makeController(settings: settings)
         controller.store._test_providerRefreshOverride = { _ in }
@@ -1327,7 +1320,7 @@ extension StatusMenuPersistentRefreshTests {
         settings.costUsageEnabled = false
         settings.openAIWebAccessEnabled = false
         settings.codexCookieSource = .off
-        self.enableOnly([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
         let controller = self.makeController(settings: settings)
         let claudeStarted = ManualRefreshGate()
         let releaseClaude = ManualRefreshGate()
@@ -1364,7 +1357,7 @@ extension StatusMenuPersistentRefreshTests {
         settings.costUsageEnabled = true
         settings.openAIWebAccessEnabled = false
         settings.codexCookieSource = .off
-        self.enableOnly([.codex], settings: settings)
+        enableTestProviders([.codex], settings: settings)
         let controller = self.makeController(settings: settings)
         let tokenRefreshStarted = ManualRefreshGate()
         let releaseTokenRefresh = ManualRefreshGate()
@@ -1438,7 +1431,7 @@ extension StatusMenuPersistentRefreshTests {
             observedAt: Date(),
             identity: .emailOnly(normalizedEmail: "fixture@example.com"))
         settings.codexActiveSource = .liveSystem
-        self.enableOnly([.codex], settings: settings)
+        enableTestProviders([.codex], settings: settings)
         let account = AccountInfo(email: "fixture@example.com", plan: "pro")
         let controller = self.makeController(settings: settings, account: account)
         controller.store.accountInfoCache[.codex] = UsageStore.AccountInfoCacheEntry(
@@ -1538,7 +1531,7 @@ extension StatusMenuPersistentRefreshTests {
         settings.costUsageEnabled = true
         settings.openAIWebAccessEnabled = false
         settings.codexCookieSource = .off
-        self.enableOnly([.codex], settings: settings)
+        enableTestProviders([.codex], settings: settings)
         let controller = self.makeController(settings: settings)
         let tokenRefreshStarted = ManualRefreshGate()
         let releaseTokenRefresh = ManualRefreshGate()
@@ -1652,7 +1645,7 @@ extension StatusMenuPersistentRefreshTests {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        self.enableOnly([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
 
         let controller = self.makeController(settings: settings)
         let codexMenu = try #require(controller.makeMenu(for: .codex) as? StatusItemMenu)
@@ -1686,7 +1679,7 @@ extension StatusMenuPersistentRefreshTests {
         let settings = self.makeSettings()
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
-        self.enableOnly([.claude, .codex], settings: settings)
+        enableTestProviders([.claude, .codex], settings: settings)
         settings.mergedMenuLastSelectedWasOverview = true
 
         let controller = self.makeController(settings: settings)

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -18,7 +18,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.costUsageEnabled = true
-        self.enableOnlyCodexForReadinessBaseline(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let snapshotA = self.makeReadinessBaselineTokenSnapshot(
             sessionTokens: 111,
@@ -77,7 +77,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.costUsageEnabled = true
-        self.enableOnlyCodexForReadinessBaseline(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let snapshotA = self.makeReadinessBaselineTokenSnapshot(
             sessionTokens: 111,
@@ -136,7 +136,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
         settings.costUsageEnabled = true
-        self.enableOnlyCodexForReadinessBaseline(settings)
+        enableTestProviders([.codex], settings: settings)
         if let claudeMetadata = ProviderRegistry.shared.metadata[.claude] {
             settings.setProviderEnabled(provider: .claude, metadata: claudeMetadata, enabled: true)
         }
@@ -193,7 +193,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.costUsageEnabled = true
-        self.enableOnlyCodexForReadinessBaseline(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let snapshotA = self.makeReadinessBaselineTokenSnapshot(
             sessionTokens: 111,
@@ -254,7 +254,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.costUsageEnabled = true
-        self.enableOnlyCodexForReadinessBaseline(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let snapshotA = self.makeReadinessBaselineTokenSnapshot(
             sessionTokens: 111,
@@ -311,7 +311,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.costUsageEnabled = true
-        self.enableOnlyCodexForReadinessBaseline(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let snapshotA = self.makeReadinessBaselineTokenSnapshot(
             sessionTokens: 111,
@@ -367,7 +367,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.costUsageEnabled = true
-        self.enableOnlyCodexForReadinessBaseline(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let snapshotA = self.makeReadinessBaselineTokenSnapshot(
             sessionTokens: 111,
@@ -426,7 +426,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.costUsageEnabled = true
-        self.enableOnlyCodexForReadinessBaseline(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let snapshotA = self.makeReadinessBaselineTokenSnapshot(
             sessionTokens: 111,
@@ -492,7 +492,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.costUsageEnabled = true
-        self.enableOnlyCodexForReadinessBaseline(settings)
+        enableTestProviders([.codex], settings: settings)
 
         let snapshotA = self.makeReadinessBaselineTokenSnapshot(
             sessionTokens: 111,
@@ -554,7 +554,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
         settings.costUsageEnabled = true
-        self.enableProvidersForReadinessBaseline(settings, providers: [.claude, .codex])
+        enableTestProviders([.claude, .codex], settings: settings)
 
         let snapshotA = self.makeReadinessBaselineTokenSnapshot(
             sessionTokens: 111,
@@ -604,18 +604,6 @@ extension StatusMenuTests {
         #expect(controller.menuNeedsRefresh(codexMenu))
         #expect(controller.menuNeedsRefresh(claudeMenu))
         #expect(!controller.didMenuAdjunctReadinessChange())
-    }
-
-    private func enableOnlyCodexForReadinessBaseline(_ settings: SettingsStore) {
-        self.enableProvidersForReadinessBaseline(settings, providers: [.codex])
-    }
-
-    private func enableProvidersForReadinessBaseline(_ settings: SettingsStore, providers: Set<UsageProvider>) {
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: providers.contains(provider))
-        }
     }
 
     private func makeReadinessBaselineTokenSnapshot(

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -259,13 +259,7 @@ struct StatusMenuTests {
         settings.mergeIcons = true
         settings.selectedMenuProvider = nil
 
-        let registry = ProviderRegistry.shared
-        let selectedProviders: Set<UsageProvider> = [.codex, .claude]
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = selectedProviders.contains(provider)
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .claude], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -571,12 +565,7 @@ struct StatusMenuTests {
         settings.selectedMenuProvider = .codex
         settings.usageBarsShowUsed = false
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .claude], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -632,12 +621,7 @@ struct StatusMenuTests {
         settings.selectedMenuProvider = .claude
         settings.mergedMenuLastSelectedWasOverview = false
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .claude], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -668,12 +652,7 @@ struct StatusMenuTests {
         settings.selectedMenuProvider = .claude
         settings.mergedMenuLastSelectedWasOverview = false
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .claude], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -713,12 +692,7 @@ struct StatusMenuTests {
         settings.selectedMenuProvider = .codex
         settings.mergedMenuLastSelectedWasOverview = false
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .claude], settings: settings)
 
         let activeProviders: [UsageProvider] = [.codex, .claude]
         _ = settings.setMergedOverviewProviderSelection(
@@ -770,12 +744,7 @@ struct StatusMenuTests {
         settings.selectedMenuProvider = .codex
         settings.mergedMenuLastSelectedWasOverview = true
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude || provider == .cursor
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .claude, .cursor], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -828,11 +797,7 @@ extension StatusMenuTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
-        }
+        enableTestProviders([.codex], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -1549,14 +1514,7 @@ extension StatusMenuTests {
         settings.mergedMenuLastSelectedWasOverview = true
 
         let enabledProviders: Set<UsageProvider> = [.codex, .claude, .cursor, .opencode, .warp, .gemini]
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(
-                provider: provider,
-                metadata: metadata,
-                enabled: enabledProviders.contains(provider))
-        }
+        enableTestProviders(enabledProviders, settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -1586,12 +1544,7 @@ extension StatusMenuTests {
         settings.selectedMenuProvider = .claude
         settings.mergedMenuLastSelectedWasOverview = true
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude || provider == .cursor
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .claude, .cursor], settings: settings)
         _ = settings.setMergedOverviewProviderSelection(
             provider: .claude,
             isSelected: false,
@@ -1630,14 +1583,7 @@ extension StatusMenuTests {
         settings.mergedMenuLastSelectedWasOverview = true
         settings.mergedOverviewSelectedProviders = []
         let enabledProviders: Set<UsageProvider> = [.codex, .claude, .cursor, .opencode, .warp, .gemini, .grok]
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(
-                provider: provider,
-                metadata: metadata,
-                enabled: enabledProviders.contains(provider))
-        }
+        enableTestProviders(enabledProviders, settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -1676,12 +1622,7 @@ extension StatusMenuTests {
         settings.selectedMenuProvider = .codex
         settings.mergedMenuLastSelectedWasOverview = true
 
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
+        enableTestProviders([.codex, .claude], settings: settings)
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -260,6 +260,21 @@ func testSettingsStore(
         tokenAccountStore: tokenAccountStore)
 }
 
+/// Arrange provider selection without persisting every already-correct entry. Actions under test use the setter
+/// directly.
+@MainActor
+func enableTestProviders(_ enabledProviders: Set<UsageProvider>, settings: SettingsStore) {
+    let metadata = ProviderRegistry.shared.metadata
+    for provider in UsageProvider.allCases {
+        guard let providerMetadata = metadata[provider] else { continue }
+        let enabled = enabledProviders.contains(provider)
+        let isSelected = settings.selectedMenuProvider == provider.instanceID
+        guard settings.config.providerConfig(for: provider.instanceID)?.enabled != enabled || isSelected
+        else { continue }
+        settings.setProviderEnabled(provider: provider, metadata: providerMetadata, enabled: enabled)
+    }
+}
+
 #if os(macOS)
 @MainActor
 func testStatusBar() -> NSStatusBar {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -141,6 +141,23 @@ not establish the cause of a position that changes again after launch; that requ
 make test
 ```
 
+For focused iteration, use native SwiftPM filters with the same file/Keychain isolation and process containment:
+
+```bash
+make test-fast FILTER='AdaptiveRefreshPolicyTests'
+make test-skip-build FILTER='(?<suite>AdaptiveRefreshPolicyTests)'
+./Scripts/test_fast.sh --filter FirstSuite --filter SecondSuite --configuration debug
+```
+
+`FILTER` is passed literally, including Make/shell syntax and apostrophes. The script forwards all arguments to
+`swift test`; SwiftPM owns regex syntax and repeated-filter selection. Runs are serial by default and have a
+30-minute build-and-test deadline, configurable with `CODEXBAR_TEST_NATIVE_TIMEOUT`. An explicit `--skip-build` uses
+existing binaries. No framework search-path override is added.
+
+`make test` remains the complete sharded path. Measured expensive suites run in their own groups, retaining all
+selections and their deadlines while avoiding whole-batch retries. Apple-Silicon macOS CI includes the CLI entry suite;
+the former Intel-runner exclusion is retired.
+
 `make test` and `make check` require a `python3` that provides `os.waitid` with `WNOWAIT`. Some macOS Python
 builds, including Apple's `/usr/bin/python3`, do not provide it. The test runner then stops before its initial
 Swift discovery/build and names the interpreter path, its version, and the missing attributes. Earlier

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -238,6 +238,10 @@ reads after setup has closed each file. This avoids per-file atomic publication 
 without changing corpus contents or scan budgets. The shared atomic fixture writer remains available
 for replacement and publication tests.
 
+Menu fixtures use `enableTestProviders` to arrange their initial provider selection without repeatedly persisting
+already-correct config entries. The real setter still handles changed flags and selected-provider cleanup. Keep
+provider-toggle actions under test on the production setter; the fixture helper is for setup before observing changes.
+
 ### Cost scanner CPU regressions
 
 `CostUsageJsonl` finds complete physical LF spans with bounded libc `memchr` on Darwin, Glibc, and


### PR DESCRIPTION
Focused tests currently pay for the full sharded route, and full runs waste time rewriting already-correct provider configuration while arranging menu fixtures. Add native focused/skip-build commands and remove that redundant fixture work while keeping the default `make test` fully sharded.

`make test-fast FILTER='…'` and `make test-skip-build FILTER='…'` pass literal expressions directly to SwiftPM, including Make/shell syntax and native regex extensions. Both entry points share credential-file and Keychain isolation. Native runs use the existing audited process containment with a separate 1,800-second build-and-test deadline; sharded test deadlines and retry policy remain unchanged.

CI now groups eight short selections instead of four, isolates seven measured expensive suites, and again includes CLIEntryTests on macOS. Menu setup shares `enableTestProviders`: matching raw flags are skipped unless the provider is selected, while real setters retain change and selected-provider cleanup behavior. Actual toggle actions and every existing menu assertion remain intact.

Validation:

- Complete isolated Codex review through P2 passed; final `make check` passed with zero violations across 2,242 files.
- Live native named-capture filter: five tests passed. Repeated filters with native `--parallel`: eleven tests in two suites passed. Runner scripts are unchanged by the fixture follow-up. Commands: `./Scripts/test_fast.sh --filter '(?<suite>AdaptiveRefreshPolicyTests)'`; `./Scripts/test_fast.sh --skip-build --filter AdaptiveRefreshPolicyTests --filter AdaptiveReplayPolicyTests --parallel`.
- All 176 real menu tests passed in **27.296 seconds** with the same 180-second deadline that the old setup exceeded, including on an individual retry. Stack samples tied the earlier delay to synchronous atomic config writes during fixture setup.
- Fixture differential/work checks passed: two tests with four selection cases in 1.932 seconds. They compare complete persisted config, enablement and selection against representative production-setter transitions, preserve unrelated fields, and verify that repeated unchanged setup causes no extra config revisions.
- All 13 native Keychain safety-audit tests and seven runner contract tests passed. The source audit follows the shared environment owner and verifies both entry points source it before launch; execution tests verify unsafe inherited values are overridden.
- Exact-head [CI 34728751790](https://github.com/steipete/CodexBar/actions/runs/34728751790) passed both macOS test shards, Linux x64/arm64 tests, musl release build, lint, and the aggregate check.
- Local combined dependency + fixture validation attempted 76 of 93 groups: 74 passed first try and one cost-store batch recovered through 12 individual retries. It then stopped on two RPC initialization deadlines before the teardown assertions. The same six RPC tests passed alone in 6.001 seconds, while an exact-batch diagnostic reproduced a different initialization timeout. Those RPC sources and tests are unchanged from the landed Stage 1 baseline; the cause remains unresolved and is tracked for the separate bug stage. The remaining 17 groups are being checked separately against the unchanged inventory. This is not claimed as a green complete local run.
- The freshly built dependency-candidate CLI passed five additional synthetic stdin-close runs (0.141–0.529 seconds), returning the expected ordinary error without a signal abort. No real provider access was used.

Earlier validation caught and corrected a stale source-audit assertion after environment extraction. One unchanged Grok fixture hit its four-second initialization deadline; all nine scenarios passed the focused rerun and the independent dependency run. No assertion, deadline, or coverage was relaxed to handle either result.

The original proposal's Sparkle-linking repair already landed in #3588. This maintainer repair retains hhh2210's native-runner direction and human co-author credit.
