### PR TITLE
fix(oauth): preserve reserved refresh credential characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- OAuth: preserve reserved characters in Gemini, Antigravity, and Claude refresh requests while retaining credential ownership.
+
 ## 0.60.1 — 2026-09-12
 
 ### Highlights

--- a/Sources/CodexBarCore/FormURLEncoding.swift
+++ b/Sources/CodexBarCore/FormURLEncoding.swift
@@ -2,6 +2,10 @@ import Foundation
 
 enum FormURLEncoding {
     static func body(_ parameters: [String: String]) -> Data {
+        self.body(parameters.map { ($0.key, $0.value) })
+    }
+
+    static func body(_ parameters: [(String, String)]) -> Data {
         let pairs = parameters
             .map { key, value in
                 "\(Self.encode(key))=\(Self.encode(value))"

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
@@ -554,7 +554,7 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         request.httpMethod = "POST"
         request.timeoutInterval = context.timeout
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        request.httpBody = Self.formBody([
+        request.httpBody = FormURLEncoding.body([
             "client_id": oauthClient.clientID,
             "client_secret": oauthClient.clientSecret,
             "refresh_token": refreshToken,
@@ -611,14 +611,6 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
             credentials.idToken = idToken
         }
         return credentials
-    }
-
-    private static func formBody(_ values: [String: String]) -> Data? {
-        var components = URLComponents()
-        components.queryItems = values.map { key, value in
-            URLQueryItem(name: key, value: value)
-        }
-        return components.query?.data(using: .utf8)
     }
 
     private struct TokenClaims {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1443,13 +1443,11 @@ public enum ClaudeOAuthCredentialsStore {
             request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
             request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-            var components = URLComponents()
-            components.queryItems = [
-                URLQueryItem(name: "grant_type", value: "refresh_token"),
-                URLQueryItem(name: "refresh_token", value: refreshToken),
-                URLQueryItem(name: "client_id", value: ClaudeOAuthCredentialsStore.oauthClientID),
-            ]
-            request.httpBody = (components.percentEncodedQuery ?? "").data(using: .utf8)
+            request.httpBody = FormURLEncoding.body([
+                ("grant_type", "refresh_token"),
+                ("refresh_token", refreshToken),
+                ("client_id", ClaudeOAuthCredentialsStore.oauthClientID),
+            ])
 
             let response = try await ProviderHTTPClient.shared.response(for: request)
             let data = response.data

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -836,13 +836,12 @@ public struct GeminiStatusProbe: Sendable {
             throw GeminiStatusProbeError.apiError(GeminiConsumerTierMigration.oauthRecoveryError)
         }
 
-        let body = [
-            "client_id=\(oauthCreds.clientID)",
-            "client_secret=\(oauthCreds.clientSecret)",
-            "refresh_token=\(refreshToken)",
-            "grant_type=refresh_token",
-        ].joined(separator: "&")
-        request.httpBody = body.data(using: .utf8)
+        request.httpBody = FormURLEncoding.body([
+            ("client_id", oauthCreds.clientID),
+            ("client_secret", oauthCreds.clientSecret),
+            ("refresh_token", refreshToken),
+            ("grant_type", "refresh_token"),
+        ])
 
         let (data, response) = try await dataLoader(request)
 

--- a/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
@@ -107,8 +107,10 @@ struct AntigravityRemoteUsageFetcherTests {
         #expect(snapshot.accountEmail == "selected@example.com")
     }
 
-    @Test
-    func `remote fetch refreshes selected token account without mutating shared credentials`() async throws {
+    @Test(arguments: ["", "+&=%2B /東京"])
+    func `remote fetch refreshes selected token account without mutating shared credentials`(
+        suffix: String) async throws
+    {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }
         try env.writeAntigravityCredentials(
@@ -119,15 +121,18 @@ struct AntigravityRemoteUsageFetcherTests {
             email: "shared@example.com",
             clientID: "shared-client-id",
             clientSecret: "shared-client-secret")
+        let refreshToken = "selected-refresh\(suffix)"
+        let clientID = "selected-client-id\(suffix)"
+        let clientSecret = "selected-client-secret\(suffix)"
         let selectedCredentials = AntigravityOAuthCredentials(
             accessToken: "selected-old-token",
-            refreshToken: "selected-refresh",
+            refreshToken: refreshToken,
             expiryDate: Date().addingTimeInterval(-3600),
             idToken: GeminiAPITestHelpers.makeIDToken(email: "selected-old@example.com"),
             email: "selected-old@example.com",
             projectID: nil,
-            clientID: "selected-client-id",
-            clientSecret: "selected-client-secret")
+            clientID: clientID,
+            clientSecret: clientSecret)
         let token = try AntigravityOAuthCredentialsStore.tokenAccountValue(for: selectedCredentials)
         let updateCapture = AntigravityCredentialUpdateCapture()
 
@@ -138,9 +143,13 @@ struct AntigravityRemoteUsageFetcherTests {
 
             switch host {
             case "oauth2.googleapis.com":
-                let body = String(data: request.httpBody ?? Data(), encoding: .utf8) ?? ""
-                #expect(body.contains("client_id=selected-client-id"))
-                #expect(body.contains("refresh_token=selected-refresh"))
+                let body = try #require(request.httpBody)
+                #expect(try FormBodyTestSupport.decode(body) == [
+                    "client_id": clientID,
+                    "client_secret": clientSecret,
+                    "refresh_token": refreshToken,
+                    "grant_type": "refresh_token",
+                ])
                 return GeminiAPITestHelpers.response(
                     url: url.absoluteString,
                     status: 200,

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
@@ -217,8 +217,9 @@ struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
         }
     }
 
-    @Test
-    func `rotated refresh token preserves history owner through cache restart`() async throws {
+    @Test(arguments: ["", "+&=%2B /東京"])
+    func `rotated refresh token preserves history owner through cache restart`(suffix: String) async throws {
+        let refreshToken = "refresh-before-rotation\(suffix)"
         let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
         try await self.withDeterministicCacheService(service) {
             KeychainCacheStore.setTestStoreForTesting(true)
@@ -252,7 +253,7 @@ struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
                         let expiredData = self.makeCredentialsData(
                             accessToken: "access-before-rotation",
                             expiresAt: Date(timeIntervalSinceNow: -3600),
-                            refreshToken: "refresh-before-rotation")
+                            refreshToken: refreshToken)
                         let originalCredentials = try ClaudeOAuthCredentials.parse(data: expiredData)
                         let originalHistoryOwner = try #require(originalCredentials.historyOwnerIdentifier)
                         KeychainCacheStore.store(
@@ -265,6 +266,12 @@ struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
                         let refreshedRecord = try await ClaudeOAuthCredentialsStore
                             .withIsolatedMemoryCacheForTesting {
                                 try await self.withClaudeOAuthTokenRefreshStub(handler: { request in
+                                    let body = Data(self.requestBodyString(request).utf8)
+                                    let fields = try FormBodyTestSupport.decode(body)
+                                    #expect(Set(fields.keys) == ["grant_type", "refresh_token", "client_id"])
+                                    #expect(fields["grant_type"] == "refresh_token")
+                                    #expect(fields["refresh_token"] == refreshToken)
+                                    #expect(fields["client_id"]?.isEmpty == false)
                                     let response = try HTTPURLResponse(
                                         url: #require(request.url),
                                         statusCode: 200,

--- a/Tests/CodexBarTests/FormBodyTestSupport.swift
+++ b/Tests/CodexBarTests/FormBodyTestSupport.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Testing
+
+enum FormBodyTestSupport {
+    static func decode(_ data: Data) throws -> [String: String] {
+        var fields: [String: String] = [:]
+        let text = try #require(String(data: data, encoding: .utf8))
+        for pair in text.split(separator: "&") {
+            let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            #expect(parts.count == 2)
+            guard parts.count == 2 else { continue }
+            let key = try #require(String(parts[0]).replacingOccurrences(of: "+", with: " ").removingPercentEncoding)
+            let value = try #require(String(parts[1]).replacingOccurrences(of: "+", with: " ").removingPercentEncoding)
+            #expect(fields.updateValue(value, forKey: key) == nil)
+        }
+        return fields
+    }
+}

--- a/Tests/CodexBarTests/GeminiOAuthRecoveryAPITests.swift
+++ b/Tests/CodexBarTests/GeminiOAuthRecoveryAPITests.swift
@@ -48,13 +48,16 @@ struct GeminiOAuthRecoveryAPITests {
         }
     }
 
-    @Test
-    func `available gemini cli keeps oauth refresh behavior`() async throws {
+    @Test(arguments: ["", "+&=%2B /東京"])
+    func `available gemini cli keeps oauth refresh behavior`(suffix: String) async throws {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }
+        let refreshToken = "refresh-token\(suffix)"
+        let clientID = "cli-client-id\(suffix)"
+        let clientSecret = "cli-client-secret\(suffix)"
         try env.writeCredentials(
             accessToken: "old-token",
-            refreshToken: "refresh-token",
+            refreshToken: refreshToken,
             expiry: Date().addingTimeInterval(-3600),
             idToken: nil)
 
@@ -64,9 +67,13 @@ struct GeminiOAuthRecoveryAPITests {
             }
             switch host {
             case "oauth2.googleapis.com":
-                let body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
-                guard body.contains("client_id=cli-client-id"),
-                      body.contains("client_secret=cli-client-secret")
+                let body = try #require(request.httpBody)
+                guard try FormBodyTestSupport.decode(body) == [
+                    "client_id": clientID,
+                    "client_secret": clientSecret,
+                    "refresh_token": refreshToken,
+                    "grant_type": "refresh_token",
+                ]
                 else {
                     return GeminiAPITestHelpers.response(url: url.absoluteString, status: 400, body: Data())
                 }
@@ -103,8 +110,8 @@ struct GeminiOAuthRecoveryAPITests {
             dataLoader: dataLoader,
             oauthClientResolver: {
                 GeminiOAuthConfig.ClientCredentials(
-                    clientID: "cli-client-id",
-                    clientSecret: "cli-client-secret")
+                    clientID: clientID,
+                    clientSecret: clientSecret)
             },
             antigravityAvailability: { true })
 

--- a/Tests/CodexBarTests/VertexAIRefreshTests.swift
+++ b/Tests/CodexBarTests/VertexAIRefreshTests.swift
@@ -4,9 +4,16 @@ import Testing
 
 struct VertexAIRefreshTests {
     @Test
+    func `shared form encoder preserves explicit field order`() throws {
+        let body = FormURLEncoding.body([("second", "2"), ("first", "a+b"), ("empty", "")])
+        #expect(body == Data("second=2&first=a%2Bb&empty=".utf8))
+        #expect(try FormBodyTestSupport.decode(body) == ["second": "2", "first": "a+b", "empty": ""])
+    }
+
+    @Test
     func `shared form encoder preserves keys and empty values`() throws {
         let fields = ["key+&=% /東京": "value+&=% /東京", "empty": ""]
-        #expect(try Self.decodeForm(FormURLEncoding.body(fields)) == fields)
+        #expect(try FormBodyTestSupport.decode(FormURLEncoding.body(fields)) == fields)
         #expect(FormURLEncoding.body([:]).isEmpty)
     }
 
@@ -25,7 +32,7 @@ struct VertexAIRefreshTests {
         #expect(request.timeoutInterval == 30)
         #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
         let body = try #require(request.httpBody)
-        #expect(try Self.decodeForm(body) == [
+        #expect(try FormBodyTestSupport.decode(body) == [
             "client_id": credentials.clientId,
             "client_secret": credentials.clientSecret,
             "refresh_token": credentials.refreshToken,
@@ -151,19 +158,5 @@ struct VertexAIRefreshTests {
                 url: requestURL, statusCode: statusCode, httpVersion: nil, headerFields: nil))
             return (Data(body.utf8), response)
         }
-    }
-
-    private static func decodeForm(_ data: Data) throws -> [String: String] {
-        var fields: [String: String] = [:]
-        let text = try #require(String(data: data, encoding: .utf8))
-        for pair in text.split(separator: "&") {
-            let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-            #expect(parts.count == 2)
-            guard parts.count == 2 else { continue }
-            let key = try #require(String(parts[0]).replacingOccurrences(of: "+", with: " ").removingPercentEncoding)
-            let value = try #require(String(parts[1]).replacingOccurrences(of: "+", with: " ").removingPercentEncoding)
-            #expect(fields.updateValue(value, forKey: key) == nil)
-        }
-        return fields
     }
 }

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -59,6 +59,7 @@ empty quota card.
 
 ## OAuth account switching
 
+- OAuth refresh form-encodes credential values, preserving literal plus signs, separators, and percent escapes.
 - Login still uses Antigravity's Google OAuth client, discovered from `Antigravity.app` or overridden with `ANTIGRAVITY_OAUTH_CLIENT_ID` and `ANTIGRAVITY_OAUTH_CLIENT_SECRET`.
 - A successful login writes the latest shared credentials to `~/.codexbar/antigravity/oauth_creds.json` and upserts a token-account entry for the Google account.
 - Each token-account entry stores serialized `AntigravityOAuthCredentials` and is injected into remote fetches through `ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`.

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -61,6 +61,7 @@ Admin API key setup:
 - Web extras are internal-only (not exposed in the Providers pane).
 
 ## OAuth API (preferred)
+- OAuth refresh form-encodes credential values, preserving literal plus signs and other reserved characters.
 - Credentials:
   - CodexBar OAuth cache when available.
   - File fallback: `~/.claude/.credentials.json`.

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -61,6 +61,7 @@ Gemini uses the Gemini CLI OAuth credentials and private quota APIs. No browser 
 - Token refresh:
   - `POST https://oauth2.googleapis.com/token`
   - Form body: `client_id`, `client_secret`, `refresh_token`, `grant_type=refresh_token`.
+  - Values are form-encoded so literal plus signs, separators, and percent escapes remain intact.
 
 ## Parsing + mapping
 - Quota buckets:


### PR DESCRIPTION
Gemini interpolated raw OAuth refresh values, Antigravity serialized a decoded query string, and Claude left literal plus signs in its percent-encoded query. An `application/x-www-form-urlencoded` decoder therefore changed opaque credentials containing `+`, separators, or percent escapes.

Route these three refresh bodies through the shared encoder landed in #3608. A narrow ordered-pair entry point preserves Gemini and Claude field order; Antigravity’s redundant private serializer is removed. Endpoint selection, headers, response/error handling, token rotation, scopes, credential persistence, selected-account routing, and Claude CLI/lineage policies stay with their existing owners.

Existing integration tests retain their original inputs and ownership assertions and add reserved-character cases. A shared independent form decoder replaces query-style checks that could conceal plus-sign corruption.

Validation:

- Before: all three reserved-character integration cases failed while ordinary controls and existing Vertex cases passed.
- After: `make test-fast FILTER='GeminiOAuthRecoveryAPITests|AntigravityRemoteUsageFetcherTests|ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests|VertexAIRefreshTests|CopilotDeviceFlowTests'` passed **54 tests in five suites**.
- A standalone executable linked against the actual built production Core exercised all three refresh paths through a real loopback HTTP capture server. The server independently decoded each form and returned the same successful token payload in both versions so persistence/ownership remained observable. Before: three normal requests passed and three reserved-character requests failed wire validation; all ownership controls passed. After: **all six wire and ownership cases passed**.
- Runtime ownership checks covered Gemini’s synthetic credential-file update, Antigravity’s selected-account callback with unchanged shared credentials, and Claude’s in-memory cache/rotation lineage with no CLI credential-file write. No real provider account requests, browser imports, gcloud/CLI calls, or real Keychain access were used.
- `make check` passed with zero violations across **2,254 files**. Isolated Codex review through P2 found no accepted/actionable findings.
- Full local validation on the final head passed **1,120 selections / 103 groups in 1,966.0 seconds**: 102 groups passed first try; one 180-second Claude CLI batch timeout recovered through all 12 individual suite retries. Non-timeout retries were disabled. No deadline or assertion was changed.
- Earlier local attempts stopped on Kiro identity and RPC initialization failures. The final run passed those suites unchanged; these intermittent launch failures are disclosed, not claimed fixed by request encoding.
- [Exact-head CI](https://github.com/steipete/CodexBar/actions/runs/34735517383) and all nine PR checks passed on `1c936e18fbb54dadc85487e4c54a571ca656f45d`, including both macOS shards and the aggregate gate. The final head also passed the 54 focused tests, six production-Core HTTP/ownership cases, lint, and isolated Codex review through P2.

```text
Before: normal wire 3/3 pass; reserved wire 3/3 fail; ownership 6/6 pass.
After: wire 6/6 pass; ownership 6/6 pass.
```
