### PR TITLE
fix(vertex): preserve OAuth refresh values and validate responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Codex activity: reuse validated SQLite and decoded aggregate state across unchanged refreshes, preserving replacement, writer, and compatibility invalidation (#3593, related to #3247). Thanks @brzvsk!
 
 ### Fixed
+- Vertex AI: preserve reserved characters in OAuth refresh credentials and reject successful responses that omit a usable access token.
 - Account cards: keep Grok's cached local costs out of an account card that has no usage snapshot.
 - Codex: prefer fresh authorized subscription dates over stale cache metadata, and keep empty account cards from inheriting another account's identity, usage, or credits.
 - Provider settings: preserve saved configuration for unavailable plugins when reordering providers, and localize Qoder and Qwen Cloud cookie-cache labels consistently.

--- a/Sources/CodexBarCore/FormURLEncoding.swift
+++ b/Sources/CodexBarCore/FormURLEncoding.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum FormURLEncoding {
+    static func body(_ parameters: [String: String]) -> Data {
+        let pairs = parameters
+            .map { key, value in
+                "\(Self.encode(key))=\(Self.encode(value))"
+            }
+            .joined(separator: "&")
+        return Data(pairs.utf8)
+    }
+
+    private static func encode(_ value: String) -> String {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "+&=")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+}

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
@@ -96,7 +96,7 @@ public struct CopilotDeviceFlow: Sendable {
             "client_id": self.clientID,
             "scope": self.scopes,
         ]
-        postRequest.httpBody = Self.formURLEncodedBody(body)
+        postRequest.httpBody = FormURLEncoding.body(body)
 
         let response = try await ProviderHTTPClient.shared.response(for: postRequest)
 
@@ -121,7 +121,7 @@ public struct CopilotDeviceFlow: Sendable {
             "device_code": deviceCode,
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
         ]
-        request.httpBody = Self.formURLEncodedBody(body)
+        request.httpBody = FormURLEncoding.body(body)
 
         while true {
             try await Task.sleep(nanoseconds: UInt64(interval) * 1_000_000_000)
@@ -152,22 +152,7 @@ public struct CopilotDeviceFlow: Sendable {
         }
     }
 
-    private static func formURLEncodedBody(_ parameters: [String: String]) -> Data {
-        let pairs = parameters
-            .map { key, value in
-                "\(Self.formEncode(key))=\(Self.formEncode(value))"
-            }
-            .joined(separator: "&")
-        return Data(pairs.utf8)
-    }
-
     static func makeRequestURL(host: String, path: String) -> URL? {
         URL(string: "https://\(host)\(path)")
-    }
-
-    private static func formEncode(_ value: String) -> String {
-        var allowed = CharacterSet.urlQueryAllowed
-        allowed.remove(charactersIn: "+&=")
-        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 }

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAITokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAITokenRefresher.swift
@@ -27,6 +27,13 @@ public enum VertexAITokenRefresher {
     }
 
     public static func refresh(_ credentials: VertexAIOAuthCredentials) async throws -> VertexAIOAuthCredentials {
+        try await self.refresh(credentials, session: ProviderHTTPClient.shared)
+    }
+
+    static func refresh(
+        _ credentials: VertexAIOAuthCredentials,
+        session transport: any ProviderHTTPTransport) async throws -> VertexAIOAuthCredentials
+    {
         guard !credentials.refreshToken.isEmpty else {
             throw RefreshError.invalidResponse("No refresh token available")
         }
@@ -43,13 +50,10 @@ public enum VertexAITokenRefresher {
             "grant_type": "refresh_token",
         ]
 
-        let bodyString = bodyParams
-            .map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
-            .joined(separator: "&")
-        request.httpBody = bodyString.data(using: .utf8)
+        request.httpBody = FormURLEncoding.body(bodyParams)
 
         do {
-            let response = try await ProviderHTTPClient.shared.response(for: request)
+            let response = try await transport.response(for: request)
             let data = response.data
 
             if response.statusCode == 400 || response.statusCode == 401 {
@@ -74,7 +78,11 @@ public enum VertexAITokenRefresher {
                 throw RefreshError.invalidResponse("Invalid JSON")
             }
 
-            let newAccessToken = json["access_token"] as? String ?? credentials.accessToken
+            guard let newAccessToken = json["access_token"] as? String,
+                  !newAccessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                throw RefreshError.invalidResponse("Missing access token")
+            }
             let expiresIn = json["expires_in"] as? Double ?? 3600
             let newExpiryDate = Date().addingTimeInterval(expiresIn)
 

--- a/Tests/CodexBarTests/VertexAIRefreshTests.swift
+++ b/Tests/CodexBarTests/VertexAIRefreshTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct VertexAIRefreshTests {
+    @Test
+    func `shared form encoder preserves keys and empty values`() throws {
+        let fields = ["key+&=% /東京": "value+&=% /東京", "empty": ""]
+        #expect(try Self.decodeForm(FormURLEncoding.body(fields)) == fields)
+        #expect(FormURLEncoding.body([:]).isEmpty)
+    }
+
+    @Test
+    func `refresh form preserves opaque credential values`() async throws {
+        let credentials = Self.credentials(refreshToken: "fixture+refresh&extra=value% /東京")
+        let transport = Self.transport(body: #"{"access_token":"new-access","expires_in":600}"#)
+
+        _ = try await VertexAITokenRefresher.refresh(credentials, session: transport)
+
+        let requests = await transport.requests()
+        #expect(requests.count == 1)
+        let request = try #require(requests.first)
+        #expect(request.url?.absoluteString == "https://oauth2.googleapis.com/token")
+        #expect(request.httpMethod == "POST")
+        #expect(request.timeoutInterval == 30)
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+        let body = try #require(request.httpBody)
+        #expect(try Self.decodeForm(body) == [
+            "client_id": credentials.clientId,
+            "client_secret": credentials.clientSecret,
+            "refresh_token": credentials.refreshToken,
+            "grant_type": "refresh_token",
+        ])
+    }
+
+    @Test(arguments: [
+        "{}",
+        #"{"expires_in":600}"#,
+        #"{"access_token":null}"#,
+        #"{"access_token":42}"#,
+        #"{"access_token":""}"#,
+        #"{"access_token":" \t\n "}"#,
+    ])
+    func `successful status without usable access token fails refresh`(body: String) async {
+        let transport = Self.transport(body: body)
+        let error = await #expect(throws: VertexAITokenRefresher.RefreshError.self) {
+            try await VertexAITokenRefresher.refresh(Self.credentials(), session: transport)
+        }
+        guard case .invalidResponse = error else {
+            Issue.record("Expected invalid refresh response")
+            return
+        }
+    }
+
+    @Test
+    func `missing refresh token fails before transport use`() async {
+        let transport = Self.transport(body: #"{"access_token":"new-access"}"#)
+        await #expect(throws: VertexAITokenRefresher.RefreshError.self) {
+            try await VertexAITokenRefresher.refresh(Self.credentials(refreshToken: ""), session: transport)
+        }
+        #expect(await transport.requests().isEmpty)
+    }
+
+    @Test
+    func `valid refresh preserves credential ownership and default expiry`() async throws {
+        let credentials = Self.credentials()
+        let transport = Self.transport(body: #"{"access_token":" new-access "}"#)
+        let started = Date()
+
+        let refreshed = try await VertexAITokenRefresher.refresh(credentials, session: transport)
+
+        #expect(refreshed.accessToken == " new-access ")
+        #expect(refreshed.refreshToken == credentials.refreshToken)
+        #expect(refreshed.clientId == credentials.clientId)
+        #expect(refreshed.clientSecret == credentials.clientSecret)
+        #expect(refreshed.projectId == credentials.projectId)
+        #expect(refreshed.email == credentials.email)
+        let expiry = try #require(refreshed.expiryDate)
+        #expect(expiry >= started.addingTimeInterval(3600))
+        #expect(expiry <= Date().addingTimeInterval(3600))
+    }
+
+    @Test(arguments: [false, true])
+    func `refresh preserves explicit expiry and display identity fallback`(validIdentity: Bool) async throws {
+        let payload = Data(#"{"email":"updated@example.test"}"#.utf8).base64EncodedString()
+        let identity = validIdentity ? "fixture.\(payload).fixture" : "malformed"
+        let body = """
+        {"access_token":"new-access","expires_in":600,"id_token":"\(identity)"}
+        """
+        let started = Date()
+        let refreshed = try await VertexAITokenRefresher.refresh(
+            Self.credentials(), session: Self.transport(body: body))
+
+        #expect(refreshed.email == (validIdentity ? "updated@example.test" : "fixture@example.test"))
+        let expiry = try #require(refreshed.expiryDate)
+        #expect(expiry >= started.addingTimeInterval(600))
+        #expect(expiry <= Date().addingTimeInterval(600))
+    }
+
+    @Test(arguments: [
+        (400, #"{"error":"invalid_grant"}"#, "expired"),
+        (401, #"{"error":"unauthorized_client"}"#, "revoked"),
+        (400, "{}", "expired"),
+        (400, #"{"error":"other"}"#, "invalidResponse"),
+        (503, "{}", "invalidResponse"),
+        (200, "not JSON", "invalidResponse"),
+    ])
+    func `refresh preserves response error categories`(statusCode: Int, body: String, expectedKind: String) async {
+        let error = await #expect(throws: VertexAITokenRefresher.RefreshError.self) {
+            try await VertexAITokenRefresher.refresh(
+                Self.credentials(), session: Self.transport(body: body, statusCode: statusCode))
+        }
+        guard let error else { return }
+        let kind = switch error {
+        case .expired: "expired"
+        case .revoked: "revoked"
+        case .invalidResponse: "invalidResponse"
+        case .networkError: "networkError"
+        }
+        #expect(kind == expectedKind)
+    }
+
+    @Test
+    func `refresh retains underlying transport errors`() async {
+        let transport = ProviderHTTPTransportStub { _ in throw URLError(.notConnectedToInternet) }
+        let error = await #expect(throws: VertexAITokenRefresher.RefreshError.self) {
+            try await VertexAITokenRefresher.refresh(Self.credentials(), session: transport)
+        }
+        guard case let .networkError(underlying) = error else {
+            Issue.record("Expected network refresh error")
+            return
+        }
+        #expect((underlying as? URLError)?.code == .notConnectedToInternet)
+    }
+
+    private static func credentials(refreshToken: String = "fixture-refresh") -> VertexAIOAuthCredentials {
+        VertexAIOAuthCredentials(
+            accessToken: "expired-access",
+            refreshToken: refreshToken,
+            clientId: "fixture+client&name=id",
+            clientSecret: "fixture+secret&name=value",
+            projectId: "fixture-project",
+            email: "fixture@example.test",
+            expiryDate: Date(timeIntervalSince1970: 0))
+    }
+
+    private static func transport(body: String, statusCode: Int = 200) -> ProviderHTTPTransportStub {
+        ProviderHTTPTransportStub { request in
+            let requestURL = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: requestURL, statusCode: statusCode, httpVersion: nil, headerFields: nil))
+            return (Data(body.utf8), response)
+        }
+    }
+
+    private static func decodeForm(_ data: Data) throws -> [String: String] {
+        var fields: [String: String] = [:]
+        let text = try #require(String(data: data, encoding: .utf8))
+        for pair in text.split(separator: "&") {
+            let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            #expect(parts.count == 2)
+            guard parts.count == 2 else { continue }
+            let key = try #require(String(parts[0]).replacingOccurrences(of: "+", with: " ").removingPercentEncoding)
+            let value = try #require(String(parts[1]).replacingOccurrences(of: "+", with: " ").removingPercentEncoding)
+            #expect(fields.updateValue(value, forKey: key) == nil)
+        }
+        return fields
+    }
+}

--- a/docs/vertexai.md
+++ b/docs/vertexai.md
@@ -16,6 +16,8 @@ read_when:
 - Authenticate: `gcloud auth application-default login`.
 - Project: `gcloud config set project PROJECT_ID`.
 - Fallback project env vars: `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, `CLOUDSDK_CORE_PROJECT`.
+- Refresh responses must contain a usable access token; malformed responses fail without extending the previous token's expiry.
+- gcloud retains ownership of credential-file updates; refreshed tokens are used in memory.
 
 ## API endpoints
 - Cloud Monitoring timeSeries:


### PR DESCRIPTION
Vertex refresh encoded form values using URL-query rules, so reserved characters could change the credentials sent to Google. It also treated a 200 response without a usable access token as success, retaining an expired token or accepting a blank one while assigning a fresh expiry.

Extract Copilot’s existing form encoder into one internal owner and use it for both providers. Require a nonblank access-token string before constructing refreshed Vertex credentials. The public refresh API, endpoint, timeout, existing error categories, default expiry, opaque token bytes, display-only identity handling, and gcloud-owned credential storage are preserved.

Validation:

- Before the fix, the new Swift regressions failed on form round-tripping and all six missing/unusable-token cases; input-guard and valid-response controls passed.
- An optimized standalone binary compiled the actual production refresher, credentials, identity decoder, HTTP client and form encoder. Its injected transport verified the original Google request and forwarded only to a loopback HTTP server, which independently decoded the form. Before: wire corruption plus missing/null/wrong-type/empty/blank success responses failed. After: all eight wire/response/default-expiry/identity cases passed. No real credentials or Google request were used.
- Focused command: `make test-fast FILTER='VertexAIRefreshTests|CopilotDeviceFlowTests|ProviderHTTPClientTests'` — final verification passed 31 tests in three suites in 9.101 seconds.
- Final isolated review through P2 passed with no accepted/actionable findings. `make check` passed with zero violations across 2,246 files.
- Complete local `CODEXBAR_TEST_RETRY_NON_TIMEOUT_FAILURES=0 make test` passed all 1,117 selections in 102 groups on the first attempt, with zero retries/timeouts (1,464.0 seconds total). The unchanged RPC teardown and subprocess-group suites passed in this run.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34731321499) passed both macOS shards, Linux x64/arm64, musl, lint, and the aggregate check.

Runtime proof outputs:

```text
Before: failed cases wire, missing, null, number, empty, blank; defaults and identity passed.
After: PASS wire; PASS missing/null/number/empty/blank rejection; PASS defaults; PASS identity.
```
