### PR TITLE
fix(zai): preserve unavailable quota limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.60.1 — Unreleased
 
 ### Fixed
+- z.ai: keep missing quota limits unavailable instead of displaying 100% remaining, preserving real zero usage, plan details, and optional analytics.
 - Antigravity: suppress remote model variants that exactly mirror a known pool and reset, preserve distinct quota rows and their saved visibility, and prefer known usage over reset-only duplicates (#3583). Thanks @hhh2210!
 
 ### Development

--- a/Sources/CodexBarCore/Resources/Plugins/zai.js
+++ b/Sources/CodexBarCore/Resources/Plugins/zai.js
@@ -170,29 +170,28 @@ defineProvider({
       .sort((a, b) => (a.windowMinutes || Number.MAX_SAFE_INTEGER) - (b.windowMinutes || Number.MAX_SAFE_INTEGER));
     const timeLimit = limits.filter((item) => item.raw.type === "TIME_LIMIT").pop() || null;
     const tokenLimit = tokenLimits.length ? tokenLimits[tokenLimits.length - 1] : null;
-    const sessionLimit = tokenLimits.length >= 2 ? tokenLimits[0] : null;
-    const primaryLimit = sessionLimit || tokenLimit || timeLimit;
+    const primaryLimit = tokenLimits[0] || timeLimit;
     const result = {
-      primary: primaryLimit ? window(primaryLimit) : { usedPercent: 0 },
+      primary: primaryLimit ? window(primaryLimit) : null,
       identity: {},
       details: [{ title: "Quota details", rows: [] }],
     };
-    if (sessionLimit && tokenLimit) result.secondary = window(tokenLimit);
-    if ((tokenLimit || sessionLimit) && timeLimit) {
+    if (tokenLimits.length >= 2) result.secondary = window(tokenLimit);
+    if (tokenLimit && timeLimit) {
       result.extraWindows = [{ id: "zai-mcp", title: "MCP", window: window(timeLimit) }];
     }
     if (tokenLimit)
       result.details[0].rows.push(
         limitRow(tokenLimit.raw.type === "CREDIT_LIMIT" ? "Credit quota" : "Token quota", tokenLimit),
       );
-    if (sessionLimit)
+    if (tokenLimits.length >= 2)
       result.details[0].rows.push(
         limitRow(
-          sessionLimit.raw.type === "CREDIT_LIMIT" ? "Session credit quota" : "Session token quota",
-          sessionLimit,
+          primaryLimit.raw.type === "CREDIT_LIMIT" ? "Session credit quota" : "Session token quota",
+          primaryLimit,
         ),
       );
-    const hasCreditLimit = [tokenLimit, sessionLimit].some((item) => item && item.raw.type === "CREDIT_LIMIT");
+    const hasCreditLimit = [tokenLimit, primaryLimit].some((item) => item && item.raw.type === "CREDIT_LIMIT");
     if (hasCreditLimit) result.details[0].rows.push(quotaRateRow());
     if (timeLimit) {
       result.details[0].rows.push(limitRow("MCP quota", timeLimit));

--- a/Tests/CodexBarTests/ZaiProviderTests.swift
+++ b/Tests/CodexBarTests/ZaiProviderTests.swift
@@ -3,6 +3,45 @@ import Testing
 @testable import CodexBarCore
 
 struct ZaiProviderTests {
+    @Test(arguments: BundledPluginTestSupport.engines, [
+        "",
+        #"{"type":"FUTURE_LIMIT","unit":3,"number":5,"percentage":40}"#,
+    ])
+    func `missing recognized limits never fabricate unused quota`(
+        engine: ProviderPluginEngineKind,
+        limits: String) async throws
+    {
+        let fixture = #"""
+        {"code":200,"success":true,"data":{"planName":"Pro","limits":[\#(limits)]}}
+        """#
+        for analytics in [Self.emptyModelUsageFixture, Self.modelUsageFixture] {
+            let snapshot = try await Self.pluginSnapshot(
+                quotaFixture: fixture, modelUsageFixture: analytics, engine: engine)
+            #expect(snapshot.primary == nil)
+            #expect(snapshot.secondary == nil)
+            #expect(snapshot.extraRateWindows?.isEmpty != false)
+            #expect(snapshot.identity?.loginMethod == "Pro")
+            #expect(snapshot.details.map(\.title) == (analytics == Self.emptyModelUsageFixture
+                    ? ["Quota details"] : ["Quota details", "Hourly tokens", "Daily tokens"]))
+        }
+    }
+
+    @Test(arguments: BundledPluginTestSupport.engines, ["TOKENS_LIMIT", "CREDIT_LIMIT", "TIME_LIMIT"])
+    func `explicit zero usage remains a real quota window`(
+        engine: ProviderPluginEngineKind,
+        limitType: String) async throws
+    {
+        let fixture = #"""
+        {"code":200,"success":true,"data":{"limits":[
+          {"type":"\#(limitType)","unit":3,"number":5,"percentage":0}
+        ]}}
+        """#
+        let snapshot = try await Self.pluginSnapshot(quotaFixture: fixture, engine: engine)
+        #expect(snapshot.primary?.usedPercent == 0)
+        #expect(snapshot.primary?.windowMinutes == 300)
+        #expect(snapshot.secondary == nil)
+    }
+
     @Test(arguments: BundledPluginTestSupport.engines)
     func `unrenderable optional analytics preserve required quota`(engine: ProviderPluginEngineKind) async throws {
         for (count, name, label) in [

--- a/docs/zai.md
+++ b/docs/zai.md
@@ -142,6 +142,7 @@ Copy each value once, on one line. Multi-line or duplicated IDs can make the API
   - A single Coding Plan limit becomes primary. With multiple limits, the first becomes primary and the last becomes secondary after sorting by duration; unknown durations sort last.
   - `TIME_LIMIT` → a separate MCP lane when a Coding Plan window is available, otherwise the primary MCP window; never a fabricated monthly Coding Plan window.
 - Usage percentage:
+  - Empty or unrecognized quota limits remain unavailable; they never imply 0% used. Reported zero usage remains visible, and plan details and optional analytics are retained without a quota window.
   - An integer `percentage` is required. When a positive `usage` limit and a `currentValue` or `remaining` count are present, the counts determine the used percentage. The result is clamped to 0–100%.
 - Window duration:
   - Unit + number → minutes/hours/days.


### PR DESCRIPTION
Successful z.ai responses with empty or unrecognized quota limits were converted into a real zero-usage window, incorrectly showing 100% remaining. Preserve the absence of a quota measurement while retaining plan details and optional analytics. Explicitly reported zero usage remains visible.

Simplify primary quota selection to the first sorted Coding Plan limit, falling back to MCP. Existing secondary and extra-window behavior is retained. Production code is net negative by one line. This was found during the z.ai backlog review; it does not resolve the separate reset-timestamp report #2871.

Validation: an offline run of the actual plugin fails before the fix and passes afterward for empty and unknown-only responses. New native regressions exercise both plugin engines, analytics preservation, and genuine zero usage for token, credit, and MCP limits. All 33 focused native tests passed across JavaScriptCore and QuickJS. Formatting/lint and independent P0–P2 review passed. Full `make test` passed all 1,099 selections in 92 groups (three normal full-group retries recovered; no group timeouts). [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34705022221) passed, including both macOS shards and Linux x64/ARM64. Local verification used synthetic HOME and the repository credential-suppression flags with the native SwiftPM backend. No live credentials or provider requests are used.
