### PR TITLE
refactor: reuse provider auth and diagnostic helpers

### DIFF
--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -314,21 +314,6 @@ extension UsageMenuCardView.Model {
         ]
     }
 
-    private static func topMistralModel(from entries: [MistralDailyUsageBucket]) -> String? {
-        var tokens: [String: Int] = [:]
-        for entry in entries {
-            for model in entry.models {
-                tokens[model.name, default: 0] += model.totalTokens
-            }
-        }
-        return tokens.max {
-            if $0.value == $1.value {
-                return $0.key > $1.key
-            }
-            return $0.value < $1.value
-        }?.key
-    }
-
     private static func costString(_ value: Double, currencyCode: String) -> String {
         UsageFormatter.currencyString(value, currencyCode: currencyCode)
     }

--- a/Sources/CodexBar/PreferencesDebugPane.swift
+++ b/Sources/CodexBar/PreferencesDebugPane.swift
@@ -565,7 +565,7 @@ struct DebugPane: View {
         let attempts = self.store.fetchAttempts(for: provider)
         guard !attempts.isEmpty else { return L("no_fetch_attempts") }
         return attempts.map { attempt in
-            let kind = Self.fetchKindLabel(attempt.kind)
+            let kind = ProviderDiagnosticFetchAttempt.kindLabel(attempt.kind)
             var line = "\(attempt.strategyID) (\(kind))"
             line += attempt.wasAvailable ? " available" : " unavailable"
             if let error = attempt.errorDescription, !error.isEmpty {
@@ -573,16 +573,5 @@ struct DebugPane: View {
             }
             return line
         }.joined(separator: "\n")
-    }
-
-    private static func fetchKindLabel(_ kind: ProviderFetchKind) -> String {
-        switch kind {
-        case .cli: "cli"
-        case .web: "web"
-        case .oauth: "oauth"
-        case .apiToken: "api"
-        case .localProbe: "local"
-        case .webDashboard: "web"
-        }
     }
 }

--- a/Sources/CodexBarCLI/CLIHelpers.swift
+++ b/Sources/CodexBarCLI/CLIHelpers.swift
@@ -95,7 +95,7 @@ extension CodexBarCLI {
         guard !attempts.isEmpty else { return }
         self.writeStderr("[\(provider.rawValue)] fetch strategies:\n")
         for attempt in attempts {
-            let kindLabel = Self.fetchKindLabel(attempt.kind)
+            let kindLabel = ProviderDiagnosticFetchAttempt.kindLabel(attempt.kind)
             var line = "  - \(attempt.strategyID) (\(kindLabel))"
             line += attempt.wasAvailable ? " available" : " unavailable"
             if let error = attempt.errorDescription, !error.isEmpty {
@@ -134,26 +134,14 @@ extension CodexBarCLI {
         // Provider-specific by design: Kilo exposes its ordered API-to-CLI fallback attempts in verbose output.
         guard provider == .kilo, sourceMode == .auto, !attempts.isEmpty else { return nil }
         let parts = attempts.map { attempt in
-            let label = Self.fetchKindLabel(attempt.kind)
+            let label = ProviderDiagnosticFetchAttempt.kindLabel(attempt.kind)
             let message = attempt.errorDescription?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if !message.isEmpty {
                 return "\(label): \(message)"
             }
             return "\(label): \(attempt.wasAvailable ? "success" : "unavailable")"
         }
-        guard !parts.isEmpty else { return nil }
         return "Kilo auto fallback attempts: " + parts.joined(separator: " -> ")
-    }
-
-    private static func fetchKindLabel(_ kind: ProviderFetchKind) -> String {
-        switch kind {
-        case .cli: "cli"
-        case .web: "web"
-        case .oauth: "oauth"
-        case .apiToken: "api"
-        case .localProbe: "local"
-        case .webDashboard: "web"
-        }
     }
 
     static func fetchStatus(

--- a/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
@@ -114,15 +114,14 @@ struct KiloAPIFetchStrategy: ProviderFetchStrategy {
     let id: String = "kilo.api"
     let kind: ProviderFetchKind = .apiToken
 
-    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        _ = context
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
         // Keep strategy available so missing credentials surface as KiloUsageError.missingCredentials
         // instead of generic ProviderFetchError.noAvailableStrategy.
-        return true
+        true
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        guard let apiKey = Self.resolveToken(environment: context.env) else {
+        guard let apiKey = KiloSettingsReader.apiKey(environment: context.env) else {
             throw KiloUsageError.missingCredentials
         }
         let usage = try await KiloUsageFetcher.fetchUsage(apiKey: apiKey, environment: context.env)
@@ -136,24 +135,19 @@ struct KiloAPIFetchStrategy: ProviderFetchStrategy {
         guard let kiloError = error as? KiloUsageError else { return false }
         return kiloError == .missingCredentials || kiloError == .unauthorized
     }
-
-    private static func resolveToken(environment: [String: String]) -> String? {
-        KiloSettingsReader.apiKey(environment: environment)
-    }
 }
 
 struct KiloCLIFetchStrategy: ProviderFetchStrategy {
     let id: String = "kilo.cli"
     let kind: ProviderFetchKind = .cli
 
-    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        _ = context
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
         // Keep strategy available so CLI-specific session failures are surfaced as actionable errors.
-        return true
+        true
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let token = try Self.resolveToken(environment: context.env)
+        let token = try KiloBearerTokenResolver.resolve(source: .cli, apiKey: nil, environment: context.env).token
         let usage = try await KiloUsageFetcher.fetchUsage(apiKey: token, environment: context.env)
         return self.makeResult(
             usage: usage.toUsageSnapshot(),
@@ -162,37 +156,5 @@ struct KiloCLIFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
         false
-    }
-
-    private static func resolveToken(environment: [String: String]) throws -> String {
-        let authFileURL = Self.authFileURL(environment: environment)
-        let fileManager = FileManager.default
-
-        guard fileManager.fileExists(atPath: authFileURL.path) else {
-            throw KiloUsageError.cliSessionMissing(authFileURL.path)
-        }
-
-        let data: Data
-        do {
-            data = try Data(contentsOf: authFileURL)
-        } catch {
-            throw KiloUsageError.cliSessionUnreadable(authFileURL.path)
-        }
-
-        guard let token = KiloSettingsReader.parseAuthToken(data: data) else {
-            throw KiloUsageError.cliSessionInvalid(authFileURL.path)
-        }
-
-        return token
-    }
-
-    private static func authFileURL(environment: [String: String]) -> URL {
-        if let home = SettingsValue.cleaned(environment["HOME"]) {
-            let expandedHome = NSString(string: home).expandingTildeInPath
-            return KiloSettingsReader.defaultAuthFileURL(
-                homeDirectory: URL(fileURLWithPath: expandedHome, isDirectory: true))
-        }
-        return KiloSettingsReader.defaultAuthFileURL(
-            homeDirectory: FileManager.default.homeDirectoryForCurrentUser)
     }
 }

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIIDToken.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIIDToken.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Reads display identity only; token verification belongs to the OAuth provider.
+enum VertexAIIDToken {
+    static func email(from token: String?) -> String? {
+        guard let token, !token.isEmpty else { return nil }
+
+        let parts = token.components(separatedBy: ".")
+        guard parts.count >= 2 else { return nil }
+
+        var payload = parts[1]
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        let remainder = payload.count % 4
+        if remainder > 0 {
+            payload += String(repeating: "=", count: 4 - remainder)
+        }
+
+        guard let data = Data(base64Encoded: payload, options: .ignoreUnknownCharacters),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        return json["email"] as? String
+    }
+}

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIOAuthCredentials.swift
@@ -209,8 +209,7 @@ public enum VertexAIOAuthCredentialsStore {
         // Try to get project ID from gcloud config
         let projectId = Self.loadProjectId(environment: environment)
 
-        // Try to extract email from ID token if present
-        let email = Self.extractEmailFromIdToken(json["id_token"] as? String)
+        let email = VertexAIIDToken.email(from: json["id_token"] as? String)
 
         // Parse expiry if present
         var expiryDate: Date?
@@ -299,29 +298,5 @@ public enum VertexAIOAuthCredentialsStore {
         return environment["GOOGLE_CLOUD_PROJECT"]
             ?? environment["GCLOUD_PROJECT"]
             ?? environment["CLOUDSDK_CORE_PROJECT"]
-    }
-
-    private static func extractEmailFromIdToken(_ token: String?) -> String? {
-        guard let token, !token.isEmpty else { return nil }
-
-        let parts = token.components(separatedBy: ".")
-        guard parts.count >= 2 else { return nil }
-
-        var payload = parts[1]
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-
-        let remainder = payload.count % 4
-        if remainder > 0 {
-            payload += String(repeating: "=", count: 4 - remainder)
-        }
-
-        guard let data = Data(base64Encoded: payload, options: .ignoreUnknownCharacters),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            return nil
-        }
-
-        return json["email"] as? String
     }
 }

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIOAuthCredentials.swift
@@ -228,10 +228,8 @@ public enum VertexAIOAuthCredentialsStore {
             expiryDate: expiryDate)
     }
 
-    public static func save(_ credentials: VertexAIOAuthCredentials) throws {
-        // We don't modify gcloud's credentials file; just cache the access token in memory
-        // The refresh happens on each app launch if needed
-    }
+    /// Compatibility no-op; gcloud owns credential persistence.
+    public static func save(_: VertexAIOAuthCredentials) throws {}
 
     private static func parseServiceAccountMetadata(json: [String: Any]) -> ServiceAccountMetadata? {
         guard let email = (json["client_email"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAITokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAITokenRefresher.swift
@@ -78,9 +78,8 @@ public enum VertexAITokenRefresher {
             let expiresIn = json["expires_in"] as? Double ?? 3600
             let newExpiryDate = Date().addingTimeInterval(expiresIn)
 
-            // Extract email from new ID token if present
             let idToken = json["id_token"] as? String
-            let email = Self.extractEmailFromIdToken(idToken) ?? credentials.email
+            let email = VertexAIIDToken.email(from: idToken) ?? credentials.email
 
             return VertexAIOAuthCredentials(
                 accessToken: newAccessToken,
@@ -100,29 +99,5 @@ public enum VertexAITokenRefresher {
     private static func extractErrorCode(from data: Data) -> String? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
         return json["error"] as? String
-    }
-
-    private static func extractEmailFromIdToken(_ token: String?) -> String? {
-        guard let token, !token.isEmpty else { return nil }
-
-        let parts = token.components(separatedBy: ".")
-        guard parts.count >= 2 else { return nil }
-
-        var payload = parts[1]
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-
-        let remainder = payload.count % 4
-        if remainder > 0 {
-            payload += String(repeating: "=", count: 4 - remainder)
-        }
-
-        guard let data = Data(base64Encoded: payload, options: .ignoreUnknownCharacters),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            return nil
-        }
-
-        return json["email"] as? String
     }
 }

--- a/Tests/CodexBarTests/VertexAIOAuthCredentialsTests.swift
+++ b/Tests/CodexBarTests/VertexAIOAuthCredentialsTests.swift
@@ -40,7 +40,8 @@ struct VertexAIOAuthCredentialsTests {
         {
           "client_id": "client-id",
           "client_secret": "client-secret",
-          "refresh_token": "refresh-token"
+          "refresh_token": "refresh-token",
+          "id_token": "e30.eyJlbWFpbCI6ImZpeHR1cmVAZXhhbXBsZS50ZXN0In0.signature"
         }
         """
         try credentialsJSON.write(to: credentialsURL, atomically: true, encoding: .utf8)
@@ -58,6 +59,7 @@ struct VertexAIOAuthCredentialsTests {
 
         #expect(credentials.refreshToken == "refresh-token")
         #expect(credentials.projectId == "configured-project")
+        #expect(credentials.email == "fixture@example.test")
     }
 
     private static func writeServiceAccountCredentials() throws -> URL {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,9 @@ read_when:
   rendering mode and projected layout without copying unused settings into a second state object.
 - `SettingsValue` owns whitespace and wrapping-quote normalization for config and provider settings. Readers retain
   their credential precedence, endpoint validation, and provider-specific decoding.
+- Kilo's CLI fetch strategy and organization discovery share `KiloBearerTokenResolver` for auth-file loading.
+  Vertex AI credential loading and renewal share display-only ID-token decoding; diagnostic fetch labels use
+  `ProviderDiagnosticFetchAttempt` across the app and CLI.
 - Core owns status feed fetching, decoding, and status models through `ProviderStatusFetcher`; the app supplies
   localized labels and component UI, and the CLI supplies its existing status payload and English labels.
 - `KeychainStringStore` owns generic-password operations for legacy credential migration. Provider adapters retain


### PR DESCRIPTION
Kilo's CLI fetch strategy duplicated the auth-file loader already used for organization discovery, while Vertex AI decoded the same display identity separately during credential loading and renewal. Reuse those shared implementations while retaining the existing source precedence, home resolution, failure categories, and tolerant ID-token parsing.

Route app/CLI fetch-kind labels through the existing diagnostic mapping, remove the now-redundant Kilo wrapper and empty-result check, and delete an unused inline Mistral model helper. The ADC fixture now also verifies the decoded email. The public throwing Vertex credential-save method remains a compatibility no-op, with its persistence ownership now documented accurately. Public interfaces and displayed behavior are unchanged.

Validation:

- Isolated Codex review of the complete candidate and relevant diagnostic context: clean through P2.
- `make check`: passed, zero SwiftLint violations across 2,245 files.
- Built CLI before/after proof: isolated HOME lookup, missing/malformed/empty Kilo sessions, login guidance, and ordered API/CLI fallback diagnostics all match. No real credentials or provider network requests.
- Full sharded `make test`: all 1,113 selections / 93 groups passed on the first attempt; zero retries, failures, or timeouts. Execution took 1,085.3 seconds (1,743.2 seconds including the cold build). Local validation used the installed Swift 6.4 toolchain with the native SwiftPM backend.

The full combined stage-one tree on updated main also completed all 1,112 selections / 93 groups, with one heavy batch recovered through individual-suite retries. The rebased complete candidate passed a fresh P0–P2 review.

No dependency, toolchain, or CI changes are included.
