### PR TITLE
refactor: modernize CLI decoding and test diagnostics

### DIFF
--- a/Sources/CodexBarCLI/CLIIO.swift
+++ b/Sources/CodexBarCLI/CLIIO.swift
@@ -82,7 +82,8 @@ extension CodexBarCLI {
         guard _NSGetExecutablePath(nil, &size) != 0 else { return nil }
         var buffer = [Int8](repeating: 0, count: Int(size))
         guard _NSGetExecutablePath(&buffer, &size) == 0 else { return nil }
-        return String(cString: buffer)
+        let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
         #elseif os(Linux)
         let path = "/proc/self/exe"
         guard FileManager.default.fileExists(atPath: path) else { return nil }

--- a/Sources/CodexBarCLI/CLIIO.swift
+++ b/Sources/CodexBarCLI/CLIIO.swift
@@ -82,8 +82,8 @@ extension CodexBarCLI {
         guard _NSGetExecutablePath(nil, &size) != 0 else { return nil }
         var buffer = [Int8](repeating: 0, count: Int(size))
         guard _NSGetExecutablePath(&buffer, &size) == 0 else { return nil }
-        let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
-        return String(decoding: bytes, as: UTF8.self)
+        let bytes = buffer.map { UInt8(bitPattern: $0) }
+        return String(decodingCString: bytes, as: UTF8.self)
         #elseif os(Linux)
         let path = "/proc/self/exe"
         guard FileManager.default.fileExists(atPath: path) else { return nil }

--- a/Tests/CodexBarTests/AntigravityOfflineFallbackProofTests.swift
+++ b/Tests/CodexBarTests/AntigravityOfflineFallbackProofTests.swift
@@ -56,7 +56,7 @@ struct AntigravityOfflineFallbackProofTests {
     }
 
     @Test
-    func `oauth shouldFallback when offline data exists`() async {
+    func `oauth shouldFallback when offline data exists`() {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tmp) }
@@ -66,10 +66,10 @@ struct AntigravityOfflineFallbackProofTests {
         let ctxWithData = Self.makeContext(env: ["HOME": tmp.path])
         let ctxEmpty = Self.makeContext(env: ["HOME": "/tmp/empty-\(UUID().uuidString)"])
         let oauth = AntigravityOAuthFetchStrategy()
-        let shouldFallbackWithData = await oauth.shouldFallback(
+        let shouldFallbackWithData = oauth.shouldFallback(
             on: ProviderFetchError.noAvailableStrategy(.antigravity),
             context: ctxWithData)
-        let shouldFallbackEmpty = await oauth.shouldFallback(
+        let shouldFallbackEmpty = oauth.shouldFallback(
             on: ProviderFetchError.noAvailableStrategy(.antigravity),
             context: ctxEmpty)
         #expect(shouldFallbackWithData == true)

--- a/Tests/CodexBarTests/ClaudeWebBackgroundRecoveryTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebBackgroundRecoveryTests.swift
@@ -50,7 +50,8 @@ struct ClaudeWebBackgroundRecoveryTests {
                 #expect(error.localizedDescription == Self.challengeMessage)
             }
 
-            let cached = try? #require(CookieHeaderCache.load(provider: .claude))
+            let cached = CookieHeaderCache.load(provider: .claude)
+            #expect(cached != nil)
             #expect(cached?.cookieHeader == "sessionKey=sk-ant-current-token")
             #expect(cached?.sourceLabel == "Chrome")
         }

--- a/Tests/CodexBarTests/CodexHistoricalPricingProofTests.swift
+++ b/Tests/CodexBarTests/CodexHistoricalPricingProofTests.swift
@@ -115,10 +115,14 @@ struct CodexHistoricalPricingProofTests {
         source: CostUsageFetcher.loadTokenSnapshot(provider: .codex)
         cutoffUTC: 2026-07-30T00:00:00Z
         fixture: local synthetic codex JSONL sessions scanned through the real scanner path
-        2026-07-29 gpt-5.6-terra costUSD=\(terraBefore.costUSD ?? -1) totalTokens=\(terraBefore.totalTokens)
-        2026-07-30 gpt-5.6-terra costUSD=\(terraAfter.costUSD ?? -1) totalTokens=\(terraAfter.totalTokens)
-        2026-07-29 gpt-5.6-luna costUSD=\(lunaBefore.costUSD ?? -1) totalTokens=\(lunaBefore.totalTokens)
-        2026-07-30 gpt-5.6-luna costUSD=\(lunaAfter.costUSD ?? -1) totalTokens=\(lunaAfter.totalTokens)
+        2026-07-29 gpt-5.6-terra costUSD=\(terraBefore
+            .costUSD ?? -1) totalTokens=\(String(describing: terraBefore.totalTokens))
+        2026-07-30 gpt-5.6-terra costUSD=\(terraAfter
+            .costUSD ?? -1) totalTokens=\(String(describing: terraAfter.totalTokens))
+        2026-07-29 gpt-5.6-luna costUSD=\(lunaBefore
+            .costUSD ?? -1) totalTokens=\(String(describing: lunaBefore.totalTokens))
+        2026-07-30 gpt-5.6-luna costUSD=\(lunaAfter
+            .costUSD ?? -1) totalTokens=\(String(describing: lunaAfter.totalTokens))
         """
         try log.write(
             to: proofRoot.appendingPathComponent("codex-historical-pricing-proof.log"),
@@ -127,7 +131,7 @@ struct CodexHistoricalPricingProofTests {
     }
 
     private func writeCodexSession(env: CostUsageTestEnvironment, fixture: SessionFixture) throws {
-        try env.writeCodexSessionFile(
+        _ = try env.writeCodexSessionFile(
             day: fixture.day,
             filename: fixture.filename,
             contents: env.jsonl([

--- a/Tests/CodexBarTests/CostUsagePerformanceGateTests.swift
+++ b/Tests/CodexBarTests/CostUsagePerformanceGateTests.swift
@@ -546,7 +546,7 @@ struct CostUsagePerformanceGateTests {
         print("[retention-proof] stale-coverage file retained after over-budget prune: \(retained.path)")
 
         let warmCounter = HeadParseCounter()
-        _ = CostUsageScanner.withCodexSessionHeadParseObserverForTesting {
+        CostUsageScanner.withCodexSessionHeadParseObserverForTesting {
             warmCounter.increment()
         } operation: {
             _ = CostUsageScanner.loadDailyReport(

--- a/Tests/CodexBarTests/CostUsageScannerForkSplitPricingEvidenceTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerForkSplitPricingEvidenceTests.swift
@@ -203,7 +203,7 @@ extension CostUsageScannerForkSplitTests {
         let inputPerRow = 150_000
         let outputPerRow = 10
         let tokensPerRow = inputPerRow + outputPerRow
-        let rows = (0..<2).map { index in
+        let rows = (0..<2).map { (index: Int) in
             CostUsageScanner.CodexUsageRow(
                 day: dayKey,
                 model: model,

--- a/Tests/CodexBarTests/DeepSeekUsageNativeProofTests.swift
+++ b/Tests/CodexBarTests/DeepSeekUsageNativeProofTests.swift
@@ -123,7 +123,7 @@ final class DeepSeekUsageNativeProofTests: XCTestCase {
         app.activate(ignoringOtherApps: true)
         try JSONSerialization.data(withJSONObject: [
             "pid": ProcessInfo.processInfo.processIdentifier, "window": window.windowNumber,
-            "todayTokens": summary.todayTokens, "todayCost": summary.todayCost,
+            "todayTokens": summary.todayTokens, "todayCost": XCTUnwrap(summary.todayCost),
         ]).write(to: output.appendingPathComponent("state.json"))
         let deadline = Date().addingTimeInterval(600)
         while !FileManager.default.fileExists(atPath: output.appendingPathComponent("done").path), Date() < deadline {

--- a/Tests/CodexBarTests/KeychainStringStoreTests.swift
+++ b/Tests/CodexBarTests/KeychainStringStoreTests.swift
@@ -57,9 +57,10 @@ struct KeychainStringStoreTests {
     @Test(arguments: [errSecSuccess, errSecItemNotFound])
     func `writes update existing items and add only missing items`(updateStatus: OSStatus) throws {
         let backend = Backend(updateStatus: updateStatus)
-        try KeychainAccessGate.withTaskOverrideForTesting(false) {
+        let stored = try KeychainAccessGate.withTaskOverrideForTesting(false) {
             try self.store(backend).store("  synthetic-value\n")
         }
+        #expect(stored)
         #expect(backend.calls == (updateStatus == errSecSuccess ? ["update"] : ["update", "add"]))
         #expect(backend.attributes?[kSecValueData as String] as? Data == Data("synthetic-value".utf8))
         #expect(backend.attributes?[kSecAttrAccessible as String] as? String ==
@@ -71,9 +72,10 @@ struct KeychainStringStoreTests {
     @Test(arguments: [nil, "", " \n", "invalid-cookie"] as [String?])
     func `empty or rejected writes delete the item`(value: String?) throws {
         let backend = Backend()
-        try KeychainAccessGate.withTaskOverrideForTesting(false) {
+        let stored = try KeychainAccessGate.withTaskOverrideForTesting(false) {
             try self.store(backend).store(value, isValid: { $0 != "invalid-cookie" })
         }
+        #expect(stored)
         #expect(backend.calls == ["delete"])
     }
 

--- a/Tests/CodexBarTests/MenuBarLayoutTests.swift
+++ b/Tests/CodexBarTests/MenuBarLayoutTests.swift
@@ -95,7 +95,6 @@ struct MenuBarLayoutTests {
 
     @Test
     func `conditional normalization clamps thresholds and clause count`() {
-        let predicate = MenuBarConditionalPredicate(metric: .session, comparison: .greaterThan, threshold: 0)
         let manyClauses = (0..<6).map { index in
             MenuBarConditionalClause(
                 combinator: index == 0 ? .or : .and,

--- a/Tests/CodexBarTests/MenuCardCodexAmbientCostTests.swift
+++ b/Tests/CodexBarTests/MenuCardCodexAmbientCostTests.swift
@@ -125,10 +125,10 @@ struct MenuCardCodexAmbientCostTests {
     }
 
     @Test(arguments: [2, 5], CostSummaryDisplayStyle.allCases)
-    func `both account layouts honor the shared cost display mode`(count: Int, style: CostSummaryDisplayStyle) throws {
+    func `both account layouts honor the shared cost display mode`(count: Int, style: CostSummaryDisplayStyle) {
         let fixture = Self.makeFixture()
         fixture.settings.costSummaryDisplayStyle = style
-        try withStatusItemControllerForTesting(
+        withStatusItemControllerForTesting(
             store: fixture.store,
             settings: fixture.settings,
             fetcher: fixture.fetcher)


### PR DESCRIPTION
The Swift build reported a deprecated C-string initializer in the standalone CLI path fallback and avoidable warning noise in test diagnostics. Decode the Darwin executable-path buffer as first-NUL-terminated UTF-8, retaining the previous repair behavior, and make optional diagnostic formatting and fixture types explicit.

Remove unused test setup and redundant effects. Keep the cache-presence and field assertions, additionally assert fake-Keychain write success, and unwrap the synthetic DeepSeek cost before JSON serialization. No test cases, deadlines, or runtime interfaces are removed.

Validation:

- Isolated Codex review of the complete candidate: clean through P2.
- Built probe compiled the actual `runningExecutablePath` method and exercised its empty-bundle fallback from a Unicode executable path; the resolved path matched the running binary.
- `make check`: passed, zero SwiftLint violations across 2,243 files. Full combined verification completed all 1,112 selections / 93 groups. One heavy batch reached the existing group time limit and all of its suites passed individually; no assertions or deadlines were relaxed.

No dependency, toolchain, or platform-floor changes are included.
