### PR TITLE
fix(test): resolve Sparkle for native test launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - Antigravity: suppress remote model variants that exactly mirror a known pool and reset, preserve distinct quota rows and their saved visibility, and prefer known usage over reset-only duplicates (#3583). Thanks @hhh2210!
 
+### Development
+- Tests: fix native macOS SwiftPM test launches when Sparkle is staged beside the test bundle (from #3584). Thanks @hhh2210!
+
 ## 0.60.0 — 2026-09-12
 
 ### Highlights

--- a/Package.swift
+++ b/Package.swift
@@ -221,7 +221,10 @@ let package = Package(
 
         targets.append(.testTarget(
             name: "CodexBarTests",
-            dependencies: ["CodexBar", "CodexBarCore", "CodexBarCLI", "CodexBarCostStoreCrashProbe", "CodexBarWidget"],
+            dependencies: [
+                "CodexBar", "CodexBarCore", "CodexBarCLI", "CodexBarCostStoreCrashProbe", "CodexBarWidget",
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
             path: "Tests",
             exclude: [
                 "AdaptiveReplayCLITests",
@@ -238,6 +241,10 @@ let package = Package(
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),
                 .enableExperimentalFeature("SwiftTesting"),
+            ],
+            linkerSettings: [
+                // XCTest's executable is three directories below its sibling framework products.
+                .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../.."]),
             ]))
         #endif
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -154,6 +154,10 @@ PATH="$(brew --prefix python@3.14)/libexec/bin:$PATH" make test
 
 `Scripts/test.sh --list-only` does not need process containment, but still invokes `swift test list`, which may build.
 
+The macOS test target explicitly links the existing Sparkle product and locates frameworks in the products directory
+beside its XCTest bundle. This supports native focused tests on fresh SwiftPM builds. The sharded runner retains its
+guarded runtime recovery for differing toolchain layouts, and `make test` remains the full validation path.
+
 Suite commands retain the default 180-second deadline, including SwiftPM startup and discovery.
 The runner reports elapsed time and owned PIDs every 30 seconds even when test output is buffered.
 It tracks process birth identities and descendants, including helpers that create separate process


### PR DESCRIPTION
A fresh native macOS SwiftPM test launch can fail before executing any tests because `CodexBarTests.xctest` cannot load `@rpath/Sparkle.framework/Versions/B/Sparkle`. The framework is staged in the products directory, while the test executable is three directories below it and lacks a runpath back to that directory.

The existing macOS test target now directly declares the already-pinned Sparkle product and includes that sibling-products runpath. The change is confined to test configuration, with development documentation and an Unreleased entry. This extracts the existing launch bug from #3584; the proposed fast-runner interface stays in that separate PR. Thanks @hhh2210.

Proof completed:
- Reproduced the missing-library failure on the baseline during a native focused test launch.
- A direct-dependency-only clean build still lacked the needed products-root runpath.
- With the runpath present, the first native launch passed all eight `RateWindowSyntheticPlaceholderTests`. No `DYLD_FRAMEWORK_PATH` override was supplied, and `PackageFrameworks/Sparkle.framework` was absent before and after the run.
- A subsequent incremental native run also passed those eight tests without the repair symlink.
- `make check` passed; independent review through P2 found no actionable findings.

Final validation: [exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34701074453) passed, including both full macOS test shards and all Linux builds. The first broad local run recovered one Claude version-counter timing failure and timed out in the existing cache-migration selection; a coordinated current-head isolated rerun of `CostUsageCacheWideMigrationTests` passed in 16.823 seconds with no retry or timeout. The earlier timeout remains recorded rather than being reported as a clean full local run. All local tests used synthetic HOME/defaults and the repository's Keychain/file-isolation flags. Existing sharded recovery, deadlines, and process containment are retained.
