### PR TITLE
refactor: centralize quoted settings normalization

### DIFF
--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -213,7 +213,7 @@ extension CodexBarCLI {
             apiKey
         }
 
-        guard let value = Self.cleanConfigSecret(raw) else {
+        guard let value = SettingsValue.cleaned(raw) else {
             throw CLIArgumentError("Missing API key. Pass --api-key <key> or pipe it with --stdin.")
         }
         return value
@@ -270,8 +270,8 @@ extension CodexBarCLI {
         organizationID: String?,
         workspaceID: String?) throws -> ConfigAPIKeyAccountOptions?
     {
-        let cleanedLabel = Self.cleanConfigValue(label)
-        let cleanedScope = Self.cleanConfigValue(usageScope)
+        let cleanedLabel = SettingsValue.cleaned(label)
+        let cleanedScope = SettingsValue.cleaned(usageScope)
         let cleanedOrganizationID = try Self.cleanSingleLineConfigValue(
             organizationID,
             fieldName: "organization-id")
@@ -332,26 +332,8 @@ extension CodexBarCLI {
         }
     }
 
-    private static func cleanConfigSecret(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
-    }
-
-    private static func cleanConfigValue(_ raw: String?) -> String? {
-        guard let value = self.cleanConfigSecret(raw) else { return nil }
-        return value
-    }
-
     private static func cleanSingleLineConfigValue(_ raw: String?, fieldName: String) throws -> String? {
-        guard let value = self.cleanConfigValue(raw) else { return nil }
+        guard let value = SettingsValue.cleaned(raw) else { return nil }
         guard !value.contains(where: \.isNewline) else {
             throw CLIArgumentError("--\(fieldName) must be a single line.")
         }

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -236,27 +236,27 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     }
 
     public var sanitizedAPIKey: String? {
-        Self.clean(self.apiKey)
+        SettingsValue.cleaned(self.apiKey)
     }
 
     public var sanitizedSecretKey: String? {
-        Self.clean(self.secretKey)
+        SettingsValue.cleaned(self.secretKey)
     }
 
     public var sanitizedCookieHeader: String? {
-        Self.clean(self.cookieHeader)
+        SettingsValue.cleaned(self.cookieHeader)
     }
 
     public var sanitizedRegion: String? {
-        Self.clean(self.region)
+        SettingsValue.cleaned(self.region)
     }
 
     public var sanitizedWorkspaceID: String? {
-        Self.clean(self.workspaceID)
+        SettingsValue.cleaned(self.workspaceID)
     }
 
     public var sanitizedEnterpriseHost: String? {
-        Self.clean(self.enterpriseHost)
+        SettingsValue.cleaned(self.enterpriseHost)
     }
 
     public func sanitizedForDump() -> ProviderConfig {
@@ -277,19 +277,6 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
             copy.tokenAccounts = tokenAccounts.sanitizedForDump()
         }
         return copy
-    }
-
-    static func clean(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Config/SettingsValue.swift
+++ b/Sources/CodexBarCore/Config/SettingsValue.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+package enum SettingsValue {
+    package static func cleaned(_ raw: String?) -> String? {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value = String(value.dropFirst().dropLast())
+        }
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Sources/CodexBarCore/Providers/AiAnd/AiAndSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/AiAnd/AiAndSettingsReader.swift
@@ -6,19 +6,6 @@ public enum AiAndSettingsReader {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 }

--- a/Sources/CodexBarCore/Providers/AiAnd/AiAndUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/AiAnd/AiAndUsageFetcher.swift
@@ -87,7 +87,7 @@ public enum AiAndUsageFetcher {
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> AiAndUsageSnapshot
     {
-        guard let credential = AiAndSettingsReader.cleaned(rawCredential) else {
+        guard let credential = SettingsValue.cleaned(rawCredential) else {
             throw AiAndUsageError.notConfigured
         }
 

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
@@ -31,7 +31,7 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         for key in self.apiTokenEnvironmentKeys {
-            if let token = self.cleaned(environment[key]) { return token }
+            if let token = SettingsValue.cleaned(environment[key]) { return token }
         }
         return nil
     }
@@ -40,7 +40,7 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         self.endpointValidator.validatedHost(
-            self.cleaned(environment[self.hostKey]),
+            SettingsValue.cleaned(environment[self.hostKey]),
             policy: self.endpointOverrideHostPolicy(environment: environment))
     }
 
@@ -49,7 +49,7 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
     {
         let policy = self.endpointOverrideHostPolicy(environment: environment)
         return self.endpointOverrideKeys.first { key in
-            guard let value = self.cleaned(environment[key]) else { return false }
+            guard let value = SettingsValue.cleaned(environment[key]) else { return false }
             if key == Self.hostKey {
                 return self.endpointValidator.validatedHost(value, policy: policy) == nil
             }
@@ -60,38 +60,23 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
     public static func cookieHeader(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.cookieHeaderKey])
+        SettingsValue.cleaned(environment[self.cookieHeaderKey])
     }
 
     public static func quotaURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
         self.endpointValidator.validatedURL(
-            self.cleaned(environment[self.quotaURLKey]),
+            SettingsValue.cleaned(environment[self.quotaURLKey]),
             policy: self.endpointOverrideHostPolicy(environment: environment))
     }
 
     static func endpointOverrideHostPolicy(environment: [String: String]) -> ProviderEndpointOverrideValidator
     .HostPolicy {
-        guard let value = self.cleaned(environment[self.requireProviderEndpointOverridesKey])?.lowercased(),
+        guard let value = SettingsValue.cleaned(environment[self.requireProviderEndpointOverridesKey])?.lowercased(),
               ["1", "true", "yes", "on"].contains(value)
         else { return .allowAnyHTTPSHost }
         return .providerOwnedOnly
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
@@ -287,7 +287,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
     }
 
     static func url(from rawHost: String, region: AlibabaCodingPlanAPIRegion) -> URL? {
-        let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
+        let cleaned = SettingsValue.cleaned(rawHost)
         guard let cleaned else { return nil }
 
         let base = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: cleaned)
@@ -307,7 +307,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
     }
 
     static func consoleURL(from rawHost: String, region: AlibabaCodingPlanAPIRegion) -> URL? {
-        let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
+        let cleaned = SettingsValue.cleaned(rawHost)
         guard let cleaned else { return nil }
 
         let base = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: cleaned)
@@ -368,7 +368,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
     }
 
     static func dashboardURL(from rawHost: String, region: AlibabaCodingPlanAPIRegion) -> URL? {
-        let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
+        let cleaned = SettingsValue.cleaned(rawHost)
         guard let cleaned else { return nil }
 
         let base = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: cleaned)
@@ -428,7 +428,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
     }
 
     private static func baseURL(from rawHost: String) -> URL? {
-        let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
+        let cleaned = SettingsValue.cleaned(rawHost)
         guard let cleaned else { return nil }
 
         let base = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: cleaned)

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanSettingsReader.swift
@@ -14,14 +14,14 @@ public struct AlibabaTokenPlanSettingsReader: Sendable {
     public static func cookieHeader(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.cookieHeaderKey])
+        SettingsValue.cleaned(environment[self.cookieHeaderKey])
     }
 
     public static func hostOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         self.endpointValidator.validatedHost(
-            self.cleaned(environment[self.hostKey]),
+            SettingsValue.cleaned(environment[self.hostKey]),
             policy: .allowAnyHTTPSHost)
     }
 
@@ -29,21 +29,8 @@ public struct AlibabaTokenPlanSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
         self.endpointValidator.validatedURL(
-            self.cleaned(environment[self.quotaURLKey]),
+            SettingsValue.cleaned(environment[self.quotaURLKey]),
             policy: .allowAnyHTTPSHost)
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
@@ -671,7 +671,7 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
     }
 
     private static func quotaURL(from rawHost: String, region: AlibabaTokenPlanAPIRegion) -> URL? {
-        let cleaned = AlibabaTokenPlanSettingsReader.cleaned(rawHost)
+        let cleaned = SettingsValue.cleaned(rawHost)
         guard let cleaned else { return nil }
         guard let base = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: cleaned) else { return nil }
         var components = URLComponents(url: base, resolvingAgainstBaseURL: false)

--- a/Sources/CodexBarCore/Providers/Amp/AmpSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpSettingsReader.swift
@@ -4,19 +4,6 @@ public enum AmpSettingsReader {
     public static let apiTokenKey = "AMP_API_KEY"
 
     public static func apiToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.apiTokenKey])
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(environment[self.apiTokenKey])
     }
 }

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
@@ -165,7 +165,7 @@ public struct AmpUsageFetcher: Sendable {
         logger: ((String) -> Void)? = nil,
         now: Date = Date()) async throws -> AmpUsageSnapshot
     {
-        guard let token = AmpSettingsReader.cleaned(apiToken) else {
+        guard let token = SettingsValue.cleaned(apiToken) else {
             throw AmpUsageError.missingAPIToken
         }
         let request = try Self.makeUsageAPIRequest(apiToken: token)

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
@@ -8,7 +8,7 @@ public enum AzureOpenAISettingsReader {
     public static let defaultAPIVersion = "2024-10-21"
 
     public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 
     public static func endpoint(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL? {
@@ -17,15 +17,15 @@ public enum AzureOpenAISettingsReader {
     }
 
     public static func rawEndpoint(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.endpointEnvironmentKey])
+        SettingsValue.cleaned(environment[self.endpointEnvironmentKey])
     }
 
     public static func deploymentName(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.deploymentNameEnvironmentKey])
+        SettingsValue.cleaned(environment[self.deploymentNameEnvironmentKey])
     }
 
     public static func apiVersion(environment: [String: String] = ProcessInfo.processInfo.environment) -> String {
-        self.cleaned(environment[self.apiVersionEnvironmentKey]) ?? self.defaultAPIVersion
+        SettingsValue.cleaned(environment[self.apiVersionEnvironmentKey]) ?? self.defaultAPIVersion
     }
 
     public static func endpointURL(from rawEndpoint: String) -> URL? {
@@ -41,21 +41,6 @@ public enum AzureOpenAISettingsReader {
         guard self.endpointURL(from: rawEndpoint) != nil else {
             throw AzureOpenAISettingsError.invalidEndpointOverride(self.endpointEnvironmentKey)
         }
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockCloudWatchUsage.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockCloudWatchUsage.swift
@@ -156,7 +156,7 @@ enum BedrockCloudWatchUsageFetcher {
 
     private static func endpoint(region: String, override: String?) throws -> URL {
         if override != nil {
-            guard let override = BedrockSettingsReader.cleaned(override),
+            guard let override = SettingsValue.cleaned(override),
                   let url = ProviderEndpointOverrideValidator()
                       .validatedURLAllowingLoopbackHTTP(override)
             else {
@@ -226,6 +226,6 @@ enum BedrockCloudWatchUsageFetcher {
             }
         }
 
-        return (totals, BedrockSettingsReader.cleaned(json["NextToken"] as? String))
+        return (totals, SettingsValue.cleaned(json["NextToken"] as? String))
     }
 }

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockCredentialResolver.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockCredentialResolver.swift
@@ -65,8 +65,8 @@ enum BedrockCredentialResolver {
         profile: String,
         environment: [String: String]) async throws -> String
     {
-        if let explicit = BedrockSettingsReader.cleaned(environment[BedrockSettingsReader.regionKeys[0]])
-            ?? BedrockSettingsReader.cleaned(environment[BedrockSettingsReader.regionKeys[1]])
+        if let explicit = SettingsValue.cleaned(environment[BedrockSettingsReader.regionKeys[0]])
+            ?? SettingsValue.cleaned(environment[BedrockSettingsReader.regionKeys[1]])
         {
             return explicit
         }

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderConfig.swift
@@ -12,10 +12,10 @@ extension ProviderConfig {
     }
 
     public var sanitizedAWSProfile: String? {
-        Self.clean(self.awsProfile)
+        SettingsValue.cleaned(self.awsProfile)
     }
 
     public var sanitizedAWSAuthMode: String? {
-        Self.clean(self.awsAuthMode)
+        SettingsValue.cleaned(self.awsAuthMode)
     }
 }

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockProviderDescriptor.swift
@@ -83,7 +83,7 @@ public enum BedrockProviderDescriptor {
         if let configMode {
             environment[BedrockSettingsReader.authModeKey] = configMode.rawValue
         }
-        let baseMode = BedrockSettingsReader
+        let baseMode = SettingsValue
             .cleaned(base[BedrockSettingsReader.authModeKey])
             .flatMap { BedrockAuthMode(rawValue: $0.lowercased()) }
         let mergedAccessKey = config.sanitizedAPIKey ?? BedrockSettingsReader.accessKeyID(environment: base)

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockSettingsReader.swift
@@ -18,24 +18,24 @@ public enum BedrockSettingsReader {
     public static let defaultRegion = "us-east-1"
 
     public static func accessKeyID(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.accessKeyIDKey])
+        SettingsValue.cleaned(environment[self.accessKeyIDKey])
     }
 
     public static func secretAccessKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.secretAccessKeyKey])
+        SettingsValue.cleaned(environment[self.secretAccessKeyKey])
     }
 
     public static func sessionToken(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.sessionTokenKey])
+        SettingsValue.cleaned(environment[self.sessionTokenKey])
     }
 
     public static func region(environment: [String: String] = ProcessInfo.processInfo.environment) -> String {
         for key in self.regionKeys {
-            if let value = self.cleaned(environment[key]) {
+            if let value = SettingsValue.cleaned(environment[key]) {
                 return value
             }
         }
@@ -43,7 +43,7 @@ public enum BedrockSettingsReader {
     }
 
     public static func budget(environment: [String: String] = ProcessInfo.processInfo.environment) -> Double? {
-        guard let raw = self.cleaned(environment[self.budgetKey]),
+        guard let raw = SettingsValue.cleaned(environment[self.budgetKey]),
               let value = Double(raw),
               value > 0
         else {
@@ -55,13 +55,13 @@ public enum BedrockSettingsReader {
     public static func profile(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.profileKey])
+        SettingsValue.cleaned(environment[self.profileKey])
     }
 
     public static func authMode(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> BedrockAuthMode
     {
-        if let raw = self.cleaned(environment[self.authModeKey])?.lowercased(),
+        if let raw = SettingsValue.cleaned(environment[self.authModeKey])?.lowercased(),
            let mode = BedrockAuthMode(rawValue: raw)
         {
             return mode
@@ -88,20 +88,5 @@ public enum BedrockSettingsReader {
         case .profile:
             self.profile(environment: environment) != nil
         }
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
@@ -233,7 +233,7 @@ enum BedrockUsageFetcher {
     {
         let ceRegion = "us-east-1"
         let baseURL: URL = if environment[BedrockSettingsReader.apiURLKey] != nil {
-            if let override = BedrockSettingsReader.cleaned(environment[BedrockSettingsReader.apiURLKey]),
+            if let override = SettingsValue.cleaned(environment[BedrockSettingsReader.apiURLKey]),
                let url = ProviderEndpointOverrideValidator().validatedURLAllowingLoopbackHTTP(override)
             {
                 url
@@ -294,7 +294,7 @@ enum BedrockUsageFetcher {
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw BedrockUsageError.parseFailed("Invalid Cost Explorer response")
         }
-        return BedrockSettingsReader.cleaned(json["NextPageToken"] as? String)
+        return SettingsValue.cleaned(json["NextPageToken"] as? String)
     }
 
     private static func parseTotalCost(_ pages: [Data]) throws -> Double {

--- a/Sources/CodexBarCore/Providers/Chutes/ChutesSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Chutes/ChutesSettingsReader.swift
@@ -7,7 +7,7 @@ public struct ChutesSettingsReader: Sendable {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 
     public static func apiURL(
@@ -22,28 +22,13 @@ public struct ChutesSettingsReader: Sendable {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
         throw ChutesSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
     }
 
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
-    }
-
     private static func validAPIURL(environment: [String: String]) -> URL? {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/Chutes/ChutesUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Chutes/ChutesUsageStats.swift
@@ -233,7 +233,7 @@ public struct ChutesUsageFetcher: Sendable {
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> ChutesUsageSnapshot
     {
-        guard let token = ChutesSettingsReader.cleaned(apiKey) else {
+        guard let token = SettingsValue.cleaned(apiKey) else {
             throw ChutesUsageError.missingCredentials
         }
         try ChutesSettingsReader.validateEndpointOverrides(environment: environment)

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeAdminAPISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeAdminAPISettingsReader.swift
@@ -16,18 +16,7 @@ public enum ClaudeAdminAPISettingsReader {
     }
 
     public static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(raw)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderConfig.swift
@@ -17,6 +17,6 @@ extension ProviderConfig {
     }
 
     public var sanitizedClaudeSwapExecutablePath: String? {
-        Self.clean(self.claudeSwapExecutablePath)
+        SettingsValue.cleaned(self.claudeSwapExecutablePath)
     }
 }

--- a/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/ClawRouter/ClawRouterSettingsReader.swift
@@ -21,13 +21,13 @@ public enum ClawRouterSettingsReader {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 
     public static func baseURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL
     {
-        guard let raw = self.cleaned(environment[self.baseURLEnvironmentKey]) else {
+        guard let raw = SettingsValue.cleaned(environment[self.baseURLEnvironmentKey]) else {
             return self.defaultBaseURL
         }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) ?? self.defaultBaseURL
@@ -36,22 +36,9 @@ public enum ClawRouterSettingsReader {
     public static func validateEndpointOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment[self.baseURLEnvironmentKey]) else { return }
+        guard let raw = SettingsValue.cleaned(environment[self.baseURLEnvironmentKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) != nil else {
             throw ClawRouterSettingsError.invalidEndpointOverride(self.baseURLEnvironmentKey)
         }
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/ClinePass/ClinePassSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/ClinePass/ClinePassSettingsReader.swift
@@ -12,23 +12,10 @@ public enum ClinePassSettingsReader {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         for key in self.apiKeyEnvironmentKeys {
-            if let value = self.cleaned(environment[key]) {
+            if let value = SettingsValue.cleaned(environment[key]) {
                 return value
             }
         }
         return nil
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
@@ -8,7 +8,7 @@ public enum CodebuffSettingsReader {
 
     /// Returns the API token from environment if present and non-empty.
     public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.apiTokenKey])
+        SettingsValue.cleaned(environment[self.apiTokenKey])
     }
 
     /// Returns the API base URL, defaulting to the production endpoint.
@@ -22,7 +22,7 @@ public enum CodebuffSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment["CODEBUFF_API_URL"]) else { return }
+        guard let raw = SettingsValue.cleaned(environment["CODEBUFF_API_URL"]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
         throw CodebuffSettingsError.invalidEndpointOverride("CODEBUFF_API_URL")
     }
@@ -49,26 +49,11 @@ public enum CodebuffSettingsReader {
         guard let payload = try? JSONDecoder().decode(CredentialsFile.self, from: data) else {
             return nil
         }
-        return self.cleaned(payload.default?.authToken) ?? self.cleaned(payload.authToken)
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        return SettingsValue.cleaned(payload.default?.authToken) ?? SettingsValue.cleaned(payload.authToken)
     }
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
-        guard let raw = self.cleaned(environment["CODEBUFF_API_URL"]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment["CODEBUFF_API_URL"]) else { return nil }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
@@ -5,7 +5,7 @@ public enum CopilotProviderDescriptor {
     public static let descriptor: ProviderDescriptor = Self.makeDescriptor()
     private static let credentials = ProviderCredentialAdapter.apiKey(
         environmentKey: "COPILOT_API_TOKEN",
-        resolve: { ProviderConfig.clean($0["COPILOT_API_TOKEN"]) },
+        resolve: { SettingsValue.cleaned($0["COPILOT_API_TOKEN"]) },
         tokenAccountSupport: TokenAccountSupport(
             title: "GitHub accounts",
             subtitle: "Sign in with multiple GitHub accounts via OAuth.",

--- a/Sources/CodexBarCore/Providers/Crof/CrofSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Crof/CrofSettingsReader.swift
@@ -5,23 +5,10 @@ public enum CrofSettingsReader {
 
     public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         for key in self.apiKeyEnvironmentKeys {
-            if let value = self.cleaned(environment[key]) {
+            if let value = SettingsValue.cleaned(environment[key]) {
                 return value
             }
         }
         return nil
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/DeepInfra/DeepInfraSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/DeepInfra/DeepInfraSettingsReader.swift
@@ -8,26 +8,10 @@ public struct DeepInfraSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         for key in self.apiKeyEnvironmentKeys {
-            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !raw.isEmpty
-            else {
-                continue
-            }
-            let cleaned = Self.cleaned(raw)
-            if !cleaned.isEmpty {
-                return cleaned
+            if let value = SettingsValue.cleaned(environment[key]) {
+                return value
             }
         }
         return nil
-    }
-
-    private static func cleaned(_ raw: String) -> String {
-        var value = raw
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekProviderConfig.swift
@@ -12,10 +12,10 @@ extension ProviderConfig {
     }
 
     public var sanitizedDeepSeekProfileID: String? {
-        Self.clean(self.deepseekProfileID).map(DeepSeekSettingsReader.canonicalProfileID)
+        SettingsValue.cleaned(self.deepseekProfileID).map(DeepSeekSettingsReader.canonicalProfileID)
     }
 
     public var sanitizedDeepSeekProfileScope: String? {
-        Self.clean(self.deepseekProfileScope)
+        SettingsValue.cleaned(self.deepseekProfileScope)
     }
 }

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekSettingsReader.swift
@@ -101,26 +101,10 @@ public struct DeepSeekSettingsReader: Sendable {
 
     private static func value(for keys: [String], environment: [String: String]) -> String? {
         for key in keys {
-            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !raw.isEmpty
-            else {
-                continue
-            }
-            let cleaned = Self.cleaned(raw)
-            if !cleaned.isEmpty {
-                return cleaned
+            if let value = SettingsValue.cleaned(environment[key]) {
+                return value
             }
         }
         return nil
-    }
-
-    private static func cleaned(_ raw: String) -> String {
-        var value = raw
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/CodexBarCore/Providers/Deepgram/DeepgramSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Deepgram/DeepgramSettingsReader.swift
@@ -9,43 +9,28 @@ public struct DeepgramSettingsReader: Sendable {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 
     public static func projectID(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.projectIDEnvironmentKey])
+        SettingsValue.cleaned(environment[self.projectIDEnvironmentKey])
     }
 
     public static func apiURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL
     {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return self.defaultAPIURL }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return self.defaultAPIURL }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) ?? self.defaultAPIURL
     }
 
     public static func validateEndpointOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) != nil else {
             throw DeepgramSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
         }
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoProviderDescriptor.swift
@@ -100,7 +100,7 @@ public enum DoubaoProviderDescriptor {
             environment[DoubaoSettingsReader.accessKeyIDEnvironmentKeys[0]] = accessKeyID
             environment[DoubaoSettingsReader.secretAccessKeyEnvironmentKeys[0]] = secretAccessKey
             let region = config.sanitizedRegion ?? DoubaoSettingsReader.regionEnvironmentKeys.lazy
-                .compactMap { DoubaoSettingsReader.cleaned(base[$0]) }
+                .compactMap { SettingsValue.cleaned(base[$0]) }
                 .first
             if let region {
                 environment[DoubaoSettingsReader.regionEnvironmentKeys[0]] = region

--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoSettingsReader.swift
@@ -65,22 +65,9 @@ public struct DoubaoSettingsReader: Sendable {
 
     private static func firstValue(in environment: [String: String], keys: [String]) -> String? {
         for key in keys {
-            guard let cleaned = self.cleaned(environment[key]) else { continue }
+            guard let cleaned = SettingsValue.cleaned(environment[key]) else { continue }
             return cleaned
         }
         return nil
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
@@ -10,7 +10,7 @@ public enum ElevenLabsSettingsReader {
 
     public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         for key in self.apiKeyEnvironmentKeys {
-            guard let token = self.cleaned(environment[key]) else { continue }
+            guard let token = SettingsValue.cleaned(environment[key]) else { continue }
             return token
         }
         return nil
@@ -26,26 +26,13 @@ public enum ElevenLabsSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
         throw ElevenLabsSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
     }
 
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
-    }
-
     private static func validAPIURL(environment: [String: String]) -> URL? {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/Factory/FactorySettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactorySettingsReader.swift
@@ -10,7 +10,7 @@ public enum FactorySettingsReader {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         homeDirectory: URL? = nil) -> String?
     {
-        if let fromEnv = self.cleaned(environment[self.apiTokenKey]) {
+        if let fromEnv = SettingsValue.cleaned(environment[self.apiTokenKey]) {
             return fromEnv
         }
         guard let home = homeDirectory ?? self.homeDirectory(from: environment) else {
@@ -41,31 +41,16 @@ public enum FactorySettingsReader {
             let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
             guard key == self.apiTokenKey else { continue }
             let value = String(line[line.index(after: separator)...])
-            return self.cleaned(value)
+            return SettingsValue.cleaned(value)
         }
         return nil
     }
 
     static func homeDirectory(from environment: [String: String]) -> URL? {
-        guard let home = self.cleaned(environment["HOME"]) else {
+        guard let home = SettingsValue.cleaned(environment["HOME"]) else {
             return nil
         }
         let expanded = NSString(string: home).expandingTildeInPath
         return URL(fileURLWithPath: expanded, isDirectory: true)
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/Fireworks/FireworksProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Fireworks/FireworksProviderConfig.swift
@@ -9,6 +9,6 @@ extension ProviderConfig {
     }
 
     public var sanitizedAccountSlug: String? {
-        Self.clean(self.accountSlug)
+        SettingsValue.cleaned(self.accountSlug)
     }
 }

--- a/Sources/CodexBarCore/Providers/Fireworks/FireworksSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Fireworks/FireworksSettingsReader.swift
@@ -13,14 +13,8 @@ public struct FireworksSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         for key in [self.configAPIKeyEnvironmentKey] + self.apiKeyEnvironmentKeys {
-            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !raw.isEmpty
-            else {
-                continue
-            }
-            let cleaned = Self.cleaned(raw)
-            if !cleaned.isEmpty {
-                return cleaned
+            if let value = SettingsValue.cleaned(environment[key]) {
+                return value
             }
         }
         return nil
@@ -30,26 +24,10 @@ public struct FireworksSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         for key in [self.configAccountSlugEnvironmentKey, self.accountSlugEnvironmentKey] {
-            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !raw.isEmpty
-            else {
-                continue
-            }
-            let cleaned = Self.cleaned(raw)
-            if !cleaned.isEmpty {
-                return cleaned
+            if let value = SettingsValue.cleaned(environment[key]) {
+                return value
             }
         }
         return nil
-    }
-
-    private static func cleaned(_ raw: String) -> String {
-        var value = raw
-        if (value.hasPrefix("\"") && value.hasSuffix("\""))
-            || (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
@@ -7,7 +7,7 @@ public enum GroqSettingsReader {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 
     public static func apiURL(
@@ -22,26 +22,13 @@ public enum GroqSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
         throw GroqSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
     }
 
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
-    }
-
     private static func validAPIURL(environment: [String: String]) -> URL? {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/Kilo/KiloBearerTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloBearerTokenResolver.swift
@@ -39,8 +39,8 @@ public enum KiloBearerTokenResolver {
         apiKey: String?,
         environment: [String: String]) throws -> KiloResolvedBearerToken
     {
-        let direct = KiloSettingsReader.cleaned(apiKey)
-        let envValue = KiloSettingsReader.cleaned(environment[KiloSettingsReader.apiTokenKey])
+        let direct = SettingsValue.cleaned(apiKey)
+        let envValue = SettingsValue.cleaned(environment[KiloSettingsReader.apiTokenKey])
         if let token = direct ?? envValue {
             return KiloResolvedBearerToken(token: token, sourceLabel: "api")
         }
@@ -67,7 +67,7 @@ public enum KiloBearerTokenResolver {
     }
 
     static func authFileURL(environment: [String: String]) -> URL {
-        if let home = KiloSettingsReader.cleaned(environment["HOME"]) {
+        if let home = SettingsValue.cleaned(environment["HOME"]) {
             let expandedHome = NSString(string: home).expandingTildeInPath
             return KiloSettingsReader.defaultAuthFileURL(
                 homeDirectory: URL(fileURLWithPath: expandedHome, isDirectory: true))

--- a/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
@@ -187,7 +187,7 @@ struct KiloCLIFetchStrategy: ProviderFetchStrategy {
     }
 
     private static func authFileURL(environment: [String: String]) -> URL {
-        if let home = KiloSettingsReader.cleaned(environment["HOME"]) {
+        if let home = SettingsValue.cleaned(environment["HOME"]) {
             let expandedHome = NSString(string: home).expandingTildeInPath
             return KiloSettingsReader.defaultAuthFileURL(
                 homeDirectory: URL(fileURLWithPath: expandedHome, isDirectory: true))

--- a/Sources/CodexBarCore/Providers/Kilo/KiloSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloSettingsReader.swift
@@ -4,7 +4,7 @@ public enum KiloSettingsReader {
     public static let apiTokenKey = "KILO_API_KEY"
 
     public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.apiTokenKey])
+        SettingsValue.cleaned(environment[self.apiTokenKey])
     }
 
     public static func apiURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
@@ -33,22 +33,7 @@ public enum KiloSettingsReader {
         guard let payload = try? JSONDecoder().decode(AuthFile.self, from: data) else {
             return nil
         }
-        return self.cleaned(payload.kilo?.access)
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        return SettingsValue.cleaned(payload.kilo?.access)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
@@ -10,12 +10,12 @@ public enum KimiSettingsReader {
 
     public static func authToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         let raw = environment["KIMI_AUTH_TOKEN"] ?? environment["kimi_auth_token"]
-        return self.cleaned(raw)
+        return SettingsValue.cleaned(raw)
     }
 
     public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         for key in self.apiKeyEnvironmentKeys {
-            if let value = self.cleaned(environment[key]) {
+            if let value = SettingsValue.cleaned(environment[key]) {
                 return value
             }
         }
@@ -25,7 +25,7 @@ public enum KimiSettingsReader {
     public static func codeAPIBaseURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws -> URL
     {
-        guard let raw = self.cleaned(environment[self.codeAPIBaseURLEnvironmentKey]) else {
+        guard let raw = SettingsValue.cleaned(environment[self.codeAPIBaseURLEnvironmentKey]) else {
             return self.defaultCodeAPIBaseURL
         }
 
@@ -59,7 +59,8 @@ public enum KimiSettingsReader {
         else {
             return false
         }
-        return self.cleaned(credential.accessToken) != nil || self.cleaned(credential.refreshToken) != nil
+        return SettingsValue.cleaned(credential.accessToken) != nil || SettingsValue
+            .cleaned(credential.refreshToken) != nil
     }
 
     static func kimiCodeIdentityHeaders(environment: [String: String]) -> [String: String] {
@@ -81,8 +82,8 @@ public enum KimiSettingsReader {
     }
 
     private static func hasCodeEndpointOverride(environment: [String: String]) -> Bool {
-        if self.cleaned(environment[self.codeAPIBaseURLEnvironmentKey]) != nil { return true }
-        return self.codeOAuthHostEnvironmentKeys.contains { self.cleaned(environment[$0]) != nil }
+        if SettingsValue.cleaned(environment[self.codeAPIBaseURLEnvironmentKey]) != nil { return true }
+        return self.codeOAuthHostEnvironmentKeys.contains { SettingsValue.cleaned(environment[$0]) != nil }
     }
 
     private static func kimiCodeCredential(environment: [String: String]) -> KimiCodeOAuthCredential? {
@@ -102,7 +103,7 @@ public enum KimiSettingsReader {
         let home = self.kimiCodeHomeURL(environment: environment)
         let url = home
             .appendingPathComponent("device_id", isDirectory: false)
-        if let existing = self.cleaned(try? String(contentsOf: url, encoding: .utf8)) {
+        if let existing = SettingsValue.cleaned(try? String(contentsOf: url, encoding: .utf8)) {
             return existing
         }
 
@@ -121,7 +122,7 @@ public enum KimiSettingsReader {
     }
 
     private static func kimiCodeHomeURL(environment: [String: String]) -> URL {
-        if let override = self.cleaned(environment[self.codeHomeEnvironmentKey]) {
+        if let override = SettingsValue.cleaned(environment[self.codeHomeEnvironmentKey]) {
             return URL(fileURLWithPath: override, isDirectory: true)
         }
         return FileManager.default.homeDirectoryForCurrentUser
@@ -155,21 +156,6 @@ public enum KimiSettingsReader {
         #else
         "unknown"
         #endif
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/LLMProxy/LLMProxySettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/LLMProxy/LLMProxySettingsReader.swift
@@ -7,13 +7,13 @@ public enum LLMProxySettingsReader {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 
     public static func baseURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
-        guard let raw = self.cleaned(environment[self.baseURLEnvironmentKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.baseURLEnvironmentKey]) else { return nil }
         // The API key is sent to this URL as a bearer token, so validate it like every other
         // provider override. HTTP stays allowed for loopback and private-network proxies; public
         // hosts must use HTTPS, and no endpoint may carry embedded credentials.
@@ -28,19 +28,6 @@ public enum LLMProxySettingsReader {
     public static func hasBaseURLOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool
     {
-        self.cleaned(environment[self.baseURLEnvironmentKey]) != nil
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(environment[self.baseURLEnvironmentKey]) != nil
     }
 }

--- a/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMSettingsReader.swift
@@ -7,13 +7,13 @@ public enum LiteLLMSettingsReader {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 
     public static func baseURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
-        guard let raw = self.cleaned(environment[self.baseURLEnvironmentKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.baseURLEnvironmentKey]) else { return nil }
         // The API key is sent to this URL as a bearer token, so validate it like every other
         // provider override. HTTP stays allowed for loopback and private-network proxies; public
         // hosts must use HTTPS, and no endpoint may carry embedded credentials.
@@ -28,19 +28,6 @@ public enum LiteLLMSettingsReader {
     public static func hasBaseURLOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool
     {
-        self.cleaned(environment[self.baseURLEnvironmentKey]) != nil
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(environment[self.baseURLEnvironmentKey]) != nil
     }
 }

--- a/Sources/CodexBarCore/Providers/LongCat/LongCatSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/LongCat/LongCatSettingsReader.swift
@@ -6,28 +6,13 @@ public enum LongCatSettingsReader {
     /// Manual cookie header for the LongCat web console (longcat.chat).
     public static func cookieHeader(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         let raw = environment[self.cookieHeaderKey] ?? environment["longcat_manual_cookie"]
-        return self.cleaned(raw)
+        return SettingsValue.cleaned(raw)
     }
 
     /// LongCat OpenAI/Anthropic-compatible API key. Not used for usage (the public
     /// API exposes no usage endpoint) but kept for parity and future signals.
     public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         let raw = environment["LONGCAT_API_KEY"] ?? environment["longcat_api_key"]
-        return self.cleaned(raw)
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        return SettingsValue.cleaned(raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/Manus/ManusSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Manus/ManusSettingsReader.swift
@@ -6,26 +6,11 @@ public enum ManusSettingsReader {
             ?? environment["manus_session_token"]
             ?? environment["MANUS_SESSION_ID"]
             ?? environment["manus_session_id"]
-        if let token = ManusCookieHeader.token(from: self.cleaned(rawToken)) {
+        if let token = ManusCookieHeader.token(from: SettingsValue.cleaned(rawToken)) {
             return token
         }
 
         let rawCookie = environment["MANUS_COOKIE"] ?? environment["manus_cookie"]
-        return ManusCookieHeader.token(from: self.cleaned(rawCookie))
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        return ManusCookieHeader.token(from: SettingsValue.cleaned(rawCookie))
     }
 }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPISettingsReader.swift
@@ -18,7 +18,7 @@ public struct MiniMaxAPISettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         for key in self.apiTokenEnvironmentKeys {
-            if let token = self.cleaned(environment[key]) { return token }
+            if let token = SettingsValue.cleaned(environment[key]) { return token }
         }
         return nil
     }
@@ -30,25 +30,10 @@ public struct MiniMaxAPISettingsReader: Sendable {
     }
 
     public static func apiKeyKind(token: String?) -> APIKeyKind? {
-        guard let cleaned = self.cleaned(token) else { return nil }
+        guard let cleaned = SettingsValue.cleaned(token) else { return nil }
         if cleaned.hasPrefix("sk-cp-") { return .codingPlan }
         if cleaned.hasPrefix("sk-api-") { return .standard }
         return .unknown
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
@@ -38,7 +38,7 @@ public struct MiniMaxSettingsReader: Sendable {
 
     public static func hostOverride(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         self.endpointValidator.validatedHost(
-            self.cleaned(environment[self.hostKey]),
+            SettingsValue.cleaned(environment[self.hostKey]),
             policy: self.endpointOverrideHostPolicy(environment: environment))
     }
 
@@ -47,7 +47,7 @@ public struct MiniMaxSettingsReader: Sendable {
     {
         let policy = self.endpointOverrideHostPolicy(environment: environment)
         return self.endpointOverrideKeys.first { key in
-            guard let value = self.cleaned(environment[key]) else { return false }
+            guard let value = SettingsValue.cleaned(environment[key]) else { return false }
             if key == Self.hostKey {
                 return self.endpointValidator.validatedHost(value, policy: policy) == nil
             }
@@ -59,7 +59,7 @@ public struct MiniMaxSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
         self.endpointValidator.validatedURL(
-            self.cleaned(environment[self.codingPlanURLKey]),
+            SettingsValue.cleaned(environment[self.codingPlanURLKey]),
             policy: self.endpointOverrideHostPolicy(environment: environment))
     }
 
@@ -67,7 +67,7 @@ public struct MiniMaxSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
         self.endpointValidator.validatedURL(
-            self.cleaned(environment[self.remainsURLKey]),
+            SettingsValue.cleaned(environment[self.remainsURLKey]),
             policy: self.endpointOverrideHostPolicy(environment: environment))
     }
 
@@ -75,31 +75,16 @@ public struct MiniMaxSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
         self.endpointValidator.validatedURL(
-            self.cleaned(environment[self.billingHistoryURLKey]),
+            SettingsValue.cleaned(environment[self.billingHistoryURLKey]),
             policy: self.endpointOverrideHostPolicy(environment: environment))
     }
 
     static func endpointOverrideHostPolicy(environment: [String: String]) -> ProviderEndpointOverrideValidator
     .HostPolicy {
-        guard let value = self.cleaned(environment[self.requireProviderEndpointOverridesKey])?.lowercased(),
+        guard let value = SettingsValue.cleaned(environment[self.requireProviderEndpointOverridesKey])?.lowercased(),
               ["1", "true", "yes", "on"].contains(value)
         else { return .allowAnyHTTPSHost }
         return .providerOwnedOnly
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -659,7 +659,7 @@ public struct MiniMaxUsageFetcher: Sendable {
     }
 
     static func url(from raw: String, path: String? = nil, query: String? = nil) -> URL? {
-        guard let cleaned = MiniMaxSettingsReader.cleaned(raw) else { return nil }
+        guard let cleaned = SettingsValue.cleaned(raw) else { return nil }
 
         func compose(_ base: URL) -> URL? {
             var components = URLComponents(url: base, resolvingAgainstBaseURL: false)!

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderConfig.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderConfig.swift
@@ -8,6 +8,6 @@ extension ProviderConfig {
     }
 
     public var sanitizedAPIKeyRegion: String? {
-        Self.clean(self.apiKeyRegion)
+        SettingsValue.cleaned(self.apiKeyRegion)
     }
 }

--- a/Sources/CodexBarCore/Providers/NeuralWatt/NeuralWattSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/NeuralWatt/NeuralWattSettingsReader.swift
@@ -9,7 +9,7 @@ public enum NeuralWattSettingsReader {
 
     public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         for key in self.apiKeyEnvironmentKeys {
-            guard let token = self.cleaned(environment[key]) else { continue }
+            guard let token = SettingsValue.cleaned(environment[key]) else { continue }
             return token
         }
         return nil
@@ -25,26 +25,13 @@ public enum NeuralWattSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
         throw NeuralWattSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
     }
 
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
-    }
-
     private static func validAPIURL(environment: [String: String]) -> URL? {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -913,24 +913,10 @@ public struct OllamaAPISettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         for key in self.apiKeyEnvironmentKeys {
-            guard let value = self.cleaned(environment[key]), !value.isEmpty else { continue }
+            guard let value = SettingsValue.cleaned(environment[key]) else { continue }
             return value
         }
         return nil
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty
-        else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPISettingsReader.swift
@@ -11,32 +11,17 @@ public enum OpenAIAPISettingsReader {
 
     public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         for key in self.apiKeyEnvironmentKeys {
-            if let token = self.cleaned(environment[key]) { return token }
+            if let token = SettingsValue.cleaned(environment[key]) { return token }
         }
         return nil
     }
 
     public static func adminAPIKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.adminAPIKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.adminAPIKeyEnvironmentKey])
     }
 
     public static func projectID(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.projectIDEnvironmentKey])
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(environment[self.projectIDEnvironmentKey])
     }
 }
 

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageFetcher.swift
@@ -77,7 +77,7 @@ public enum OpenAIAPIUsageFetcher {
         guard !trimmed.isEmpty else {
             throw OpenAIAPIUsageError.missingCredentials
         }
-        let normalizedProjectID = OpenAIAPISettingsReader.cleaned(projectID)
+        let normalizedProjectID = SettingsValue.cleaned(projectID)
 
         let calendar = Self.utcCalendar
         let clampedHistoryDays = max(1, min(365, historyDays))
@@ -121,7 +121,7 @@ public enum OpenAIAPIUsageFetcher {
                 now: now,
                 calendar: calendar,
                 historyDays: historyDays,
-                projectID: OpenAIAPISettingsReader.cleaned(projectID)))
+                projectID: SettingsValue.cleaned(projectID)))
     }
 
     private static func costsEndpoint(baseURL: URL) -> UsageEndpoint<OpenAICostBucket> {

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageSnapshot.swift
@@ -122,7 +122,7 @@ public struct OpenAIAPIUsageSnapshot: Codable, Equatable, Sendable {
         self.daily = daily.sorted { $0.startTime < $1.startTime }
         self.updatedAt = updatedAt
         self.historyDays = max(1, min(365, historyDays))
-        self.projectID = OpenAIAPISettingsReader.cleaned(projectID)
+        self.projectID = SettingsValue.cleaned(projectID)
     }
 
     public var last30Days: Summary {

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
@@ -12,14 +12,14 @@ public enum OpenRouterSettingsReader {
 
     /// Returns the API token from environment if present and non-empty
     public static func apiToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.envKey])
+        SettingsValue.cleaned(environment[self.envKey])
     }
 
     public static func managementAPIKey(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         configured: String? = nil) -> String?
     {
-        self.cleaned(configured) ?? self.cleaned(environment[self.managementAPIKeyEnvironmentKey])
+        SettingsValue.cleaned(configured) ?? SettingsValue.cleaned(environment[self.managementAPIKeyEnvironmentKey])
     }
 
     /// Returns the API URL, defaulting to production endpoint
@@ -33,36 +33,21 @@ public enum OpenRouterSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
         throw OpenRouterSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
     }
 
     public static func httpReferer(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.httpRefererEnvironmentKey])
+        SettingsValue.cleaned(environment[self.httpRefererEnvironmentKey])
     }
 
     public static func clientTitle(environment: [String: String] = ProcessInfo.processInfo.environment) -> String {
-        self.cleaned(environment[self.clientTitleEnvironmentKey]) ?? self.defaultClientTitle
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(environment[self.clientTitleEnvironmentKey]) ?? self.defaultClientTitle
     }
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
-        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexitySettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexitySettingsReader.swift
@@ -6,11 +6,11 @@ public enum PerplexitySettingsReader {
     {
         let raw = environment["PERPLEXITY_SESSION_TOKEN"]
             ?? environment["perplexity_session_token"]
-        if let token = self.cleaned(raw) { return PerplexityCookieHeader.override(from: token) }
+        if let token = SettingsValue.cleaned(raw) { return PerplexityCookieHeader.override(from: token) }
 
         // PERPLEXITY_COOKIE may be a full Cookie header string; preserve the matching session cookie name.
         if let cookieRaw = environment["PERPLEXITY_COOKIE"] {
-            return PerplexityCookieHeader.override(from: self.cleaned(cookieRaw))
+            return PerplexityCookieHeader.override(from: SettingsValue.cleaned(cookieRaw))
         }
         return nil
     }
@@ -19,20 +19,5 @@ public enum PerplexitySettingsReader {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         self.sessionCookieOverride(environment: environment)?.token
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/Poe/PoeSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Poe/PoeSettingsReader.swift
@@ -6,21 +6,6 @@ public enum PoeSettingsReader {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 }

--- a/Sources/CodexBarCore/Providers/QwenCloud/QwenCloudSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/QwenCloud/QwenCloudSettingsReader.swift
@@ -8,13 +8,13 @@ public struct QwenCloudSettingsReader: Sendable {
     public static func cookieHeader(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.cookieHeaderKey])
+        SettingsValue.cleaned(environment[self.cookieHeaderKey])
     }
 
     public static func hostOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        guard let raw = self.cleaned(environment[self.hostKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.hostKey]) else { return nil }
         // Accept full https:// URLs and normalize bare hosts (e.g. "qwen-cloud.test"
         // or "qwen-cloud.test:8443") to HTTPS, so dashboardURL / defaultQuotaURL
         // always build valid URLs. Mirrors the shared endpoint-override rules used
@@ -25,24 +25,11 @@ public struct QwenCloudSettingsReader: Sendable {
     public static func quotaURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
-        guard let raw = self.cleaned(environment[self.quotaURLKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.quotaURLKey]) else { return nil }
         if let url = URL(string: raw), let scheme = url.scheme {
             return scheme.lowercased() == "https" ? url : nil
         }
         return URL(string: "https://\(raw)")
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Sakana/SakanaSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Sakana/SakanaSettingsReader.swift
@@ -4,19 +4,6 @@ public enum SakanaSettingsReader {
     public static let cookieHeaderKey = "SAKANA_COOKIE"
 
     public static func cookieHeader(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        CookieHeaderNormalizer.normalize(self.cleaned(environment[self.cookieHeaderKey]))
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        CookieHeaderNormalizer.normalize(SettingsValue.cleaned(environment[self.cookieHeaderKey]))
     }
 }

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift
@@ -8,31 +8,18 @@ public struct StepFunSettingsReader: Sendable {
     public static func username(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.usernameEnvironmentKey])
+        SettingsValue.cleaned(environment[self.usernameEnvironmentKey])
     }
 
     public static func password(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.passwordEnvironmentKey])
+        SettingsValue.cleaned(environment[self.passwordEnvironmentKey])
     }
 
     public static func token(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.tokenEnvironmentKey])
-    }
-
-    private static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(environment[self.tokenEnvironmentKey])
     }
 }

--- a/Sources/CodexBarCore/Providers/Sub2API/Sub2APISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Sub2API/Sub2APISettingsReader.swift
@@ -19,13 +19,13 @@ public enum Sub2APISettingsReader {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 
     public static func baseURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
-        guard let raw = self.cleaned(environment[self.baseURLEnvironmentKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[self.baseURLEnvironmentKey]) else { return nil }
         let validator = ProviderEndpointOverrideValidator()
         guard let url = validator.validatedURLAllowingLoopbackHTTP(raw),
               url.query == nil,
@@ -40,18 +40,5 @@ public enum Sub2APISettingsReader {
         guard self.baseURL(environment: environment) != nil else {
             throw Sub2APISettingsError.invalidBaseURL
         }
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/Synthetic/SyntheticSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Synthetic/SyntheticSettingsReader.swift
@@ -6,23 +6,8 @@ public struct SyntheticSettingsReader: Sendable {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        if let token = self.cleaned(environment[apiKeyKey]) { return token }
+        if let token = SettingsValue.cleaned(environment[apiKeyKey]) { return token }
         return nil
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Venice/VeniceSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceSettingsReader.swift
@@ -8,26 +8,10 @@ public struct VeniceSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         for key in self.apiKeyEnvironmentKeys {
-            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !raw.isEmpty
-            else {
-                continue
-            }
-            let cleaned = Self.cleaned(raw)
-            if !cleaned.isEmpty {
-                return cleaned
+            if let value = SettingsValue.cleaned(environment[key]) {
+                return value
             }
         }
         return nil
-    }
-
-    private static func cleaned(_ raw: String) -> String {
-        var value = raw
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/CodexBarCore/Providers/Warp/WarpSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Warp/WarpSettingsReader.swift
@@ -10,26 +10,10 @@ public struct WarpSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         for key in self.apiKeyEnvironmentKeys {
-            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !raw.isEmpty
-            else {
-                continue
-            }
-            let cleaned = Self.cleaned(raw)
-            if !cleaned.isEmpty {
-                return cleaned
+            if let value = SettingsValue.cleaned(environment[key]) {
+                return value
             }
         }
         return nil
-    }
-
-    private static func cleaned(_ raw: String) -> String {
-        var value = raw
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/CodexBarCore/Providers/Wayfinder/WayfinderSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Wayfinder/WayfinderSettingsReader.swift
@@ -19,7 +19,7 @@ public enum WayfinderSettingsReader {
     public static func baseURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL
     {
-        guard let raw = self.cleaned(environment[self.baseURLEnvironmentKey]) else {
+        guard let raw = SettingsValue.cleaned(environment[self.baseURLEnvironmentKey]) else {
             return self.defaultBaseURL
         }
         // Loopback HTTP is allowed because the gateway is a local service; the default
@@ -30,7 +30,7 @@ public enum WayfinderSettingsReader {
     public static func validateEndpointOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment[self.baseURLEnvironmentKey]) else { return }
+        guard let raw = SettingsValue.cleaned(environment[self.baseURLEnvironmentKey]) else { return }
         guard ProviderEndpointOverrideValidator().validatedURLAllowingLoopbackHTTP(raw) != nil else {
             throw WayfinderSettingsError.invalidEndpointOverride(self.baseURLEnvironmentKey)
         }
@@ -49,18 +49,5 @@ public enum WayfinderSettingsReader {
         components.query = nil
         components.fragment = nil
         return components.url ?? baseURL
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/CodexBarCore/Providers/XAI/XAISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/XAI/XAISettingsReader.swift
@@ -7,13 +7,13 @@ public enum XAISettingsReader {
     public static func apiKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiKeyEnvironmentKey])
+        SettingsValue.cleaned(environment[self.apiKeyEnvironmentKey])
     }
 
     public static func teamID(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.teamIDEnvironmentKey])
+        SettingsValue.cleaned(environment[self.teamIDEnvironmentKey])
     }
 
     static func validatedTeamID(environment: [String: String]) throws -> String {
@@ -24,19 +24,6 @@ public enum XAISettingsReader {
             throw XAISettingsError.invalidTeamID
         }
         return teamID
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Zai/ZaiAPIRegion.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiAPIRegion.swift
@@ -124,7 +124,7 @@ public enum ZaiEndpointRouter {
     }
 
     private static func endpointURL(baseURLString: String, path: String) -> URL? {
-        guard let cleaned = ZaiSettingsReader.cleaned(baseURLString),
+        guard let cleaned = SettingsValue.cleaned(baseURLString),
               let url = ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: cleaned)
         else { return nil }
         if url.path.isEmpty || url.path == "/" {

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderSettings.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderSettings.swift
@@ -10,8 +10,8 @@ public struct ZaiBigModelTeamContext: Equatable, Sendable {
     public let projectID: String
 
     public init?(organizationID: String?, projectID: String?) {
-        guard let organizationID = ZaiSettingsReader.cleaned(organizationID),
-              let projectID = ZaiSettingsReader.cleaned(projectID)
+        guard let organizationID = SettingsValue.cleaned(organizationID),
+              let projectID = SettingsValue.cleaned(projectID)
         else { return nil }
         self.organizationID = organizationID
         self.projectID = projectID

--- a/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
@@ -32,12 +32,12 @@ public struct ZaiSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> String?
     {
-        if let token = self.cleaned(environment[self.apiTokenKey]) {
+        if let token = SettingsValue.cleaned(environment[self.apiTokenKey]) {
             return token
         }
         guard region == .bigmodelCN else { return nil }
         for key in self.bigModelAPITokenKeys {
-            if let token = self.cleaned(environment[key]) {
+            if let token = SettingsValue.cleaned(environment[key]) {
                 return token
             }
         }
@@ -45,7 +45,7 @@ public struct ZaiSettingsReader: Sendable {
             let url = homeDirectory.appendingPathComponent(relativePath, isDirectory: false)
             guard FileManager.default.isReadableFile(atPath: url.path),
                   let raw = try? String(contentsOf: url, encoding: .utf8),
-                  let token = self.cleaned(raw.split(whereSeparator: \.isNewline).first.map(String.init))
+                  let token = SettingsValue.cleaned(raw.split(whereSeparator: \.isNewline).first.map(String.init))
             else { continue }
             return token
         }
@@ -55,20 +55,20 @@ public struct ZaiSettingsReader: Sendable {
     public static func apiHost(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.apiHostKey])
+        SettingsValue.cleaned(environment[self.apiHostKey])
     }
 
     public static func quotaURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
-        guard let raw = self.cleaned(environment[quotaURLKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[quotaURLKey]) else { return nil }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 
     public static func balanceURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
-        guard let raw = self.cleaned(environment[balanceURLKey]) else { return nil }
+        guard let raw = SettingsValue.cleaned(environment[balanceURLKey]) else { return nil }
         return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 
@@ -96,7 +96,7 @@ public struct ZaiSettingsReader: Sendable {
     static func validateBalanceEndpointOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard self.cleaned(environment[self.balanceURLKey]) != nil else { return }
+        guard SettingsValue.cleaned(environment[self.balanceURLKey]) != nil else { return }
         guard self.balanceURL(environment: environment) != nil else {
             throw ZaiSettingsError.invalidEndpointOverride(self.balanceURLKey)
         }
@@ -105,7 +105,7 @@ public struct ZaiSettingsReader: Sendable {
     public static func validateQuotaEndpointOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        if let raw = self.cleaned(environment[self.quotaURLKey]) {
+        if let raw = SettingsValue.cleaned(environment[self.quotaURLKey]) {
             guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) != nil else {
                 throw ZaiSettingsError.invalidEndpointOverride(self.quotaURLKey)
             }
@@ -134,7 +134,7 @@ public struct ZaiSettingsReader: Sendable {
     public static func validateAPIHostEndpointOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        guard let raw = self.cleaned(environment[self.apiHostKey]) else { return }
+        guard let raw = SettingsValue.cleaned(environment[self.apiHostKey]) else { return }
         guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) != nil else {
             throw ZaiSettingsError.invalidEndpointOverride(self.apiHostKey)
         }
@@ -166,21 +166,6 @@ public struct ZaiSettingsReader: Sendable {
         guard host == region.quotaLimitURL.host?.lowercased() else {
             throw ZaiSettingsError.endpointRegionMismatch(key, region)
         }
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ZenMux/ZenMuxSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/ZenMux/ZenMuxSettingsReader.swift
@@ -6,19 +6,6 @@ public enum ZenMuxSettingsReader {
     public static func managementAPIKey(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.managementAPIKeyEnvironmentKey])
-    }
-
-    static func cleaned(_ raw: String?) -> String? {
-        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-            return nil
-        }
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-            (value.hasPrefix("'") && value.hasSuffix("'"))
-        {
-            value = String(value.dropFirst().dropLast())
-        }
-        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        SettingsValue.cleaned(environment[self.managementAPIKeyEnvironmentKey])
     }
 }

--- a/Sources/CodexBarCore/Providers/ZenMux/ZenMuxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/ZenMux/ZenMuxUsageFetcher.swift
@@ -127,7 +127,7 @@ public enum ZenMuxUsageFetcher {
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> (usage: ZenMuxUsageSnapshot, paygBalanceUSD: Double?)
     {
-        guard let credential = ZenMuxSettingsReader.cleaned(rawCredential) else {
+        guard let credential = SettingsValue.cleaned(rawCredential) else {
             throw ZenMuxUsageError.notConfigured
         }
         let subscriptionData = try await self.get(

--- a/TestsLinux/SettingsReaderQuoteUnwrapTrapTests.swift
+++ b/TestsLinux/SettingsReaderQuoteUnwrapTrapTests.swift
@@ -2,57 +2,34 @@ import CodexBarCore
 import Foundation
 import Testing
 
-/// Regression tests for a copy-pasted quote-unwrap helper that traps on length-1 input.
-///
-/// 32 provider settings readers (plus `CodexBarConfig` and `CLIConfigCommand`) share a
-/// `cleaned(_:)` helper of the form:
-///
-///     if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
-///         (value.hasPrefix("'") && value.hasSuffix("'"))
-///     {
-///         value.removeFirst()
-///         value.removeLast()
-///     }
-///
-/// For a value of length 1 (the single character `"` or `'`), both `hasPrefix` and
-/// `hasSuffix` return true, `removeFirst()` empties the string, and `removeLast()` then
-/// traps with "Can't remove last element from empty collection." This is reachable from
-/// a misconfigured env var (e.g. `ALIBABA_TOKEN_PLAN_COOKIE='"'`) and from quoted JSON
-/// values in `~/.codexbar/config.json`, both of which are user-controllable.
-///
-/// These tests exercise two representative public readers — Alibaba Token Plan (the
-/// newest addition in #1098) and the Ollama API key reader (added in #1087) — by
-/// passing the trap-inducing single-quote inputs and asserting the readers return nil
-/// instead of crashing. The patch swaps `removeFirst()/removeLast()` for
-/// `String(value.dropFirst().dropLast())`, which is empty-safe.
-@Suite
+/// Removing both quotes with mutating String operations formerly trapped on a lone quote.
 struct SettingsReaderQuoteUnwrapTrapTests {
     @Test
-    func alibabaTokenPlanCookieHeader_returnsNilForLoneDoubleQuoteValue() {
+    func `Alibaba cookie rejects a lone double quote`() {
         let env = [AlibabaTokenPlanSettingsReader.cookieHeaderKey: "\""]
         #expect(AlibabaTokenPlanSettingsReader.cookieHeader(environment: env) == nil)
     }
 
     @Test
-    func alibabaTokenPlanCookieHeader_returnsNilForLoneApostropheValue() {
+    func `Alibaba cookie rejects a lone apostrophe`() {
         let env = [AlibabaTokenPlanSettingsReader.cookieHeaderKey: "'"]
         #expect(AlibabaTokenPlanSettingsReader.cookieHeader(environment: env) == nil)
     }
 
     @Test
-    func alibabaTokenPlanCookieHeader_unwrapsProperlyDoubleQuotedValue() {
+    func `Alibaba cookie unwraps double quotes`() {
         let env = [AlibabaTokenPlanSettingsReader.cookieHeaderKey: "\"abc=def\""]
         #expect(AlibabaTokenPlanSettingsReader.cookieHeader(environment: env) == "abc=def")
     }
 
     @Test
-    func alibabaTokenPlanCookieHeader_unwrapsProperlySingleQuotedValue() {
+    func `Alibaba cookie unwraps single quotes`() {
         let env = [AlibabaTokenPlanSettingsReader.cookieHeaderKey: "'abc=def'"]
         #expect(AlibabaTokenPlanSettingsReader.cookieHeader(environment: env) == "abc=def")
     }
 
     @Test
-    func ollamaAPIKey_returnsNilForLoneDoubleQuoteValue() {
+    func `Ollama API key rejects a lone double quote`() {
         for key in OllamaAPISettingsReader.apiKeyEnvironmentKeys {
             let env = [key: "\""]
             #expect(OllamaAPISettingsReader.apiKey(environment: env) == nil)
@@ -60,7 +37,7 @@ struct SettingsReaderQuoteUnwrapTrapTests {
     }
 
     @Test
-    func ollamaAPIKey_returnsNilForLoneApostropheValue() {
+    func `Ollama API key rejects a lone apostrophe`() {
         for key in OllamaAPISettingsReader.apiKeyEnvironmentKeys {
             let env = [key: "'"]
             #expect(OllamaAPISettingsReader.apiKey(environment: env) == nil)
@@ -68,7 +45,7 @@ struct SettingsReaderQuoteUnwrapTrapTests {
     }
 
     @Test
-    func ollamaAPIKey_unwrapsProperlyQuotedValue() {
+    func `Ollama API key unwraps quotes`() {
         let env = [OllamaAPISettingsReader.apiKeyEnvironmentKeys[0]: "\"sk-token\""]
         #expect(OllamaAPISettingsReader.apiKey(environment: env) == "sk-token")
     }

--- a/TestsLinux/SettingsValueTests.swift
+++ b/TestsLinux/SettingsValueTests.swift
@@ -1,0 +1,39 @@
+import CodexBarCore
+import Testing
+
+struct SettingsValueTests {
+    @Test(arguments: [
+        (nil, nil),
+        ("", nil),
+        (" \n\t ", nil),
+        ("\"", nil),
+        ("'", nil),
+        ("\"\"", nil),
+        ("''", nil),
+        ("  \" \t \"  ", nil),
+        ("  fixture-token  ", "fixture-token"),
+        (" \" fixture-token \" ", "fixture-token"),
+        (" ' fixture-token ' ", "fixture-token"),
+        ("\"nested 'quotes'\"", "nested 'quotes'"),
+        ("\"\"fixture\"\"", "\"fixture\""),
+        ("\"mismatched'", "\"mismatched'"),
+        ("line one\nline two", "line one\nline two"),
+        (" '\u{1F99E}' ", "\u{1F99E}"),
+    ] as [(String?, String?)])
+    func `settings trim whitespace and unwrap one matching quote layer`(raw: String?, expected: String?) {
+        #expect(SettingsValue.cleaned(raw) == expected)
+        #expect(ProviderConfig(id: .codex, apiKey: raw).sanitizedAPIKey == expected)
+        #expect(ClaudeAdminAPISettingsReader.cleaned(raw) == expected)
+        #expect(ClinePassSettingsReader.apiKey(environment: raw.map { ["CLINE_API_KEY": $0] } ?? [:]) == expected)
+    }
+
+    @Test
+    func `empty first credentials retain provider fallback order`() {
+        let environment = ["CLINE_API_KEY": " \" \" ", "CLINEPASS_API_KEY": " 'fallback-token' "]
+        #expect(ClinePassSettingsReader.apiKey(environment: environment) == "fallback-token")
+        #expect(ClinePassSettingsReader.apiKey(environment: [
+            "CLINE_API_KEY": "'preferred-token'",
+            "CLINEPASS_API_KEY": "fallback-token",
+        ]) == "preferred-token")
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,8 @@ read_when:
 - The native status-item controller owns menu composition. Persistent refresh-row metrics are independent of menu
   rendering, and screenshot fixtures exercise the active card views. Legacy menu-layout resolution retains its
   rendering mode and projected layout without copying unused settings into a second state object.
+- `SettingsValue` owns whitespace and wrapping-quote normalization for config and provider settings. Readers retain
+  their credential precedence, endpoint validation, and provider-specific decoding.
 - Core owns status feed fetching, decoding, and status models through `ProviderStatusFetcher`; the app supplies
   localized labels and component UI, and the CLI supplies its existing status payload and English labels.
 - `KeychainStringStore` owns generic-password operations for legacy credential migration. Provider adapters retain


### PR DESCRIPTION
Config loading, the CLI, and provider readers each carried their own copy of whitespace and quote normalization. Route them through one package-scoped `SettingsValue` implementation so fixes to single-quote handling and empty values have one owner.

Preserve environment-key precedence, endpoint validation, provider-specific decoding, and all public entry points. The public Claude normalization method delegates to the shared implementation. Moonshot retains its distinct quote-before-trim behavior. Remove the CLI's no-op normalization wrapper and shorten stale regression-test commentary without removing assertions.

Validation:

- Isolated Codex autoreview of the complete candidate: clean through P2.
- `make check`: passed; SwiftLint reported zero violations across 2,244 files.
- Added portable cases for empty/lone/mismatched/nested quotes, whitespace, Unicode, and fallback-key ordering.
- Built CLI, isolated config: accepted four whitespace/quoted fixtures; rejected five empty inputs without changing the file; redacted `config dump`; preserved provider toggles and mode `0600`. No live provider requests or real credential access.
- First full local run: 75 groups passed, then the unchanged RPC closed-stdin fixture timed out during initialize; the six-test focused rerun passed. [#3597](https://github.com/steipete/CodexBar/pull/3597) removes its unnecessary Python startup without changing deadlines or assertions. Full combined verification on updated main completed all 1,112 selections / 93 groups. One heavy 12-suite batch reached the existing 180-second group limit; every selection passed on the standard individual-suite retry. No assertions or deadlines were relaxed.

This is a behavior-preserving refactor. Dependency, toolchain, and CI changes remain a separate follow-up.
