### PR TITLE
docs: refresh maintenance guidance and lint config

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -48,4 +48,4 @@
 --allman false
 
 # Exclusions
---exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata,Core/PeekabooCore/Sources/PeekabooCore/Extensions/NSArray+Extensions.swift
+--exclude .build,.swiftpm,DerivedData,node_modules,dist,coverage,xcuserdata

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-# SwiftLint configuration for Peekaboo - Swift 6 compatible
+# SwiftLint configuration for CodexBar
 
 # Paths to include
 included:
@@ -22,8 +22,6 @@ excluded:
   - fastlane
   - vendor
   - "*.playground"
-  # Exclude specific files that should not be linted/formatted
-  - "Core/PeekabooCore/Sources/PeekabooCore/Extensions/NSArray+Extensions.swift"
 
 # Analyzer rules (require compilation)
 analyzer_rules:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -518,7 +518,8 @@ defaults delete com.steipete.codexbar debugMainThreadHangWatchdog
 ### Cookie Management
 - Automatic browser import via SweetCookieKit
 - Keychain cache for some imported browser cookies and OAuth/device-flow credentials
-- `~/.codexbar/config.json` for provider settings, manual cookies, and stored API keys
+- The resolved config file for provider settings, manual cookies, and stored API keys: new installs use
+  `~/.config/codexbar/config.json`, while existing `~/.codexbar/config.json` installs retain their legacy path
 - Manual override for debugging
 - Browser-cookie import when cached sessions need refresh
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,10 +1,16 @@
 ---
-summary: "Pending cleanup items for CodexBar (e.g., retire Claude Opus fallback)."
+summary: "Compatibility constraints to check before retiring legacy Claude quota fields."
 read_when:
   - Grooming backlog or planning maintenance
-  - Removing legacy Claude Opus handling
+  - Reviewing legacy Claude quota compatibility
 ---
 
-## TODO
+## Claude quota compatibility
 
-- December 2025: remove the Claude Opus fallback logic (Claude Code) once users have fully migrated; clean up any UI labels and parsers that reference Opus as a tertiary limit.
+The former December 2025 cleanup deadline did not establish that Claude's Opus quota fallback is unused.
+The CLI parser still accepts `Current week (Opus)`, and the OAuth mapper still falls back to `sevenDayOpus`.
+Public snapshots also retain the legacy `opus` fields used to project the tertiary quota window.
+
+Keep those paths while these source formats and public fields are supported. Any retirement must name the
+replacement formats and migration boundary, preserve remaining model-scoped quota windows, and document the
+compatibility change. A date alone is not evidence that the fallback is dead.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -17,7 +17,9 @@ Source labels (CLI/header): `openai-web`, `web`, `oauth`, `api`, `local`, `cli`,
 
 Cookie-based providers expose a Cookie source picker (Automatic or Manual) in Settings → Providers.
 Some browser cookie imports are cached in Keychain and reused until the session is invalid. API keys, manual cookie
-headers, source selection, provider ordering, and token accounts are stored in `~/.codexbar/config.json`.
+headers, source selection, provider ordering, and token accounts are stored in the resolved config file.
+New installs use `~/.config/codexbar/config.json`; existing `~/.codexbar/config.json` installs retain that legacy path.
+See [CLI configuration](cli-configuration.md) for `XDG_CONFIG_HOME` and `CODEXBAR_CONFIG` overrides.
 
 ## Usage & Spend settings
 


### PR DESCRIPTION
Maintenance guidance still prescribed a December 2025 removal deadline for Claude quota fields that remain in supported CLI/API payloads and public snapshots. Replace that stale task with the actual compatibility boundary, and correct the provider/development guides to describe the XDG config default and retained legacy path.

Remove a copied Peekaboo file exclusion and heading from CodexBar's lint configuration. No lint rules, supported platforms, runtime code, dependencies, or language-version settings change.

Validation:

- Isolated Codex review: clean through P2.
- `make check`: passed, zero SwiftLint violations across 2,244 files.
- Built CLI: documented absolute `XDG_CONFIG_HOME` and overriding `CODEXBAR_CONFIG` commands created only their isolated fixture files, validated the config, and retained mode `0600`.
- `git diff --exit-code 596320ffb3c HEAD -- Sources Package.swift Package.resolved`: no Swift or package-input changes. The live CLI proof exercises the unchanged config-path implementation.
