### PR TITLE
build: refresh dependencies and pinned validation toolchains

### DIFF
--- a/.github/actions/build-linux-desktop/action.yml
+++ b/.github/actions/build-linux-desktop/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         set -euo pipefail
         [[ "$DESKTOP_VERSION" =~ ^[0-9][0-9A-Za-z._-]{0,79}$ ]] || { echo 'Invalid desktop version' >&2; exit 1; }
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22'
     - name: Install Qt 6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,18 +119,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Select Xcode 26.3 or 26.2
+      - name: Select Xcode 26.6
         run: |
           set -euo pipefail
-          # Both versions are part of the official macOS 26 runner image.
-          for candidate in /Applications/Xcode_26.3.app /Applications/Xcode_26.2.app; do
-            if [[ -d "$candidate" ]]; then
-              sudo xcode-select -s "${candidate}/Contents/Developer"
-              echo "DEVELOPER_DIR=${candidate}/Contents/Developer" >> "$GITHUB_ENV"
-              break
-            fi
-          done
-          [[ "$(/usr/bin/xcodebuild -version)" == Xcode\ 26.* ]]
+          sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
+          echo "DEVELOPER_DIR=/Applications/Xcode_26.6.app/Contents/Developer" >> "$GITHUB_ENV"
+          [[ "$(/usr/bin/xcodebuild -version)" == Xcode\ 26.6* ]]
           /usr/bin/xcodebuild -version
 
       - name: Restore SwiftPM build cache
@@ -276,14 +270,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
-      SWIFT_VERSION: 6.2.1
-      SWIFT_STATIC_LINUX_SDK: swift-6.2.1-RELEASE_static-linux-0.0.1
+      SWIFT_VERSION: 6.2.4
+      SWIFT_STATIC_LINUX_SDK: swift-6.2.4-RELEASE_static-linux-0.1.0
       SWIFT_STATIC_LINUX_SDK_TRIPLE: x86_64-swift-linux-musl
       SWIFT_STATIC_LINUX_SDK_ARCH: x86_64
-      SWIFT_STATIC_LINUX_SDK_URL: https://download.swift.org/swift-6.2.1-release/static-sdk/swift-6.2.1-RELEASE/swift-6.2.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
-      SWIFT_STATIC_LINUX_SDK_CHECKSUM: 08e1939a504e499ec871b36826569173103e4562769e12b9b8c2a50f098374ad
-      SQLITE_AMALGAMATION_VERSION: "3530300"
-      SQLITE_AMALGAMATION_SHA3_256: d45c688a8cb23f68611a894a756a12d7eb6ab6e9e2468ca70adbeab3808b5ab9
+      SWIFT_STATIC_LINUX_SDK_URL: https://download.swift.org/swift-6.2.4-release/static-sdk/swift-6.2.4-RELEASE/swift-6.2.4-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz
+      SWIFT_STATIC_LINUX_SDK_CHECKSUM: 24bdf84495dd31a6de2eb679647c1982b747bfbfe1a2060c779d84dcecd902a4
+      SQLITE_AMALGAMATION_VERSION: "3530400"
+      SQLITE_AMALGAMATION_SHA3_256: 628a44cfe82c66aed1ccbbe85a562d2e33ebe64b3288981ed76285612227934e
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -48,7 +48,7 @@ jobs:
             asset-arch: x86_64
             build-arch: ""
             static-swift-stdlib: false
-            swift-sdk: swift-6.2.1-RELEASE_static-linux-0.0.1
+            swift-sdk: swift-6.2.4-RELEASE_static-linux-0.1.0
             swift-sdk-triple: x86_64-swift-linux-musl
             swift-sdk-arch: x86_64
             file-arch-pattern: x86-64
@@ -59,7 +59,7 @@ jobs:
             asset-arch: aarch64
             build-arch: ""
             static-swift-stdlib: false
-            swift-sdk: swift-6.2.1-RELEASE_static-linux-0.0.1
+            swift-sdk: swift-6.2.4-RELEASE_static-linux-0.1.0
             swift-sdk-triple: aarch64-swift-linux-musl
             swift-sdk-arch: aarch64
             file-arch-pattern: aarch64
@@ -88,13 +88,13 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
-      SWIFT_VERSION: 6.2.1
+      SWIFT_VERSION: 6.2.4
       SWIFTLY_VERSION: 1.1.3
       SWIFTLY_SIGNING_FINGERPRINT: E813C892820A6FA13755B268F167DF1ACF9CE069
-      SWIFT_STATIC_LINUX_SDK_URL: https://download.swift.org/swift-6.2.1-release/static-sdk/swift-6.2.1-RELEASE/swift-6.2.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
-      SWIFT_STATIC_LINUX_SDK_CHECKSUM: 08e1939a504e499ec871b36826569173103e4562769e12b9b8c2a50f098374ad
-      SQLITE_AMALGAMATION_VERSION: "3530300"
-      SQLITE_AMALGAMATION_SHA3_256: d45c688a8cb23f68611a894a756a12d7eb6ab6e9e2468ca70adbeab3808b5ab9
+      SWIFT_STATIC_LINUX_SDK_URL: https://download.swift.org/swift-6.2.4-release/static-sdk/swift-6.2.4-RELEASE/swift-6.2.4-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz
+      SWIFT_STATIC_LINUX_SDK_CHECKSUM: 24bdf84495dd31a6de2eb679647c1982b747bfbfe1a2060c779d84dcecd902a4
+      SQLITE_AMALGAMATION_VERSION: "3530400"
+      SQLITE_AMALGAMATION_SHA3_256: 628a44cfe82c66aed1ccbbe85a562d2e33ebe64b3288981ed76285612227934e
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release-linux-desktop.yml
+++ b/.github/workflows/release-linux-desktop.yml
@@ -70,7 +70,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: desktop-linux-*
           merge-multiple: true

--- a/.swiftformat
+++ b/.swiftformat
@@ -39,8 +39,10 @@
 --enumthreshold 0
 
 # Swift 6 specific
---swiftversion 6.3
+--swiftversion 6.2
 --disable redundantSendable # Keep explicit concurrency contracts visible
+--disable wrapIfStatementBodies,wrapFunctionBodies # Retain compact guards and simple test fixtures
+--disable swiftTestingTestCaseNames,redundantSwiftTestingSuite # Preserve discovered test names and suite declarations
 
 # Other
 --stripunusedargs closure-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Web dashboard: preserve account aliases and organization labels so Claude accounts sharing an email remain distinguishable, including in redacted mode (follow-up to #3082).
 
 ### Development
+- Refresh Swift Crypto and KeyboardShortcuts, checksum-pinned lint tools, and CI/release build toolchains while retaining the Swift 6.2 and macOS deployment floors; isolate plugin typechecking from unrelated ancestor packages.
 - Remove retired menu views, unused provider helpers, and no-op credential-loading hooks; reuse shared config accessors and simplify redundant menu and account state.
 - Tests: fix native macOS SwiftPM test launches when Sparkle is staged beside the test bundle (from #3584). Thanks @hhh2210!
 - Consolidate status feeds, legacy Keychain string operations, API-token strategies, quota presentation, test-runner detection, and checked usage totals under shared owners while preserving provider-specific behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@
 - Web dashboard: preserve account aliases and organization labels so Claude accounts sharing an email remain distinguishable, including in redacted mode (follow-up to #3082).
 
 ### Development
-- Refresh Swift Crypto and KeyboardShortcuts, checksum-pinned lint tools, and CI/release build toolchains while retaining the Swift 6.2 and macOS deployment floors; isolate plugin typechecking from unrelated ancestor packages.
 - Remove retired menu views, unused provider helpers, and no-op credential-loading hooks; reuse shared config accessors and simplify redundant menu and account state.
 - Tests: fix native macOS SwiftPM test launches when Sparkle is staged beside the test bundle (from #3584). Thanks @hhh2210!
 - Consolidate status feeds, legacy Keychain string operations, API-token strategies, quota presentation, test-runner detection, and checked usage totals under shared owners while preserving provider-specific behavior.
 - Share browser-profile cookie merging, legacy cookie-file encoding, short-lived import caches, OpenCode web parsing, OneConsole quota projection, and terminal scan buffers without merging provider identities or authentication policies.
 - Centralize Chromium local-storage discovery, plugin management-auth policy, and Codex spend-limit number decoding.
+- Refresh Swift Crypto and KeyboardShortcuts, checksum-pinned lint tools, and CI/release build toolchains while retaining the Swift 6.2 and macOS deployment floors; isolate plugin typechecking from unrelated ancestor packages.
 
 ## 0.60.0 — 2026-09-12
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6d90b957f185c55cc3bf7000d43887034c8e7ea57e7254608470d41815cb15ed",
+  "originHash" : "b30c2e55490a09a52862aca36b5f8da37482878f58fa4b0a7a6fd6601aaeec0e",
   "pins" : [
     {
       "identity" : "commander",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
-        "version" : "2.4.0"
+        "revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06",
+        "version" : "3.0.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -46,9 +46,9 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.6"),
         .package(url: "https://github.com/steipete/Commander", from: "0.2.4"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.2"),
         .package(url: "https://github.com/apple/swift-log", from: "1.15.1"),
-        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.4.0"),
+        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "3.0.1"),
         .package(url: "https://github.com/zats/Vortex", revision: "ef5392088d4aeb255c4eee83157dbdafcd31bf07"),
         sweetCookieKitDependency,
     ],

--- a/Scripts/install_lint_tools.sh
+++ b/Scripts/install_lint_tools.sh
@@ -6,18 +6,18 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TOOLS_DIR="${ROOT_DIR}/.build/lint-tools"
 BIN_DIR="${TOOLS_DIR}/bin"
 
-SWIFTFORMAT_VERSION="0.61.1"
+SWIFTFORMAT_VERSION="0.63.0"
 SWIFTLINT_VERSION="0.65.1"
 OXLINT_VERSION="1.82.0"
 OXFMT_VERSION="0.67.0"
 OXC_APPS_RELEASE="1.82.0"
-TYPESCRIPT_VERSION="5.9.3"
+TYPESCRIPT_VERSION="7.0.2"
 
-SWIFTFORMAT_SHA256_DARWIN="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"
+SWIFTFORMAT_SHA256_DARWIN="28c7802e11fa5ae113d903066439c6bb1be20a8ac1ad9709c42616a7e273fb0f"
 SWIFTLINT_SHA256_DARWIN="c1e429b0599cf1b516f369a2d9ec04eaf0e436f3c12b637df8851fa52ff694d0"
-SWIFTFORMAT_SHA256_LINUX_X86_64="7bc8706e3fd51963f1f29eb99098ebdf482f3497fa527c68e6cf75cbee29c77a"
+SWIFTFORMAT_SHA256_LINUX_X86_64="b4a3cbb8c852a0baaf9adf853e221ff1dabf921a3d8957a602e0bda3af8470f1"
 SWIFTLINT_SHA256_LINUX_X86_64="caeed6f4a679c35539ffaf124f6c4ab4a8416917f7d8796279dc52b74026059d"
-SWIFTFORMAT_SHA256_LINUX_ARM64="42a35b557a6d56975fba3a48e78d39ab5388c8faac65d4819f25d3e20c7504c0"
+SWIFTFORMAT_SHA256_LINUX_ARM64="b0335af32e2c5944a17b3e6d916ff4552eb757ed88f68b80fd19415824850717"
 SWIFTLINT_SHA256_LINUX_ARM64="9ffa52f478e6d8eb485d37d14715ffac90abc81c58f3370d598bf75be05605f8"
 OXLINT_SHA256_DARWIN_X86_64="42206a631be5a65e4f32de5983e9e8991197ef2756870c257a5db2e6f493a86f"
 OXLINT_SHA256_DARWIN_ARM64="e420b7f67fc1ec5426c932a7e5b07e546c67c661c9b7116ba6c8c9648ff96074"
@@ -27,7 +27,11 @@ OXFMT_SHA256_DARWIN_X86_64="20e82289d7f41399a4d9670a0d78135e14dbe04f421163be2cc0
 OXFMT_SHA256_DARWIN_ARM64="2c0a483844922828a8b9b78684cb01e9283242250cad5d7303eb2cce0e027175"
 OXFMT_SHA256_LINUX_X86_64="7fcda58499e25a261069022f3c6b9827da4bcc729a6181214c0645b3e30d1603"
 OXFMT_SHA256_LINUX_ARM64="b738733446781432fc6874b9e9328def0c5cd1c69335bcf258078e429e4887e1"
-TYPESCRIPT_SHA256="10e108c9cf7d5f2879053dff18515fb405abf2ccef63eaaf017d9c571687a1d3"
+TYPESCRIPT_SHA256="da2513f4b95176d6dde8b51aab7afe8a927656c9d277369793f77f7e59371c08"
+TYPESCRIPT_SHA256_DARWIN_ARM64="902e2fe1cf0799198ef902c6b8c310a450fef629a6baba41d45641ef75c04ebd"
+TYPESCRIPT_SHA256_DARWIN_X64="eba158cb54050f723d5ff781438f33de5640054440bb4f2bd170cfe9bc2eb551"
+TYPESCRIPT_SHA256_LINUX_ARM64="c83d931ac9dd7549cde6e71246aa9d6a9812843023df3e277fe3b5dcf41dd0ea"
+TYPESCRIPT_SHA256_LINUX_X64="7ecad6f67377e831856367ab062ef394f21506a611405bf8ac0ff039348637d3"
 
 log() { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -174,11 +178,22 @@ install_tar_binary() {
   rm -rf "$tmp_dir"
 }
 
-install_typescript() {
-  local tmp_tar
-  tmp_tar="$(mktemp -t "typescript.XXXX")"
+install_typescript() (
+  # Match the Node wrapper's package selection, including Node running under Rosetta.
+  local target native_sha
+  target="$(node -p 'process.platform + "-" + process.arch')"
+  case "$target" in
+    darwin-arm64) native_sha="$TYPESCRIPT_SHA256_DARWIN_ARM64" ;;
+    darwin-x64) native_sha="$TYPESCRIPT_SHA256_DARWIN_X64" ;;
+    linux-arm64) native_sha="$TYPESCRIPT_SHA256_LINUX_ARM64" ;;
+    linux-x64) native_sha="$TYPESCRIPT_SHA256_LINUX_X64" ;;
+    *) fail "Unsupported TypeScript platform: ${target}" ;;
+  esac
+
   local tmp_dir
   tmp_dir="$(mktemp -d -t "typescript.XXXX")"
+  trap 'rm -rf "$tmp_dir"' EXIT
+  local tmp_tar="${tmp_dir}/typescript.tgz"
   local url="https://registry.npmjs.org/typescript/-/typescript-${TYPESCRIPT_VERSION}.tgz"
 
   log "==> Downloading TypeScript ${TYPESCRIPT_VERSION}"
@@ -186,17 +201,23 @@ install_typescript() {
   local actual_sha
   actual_sha="$(sha256_value "$tmp_tar")"
   if [[ "$actual_sha" != "$TYPESCRIPT_SHA256" ]]; then
-    rm -f "$tmp_tar"
-    rm -rf "$tmp_dir"
     fail "TypeScript ${TYPESCRIPT_VERSION} SHA256 mismatch (expected ${TYPESCRIPT_SHA256}, got ${actual_sha})"
   fi
 
   tar -xzf "$tmp_tar" -C "$tmp_dir"
+  local native_dir="${tmp_dir}/package/node_modules/@typescript/typescript-${target}"
+  local native_url="https://registry.npmjs.org/@typescript/typescript-${target}/-/typescript-${target}-${TYPESCRIPT_VERSION}.tgz"
+  download_file "$native_url" "$tmp_tar"
+  actual_sha="$(sha256_value "$tmp_tar")"
+  if [[ "$actual_sha" != "$native_sha" ]]; then
+    fail "TypeScript ${target} SHA256 mismatch (expected ${native_sha}, got ${actual_sha})"
+  fi
+  mkdir -p "$native_dir"
+  tar -xzf "$tmp_tar" --strip-components=1 -C "$native_dir"
+  node "${tmp_dir}/package/bin/tsc" --version
   rm -rf "${TOOLS_DIR}/typescript"
   mv "${tmp_dir}/package" "${TOOLS_DIR}/typescript"
-  rm -f "$tmp_tar"
-  rm -rf "$tmp_dir"
-}
+)
 
 mkdir -p "$BIN_DIR"
 

--- a/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
-        "version" : "2.4.0"
+        "revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06",
+        "version" : "3.0.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -138,6 +138,12 @@ cover this cleanup without creating status items or changing the user's saved pr
 not establish the cause of a position that changes again after launch; that requires runtime placement evidence.
 
 ### Run Tests Only
+
+Lint tools are installed at repository-pinned versions by `Scripts/install_lint_tools.sh`, with archive checksums
+verified before installation. TypeScript 7 installs its native package for the running Node platform and architecture
+(including Rosetta). Plugin typechecking uses only its declared libraries and source declarations, so unrelated
+ancestor `node_modules/@types` packages do not affect the result. SwiftFormat targets the package's Swift 6.2 floor.
+
 ```bash
 make test
 ```

--- a/tsconfig.plugins.json
+++ b/tsconfig.plugins.json
@@ -3,7 +3,8 @@
     "lib": ["ES2022"],
     "noEmit": true,
     "strict": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "types": []
   },
   "include": [
     "Sources/CodexBarCore/Resources/Plugins/*.ts"


### PR DESCRIPTION
Refresh the pinned dependencies and validation tools without raising the Swift 6.2 or macOS deployment floors. Root and widget lockfiles now agree on Swift Crypto 4.5.2 and KeyboardShortcuts 3.0.1. The newer KeyboardShortcuts 3.1.0 was excluded because it was less than 48 hours old at selection time.

| Pin | Before → after | Reason / source |
|---|---|---|
| Swift Crypto | 3.15.1 → 4.5.2 | Maintained stable [release](https://github.com/apple/swift-crypto/releases/tag/4.5.2), Swift tools 6.1 |
| KeyboardShortcuts | 2.4.0 → 3.0.1 | Mature Swift 6.2 [release](https://github.com/sindresorhus/KeyboardShortcuts/releases/tag/3.0.1) |
| SwiftFormat | 0.61.1 → 0.63.0 | [Release](https://github.com/nicklockwood/SwiftFormat/releases/tag/0.63.0); grammar aligned to the declared Swift 6.2 floor, existing compact fixtures and discovered test names preserved |
| TypeScript | 5.9.3 → 7.0.2 | [Registry version](https://www.npmjs.com/package/typescript/v/7.0.2); checksum-verify common and native archives before replacement; select native package using Node's platform/architecture, including Rosetta |
| macOS CI | Xcode 26.3/26.2 → 26.6 | Available in the [macOS 26 runner image](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md); macOS 15 release runners retain their available Xcode selection |
| Static Linux SDK / Swift | 6.2.1 → 6.2.4 | Maintained floor-line compiler and matching static SDK 0.1.0; checksum from [Swift release metadata](https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/swift_releases.yml) |
| Static SQLite | 3.53.3 → 3.53.4 | [Stable patch fixes](https://www.sqlite.org/releaselog/3_53_4.html), SHA3-256 pinned |
| Linux desktop actions | setup-node v4 → v7.0.0; download-artifact v4 → v8.0.1 | Current SHA-pinned action runtimes; requested Node 22 remains unchanged |

All selected releases predate this change by more than 48 hours. Existing SwiftLint, Oxc, Swiftly, latest-line Linux Swift, and other action pins were already current. The revision-pinned Vortex dependency is retained.

Plugin typechecking now declares `types: []`: plugin sources and standard ES2022 declarations are still checked, while unrelated ancestor `node_modules/@types` no longer leak into this embedded runtime. A synthetic invalid ancestor declaration reproduced the prior failure.

Validation on this head:

- `make check` passed: no formatting changes needed and zero SwiftLint violations across 2,239 files; existing script, containment, manifest and plugin checks passed.
- Isolated Codex review: no accepted P0–P2 findings.
- Executed the new TypeScript installer and compiler: version 7.0.2; all plugin sources typechecked successfully with a deliberately invalid ancestor `@types` package.
- Executed the installer against a corrupt native archive: checksum rejection retained the previous installation. Verified common/native archives then replaced it with a working compiler.
- Freshly built CLI smoke proof passed: synthetic `config enable`/`config validate` exercised XDG and explicit config paths with mode 0600; Kilo missing/malformed/empty fixture credentials preserved recovery and ordered fallback diagnostics without provider network requests.
- Exact-head [CI 34724610482](https://github.com/steipete/CodexBar/actions/runs/34724610482) passed both macOS shards, Linux x64/arm64, musl, lint and aggregate checks; [desktop CI 34724610529](https://github.com/steipete/CodexBar/actions/runs/34724610529) passed x64 and arm64.
- Xcode resolved the separate widget project using `-onlyUsePackageVersionsFromResolvedFile`, accepting the intended pins without source changes.
- Local full validation exposed redundant menu-fixture config writes; the correction landed separately in #3584, where all 176 menu tests passed in 27.296 seconds under the unchanged 180-second limit. Combined dependency + fixture validation passed 74 groups initially and recovered one cost-store batch through existing timeout retries, then failed unchanged RPC initialization cases. An isolated six-test RPC run passed, while the exact batch reproduced another initialization timeout. Remaining-group validation stopped on a missing heartbeat file in an unchanged process fixture. These local runs are not claimed as fully green; root-cause investigation continues separately from dependency changes.
- The freshly built CLI passed five additional synthetic stdin-close checks in 0.141–0.529 seconds, returning the expected ordinary error without signal abort or real provider access.

No app version, release, publication, or deploy is part of this change.
