### PR TITLE
test: remove Python startup from RPC teardown fixture

### DIFF
--- a/Tests/CodexBarTests/RPCChildProcessTeardownTests.swift
+++ b/Tests/CodexBarTests/RPCChildProcessTeardownTests.swift
@@ -53,15 +53,12 @@ struct RPCChildProcessTeardownTests {
             .appendingPathComponent("codex-closed-stdin-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: scriptURL) }
 
+        // Keep interpreter startup outside the behavior exercised by the RPC deadline.
         let script = """
-        #!/usr/bin/python3 -S
-        import os
-        import sys
-
-        sys.stdin.readline()
-        os.close(0)
-        print('{"id":1,"result":{}}', flush=True)
-        os._exit(0)
+        #!/bin/sh
+        IFS= read -r line
+        exec 0<&-
+        printf '%s\\n' '{"id":1,"result":{}}'
         """
         try script.write(to: scriptURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)


### PR DESCRIPTION
The closed-stdin RPC fixture loaded Python before acknowledging initialization. In a full local suite it consumed the five-second initialization deadline, producing a timeout before the intended broken-pipe behavior was exercised. A focused rerun passed; a standalone startup comparison measured 1.719s for the first Python launch versus 0.236s for shell builtins.

Use shell builtins to retain the same sequence: read one request, close fd 0, emit the same newline-terminated acknowledgment, and exit. All six tests, error assertions, and initialization/request deadlines remain unchanged. This is a fixture simplification, not a production RPC behavior change.

Validation:

- Isolated Codex review: clean through P2.
- Built CodexBarCLI against the replacement fake child: five runs returned the expected stdin-closed error without a signal abort (0.119–0.422s). No real accounts or provider requests.
- Old/replacement child comparison: both emit the same acknowledgment; startup timings are local observations, not a general benchmark.
- `make check`: passed, zero SwiftLint violations across 2,243 files.
- Integrated focused check: 10 tests in three suites passed, including all six RPC teardown tests.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34716587599): macOS shards, Linux x86_64/ARM64 builds and tests, and the aggregate check passed. The existing path gate legitimately skipped musl for this test-only change.
